### PR TITLE
[pcl/programgen] PCL component block, binding and dotnet program-gen implementation

### DIFF
--- a/changelog/pending/20230306--programgen-dotnet--pcl-components-and-dotnet-program-gen-implementation.yaml
+++ b/changelog/pending/20230306--programgen-dotnet--pcl-components-and-dotnet-program-gen-implementation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet
+  description: PCL components and dotnet program-gen implementation

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -820,6 +820,20 @@ func (g *generator) withinFunctionInvoke(run func()) {
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
+	if g.isComponent {
+		configVars := map[string]*pcl.ConfigVariable{}
+		for _, configVar := range g.program.ConfigVariables() {
+			configVars[configVar.Name()] = configVar
+		}
+
+		if _, isConfig := configVars[expr.RootName]; isConfig {
+			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
+				g.Fgenf(w, "args.%s", Title(expr.RootName))
+				return
+			}
+		}
+	}
+
 	rootName := makeValidIdentifier(expr.RootName)
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"

--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -126,11 +126,11 @@ func getHelperMethodIfNeeded(functionName string) (string, bool) {
 	switch functionName {
 	case "filebase64":
 		return `private static string ReadFileBase64(string path) {
-		return Convert.ToBase64String(Encoding.UTF8.GetBytes(File.ReadAllText(path)))
+		return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(File.ReadAllText(path)));
 	}`, true
 	case "filebase64sha256":
 		return `private static string ComputeFileBase64Sha256(string path) {
-		var fileData = Encoding.UTF8.GetBytes(File.ReadAllText(path));
+		var fileData = System.Text.Encoding.UTF8.GetBytes(File.ReadAllText(path));
 		var hashData = SHA256.Create().ComputeHash(fileData);
 		return Convert.ToBase64String(hashData);
 	}`, true

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -1,0 +1,241 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:goconst
+package pcl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+)
+
+// componentVariableType returns the type of the variable of which the value is a component.
+// The type is derived from the outputs of the sub-program of the component into an ObjectType
+func componentVariableType(program *Program) model.Type {
+	properties := map[string]model.Type{}
+	for _, node := range program.Nodes {
+		switch node := node.(type) {
+		case *OutputVariable:
+			switch nodeType := node.Type().(type) {
+			case *model.OutputType:
+				// if the output variable is already an Output<T>, keep it as is
+				properties[node.LogicalName()] = nodeType
+			default:
+				// otherwise, wrap it as an output
+				properties[node.LogicalName()] = &model.OutputType{
+					ElementType: nodeType,
+				}
+			}
+		}
+	}
+
+	return &model.ObjectType{Properties: properties}
+}
+
+type componentInput struct {
+	key      string
+	required bool
+}
+
+func componentInputs(program *Program) map[string]componentInput {
+	inputs := map[string]componentInput{}
+	for _, node := range program.Nodes {
+		switch node := node.(type) {
+		case *ConfigVariable:
+			inputs[node.LogicalName()] = componentInput{
+				required: node.DefaultValue == nil,
+				key:      node.LogicalName(),
+			}
+		}
+	}
+
+	return inputs
+}
+
+func contains(slice []string, item string) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+
+	_, ok := set[item]
+	return ok
+}
+
+// ComponentProgramBinderFromFileSystem returns the default component program binder which uses the file system
+// to parse and bind PCL files into a program.
+func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
+	return func(args ComponentProgramBinderArgs) (*Program, hcl.Diagnostics, error) {
+		var diagnostics hcl.Diagnostics
+		binderDirPath := args.binderDirPath
+		componentSource := args.componentSource
+		nodeRange := args.componentNodeRange
+		loader := args.binderLoader
+		// bind the component here as if it was a new program
+		// this becomes the DirPath for the new binder
+		componentSourceDir := filepath.Join(binderDirPath, componentSource)
+
+		parser := hclsyntax.NewParser()
+		// Load all .pp files in the components' directory
+		files, err := os.ReadDir(componentSourceDir)
+		if err != nil {
+			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			return nil, diagnostics, nil
+		}
+
+		if len(files) == 0 {
+			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			return nil, diagnostics, nil
+		}
+
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			fileName := file.Name()
+			path := filepath.Join(componentSourceDir, fileName)
+
+			if filepath.Ext(fileName) == ".pp" {
+				file, err := os.Open(path)
+				if err != nil {
+					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					return nil, diagnostics, err
+				}
+
+				err = parser.ParseFile(file,
+					fmt.Sprintf("%s/%s", filepath.Base(componentSourceDir), filepath.Base(path)))
+
+				if err != nil {
+					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+					return nil, diagnostics, err
+				}
+
+				diags := parser.Diagnostics
+				if diags.HasErrors() {
+					return nil, diagnostics, err
+				}
+			}
+		}
+
+		if err != nil {
+			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			return nil, diagnostics, err
+		}
+
+		componentProgram, programDiags, err := BindProgram(parser.Files,
+			Loader(loader),
+			DirPath(componentSourceDir))
+
+		return componentProgram, programDiags, err
+	}
+}
+
+func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
+	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options.modelOptions()...)
+	node.Definition = block
+
+	// check we can use components and load the program
+	if b.options.dirPath == "" {
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(),
+			"components require the binder to have set a directory path"))
+		return diagnostics
+	}
+
+	if b.options.componentProgramBinder == nil {
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(),
+			"components require the binder to have set the component program binder"))
+		return diagnostics
+	}
+
+	componentProgram, programDiags, err := b.options.componentProgramBinder(ComponentProgramBinderArgs{
+		binderLoader:       b.options.loader,
+		binderDirPath:      b.options.dirPath,
+		componentSource:    node.source,
+		componentNodeRange: node.SyntaxNode().Range(),
+	})
+	if err != nil {
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), err.Error()))
+		return diagnostics
+	}
+
+	if programDiags.HasErrors() || componentProgram == nil {
+		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), programDiags.Error()))
+		return diagnostics
+	}
+
+	node.Program = componentProgram
+	node.VariableType = componentVariableType(componentProgram)
+	node.dirPath = filepath.Join(b.options.dirPath, node.source)
+
+	componentInputs := componentInputs(componentProgram)
+	providedInputs := []string{}
+
+	var options *model.Block
+	for _, item := range block.Body.Items {
+		switch item := item.(type) {
+		case *model.Attribute:
+			// logical name is a special attribute
+			if item.Name == LogicalNamePropertyKey {
+				logicalName, lDiags := getStringAttrValue(item)
+				if lDiags != nil {
+					diagnostics = diagnostics.Append(lDiags)
+				} else {
+					node.logicalName = logicalName
+				}
+				continue
+			}
+			// all other attributes are part of the inputs
+			_, knownInput := componentInputs[item.Name]
+
+			if !knownInput {
+				diagnostics = append(diagnostics, unsupportedAttribute(item.Name, item.Syntax.NameRange))
+				return diagnostics
+			}
+
+			node.Inputs = append(node.Inputs, item)
+			providedInputs = append(providedInputs, item.Name)
+		case *model.Block:
+			switch item.Type {
+			case "options":
+				if options != nil {
+					diagnostics = append(diagnostics, duplicateBlock(item.Type, item.Syntax.TypeRange))
+				} else {
+					options = item
+				}
+			default:
+				diagnostics = append(diagnostics, unsupportedBlock(item.Type, item.Syntax.TypeRange))
+			}
+		}
+	}
+
+	// check that all required inputs are actually set
+	for inputKey, componentInput := range componentInputs {
+		if componentInput.required && !contains(providedInputs, inputKey) {
+			diagnostics = append(diagnostics, missingRequiredAttribute(inputKey, node.SyntaxNode().Range()))
+		}
+	}
+
+	if options != nil {
+		resourceOptions, optionsDiags := bindResourceOptions(options)
+		diagnostics = append(diagnostics, optionsDiags...)
+		node.Options = resourceOptions
+	}
+
+	return diagnostics
+}

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -61,6 +61,9 @@ func (b *binder) bindNode(node Node) hcl.Diagnostics {
 	case *Resource:
 		diags := b.bindResource(node)
 		diagnostics = append(diagnostics, diags...)
+	case *Component:
+		diags := b.bindComponent(node)
+		diagnostics = append(diagnostics, diags...)
 	case *OutputVariable:
 		diags := b.bindOutputVariable(node)
 		diagnostics = append(diagnostics, diags...)

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -65,11 +65,20 @@ func TestBindProgram(t *testing.T) {
 				var bindError error
 				var diags hcl.Diagnostics
 				loader := pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath)))
