### PR TITLE
sdk: Drop date from provider conflict warning

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1050,7 +1050,7 @@ func (ctx *Context) mergeProviders(t string, parent Resource, provider ProviderR
 		// So we need to also check that it's a different provider.
 		if other, alreadyExists := providerMap[pkg]; alreadyExists && other != provider {
 			err := ctx.Log.Warn(fmt.Sprintf("Provider for %s conflicts with providers map. %s %s", pkg,
-				"This will become an error in july 2022.",
+				"This will become an error in a future version.",
 				"See https://github.com/pulumi/pulumi/issues/8799 for more details.",
 			), nil)
 			if err != nil {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -597,7 +597,7 @@ async function prepareResource(label: string, res: Resource, parent: Resource | 
                 } else if ((<ProviderResource[]> componentOpts.providers)?.indexOf(componentOpts.provider) !== -1) {
                     const pkg = componentOpts.provider.getPackage();
                     const message = `There is a conflit between the 'provider' field (${pkg}) and a member of the 'providers' map'. `;
-                    const deprecationd = "This will become an error by the end of July 2022. See https://github.com/pulumi/pulumi/issues/8799 for more details";
+                    const deprecationd = "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details";
                     log.warn(message+deprecationd);
                 } else {
                     (<ProviderResource[]> componentOpts.providers).push(componentOpts.provider);

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -934,7 +934,7 @@ class Resource:
             # providers map, so that it can be used for child resources.
             if provider_pkg in opts_providers:
                 message = f"There is a conflict between the `provider` field ({provider_pkg}) and a member of the `providers` map"
-                depreciation = "This will become an error by the end of July 2022. See https://github.com/pulumi/pulumi/issues/8799 for more details"
+                depreciation = "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details"
                 warnings.warn(f"{message} for resource {t}. " + depreciation)
                 log.warn(f"{message}. {depreciation}", resource=self)
             else:


### PR DESCRIPTION
We added a warning here with the intention of turning it into an error
in July 2022, but we never did.

While we're discussing whether we still want this to become an error,
drop the specific date and just refer to "a future version."

Refs #8799
