### PR TITLE
sdk/go: Add common/testing/iotest package

### DIFF
--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 )
@@ -194,8 +195,10 @@ func pyTestCheck(t *testing.T, codeDir string) {
 		t.Logf("cd %s && %s %s", codeDir, name, strings.Join(args, " "))
 		cmd := python.VirtualEnvCommand(venvDir, name, args...)
 		cmd.Dir = codeDir
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
+
+		outw := iotest.LogWriter(t)
+		cmd.Stderr = outw
+		cmd.Stdout = outw
 		return cmd.Run()
 	}
 

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,9 +37,10 @@ func TestRunCommandLog(t *testing.T) {
 		t.Skip("Couldn't find Node on PATH")
 	}
 
+	testw := iotest.LogWriter(t)
 	opts := &ProgramTestOptions{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Stdout: testw,
+		Stderr: testw,
 	}
 
 	tempdir := t.TempDir()

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -346,9 +347,10 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
+	testw := iotest.LogWriter(t)
 	sink := diag.DefaultSink(
-		os.Stdout,
-		os.Stderr,
+		testw,
+		testw,
 		diag.FormatOptions{
 			Color: colors.Never,
 		},

--- a/sdk/go/common/testing/iotest/log_writer.go
+++ b/sdk/go/common/testing/iotest/log_writer.go
@@ -1,0 +1,88 @@
+package iotest
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+)
+
+// logWriter is an io.Writer that writes to a testing.T.
+type logWriter struct {
+	// t holds the subset of testing.TB
+	// that we are allowed to use.
+	//
+	// We're not storing testing.TB directly to ensure that
+	// we don't accidentally use other log methods.
+	t interface {
+		Logf(string, ...interface{})
+		Helper()
+	}
+
+	// Holds buffered text for the next write or flush
+	// if we haven't yet seen a newline.
+	buff bytes.Buffer
+	mu   sync.Mutex // guards buff
+}
+
+var _ io.Writer = (*logWriter)(nil)
+
+// LogWriter builds and returns an io.Writer that
+// writes messages to the given testing.TB.
+// It ensures that each line is logged separately.
+//
+// Any trailing buffered text that does not end with a newline
+// is flushed when the test finishes.
+//
+// The returned writer is safe for concurrent use
+// from multiple parallel tests.
+func LogWriter(t testing.TB) io.Writer {
+	w := logWriter{t: t}
+	t.Cleanup(w.flush)
+	return &w
+}
+
+func (w *logWriter) Write(bs []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.t.Helper() // so that the log message points to the caller
+
+	// t.Logf adds a newline so we should not write bs as-is.
+	// Instead, we'll call t.Log one line at a time.
+	//
+	// To handle the case when Write is called with a partial line,
+	// we use a buffer.
+	total := len(bs)
+	for len(bs) > 0 {
+		idx := bytes.IndexByte(bs, '\n')
+		if idx < 0 {
+			// No newline. Buffer it for later.
+			w.buff.Write(bs)
+			break
+		}
+
+		var line []byte
+		line, bs = bs[:idx], bs[idx+1:]
+
+		if w.buff.Len() == 0 {
+			// Nothing buffered from a prior partial write.
+			// This is the majority case.
+			w.t.Logf("%s", line)
+			continue
+		}
+
+		// There's a prior partial write. Join and flush.
+		w.buff.Write(line)
+		w.t.Logf("%s", w.buff.String())
+		w.buff.Reset()
+	}
+	return total, nil
+}
+
+// flush flushes buffered text, even if it doesn't end with a newline.
+func (w *logWriter) flush() {
+	if w.buff.Len() > 0 {
+		w.t.Logf("%s", w.buff.String())
+	}
+}

--- a/sdk/go/common/testing/iotest/log_writer_test.go
+++ b/sdk/go/common/testing/iotest/log_writer_test.go
@@ -1,0 +1,127 @@
+package iotest
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+
+		writes []string // individual write calls
+		want   []string // expected log output
+	}{
+		{
+			desc:   "empty strings",
+			writes: []string{"", "", ""},
+		},
+		{
+			desc:   "no newline",
+			writes: []string{"foo", "bar", "baz"},
+			want:   []string{"foobarbaz"},
+		},
+		{
+			desc: "newline separated",
+			writes: []string{
+				"foo\n",
+				"bar\n",
+				"baz\n\n",
+				"qux",
+			},
+			want: []string{
+				"foo",
+				"bar",
+				"baz",
+				"",
+				"qux",
+			},
+		},
+		{
+			desc:   "partial line",
+			writes: []string{"foo", "bar\nbazqux"},
+			want: []string{
+				"foobar",
+				"bazqux",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			fakeT := fakeT{TB: t}
+			w := LogWriter(&fakeT)
+
+			for _, input := range tt.writes {
+				n, err := w.Write([]byte(input))
+				assert.NoError(t, err)
+				assert.Equal(t, len(input), n)
+			}
+
+			fakeT.runCleanup()
+
+			assert.Equal(t, tt.want, fakeT.msgs)
+		})
+	}
+}
+
+// Ensures that there are no data races in LogWriter
+// by writing to it from multiple concurrent goroutines.
+// 'go test -race' will explode if there's a data race.
+func TestLogWriterRace(t *testing.T) {
+	t.Parallel()
+
+	const N = 100 // number of concurrent writers
+
+	fakeT := fakeT{TB: t}
+	w := LogWriter(&fakeT)
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+
+			_, err := io.WriteString(w, "foo\n")
+			require.NoError(t, err)
+			_, err = io.WriteString(w, "bar\n")
+			require.NoError(t, err)
+			_, err = io.WriteString(w, "baz\n")
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+// Wraps a testing.TB and intercepts log messages.
+type fakeT struct {
+	testing.TB
+
+	msgs     []string
+	cleanups []func()
+}
+
+func (t *fakeT) Logf(msg string, args ...interface{}) {
+	t.msgs = append(t.msgs, fmt.Sprintf(msg, args...))
+}
+
+func (t *fakeT) Cleanup(f func()) {
+	t.cleanups = append(t.cleanups, f)
+}
+
+func (t *fakeT) runCleanup() {
+	// cleanup functions are called in reverse order.
+	for i := len(t.cleanups) - 1; i >= 0; i-- {
+		t.cleanups[i]()
+	}
+}


### PR DESCRIPTION
Adds a new iotest subpackage to the common/testing package
and moves the testLogWriter used in a prior integration test
into this directory.

The new API is:

    package iotest

    func LogWriter(testing.TB) io.Writer

This is a generally useful utility in any test that needs an io.Writer,
where we want them to not pollute actual stdout or stderr.

There are a few direct uses of os.Stderr and os.Stdout in our tests.
The second commit switches these to use iotest.LogWriter where appropriate,

Uses of os.Stdout/Stderr that were omitted:

- Example tests: These don't have a testing.TB to log to.
- pulumi/main_test: Replaces the global os.Stdout/Stderr in TestMain.
  LogWriter isn't relevant there.
