### PR TITLE
[cli] Improve interactive scrolling

### DIFF
--- a/changelog/pending/20230307--cli-display--autoscroll-the-interactive-display-and-support-pgup-pgdown.yaml
+++ b/changelog/pending/20230307--cli-display--autoscroll-the-interactive-display-and-support-pgup-pgdown.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Autoscroll the interactive display and support pgup/pgdown

--- a/pkg/backend/display/internal/terminal/term_test.go
+++ b/pkg/backend/display/internal/terminal/term_test.go
@@ -1,0 +1,107 @@
+package terminal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ansiCase struct {
+	in           string
+	kind         ansiKind
+	params       string
+	intermediate string
+	final        byte
+}
+
+func (c ansiCase) run(t *testing.T) {
+	t.Run(c.in, func(t *testing.T) {
+		t.Parallel()
+
+		var d ansiDecoder
+		err := d.decode(strings.NewReader(c.in))
+		require.NoError(t, err)
+		assert.Equal(t, c.kind, d.kind)
+		assert.Equal(t, c.params, string(d.params))
+		assert.Equal(t, c.intermediate, string(d.intermediate))
+		assert.Equal(t, c.final, d.final)
+	})
+}
+
+func ansiErrorCase(lead, params, intermediate string, final byte) ansiCase {
+	return ansiCase{
+		in:           fmt.Sprintf("%v%v%v%v", lead, params, intermediate, string([]byte{final})),
+		kind:         ansiError,
+		params:       params,
+		intermediate: intermediate,
+		final:        final,
+	}
+}
+
+func ansiKeyCase(in byte) ansiCase {
+	return ansiCase{in: string([]byte{in}), kind: ansiKey, final: in}
+}
+
+func ansiEscapeCase(intermediate string, final byte) ansiCase {
+	return ansiCase{
+		in:           fmt.Sprintf("\x1b%v%v", intermediate, string([]byte{final})),
+		kind:         ansiEscape,
+		intermediate: intermediate,
+		final:        final,
+	}
+}
+
+func ansiControlCase(params, intermediate string, final byte) ansiCase {
+	return ansiCase{
+		in:           fmt.Sprintf("\x1b[%v%v%v", params, intermediate, string([]byte{final})),
+		kind:         ansiControl,
+		params:       params,
+		intermediate: intermediate,
+		final:        final,
+	}
+}
+
+func TestANSIDecoder(t *testing.T) {
+	t.Parallel()
+
+	// check all key sequences
+	for i := 0; i < 0x7f; i++ {
+		if i != 0x1b {
+			ansiKeyCase(byte(i)).run(t)
+		}
+	}
+
+	// check a selection of escape sequences
+	escapeCases := []ansiCase{
+		ansiEscapeCase("", '7'),
+		ansiEscapeCase("", '8'),
+		ansiEscapeCase("(", 'A'),
+		ansiEscapeCase(")", 'A'),
+		ansiErrorCase("\x1b", "", "", 3),
+		ansiErrorCase("\x1b", "", "(", 3),
+		ansiErrorCase("\x1b", "", "", 0x7f),
+	}
+	for _, c := range escapeCases {
+		c.run(t)
+	}
+
+	// check a selection of control sequences
+	controlCases := []ansiCase{
+		ansiControlCase("5", "", '~'),
+		ansiControlCase("6", "", '~'),
+		ansiControlCase("5;1", "", '~'),
+		ansiControlCase("6;1", "", '~'),
+		ansiControlCase("", "", 'A'),
+		ansiControlCase("", "", 'B'),
+		ansiControlCase("80;24", " ", 'T'),
+		ansiErrorCase("\x1b[", "5", "", 3),
+		ansiErrorCase("\x1b[", "80;24", " ", 4),
+		ansiErrorCase("\x1b[", "5;1", "", 0x7f),
+	}
+	for _, c := range controlCases {
+		c.run(t)
+	}
+}

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
@@ -689,7 +689,6 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
                                                                           more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
@@ -711,8 +710,8 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
@@ -734,9 +733,8 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -757,9 +755,9 @@
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -780,10 +778,9 @@
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -803,10 +800,10 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -826,11 +823,10 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -849,11 +845,11 @@
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -872,12 +868,11 @@
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -895,12 +890,12 @@
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -918,13 +913,12 @@
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -941,13 +935,13 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -964,14 +958,13 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
@@ -987,14 +980,14 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
@@ -1010,15 +1003,14 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1033,15 +1025,15 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1056,16 +1048,15 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1079,16 +1070,16 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1102,17 +1093,16 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1125,17 +1115,17 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1148,18 +1138,17 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1171,18 +1160,18 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1194,19 +1183,18 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%bold%}><{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1217,19 +1205,19 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1240,20 +1228,19 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      [K
@@ -1263,20 +1250,20 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                            [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role          [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd      [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2      [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97      [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                    [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823           [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName               [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup    [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRul[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      [K
@@ -1286,21 +1273,20 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                            [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role          [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd      [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2      [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97      [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                    [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823           [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName               [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup    [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRul[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
@@ -1309,21 +1295,21 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
@@ -1332,22 +1318,21 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
@@ -1355,22 +1340,22 @@
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
@@ -1378,1134 +1363,1149 @@
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     └─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
@@ -689,7 +689,6 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
                                                                           more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
@@ -711,8 +710,8 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
@@ -734,9 +733,8 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -757,9 +755,9 @@
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -780,10 +778,9 @@
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -803,10 +800,10 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -826,11 +823,10 @@
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -849,11 +845,11 @@
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
@@ -872,12 +868,11 @@
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -895,12 +890,12 @@
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -918,13 +913,12 @@
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -941,13 +935,13 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       [K
@@ -964,14 +958,13 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
@@ -987,14 +980,14 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
@@ -1010,15 +1003,14 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1033,15 +1025,15 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1056,16 +1048,15 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1079,16 +1070,16 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
@@ -1102,17 +1093,16 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1125,17 +1115,17 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1148,18 +1138,17 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1171,18 +1160,18 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%bold%}><{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1194,19 +1183,18 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%bold%}><{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1217,19 +1205,19 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru[K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>[K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  [K
@@ -1240,20 +1228,19 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role        <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97    <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                  <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99         <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName             <{%reset%}><{%reset%}>  [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      [K
@@ -1263,20 +1250,20 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                            [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role          [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd      [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2      [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97      [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                    [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823           [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName               [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup    [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRul[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      [K
@@ -1286,21 +1273,20 @@
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              [K
  <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                            [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role          [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd      [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2      [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97      [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                    [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role               [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823           [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName               [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup    [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRul[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
@@ -1309,21 +1295,21 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
@@ -1332,22 +1318,21 @@
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
@@ -1355,22 +1340,22 @@
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
@@ -1378,1134 +1363,1149 @@
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
- <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               [K
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     [K
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               [K
-                                                                          more⬇ [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     └─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     └─ aws:eks:Cluster                   cluster-eksCluster                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     └─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                     [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              [K
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          [K
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                [K
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         [K
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr[K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule [K
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                [K
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   [K
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     [K
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  [K
+                                                                        ⬆ more  [K[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A[1A     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              [K
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    [K
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               [K
  <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             [K


### PR DESCRIPTION
These changes make two improvements to scrolling in the interactive display:

1. The interactive display can now be scrolled using the page-down and
   page-up keys. These keys scroll the display N lines at a time, where N is
   the height of the terminal.
2. If the display is scrolled to the bottom, it will now autoscroll it as new lines
   are added to the output.

Fixes #12320 
Fixes #12295 