### PR TITLE
[sdk/nodejs/tests] Fix bug in test that prevents concurrent runs

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -91,7 +91,7 @@ describe("LocalWorkspace", () => {
     describe("Tag methods: get/set/remove/list", () => {
         const projectName = "testProjectName";
         const runtime = "nodejs";
-        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, "testStack");
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
         const projectSettings: ProjectSettings = {
             name: projectName,
             runtime,


### PR DESCRIPTION
Fix the test to use a random suffix in the stack name (like the other tests) to prevent failures during concurrent runs.

Fixes #12385