### PR TITLE
Don't send empty token/Bearer headers

### DIFF
--- a/changelog/pending/20230309--cli-plugin--fix-sending-empty-tokens-to-github-api.yaml
+++ b/changelog/pending/20230309--cli-plugin--fix-sending-empty-tokens-to-github-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix sending empty tokens to GitHub API.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -238,7 +238,12 @@ func newGitlabSource(url *url.URL, name string, kind PluginKind) (*gitlabSource,
 }
 
 func (source *gitlabSource) newHTTPRequest(url, accept string) (*http.Request, error) {
-	req, err := buildHTTPRequest(url, fmt.Sprintf("Bearer %s", source.token))
+	var authorization string
+	if source.token != "" {
+		authorization = fmt.Sprintf("Bearer %s", source.token)
+	}
+
+	req, err := buildHTTPRequest(url, authorization)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +360,12 @@ func newGithubSource(url *url.URL, name string, kind PluginKind) (*githubSource,
 }
 
 func (source *githubSource) newHTTPRequest(url, accept string) (*http.Request, error) {
-	req, err := buildHTTPRequest(url, fmt.Sprintf("token %s", source.token))
+	var authorization string
+	if source.token != "" {
+		authorization = fmt.Sprintf("token %s", source.token)
+	}
+
+	req, err := buildHTTPRequest(url, authorization)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -281,6 +281,7 @@ func TestPluginDownload(t *testing.T) {
 		require.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.30.0" {
+				assert.Equal(t, "", req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -480,6 +481,7 @@ func TestPluginDownload(t *testing.T) {
 		version := semver.MustParse("4.30.0")
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.30.0" {
+				assert.Equal(t, "", req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12391

This looks to be the cause of the 401 responses from GitHub. When we refactored some code to add GitLab authorization headers we started sending half-filled headers when the envvars weren't set (e.g. Authorization = "token "). Looks like this was triggering GitHub to just blanket fail these requests to the /releases endpoint even though authorization wasn't even needed.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
