### PR TITLE
sdk/go: Deprecate non-f Assert and Require functions

### DIFF
--- a/changelog/pending/20230210--sdk-go--common-util-contract-deprecate-functions-that-dont-accept-printf-style-arguments.yaml
+++ b/changelog/pending/20230210--sdk-go--common-util-contract-deprecate-functions-that-dont-accept-printf-style-arguments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: "common/util/contract: Deprecate functions that don't accept printf-style arguments."

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -153,7 +153,7 @@ func (dctx *docGenContext) decomposeDocstring(docstring string) docInfo {
 
 		return ast.WalkContinue, nil
 	})
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error walking AST")
 	pushExamples()
 
 	if examplesShortcode != nil {

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -582,7 +582,7 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 	docLanguageHelper := mod.docGenContext.getLanguageDocHelper(lang)
 	modName := mod.getLanguageModuleName(lang)
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get package definition for %q", mod.pkg.Name())
 	langTypeString := docLanguageHelper.GetLanguageTypeString(def, modName, t, characteristics.input)
 
 	if optional, ok := t.(*schema.OptionalType); ok {
@@ -696,7 +696,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 	}
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -738,7 +738,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 	docLangHelper := mod.docGenContext.getLanguageDocHelper("go")
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -797,7 +797,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 	docLangHelper := mod.docGenContext.getLanguageDocHelper("csharp")
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -854,7 +854,7 @@ func (mod *modContext) genConstructorJava(r *schema.Resource, argsOverload bool)
 	docLangHelper := mod.docGenContext.getLanguageDocHelper("java")
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	result := []formalParam{
 		{
@@ -964,7 +964,7 @@ func (mod *modContext) genConstructorPython(r *schema.Resource, argsOptional, ar
 			continue
 		}
 		def, err := mod.pkg.Definition()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 		typ := docLanguageHelper.GetLanguageTypeString(def, mod.mod, codegen.PlainType(codegen.OptionalType(p)), true /*input*/)
 		params = append(params, formalParam{
 			Name:         python.InitParamName(p.Name),
@@ -994,7 +994,7 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 	for _, token := range sortedTokens {
 		for iter := mod.pkg.Types().Range(); iter.Next(); {
 			t, err := iter.Type()
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "error iterating types")
 			switch typ := t.(type) {
 			case *schema.ObjectType:
 				if typ.Token != token || len(typ.Properties) == 0 || typ.IsInputShape() {
@@ -1281,7 +1281,7 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName, tok string) 
 			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", namespace, modName, resourceTypeName)
 		case "yaml":
 			def, err := mod.pkg.Definition()
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 			resourceMap[lang] = propertyType{
 				Name:        resourceTypeName,
 				DisplayName: docLangHelper.GetLanguageTypeString(def, mod.mod, &schema.ResourceType{Token: tok}, false),
@@ -1307,7 +1307,7 @@ func (mod *modContext) getTSLookupParams(r *schema.Resource, stateParam string) 
 	dctx := mod.docGenContext
 	docLangHelper := dctx.getLanguageDocHelper("nodejs")
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -1347,7 +1347,7 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 	docLangHelper := dctx.getLanguageDocHelper("go")
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -1394,7 +1394,7 @@ func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) 
 	docLangHelper := dctx.getLanguageDocHelper("csharp")
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -1433,7 +1433,7 @@ func (mod *modContext) getJavaLookupParams(r *schema.Resource, stateParam string
 	dctx := mod.docGenContext
 	docLangHelper := dctx.getLanguageDocHelper("java")
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	return []formalParam{
 		{
@@ -1473,7 +1473,7 @@ func (mod *modContext) getPythonLookupParams(r *schema.Resource, stateParam stri
 	params := make([]formalParam, 0, len(r.StateInputs.Properties))
 	for _, p := range r.StateInputs.Properties {
 		def, err := mod.pkg.Definition()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 		typ := docLanguageHelper.GetLanguageTypeString(def, mod.mod, codegen.PlainType(codegen.OptionalType(p)), true /*input*/)
 		params = append(params, formalParam{
@@ -1634,7 +1634,7 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 	}
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %s", mod.pkg.Name())
 	packageDetails := packageDetails{
 		DisplayName:    getPackageDisplayName(def.Name),
 		Repository:     def.Repository,
@@ -1877,7 +1877,7 @@ func (mod *modContext) genIndex() indexData {
 	title := modName
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	// An empty string indicates that this is the root module.
 	if title == "" {

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -154,7 +154,7 @@ func (mod *modContext) genFunctionTS(f *schema.Function, funcName string, output
 		})
 	}
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 	params = append(params, formalParam{
 		Name:         "opts",
 		OptionalFlag: "?",
@@ -230,7 +230,7 @@ func (mod *modContext) genFunctionCS(f *schema.Function, funcName string, output
 	}
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 	params = append(params, formalParam{
 		Name:         "opts",
 		OptionalFlag: "?",
@@ -265,7 +265,7 @@ func (mod *modContext) genFunctionJava(f *schema.Function, funcName string, outp
 		})
 	}
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	params = append(params, formalParam{
 		Name:         "options",
@@ -303,7 +303,7 @@ func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string
 			}
 
 			def, err := mod.pkg.Definition()
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 			typ := docLanguageHelper.GetLanguageTypeString(def, mod.mod,
 				schemaType, true /*input*/)
@@ -459,7 +459,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 	}
 
 	def, err := mod.pkg.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 
 	packageDetails := packageDetails{
 		DisplayName:    getPackageDisplayName(def.Name),

--- a/pkg/codegen/docs/gen_method.go
+++ b/pkg/codegen/docs/gen_method.go
@@ -220,7 +220,7 @@ func (mod *modContext) genMethodPython(f *schema.Function) []formalParam {
 		})
 		for _, arg := range args {
 			def, err := mod.pkg.Definition()
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 			typ := docLanguageHelper.GetLanguageTypeString(def, mod.mod, arg.Type, true /*input*/)
 			var defaultValue string
 			if !arg.IsRequired() {
@@ -328,7 +328,7 @@ func (mod *modContext) getMethodResult(r *schema.Resource, m *schema.Method) map
 	for _, lang := range dctx.supportedLanguages {
 		if m.Function.ReturnType != nil {
 			def, err := mod.pkg.Definition()
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
 			resultTypeName = dctx.getLanguageDocHelper(lang).GetMethodResultName(def, mod.mod, r, m)
 		}
 		resourceMap[lang] = propertyType{

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -374,8 +374,9 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			extPkg := t.PackageReference
 			var info CSharpPackageInfo
 			def, err := extPkg.Definition()
-			contract.AssertNoError(err)
-			contract.AssertNoError(def.ImportLanguages(map[string]schema.Language{"csharp": Importer}))
+			contract.AssertNoErrorf(err, "error loading definition for package %q", extPkg.Name())
+			contract.AssertNoErrorf(def.ImportLanguages(map[string]schema.Language{"csharp": Importer}),
+				"error importing csharp for package %q", extPkg.Name())
 			if v, ok := def.Language["csharp"].(CSharpPackageInfo); ok {
 				info = v
 			}
@@ -410,8 +411,9 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			extPkg := t.Resource.PackageReference
 			var info CSharpPackageInfo
 			def, err := extPkg.Definition()
-			contract.AssertNoError(err)
-			contract.AssertNoError(def.ImportLanguages(map[string]schema.Language{"csharp": Importer}))
+			contract.AssertNoErrorf(err, "error loading definition for package %q", extPkg.Name())
+			contract.AssertNoErrorf(def.ImportLanguages(map[string]schema.Language{"csharp": Importer}),
+				"error importing csharp for package %q", extPkg.Name())
 			if v, ok := def.Language["csharp"].(CSharpPackageInfo); ok {
 				info = v
 			}
@@ -2279,11 +2281,11 @@ func generateModuleContextMap(tool string, pkg *schema.Package) (map[string]*mod
 	infos := map[*schema.Package]*CSharpPackageInfo{}
 	getPackageInfo := func(p schema.PackageReference) *CSharpPackageInfo {
 		def, err := p.Definition()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "error loading definition for package %v", p.Name())
 		info, ok := infos[def]
 		if !ok {
 			err := def.ImportLanguages(map[string]schema.Language{"csharp": Importer})
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "error importing csharp language info for package %q", p.Name())
 			csharpInfo, _ := pkg.Language["csharp"].(CSharpPackageInfo)
 			info = &csharpInfo
 			infos[def] = info

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -311,7 +311,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program) {
 				var info CSharpPackageInfo
 				if r.Schema != nil && r.Schema.PackageReference != nil {
 					def, err := r.Schema.PackageReference.Definition()
-					contract.AssertNoError(err)
+					contract.AssertNoErrorf(err, "error loading definition for package %q", r.Schema.PackageReference.Name())
 					if csharpinfo, ok := def.Language["csharp"].(CSharpPackageInfo); ok {
 						info = csharpinfo
 					}
@@ -339,7 +339,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program) {
 			}
 			return n, nil
 		})
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	}
 
 	if g.asyncInit {
@@ -430,7 +430,7 @@ func (g *generator) resourceTypeName(r *pcl.Resource) string {
 	pcl.FixupPulumiPackageTokens(r)
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diags := r.DecomposeToken()
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
 
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)
@@ -469,7 +469,7 @@ func (g *generator) extractInputPropertyNameMap(r *pcl.Resource) map[string]stri
 func (g *generator) resourceArgsTypeName(r *pcl.Resource) string {
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diags := r.DecomposeToken()
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
 
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)
@@ -492,7 +492,7 @@ func (g *generator) functionName(tokenArg model.Expression) (string, string) {
 
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diags := pcl.DecomposeToken(token, tokenRange)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)
 	namespace := namespaceName(namespaces, module)
@@ -541,7 +541,7 @@ func (g *generator) argumentTypeNameWithSuffix(expr model.Expression, destType m
 	}
 
 	pkg, _, member, diags := pcl.DecomposeToken(token, tokenRange)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
 	module := g.tokenToModules[pkg](token)
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -345,7 +345,7 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 	if syntax.KeyVar != "" {
 		keyVariable = &Variable{Name: syntax.KeyVar, VariableType: keyType}
 		ok := b.scope.Define(syntax.KeyVar, keyVariable)
-		contract.Assert(ok)
+		contract.Assertf(ok, "key variable %q already defined", syntax.KeyVar)
 	}
 	valueVariable := &Variable{Name: syntax.ValVar, VariableType: valueType}
 	if ok := b.scope.Define(syntax.ValVar, valueVariable); !ok {

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -195,7 +195,7 @@ func (x hclExpression) Variables() []hcl.Traversal {
 		}
 		return n, nil
 	})
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return variables
 }
 
@@ -388,7 +388,8 @@ func (x *BinaryOpExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 
 	// Compute the signature for the operator and typecheck the arguments.
 	signature := getOperationSignature(x.Operation)
-	contract.Assert(len(signature.Parameters) == 2)
+	contract.Assertf(len(signature.Parameters) == 2,
+		"expected binary operator signature to have two parameters, got %v", len(signature.Parameters))
 
 	x.leftType = signature.Parameters[0].Type
 	x.rightType = signature.Parameters[1].Type
@@ -2559,7 +2560,8 @@ func (x *UnaryOpExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 
 	// Compute the signature for the operator and typecheck the arguments.
 	signature := getOperationSignature(x.Operation)
-	contract.Assert(len(signature.Parameters) == 1)
+	contract.Assertf(len(signature.Parameters) == 1,
+		"expected unary operator signature to have 1 parameter, got %d", len(signature.Parameters))
 
 	x.operandType = signature.Parameters[0].Type
 

--- a/pkg/codegen/hcl2/model/format/gen.go
+++ b/pkg/codegen/hcl2/model/format/gen.go
@@ -111,11 +111,11 @@ func (e *Formatter) gen(w io.Writer, parentPrecedence int, rhs bool, x model.Exp
 		// OK
 	case precedence < parentPrecedence || rhs:
 		_, err := fmt.Fprint(w, "(")
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "write error")
 
 		defer func() {
 			_, err = fmt.Fprint(w, ")")
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "write error")
 		}()
 	}
 
@@ -163,7 +163,7 @@ func (e *Formatter) Fgen(w io.Writer, vs ...interface{}) {
 			e.gen(w, math.MaxInt32, false, x)
 		} else {
 			_, err := fmt.Fprint(w, v)
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "write error")
 		}
 	}
 }

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -103,7 +103,7 @@ func conversionFrom(dest, src Type, unifying bool, seen map[Type]struct{},
 }
 
 func unify(t0, t1 Type, unify func() (Type, ConversionKind)) (Type, ConversionKind) {
-	contract.Assert(t0 != nil)
+	contract.Requiref(t0 != nil, "t0", "must not be nil")
 
 	// Normalize s.t. dynamic is always on the right.
 	if t0 == DynamicType {
@@ -133,8 +133,10 @@ func unify(t0, t1 Type, unify func() (Type, ConversionKind)) (Type, ConversionKi
 		}
 
 		unified, conversionKind := unify()
-		contract.Assert(conversionKind >= conversionFrom)
-		contract.Assert(conversionKind >= conversionTo)
+		contract.Assertf(conversionKind >= conversionFrom,
+			"conversionKind (%v) < conversionFrom (%v)", conversionKind, conversionFrom)
+		contract.Assertf(conversionKind >= conversionTo,
+			"conversionKind (%v) < conversionTo (%v)", conversionKind, conversionTo)
 		return unified, conversionKind
 	}
 }

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -81,7 +81,7 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 	}
 
 	keyString, err := convert.Convert(key, cty.String)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "error converting key (%#v) to string", key)
 
 	propertiesLower := make(map[string]string)
 	for p := range t.Properties {

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -73,7 +73,7 @@ func (t *OpaqueType) conversionFromImpl(
 		switch {
 		case t == NumberType:
 			// src == NumberType is handled by t == src above
-			contract.Assert(src != NumberType)
+			contract.Assertf(src != NumberType, "unexpected number-to-number conversion")
 
 			cki, _ := IntType.conversionFromImpl(src, unifying, false, seen)
 			switch cki {

--- a/pkg/codegen/hcl2/model/utilities.go
+++ b/pkg/codegen/hcl2/model/utilities.go
@@ -59,7 +59,7 @@ func VariableReference(v *Variable) *ScopeTraversalExpression {
 		Parts:     []Traversable{v},
 	}
 	diags := x.Typecheck(false)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error typechecking variable reference: %v", diags)
 	return x
 }
 
@@ -70,6 +70,6 @@ func ConstantReference(c *Constant) *ScopeTraversalExpression {
 		Parts:     []Traversable{c},
 	}
 	diags := x.Typecheck(false)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error typechecking constant reference: %v", diags)
 	return x
 }

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -172,7 +172,7 @@ func (m *tokenMapper) mapRelativeTraversalTokens(traversal hcl.Traversal) []Trav
 		return nil
 	}
 
-	contract.Assert(traversal.IsRelative())
+	contract.Requiref(traversal.IsRelative(), "traversal", "must be relative")
 	items := make([]TraverserTokens, len(traversal))
 	for i, t := range traversal {
 		rng := t.SourceRange()
@@ -698,7 +698,8 @@ func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node,
 	}
 
 	// If we had any tokens, we should have attached all trivia to something.
-	contract.Assert(len(trivia) == 0 || len(tokens) == 0)
+	contract.Assertf(len(trivia) == 0 || len(tokens) == 0,
+		"unexpected unattached trivia (%d found)", len(trivia))
 
 	// Now build the token map.
 	//
@@ -714,7 +715,7 @@ func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node,
 		tokens:               tokens,
 		templateControlExprs: codegen.Set{},
 	})
-	contract.Assert(diags == nil)
+	contract.Assertf(diags == nil, "error building token map: %v", diags)
 
 	// If the root was a Body and there is a trailing end-of-file token, attach it to the body.
 	body, isBody := root.(*hclsyntax.Body)
@@ -788,12 +789,12 @@ func processBlockComment(text string) []string {
 		switch i {
 		case 0:
 			start := blockStartPat.FindString(l)
-			contract.Assert(start != "")
+			contract.Assertf(start != "", "unexpected block comment start: %q", l)
 			l = l[len(start):]
 
 			// If this is a single-line block comment, trim the end pattern as well.
 			if len(lines) == 1 {
-				contract.Assert(prefix == "")
+				contract.Assertf(prefix == "", "unexpected block comment prefix: %q", prefix)
 
 				if end := blockEndPat.FindString(l); end != "" {
 					l = l[:len(l)-len(end)]

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -96,7 +96,7 @@ func (b *binder) getDependencies(node Node) []Node {
 		}
 		return nil
 	})
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return SourceOrderNodes(deps)
 }
 

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -283,7 +283,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 						}),
 					}
 					diags := condExpr.Typecheck(false)
-					contract.Assert(len(diags) == 0)
+					contract.Assertf(len(diags) == 0, "failed to typecheck conditional expression: %v", diags)
 
 					node.VariableType = condExpr.Type()
 				case model.InputType(model.NumberType).ConversionFrom(typ) != model.NoConversion:
@@ -303,7 +303,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 						Value: model.VariableReference(resourceVar),
 					}
 					diags := rangeExpr.Typecheck(false)
-					contract.Assert(len(diags) == 0)
+					contract.Assertf(len(diags) == 0, "failed to typecheck range expression: %v", diags)
 
 					rangeValue = model.IntType
 

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -57,7 +57,7 @@ func LookupResource(pkg schema.PackageReference, token string) (*schema.Resource
 }
 
 func (ps *packageSchema) LookupFunction(token string) (*schema.Function, string, bool, error) {
-	contract.Assert(ps != nil)
+	contract.Assertf(ps != nil, "packageSchema must not be nil")
 
 	if ps.functionTokenMap == nil {
 		ps.initFunctionMap()
@@ -77,7 +77,7 @@ func (ps *packageSchema) LookupFunction(token string) (*schema.Function, string,
 }
 
 func (ps *packageSchema) LookupResource(token string) (*schema.Resource, string, bool, error) {
-	contract.Assert(ps != nil)
+	contract.Assertf(ps != nil, "packageSchema must not be nil")
 
 	if ps.resourceTokenMap == nil {
 		ps.initResourceMap()
@@ -264,7 +264,7 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 		}
 		return nil
 	})
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 
 	for _, name := range packageNames.SortedValues() {
 		if _, ok := b.referencedPackages[name]; ok && pkgOpts.version == "" || name == "" {
@@ -490,7 +490,7 @@ func GetSchemaForType(t model.Type) (schema.Type, bool) {
 	case *model.EnumType:
 		for _, t := range t.Annotations {
 			if t, ok := t.(enumSchemaType); ok {
-				contract.Assert(t.Type != nil)
+				contract.Assertf(t.Type != nil, "enum schema type must not be nil")
 				return t.Type, true
 			}
 		}

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -19,7 +18,9 @@ func BenchmarkLoadPackage(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		_, err := NewPackageCache().loadPackageSchema(loader, "aws", "")
-		contract.AssertNoError(err)
+		if err != nil {
+			b.Fatalf("failed to load package schema: %v", err)
+		}
 	}
 }
 

--- a/pkg/codegen/pcl/intrinsics.go
+++ b/pkg/codegen/pcl/intrinsics.go
@@ -81,7 +81,7 @@ func NewApplyCall(args []model.Expression, then *model.AnonymousFunctionExpressi
 func ParseApplyCall(c *model.FunctionCallExpression) (applyArgs []model.Expression,
 	then *model.AnonymousFunctionExpression,
 ) {
-	contract.Assert(c.Name == IntrinsicApply)
+	contract.Requiref(c.Name == IntrinsicApply, "c", "must be a call to %q, got %q", IntrinsicApply, c.Name)
 	return c.Args[:len(c.Args)-1], c.Args[len(c.Args)-1].(*model.AnonymousFunctionExpression)
 }
 
@@ -103,6 +103,6 @@ func NewConvertCall(from model.Expression, to model.Type) *model.FunctionCallExp
 // ParseConvertCall extracts the value being converted and the type it is being converted to from a call to the convert
 // intrinsic.
 func ParseConvertCall(c *model.FunctionCallExpression) (model.Expression, model.Type) {
-	contract.Assert(c.Name == IntrinsicConvert)
+	contract.Requiref(c.Name == IntrinsicConvert, "c", "must be a call to %q, got %q", IntrinsicConvert, c.Name)
 	return c.Args[0], c.Signature.ReturnType
 }

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -482,7 +482,7 @@ func (ctx *observeContext) rewriteScopeTraversalExpression(expr *model.ScopeTrav
 
 // rewriteRoot replaces the root node in a bound expression with a call to the __apply intrinsic if necessary.
 func (ctx *observeContext) rewriteRoot(expr model.Expression) model.Expression {
-	contract.Require(expr == ctx.root, "expr")
+	contract.Requiref(expr == ctx.root, "expr", "must be root expression")
 
 	if len(ctx.applyArgs) == 0 {
 		return expr
@@ -553,7 +553,7 @@ func (ctx *observeContext) PostVisit(expr model.Expression) (model.Expression, h
 
 	// TODO(pdg): arrays of outputs, for expressions, etc.
 	diagnostics := expr.Typecheck(false)
-	contract.Assert(len(diagnostics) == 0)
+	contract.Assertf(len(diagnostics) == 0, "error typechecking expression: %v", diagnostics)
 
 	if isIteratorExpr, _ := ctx.isIteratorExpr(expr); isIteratorExpr {
 		return expr, nil

--- a/pkg/codegen/pcl/rewrite_convert.go
+++ b/pkg/codegen/pcl/rewrite_convert.go
@@ -279,7 +279,7 @@ func convertPrimitiveValues(from model.Expression, to model.Type) (model.Express
 	}
 
 	diags := expression.Typecheck(false)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error typechecking expression: %v", diags)
 
 	expression.SetLeadingTrivia(from.GetLeadingTrivia())
 	expression.SetTrailingTrivia(from.GetTrailingTrivia())

--- a/pkg/codegen/pcl/rewrite_properties.go
+++ b/pkg/codegen/pcl/rewrite_properties.go
@@ -59,11 +59,11 @@ func RewritePropertyReferences(expr model.Expression) model.Expression {
 		value.SetLeadingTrivia(expr.GetLeadingTrivia())
 		value.SetTrailingTrivia(expr.GetTrailingTrivia())
 		diags := value.Typecheck(false)
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "error typechecking template expression: %v", diags)
 		return value, nil
 	}
 
 	expr, diags := model.VisitExpression(expr, model.IdentityVisitor, rewriter)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "error rewriting property references: %v", diags)
 	return expr
 }

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -70,7 +70,7 @@ func memberPath(section, token string, rest ...string) string {
 }
 
 func errorf(path, message string, args ...interface{}) *hcl.Diagnostic {
-	contract.Require(path != "", "path")
+	contract.Requiref(path != "", "path", "must not be empty")
 
 	summary := path + ": " + fmt.Sprintf(message, args...)
 	return &hcl.Diagnostic{
@@ -795,7 +795,7 @@ func (t *types) bindTypeSpecRef(path string, spec TypeSpec, inputShape bool) (Ty
 		case *EnumType:
 			return typ, diags, nil
 		default:
-			contract.Assert(typ == nil)
+			contract.Assertf(typ == nil, "unexpected type %T", typ)
 		}
 
 		// If the type is not a known type, bind it as an opaque token type.
@@ -909,8 +909,8 @@ func (t *types) bindTypeSpec(path string, spec TypeSpec,
 		return t.newArrayType(elementType), diags, nil
 	case "object":
 		elementType, elementDiags, err := t.bindTypeSpec(path, TypeSpec{Type: "string"}, inputShape)
-		contract.Assert(len(elementDiags) == 0)
-		contract.Assert(err == nil)
+		contract.Assertf(len(elementDiags) == 0, "unexpected diagnostics: %v", elementDiags)
+		contract.Assertf(err == nil, "error binding type spec")
 
 		if spec.AdditionalProperties != nil {
 			et, elementDiags, err := t.bindTypeSpec(path+"/additionalProperties", *spec.AdditionalProperties, inputShape)
@@ -1413,7 +1413,7 @@ func (t *types) bindProvider(decl *Resource) (hcl.Diagnostics, error) {
 	if err != nil {
 		return nil, err
 	}
-	contract.Assert(ok)
+	contract.Assertf(ok, "provider resource %q not found", t.pkg.Name)
 
 	diags, err := t.bindResourceDetails("#/provider", "pulumi:providers:"+t.pkg.Name, spec, decl)
 	if err != nil {

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -114,6 +114,6 @@ func RenderDocs(w io.Writer, source []byte, node ast.Node, options ...RendererOp
 func RenderDocsToString(source []byte, node ast.Node, options ...RendererOption) string {
 	var buf bytes.Buffer
 	err := RenderDocs(&buf, source, node, options...)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error rendering docs")
 	return buf.String()
 }

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -261,7 +261,7 @@ func (l *pluginLoader) loadPluginSchemaBytes(pkg string, version *semver.Version
 	if err != nil {
 		return nil, nil, err
 	}
-	contract.Assert(provider != nil)
+	contract.Assertf(provider != nil, "unexpected nil provider for %s@%v", pkg, version)
 
 	schemaFormatVersion := 0
 	schemaBytes, err := provider.GetSchema(schemaFormatVersion)

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/require"
 )
 
 func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {
 	cwd, err := os.Getwd()
-	contract.AssertNoError(err)
+	require.NoError(b, err)
 	sink := cmdutil.Diag()
 	ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
-	contract.AssertNoError(err)
+	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)
 
 	return loader
@@ -24,14 +24,14 @@ func BenchmarkLoadPackageReference(b *testing.B) {
 	cacheWarmingLoader := initLoader(b, pluginLoaderCacheOptions{})
 	// ensure the file cache exists for later tests:
 	_, err := cacheWarmingLoader.LoadPackageReference("azure-native", nil)
-	contract.AssertNoError(err)
+	require.NoError(b, err)
 
 	b.Run("full-load", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			loader := initLoader(b, pluginLoaderCacheOptions{})
 
 			_, err := loader.LoadPackageReference("azure-native", nil)
-			contract.AssertNoError(err)
+			require.NoError(b, err)
 		}
 	})
 
@@ -40,12 +40,12 @@ func BenchmarkLoadPackageReference(b *testing.B) {
 
 		b.StopTimer()
 		_, err := loader.LoadPackageReference("azure-native", nil)
-		contract.AssertNoError(err)
+		require.NoError(b, err)
 		b.StartTimer()
 
 		for n := 0; n < b.N; n++ {
 			_, err := loader.LoadPackageReference("azure-native", nil)
-			contract.AssertNoError(err)
+			require.NoError(b, err)
 		}
 	})
 
@@ -57,12 +57,12 @@ func BenchmarkLoadPackageReference(b *testing.B) {
 
 		b.StopTimer()
 		_, err := loader.LoadPackageReference("azure-native", nil)
-		contract.AssertNoError(err)
+		require.NoError(b, err)
 		b.StartTimer()
 
 		for n := 0; n < b.N; n++ {
 			_, err := loader.LoadPackageReference("azure-native", nil)
-			contract.AssertNoError(err)
+			require.NoError(b, err)
 		}
 	})
 
@@ -75,12 +75,12 @@ func BenchmarkLoadPackageReference(b *testing.B) {
 
 		b.StopTimer()
 		_, err := loader.LoadPackageReference("azure-native", nil)
-		contract.AssertNoError(err)
+		require.NoError(b, err)
 		b.StartTimer()
 
 		for n := 0; n < b.N; n++ {
 			_, err := loader.LoadPackageReference("azure-native", nil)
-			contract.AssertNoError(err)
+			require.NoError(b, err)
 		}
 	})
 
@@ -94,12 +94,12 @@ func BenchmarkLoadPackageReference(b *testing.B) {
 
 		b.StopTimer()
 		_, err := loader.LoadPackageReference("azure-native", nil)
-		contract.AssertNoError(err)
+		require.NoError(b, err)
 		b.StartTimer()
 
 		for n := 0; n < b.N; n++ {
 			_, err := loader.LoadPackageReference("azure-native", nil)
-			contract.AssertNoError(err)
+			require.NoError(b, err)
 		}
 	})
 }

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -42,7 +42,7 @@ func newPulumiPackage() *Package {
 	if err == nil && diags.HasErrors() {
 		err = diags
 	}
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to bind mock pulumi package")
 	return pkg
 }
 

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -519,8 +519,8 @@ func (p *PartialPackage) Snapshot() (*Package, error) {
 	})
 
 	typeList, diags, err := p.types.finishTypes(nil)
-	contract.Assert(err == nil)
-	contract.Assert(len(diags) == 0)
+	contract.AssertNoErrorf(err, "error snapshotting types")
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 
 	typeDefs := make(map[string]Type, len(p.types.typeDefs))
 	for token, typ := range p.types.typeDefs {

--- a/pkg/graph/dotconv/print.go
+++ b/pkg/graph/dotconv/print.go
@@ -69,7 +69,7 @@ func Print(g graph.Graph, w io.Writer) error {
 		// Dequeue the head of the frontier.
 		v := frontier[0]
 		frontier = frontier[1:]
-		contract.Assert(!emitted[v])
+		contract.Assertf(!emitted[v], "vertex was emitted twice")
 		emitted[v] = true
 
 		// Get and lazily allocate the ID for this vertex.

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -71,7 +71,7 @@ func symmetricCrypterFromPhraseAndState(phrase string, state string) (config.Cry
 }
 
 func indexN(s string, substr string, n int) int {
-	contract.Require(n > 0, "n")
+	contract.Requiref(n > 0, "n", "must be greater than 0")
 	scratch := s
 
 	for i := n; i > 0; i-- {
@@ -106,12 +106,12 @@ func (sm *localSecretsManager) State() interface{} {
 }
 
 func (sm *localSecretsManager) Decrypter() (config.Decrypter, error) {
-	contract.Assert(sm.crypter != nil)
+	contract.Assertf(sm.crypter != nil, "decrypter not initialized")
 	return sm.crypter, nil
 }
 
 func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
-	contract.Assert(sm.crypter != nil)
+	contract.Assertf(sm.crypter != nil, "encrypter not initialized")
 	return sm.crypter, nil
 }
 
@@ -297,7 +297,7 @@ func promptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 	// symmetricCrypter does not use ctx, safe to use context.Background()
 	ignoredCtx := context.Background()
 	msg, err := crypter.EncryptValue(ignoredCtx, "pulumi")
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "could not encrypt message")
 
 	// Encode the salt as the passphrase secrets manager state.
 	state := fmt.Sprintf("v1:%s:%s", base64.StdEncoding.EncodeToString(salt), msg)

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -111,12 +111,12 @@ func (sm *serviceSecretsManager) State() interface{} {
 }
 
 func (sm *serviceSecretsManager) Decrypter() (config.Decrypter, error) {
-	contract.Assert(sm.crypter != nil)
+	contract.Assertf(sm.crypter != nil, "decrypter not initialized")
 	return sm.crypter, nil
 }
 
 func (sm *serviceSecretsManager) Encrypter() (config.Encrypter, error) {
-	contract.Assert(sm.crypter != nil)
+	contract.Assertf(sm.crypter != nil, "encrypter not initialized")
 	return sm.crypter, nil
 }
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -385,7 +385,7 @@ func (opts *ProgramTestOptions) GetStackName() tokens.QName {
 
 		b := make([]byte, 4)
 		_, err = cryptorand.Read(b)
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failure to generate random stack suffix")
 
 		opts.StackName = strings.ToLower("p-it-" + host + "-" + test + "-" + hex.EncodeToString(b))
 	}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -83,7 +83,7 @@ func uniqueSuffix() string {
 	// .<timestamp>.<five random hex characters>
 	timestamp := time.Now().Format("20060102-150405")
 	suffix, err := resource.NewUniqueHex("."+timestamp+".", 5, -1)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "could not generate random suffix")
 	return suffix
 }
 

--- a/pkg/util/cancel/context.go
+++ b/pkg/util/cancel/context.go
@@ -41,7 +41,7 @@ type Source struct {
 // NewContext creates a new cancellation context and source parented to the given context. The returned cancellation
 // context will be terminated when the supplied root context is canceled.
 func NewContext(ctx context.Context) (*Context, *Source) {
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(ctx != nil, "ctx", "must not be nil")
 
 	// Set up two new cancellable contexts: one for termination and one for cancellation. The cancellation context is a
 	// child context of the termination context and will therefore be automatically cancelled when termination is

--- a/sdk/go/common/util/contract/assert.go
+++ b/sdk/go/common/util/contract/assert.go
@@ -21,6 +21,8 @@ import (
 const assertMsg = "An assertion has failed"
 
 // Assert checks a condition and Fails if it is false.
+//
+// Deprecated: Use Assertf.
 func Assert(cond bool) {
 	if !cond {
 		failfast(assertMsg)
@@ -35,6 +37,8 @@ func Assertf(cond bool, msg string, args ...interface{}) {
 }
 
 // AssertNoError will Fail if the error is non-nil.
+//
+// Deprecated: Use AssertNoErrorf.
 func AssertNoError(err error) {
 	if err != nil {
 		failfast(err.Error())

--- a/sdk/go/common/util/contract/fail.go
+++ b/sdk/go/common/util/contract/fail.go
@@ -21,6 +21,8 @@ import (
 const failMsg = "A failure has occurred"
 
 // Fail unconditionally abandons the process.
+//
+// Deprecated: Use Failf.
 func Fail() {
 	failfast(failMsg)
 }

--- a/sdk/go/common/util/contract/require.go
+++ b/sdk/go/common/util/contract/require.go
@@ -21,6 +21,8 @@ import (
 const requireMsg = "A precondition has failed for %v"
 
 // Require checks a precondition condition pertaining to a function parameter, and Fails if it is false.
+//
+// Deprecated: Use Requiref.
 func Require(cond bool, param string) {
 	if !cond {
 		failfast(fmt.Sprintf(requireMsg, param))

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -213,7 +213,7 @@ type gitlabSource struct {
 // Creates a new GitLab source from a gitlab://<host>/<project_id> url.
 // Uses the GITLAB_TOKEN environment variable for authentication if it's set.
 func newGitlabSource(url *url.URL, name string, kind PluginKind) (*gitlabSource, error) {
-	contract.Assert(url.Scheme == "gitlab")
+	contract.Requiref(url.Scheme == "gitlab", "url", `scheme must be "gitlab", was %q`, url.Scheme)
 
 	host := url.Host
 	if host == "" {

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -702,6 +702,6 @@ func getStackProjectBackupDir(e *ptesting.Environment, stackName string) (string
 func addRandomSuffix(s string) string {
 	b := make([]byte, 4)
 	_, err := cryptorand.Read(b)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error generating random suffix")
 	return s + "-" + hex.EncodeToString(b)
 }


### PR DESCRIPTION
This change migrates all remaining usages of non-f variants of
`contract.Assert*` and `contract.Require*` to the f variants,
which require adding meaningful error messages.

There were a couple cases where a `testing.T/B` was available.
For those, this uses t.FailNow or require.NoError.

On top of migrating all existing usages,
this prevents any new usages of these functions
by marking them as deprecated.
(staticcheck will fail if we attempt to use deprecated functions,
which is what I used to find all instances in the first place.)

This PR has two commits:
one migrates all usages, the other marks the functions deprecated.

Resolves #12132