+				absoluteFolderPath, err := filepath.Abs(folderPath)
+				if err != nil {
+					t.Fatalf("failed to bind program: unable to find the absolute path of %v", folderPath)
+				}
+				options := append(
+					bindOptions[v.Name()],
+					loader,
+					pcl.DirPath(absoluteFolderPath),
+					pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 				// PCL binder options are taken from program_driver.go
-				_, diags, bindError = pcl.BindProgram(parser.Files, append(bindOptions[v.Name()], loader)...)
+				program, diags, bindError := pcl.BindProgram(parser.Files, options...)
 
 				assert.NoError(t, bindError)
-				if diags.HasErrors() {
+				if diags.HasErrors() || program == nil {
 					t.Fatalf("failed to bind program: %v", diags)
 				}
 			})

--- a/pkg/codegen/python/gen_program_quotes_test.go
+++ b/pkg/codegen/python/gen_program_quotes_test.go
@@ -19,12 +19,14 @@ resource vpcSubnet "aws:ec2:Subnet" {
 
 	cidrBlock = "10.100.${range.key}.0/24"
 	availabilityZone = range.value
+	vpcId = 1
 }
 
 resource rta "aws:ec2:RouteTableAssociation" {
 	options { range = zones.names }
 
 	subnetId = vpcSubnet[range.key].id
+	routeTableId = 1
 }
 `
 	program, diags := parseAndBindProgram(t, source, "lower_property_access.pp")

--- a/pkg/codegen/testing/test/testdata/components-pp/components.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/components.pp
@@ -1,0 +1,9 @@
+component simpleComponent "./simpleComponent" {}
+
+component exampleComponent "./exampleComponent" {
+    input = "doggo"
+}
+
+output result {
+    value = exampleComponent.result
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Pulumi;
+using Random = Pulumi.Random;
+
+namespace Components
+{
+    public class ExampleComponentArgs : global::Pulumi.ResourceArgs
+    {
+        [Input("input")]
+        public Input<string> Input { get; set; } = null!;
+    }
+
+    public class ExampleComponent : global::Pulumi.ComponentResource
+    {
+        [Output("result")]
+        public Output<string> Result { get; private set; } = null!;
+        public ExampleComponent(string name, ExampleComponentArgs args, ComponentResourceOptions? opts = null)
+            : base("components:index:ExampleComponent", name, args, opts)
+        {
+            var password = new Random.RandomPassword($"{name}-password", new()
+            {
+                Length = 16,
+                Special = true,
+                OverrideSpecial = args.Input,
+            }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            this.Result = password.Result;
+
+            this.RegisterOutputs(new Dictionary<string, object?>
+            {
+                ["result"] = password.Result,
+            });
+        }
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/SimpleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/SimpleComponent.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Pulumi;
+using Random = Pulumi.Random;
+
+namespace Components
+{
+    public class SimpleComponent : global::Pulumi.ComponentResource
+    {
+        public SimpleComponent(string name, ComponentResourceOptions? opts = null)
+            : base("components:index:SimpleComponent", name, ResourceArgs.Empty, opts)
+        {
+            var firstPassword = new Random.RandomPassword($"{name}-firstPassword", new()
+            {
+                Length = 16,
+                Special = true,
+            }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            var secondPassword = new Random.RandomPassword($"{name}-secondPassword", new()
+            {
+                Length = 16,
+                Special = true,
+            }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            this.RegisterOutputs();
+        }
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var simpleComponent = new Components.SimpleComponent("simpleComponent");
+
+    var exampleComponent = new Components.ExampleComponent("exampleComponent", new()
+    {
+        Input = "doggo",
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["result"] = exampleComponent.Result,
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -1,0 +1,12 @@
+config input string {
+}
+
+resource password "random:index/randomPassword:RandomPassword" {
+  length = 16
+  special = true
+  overrideSpecial = input
+}
+
+output result {
+    value = password.result
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/simpleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/simpleComponent/main.pp
@@ -1,0 +1,9 @@
+resource firstPassword "random:index/randomPassword:RandomPassword" {
+  length = 16
+  special = true
+}
+
+resource secondPassword "random:index/randomPassword:RandomPassword" {
+  length = 16
+  special = true
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR implements resource components as a construct at the PCL level to be consumed by program-gen and emit components for every language. As a starting point, I've implemented the program-gen implementation for dotnet and it works great! 

for PCL binding, added the new type of node called `Component` which now part of a PCL program along with config, resource, local variables and output variables. 

The binder for the _root_ PCL program now requires `DirPath` option when encountering a component declaration because we need to resolve the source files of the component, relative to the component that declares it. When binding a component, we create a new binder for the child program of that component and providing `Join(dirPath, componentSource)` as the new `DirPath` of that component. 

PCL binder no longer searches for files in nested directories, only the directory with one level: sub directories are only visited when binding components defined there. 

As for the _type_ of the component itself: it is an `ObjectType` where the properties and their types are derived from the output variables of that component. 

The inputs for the component, if any, are derived from the config variable declaration of the component. 

Still To-Do but maybe not in this PR: 
 - Type checking the inputs of a components; now we only check for missing required ones and whether an input is known. This can be easily added
 - Better testing strategy and unit tests around components since they generate multiple files and `ProgramTest` only checks the root program. 

### Example 

See repo [pcl-components-to-dotnet](https://github.com/Zaid-Ajaj/pcl-components-to-dotnet)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
