### PR TITLE
Pass *workspace.Project to GetBackendConfigDefaultOrg

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -622,7 +622,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	if qualifiedName.Owner == "" {
 		// if the qualifiedName doesn't include an owner then let's check to see if there is a default org which *will*
 		// be the stack owner. If there is no defaultOrg, then we revert to checking the CurrentUser
-		defaultOrg, err := workspace.GetBackendConfigDefaultOrg()
+		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(b.currentProject)
 		if err != nil {
 			return nil, err
 		}
@@ -639,13 +639,12 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	}
 
 	if qualifiedName.Project == "" {
-		currentProject, projectErr := workspace.DetectProject()
-		if projectErr != nil {
-			return nil, fmt.Errorf("If you're using the --stack flag, "+
-				"pass the fully qualified name (org/project/stack): %w", projectErr)
+		if b.currentProject == nil {
+			return nil, fmt.Errorf("If you're using the --stack flag, " +
+				"pass the fully qualified name (org/project/stack)")
 		}
 
-		qualifiedName.Project = currentProject.Name.String()
+		qualifiedName.Project = b.currentProject.Name.String()
 	}
 
 	if !tokens.IsName(qualifiedName.Name) {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -50,13 +50,13 @@ type cloudBackendReference struct {
 
 func (c cloudBackendReference) String() string {
 	// When stringifying backend references, we take the current project (if present) into account.
-	currentProject, _ := workspace.DetectProject()
+	currentProject := c.b.currentProject
 
 	// If the project names match, we can elide them.
 	if currentProject != nil && c.project == string(currentProject.Name) {
 
 		// Elide owner too, if it is the default owner.
-		defaultOrg, err := workspace.GetBackendConfigDefaultOrg()
+		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(currentProject)
 		if err == nil && defaultOrg != "" {
 			// The default owner is the org
 			if c.owner == defaultOrg {

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -60,7 +60,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -83,7 +83,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -107,7 +107,7 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
@@ -201,9 +201,10 @@ func loadStackName(t *testing.T) string {
 	return w.Settings().Stack
 }
 
-func removeStack(t *testing.T, name string) {
+func removeStack(t *testing.T, dir, name string) {
+	project := loadProject(t, dir)
 	ctx := context.Background()
-	b, err := currentBackend(ctx, nil, display.Options{})
+	b, err := currentBackend(ctx, project, display.Options{})
 	assert.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
 	assert.NoError(t, err)

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -71,7 +71,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -96,7 +96,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -124,7 +124,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -149,7 +149,7 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, uniqueProjectName, proj.Name.String())
@@ -174,7 +174,7 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
-	removeStack(t, stackName)
+	removeStack(t, tempdir, stackName)
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, uniqueProjectName, proj.Name.String())

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -46,7 +46,7 @@ func newOrgCmd() *cobra.Command {
 				return err
 			}
 
-			defaultOrg, err := workspace.GetBackendConfigDefaultOrg()
+			defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
 			if err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			defaultOrg, err := workspace.GetBackendConfigDefaultOrg()
+			defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -983,7 +983,9 @@ func buildStackName(stackName string) (string, error) {
 		return stackName, nil
 	}
 
-	defaultOrg, err := workspace.GetBackendConfigDefaultOrg()
+	// We never have a project at the point of calling buildStackName (only called from new), so we just pass
+	// nil for the project and only check the global settings.
+	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(nil)
 	if err != nil {
 		return "", err
 	}

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -17,7 +17,6 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -347,19 +346,10 @@ func SetBackendConfigDefaultOrg(backendURL, defaultOrg string) error {
 	return StorePulumiConfig(config)
 }
 
-func GetBackendConfigDefaultOrg() (string, error) {
+func GetBackendConfigDefaultOrg(project *Project) (string, error) {
 	config, err := GetPulumiConfig()
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
-	}
-
-	var project *Project
-	projPath, err := DetectProjectPath()
-	if err == nil && !errors.Is(err, ErrProjectNotFound) {
-		project, err = LoadProject(projPath)
-		if err != nil {
-			return "", fmt.Errorf("could not load current project: %w", err)
-		}
 	}
 
 	backendURL, err := GetCurrentCloudURL(project)


### PR DESCRIPTION
Next step towards project cache cleanup. This passes the project explicitly to GetBackendConfigDefaultOrg rather than that doing a lookup for the project. It also fixes up the http stack references to use the `backend.currentProject` rather than looking up the current project on the file system.