### PR TITLE
Remove the global caches for project files

### DIFF
--- a/changelog/pending/20230307--auto-go--the-various-workspace-load-routines-e-g-loadproject-are-no-longer-singularly-cached.yaml
+++ b/changelog/pending/20230307--auto-go--the-various-workspace-load-routines-e-g-loadproject-are-no-longer-singularly-cached.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: The various workspace load routines (e.g. LoadProject) are no longer singularly cached.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12152

This caching was originally added in https://github.com/pulumi/pulumi/pull/6576 two years ago. It saved a lot of file access because the system was repeatedly calling into the workspace module to load and re-load project files. We've cleaned up the system code to instead load the project files once, and pass the loaded `workspace.Project` object down the callchain to other sites that need it, rather than each site searching and loading the project. As such removing these caches shouldn't regress performance.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
