### PR TITLE
pulumi refresh `pending create` ordering

### DIFF
--- a/changelog/pending/20230307--cli-display--reorder-options-to-handle-pending-creates-users-can-now-hold-enter-to-select-the-clear-option-which-should-be-more-ergonomic.yaml
+++ b/changelog/pending/20230307--cli-display--reorder-options-to-handle-pending-creates-users-can-now-hold-enter-to-select-the-clear-option-which-should-be-more-ergonomic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Reorder options to handle pending creates. Users can now hold enter to select the clear option which should be more ergonomic.

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -441,9 +441,9 @@ func interactiveFixPendingCreate(op resource.Operation) (*resource.Operation, er
 	for {
 		option := ""
 		options := []string{
-			"import (the CREATE succeeded; provide a resource ID and complete the CREATE operation)",
 			"clear (the CREATE failed; remove the pending CREATE)",
 			"skip (do nothing)",
+			"import (the CREATE succeeded; provide a resource ID and complete the CREATE operation)",
 		}
 		if err := survey.AskOne(&survey.Select{
 			Message: fmt.Sprintf("Options for pending CREATE of %s", op.Resource.URN),
@@ -455,6 +455,10 @@ func interactiveFixPendingCreate(op resource.Operation) (*resource.Operation, er
 		var err error
 		switch option {
 		case options[0]:
+			return nil, nil
+		case options[1]:
+			return &op, nil
+		case options[2]:
 			var id string
 			err = survey.AskOne(&survey.Input{
 				Message: "ID: ",
@@ -464,10 +468,6 @@ func interactiveFixPendingCreate(op resource.Operation) (*resource.Operation, er
 				op.Type = resource.OperationTypeImporting
 				return &op, nil
 			}
-		case options[1]:
-			return nil, nil
-		case options[2]:
-			return &op, nil
 		default:
 			return nil, fmt.Errorf("unknown option: %q", option)
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
When deleting a large number of resources from pending_creates, it is tedious to hit down and enter for each resource. 
Reordered pending create options to make it more ergonomic for users to hold Enter to resolve it.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Part of #12335 (I don't want to close the issue since there are some other ideas we could do to make it nicer, but this fix is very simple in the meantime.)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
