### PR TITLE
whoami: Add --json flag, expose everything in Auto API

### DIFF
--- a/changelog/pending/20230304--cli--add-json-flag-to-pulumi-whoami-to-emit-output-as-json.yaml
+++ b/changelog/pending/20230304--cli--add-json-flag-to-pulumi-whoami-to-emit-output-as-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--json` flag to `pulumi whoami` to emit output as JSON

--- a/changelog/pending/20230305--auto-nodejs--add-url-and-organizations-to-whoamiresult-for-nodejs-automation-api.yaml
+++ b/changelog/pending/20230305--auto-nodejs--add-url-and-organizations-to-whoamiresult-for-nodejs-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add url and organizations to WhoAmIResult for NodeJS Automation API

--- a/changelog/pending/20230305--auto-python--add-url-and-organizations-to-whoamiresult-for-python-automation-api.yaml
+++ b/changelog/pending/20230305--auto-python--add-url-and-organizations-to-whoamiresult-for-python-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add url and organizations to WhoAmIResult for Python Automation API

--- a/changelog/pending/20230306--auto-go--add-whoamidetailed-which-includes-user-url-and-organizations-to-go-automation-api.yaml
+++ b/changelog/pending/20230306--auto-go--add-whoamidetailed-which-includes-user-url-and-organizations-to-go-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add WhoAmIDetailed which includes user, url and organizations to Go Automation API

--- a/changelog/pending/20230306--auto-go--add-whoamidetailed-which-includes-user-url-and-organizations-to-go-automation-api.yaml
+++ b/changelog/pending/20230306--auto-go--add-whoamidetailed-which-includes-user-url-and-organizations-to-go-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go
-  description: Add WhoAmIDetailed which includes user, url and organizations to Go Automation API
+  description: Add WhoAmIDetails which includes user, url and organizations to Go Automation API

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -25,9 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var verbose bool
-
 func newWhoAmICmd() *cobra.Command {
+	var jsonOut bool
+	var verbose bool
+
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Display the current logged-in user",
@@ -57,6 +58,14 @@ func newWhoAmICmd() *cobra.Command {
 				return err
 			}
 
+			if jsonOut {
+				return printJSON(WhoAmIJSON{
+					User:          name,
+					Organizations: orgs,
+					URL:           b.URL(),
+				})
+			}
+
 			if verbose {
 				fmt.Printf("User: %s\n", name)
 				fmt.Printf("Organizations: %s\n", strings.Join(orgs, ", "))
@@ -70,8 +79,18 @@ func newWhoAmICmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVarP(
+		&jsonOut, "json", "j", false, "Emit output as JSON")
+
+	cmd.PersistentFlags().BoolVarP(
 		&verbose, "verbose", "v", false,
 		"Print detailed whoami information")
 
 	return cmd
+}
+
+// WhoAmIJSON is the shape of the --json output of this command.
+type WhoAmIJSON struct {
+	User          string   `json:"user"`
+	Organizations []string `json:"organizations,omitempty"`
+	URL           string   `json:"url"`
 }

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -310,8 +310,8 @@ func (l *LocalWorkspace) WhoAmI(ctx context.Context) (string, error) {
 
 // WhoAmIDetails returns detailed information about the currently
 // logged-in Pulumi identity.
-func (l *LocalWorkspace) WhoAmIDetails(ctx context.Context) (WhoAmIDetailedInfo, error) {
-	var whoAmIDetailedInfo WhoAmIDetailedInfo
+func (l *LocalWorkspace) WhoAmIDetails(ctx context.Context) (WhoAmIResult, error) {
+	var whoAmIDetailedInfo WhoAmIResult
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "whoami", "--json")
 	if err != nil {
 		return whoAmIDetailedInfo, newAutoError(

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -308,8 +308,9 @@ func (l *LocalWorkspace) WhoAmI(ctx context.Context) (string, error) {
 	return strings.TrimSpace(stdout), nil
 }
 
-// WhoAmIDetailed returns the currently authenticated user
-func (l *LocalWorkspace) WhoAmIDetailed(ctx context.Context) (WhoAmIDetailedInfo, error) {
+// WhoAmIDetails returns detailed information about the currently
+// logged-in Pulumi identity.
+func (l *LocalWorkspace) WhoAmIDetails(ctx context.Context) (WhoAmIDetailedInfo, error) {
 	var whoAmIDetailedInfo WhoAmIDetailedInfo
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "whoami", "--json")
 	if err != nil {

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -308,6 +308,21 @@ func (l *LocalWorkspace) WhoAmI(ctx context.Context) (string, error) {
 	return strings.TrimSpace(stdout), nil
 }
 
+// WhoAmIDetailed returns the currently authenticated user
+func (l *LocalWorkspace) WhoAmIDetailed(ctx context.Context) (WhoAmIDetailedInfo, error) {
+	var whoAmIDetailedInfo WhoAmIDetailedInfo
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "whoami", "--json")
+	if err != nil {
+		return whoAmIDetailedInfo, newAutoError(
+			fmt.Errorf("could not retrieve WhoAmIDetailedInfo: %w", err), stdout, stderr, errCode)
+	}
+	err = json.Unmarshal([]byte(stdout), &whoAmIDetailedInfo)
+	if err != nil {
+		return whoAmIDetailedInfo, fmt.Errorf("unable to unmarshal WhoAmIDetailedInfo: %w", err)
+	}
+	return whoAmIDetailedInfo, nil
+}
+
 // Stack returns a summary of the currently selected stack, if any.
 func (l *LocalWorkspace) Stack(ctx context.Context) (*StackSummary, error) {
 	stacks, err := l.ListStacks(ctx)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2283,6 +2283,41 @@ func TestConfigSecretWarnings(t *testing.T) {
 	validate(previewEvents)
 }
 
+func TestWhoAmIDetailed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, randomStackName())
+
+	// initialize
+	pDir := filepath.Join(".", "test", "testproj")
+	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
+	if err != nil {
+		t.Errorf("failed to initialize stack, err: %v", err)
+		t.FailNow()
+	}
+
+	whoAmIDetailedInfo, err := s.Workspace().WhoAmIDetailed(ctx)
+	if err != nil {
+		t.Errorf("failed to get WhoAmIDetailedInfo, err: %v", err)
+		t.FailNow()
+	}
+	assert.NotNil(t, whoAmIDetailedInfo.User, "failed to get WhoAmIDetailedInfo user")
+	assert.NotNil(t, whoAmIDetailedInfo.URL, "failed to get WhoAmIDetailedInfo url")
+
+	// cleanup
+	_, err = s.Destroy(ctx)
+	if err != nil {
+		t.Errorf("destroy failed during cleanup, err: %v", err)
+		t.FailNow()
+	}
+	err = s.Workspace().RemoveStack(ctx, s.Name())
+	if err != nil {
+		t.Errorf("failed to remove stack during cleanup. Resources have leaked, err: %v", err)
+		t.FailNow()
+	}
+}
+
 func BenchmarkBulkSetConfigMixed(b *testing.B) {
 	ctx := context.Background()
 	stackName := FullyQualifiedStackName(pulumiOrg, "set_config_mixed", "dev")

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2297,7 +2297,7 @@ func TestWhoAmIDetailed(t *testing.T) {
 		t.FailNow()
 	}
 
-	whoAmIDetailedInfo, err := s.Workspace().WhoAmIDetailed(ctx)
+	whoAmIDetailedInfo, err := s.Workspace().WhoAmIDetails(ctx)
 	if err != nil {
 		t.Errorf("failed to get WhoAmIDetailedInfo, err: %v", err)
 		t.FailNow()

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -81,7 +81,7 @@ type Workspace interface {
 	WhoAmI(context.Context) (string, error)
 	// WhoAmIDetails returns detailed information about the currently
 	// logged-in Pulumi identity.
-	WhoAmIDetails(ctx context.Context) (WhoAmIDetailedInfo, error)
+	WhoAmIDetails(ctx context.Context) (WhoAmIResult, error)
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.
@@ -137,8 +137,8 @@ type StackSummary struct {
 	URL              string `json:"url,omitempty"`
 }
 
-// WhoAmIDetailedInfo contains detailed information about the currently logged-in Pulumi identity.
-type WhoAmIDetailedInfo struct {
+// WhoAmIResult contains detailed information about the currently logged-in Pulumi identity.
+type WhoAmIResult struct {
 	User          string   `json:"user"`
 	Organizations []string `json:"organizations,omitempty"`
 	URL           string   `json:"url"`

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -79,8 +79,9 @@ type Workspace interface {
 	PulumiVersion() string
 	// WhoAmI returns the currently authenticated user.
 	WhoAmI(context.Context) (string, error)
-	// WhoAmIDetailed returns detailed information about the currently logged-in Pulumi identity, including backendUrl.
-	WhoAmIDetailed(ctx context.Context) (WhoAmIDetailedInfo, error)
+	// WhoAmIDetails returns detailed information about the currently
+	// logged-in Pulumi identity.
+	WhoAmIDetails(ctx context.Context) (WhoAmIDetailedInfo, error)
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -79,6 +79,8 @@ type Workspace interface {
 	PulumiVersion() string
 	// WhoAmI returns the currently authenticated user.
 	WhoAmI(context.Context) (string, error)
+	// WhoAmIDetailed returns detailed information about the currently logged-in Pulumi identity, including backendUrl.
+	WhoAmIDetailed(ctx context.Context) (WhoAmIDetailedInfo, error)
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.
@@ -132,4 +134,11 @@ type StackSummary struct {
 	UpdateInProgress bool   `json:"updateInProgress"`
 	ResourceCount    *int   `json:"resourceCount,omitempty"`
 	URL              string `json:"url,omitempty"`
+}
+
+// WhoAmIDetailedInfo contains detailed information about the currently logged-in Pulumi identity.
+type WhoAmIDetailedInfo struct {
+	User          string   `json:"user"`
+	Organizations []string `json:"organizations,omitempty"`
+	URL           string   `json:"url"`
 }

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -547,8 +547,8 @@ export class LocalWorkspace implements Workspace {
      * Returns the currently authenticated user.
      */
     async whoAmI(): Promise<WhoAmIResult> {
-        const result = await this.runPulumiCmd(["whoami"]);
-        return { user: result.stdout.trim() };
+        const result = await this.runPulumiCmd(["whoami", "--json"]);
+        return JSON.parse(result.stdout);
     }
     /**
      * Returns a summary of the currently selected stack, if any.

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -289,6 +289,8 @@ export type PulumiFn = () => Promise<Record<string, any> | void>;
  */
 export interface WhoAmIResult {
     user: string;
+    url: string;
+    organizations?: string[];
 }
 
 export interface PluginInfo {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -245,6 +245,17 @@ describe("LocalWorkspace", () => {
             await ws.removeStack(name);
         }
     });
+    it(`returns valid whoami result`, async () => {
+        const projectName = "node_test";
+        const projectSettings: ProjectSettings = {
+            name: projectName,
+            runtime: "nodejs",
+        };
+        const ws = await LocalWorkspace.create({ projectSettings });
+        const whoAmIResult = await ws.whoAmI();
+        assert(whoAmIResult.user !== null);
+        assert(whoAmIResult.url !== null);
+    });
     it(`stack status methods`, async () => {
         const projectName = "node_test";
         const projectSettings: ProjectSettings = {

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -274,8 +274,9 @@ class LocalWorkspace(Workspace):
         self.get_all_config(stack_name)
 
     def who_am_i(self) -> WhoAmIResult:
-        result = self._run_pulumi_cmd_sync(["whoami"])
-        return WhoAmIResult(user=result.stdout.strip())
+        result = self._run_pulumi_cmd_sync(["whoami", "--json"])
+        who_am_i_json = json.loads(result.stdout)
+        return WhoAmIResult(**who_am_i_json)
 
     def stack(self) -> Optional[StackSummary]:
         stacks = self.list_stacks()

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -55,9 +55,15 @@ class WhoAmIResult:
     """The currently logged-in Pulumi identity."""
 
     user: str
+    url: str
+    organizations: Optional[List[str]]
 
-    def __init__(self, user: str):
+    def __init__(
+        self, user: str, url: str, organizations: Optional[List[str]] = None
+    ) -> None:
         self.user = user
+        self.url = url
+        self.organizations = organizations
 
 
 class PluginInfo:

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -203,6 +203,7 @@ class TestLocalWorkspace(unittest.TestCase):
         ws = LocalWorkspace()
         result = ws.who_am_i()
         self.assertIsNotNone(result.user)
+        self.assertIsNotNone(result.url)
 
     def test_stack_init(self):
         project_name = "python_test"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

* Adds `--json` flag to `pulumi whoami` (CLI)
* Adds `url` and `organizations` to WhoAmIResult in NodeJS, Go and Python (automation API)

I sanity tested the auto api in the 3 runtimes and the cli output looks like:

```bash
$ pulumi whoami -j
{
  "user": "me",
  "organizations": [
    "me",
    "company"
  ],
  "url": "https://app.pulumi.com/me"
}
```

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # https://github.com/pulumi/pulumi/issues/10356

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
