### PR TITLE
[nodejs/program-gen] Component resource implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ __pycache__
 # Temporary files
 *.tmp
 test-results/
+yarn-error.log

--- a/changelog/pending/20230309--programgen-dotnet-nodejs--component-resources-implementation-including-nested-components.yaml
+++ b/changelog/pending/20230309--programgen-dotnet-nodejs--component-resources-implementation-including-nested-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,nodejs
+  description: Component resources implementation including nested components

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -656,6 +656,26 @@ func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.Rela
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
+	if g.isComponent {
+		if expr.RootName == "this" {
+			// special case for parent: this
+			g.Fgenf(w, "%s", expr.RootName)
+			return
+		}
+
+		configVars := map[string]*pcl.ConfigVariable{}
+		for _, configVar := range g.program.ConfigVariables() {
+			configVars[configVar.Name()] = configVar
+		}
+
+		if _, isConfig := configVars[expr.RootName]; isConfig {
+			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
+				g.Fgenf(w, "args.%s", expr.RootName)
+				return
+			}
+		}
+	}
+
 	rootName := makeValidIdentifier(expr.RootName)
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -139,7 +139,8 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 
 		componentProgram, programDiags, err := BindProgram(parser.Files,
 			Loader(loader),
-			DirPath(componentSourceDir))
+			DirPath(componentSourceDir),
+			ComponentBinder(ComponentProgramBinderFromFileSystem()))
 
 		return componentProgram, programDiags, err
 	}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -234,7 +234,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "components",
 		Description: "Components",
-		Skip:        allProgLanguages.Except("dotnet"),
+		Skip:        allProgLanguages.Except("dotnet").Except("nodejs"),
 		SkipCompile: allProgLanguages.Except("dotnet"),
 	},
 	{

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -235,7 +235,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "components",
 		Description: "Components",
 		Skip:        allProgLanguages.Except("dotnet").Except("nodejs"),
-		SkipCompile: allProgLanguages.Except("dotnet"),
+		SkipCompile: allProgLanguages.Except("dotnet").Except("nodejs"),
 	},
 	{
 		Directory:   "retain-on-delete",

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -13,7 +13,7 @@ namespace Components
     public class ExampleComponent : global::Pulumi.ComponentResource
     {
         [Output("result")]
-        public Output<string> Result { get; private set; } = null!;
+        public Output<string> Result { get; private set; }
         public ExampleComponent(string name, ExampleComponentArgs args, ComponentResourceOptions? opts = null)
             : base("components:index:ExampleComponent", name, args, opts)
         {
@@ -23,6 +23,11 @@ namespace Components
                 Special = true,
                 OverrideSpecial = args.Input,
             }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            var simpleComponent = new Components.SimpleComponent($"{name}-simpleComponent", new ComponentResourceOptions
             {
                 Parent = this,
             });

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -7,6 +7,8 @@ resource password "random:index/randomPassword:RandomPassword" {
   overrideSpecial = input
 }
 
+component simpleComponent "../simpleComponent" {}
+
 output result {
     value = password.result
 }

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -1,0 +1,3 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const result = exampleComponent.result;

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -1,3 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
+import { ExampleComponent } from "./exampleComponent";
+import { SimpleComponent } from "./simpleComponent";
 
+const simpleComponent = new SimpleComponent("simpleComponent");
+const exampleComponent = new ExampleComponent("exampleComponent", {input: "doggo"});
 export const result = exampleComponent.result;

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
+import { SimpleComponent } from "./simpleComponent";
 
 interface ExampleComponentArgs {
     input: pulumi.Input<string>,
@@ -17,5 +18,13 @@ export class ExampleComponent extends pulumi.ComponentResource {
             parent: this,
         });
 
+        const simpleComponent = new SimpleComponent(`${name}-simpleComponent`, {
+            parent: this,
+        });
+
+        this.result = password.result;
+        this.registerOutputs({
+            result: password.result,
+        });
     }
 }

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -1,0 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+interface ExampleComponentArgs {
+    input: pulumi.Input<string>,
+}
+
+export class ExampleComponent extends pulumi.ComponentResource {
+    public result: pulumi.Output<string>;
+    constructor(name: string, args: ExampleComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:ExampleComponent", name, args, opts);
+        const password = new random.RandomPassword(`${name}-password`, {
+            length: 16,
+            special: true,
+            overrideSpecial: args.input,
+        }, {
+            parent: this,
+        });
+
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/simpleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/simpleComponent.ts
@@ -1,0 +1,22 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+export class SimpleComponent extends pulumi.ComponentResource {
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:SimpleComponent", name, {}, opts);
+        const firstPassword = new random.RandomPassword(`${name}-firstPassword`, {
+            length: 16,
+            special: true,
+        }, {
+            parent: this,
+        });
+
+        const secondPassword = new random.RandomPassword(`${name}-secondPassword`, {
+            length: 16,
+            special: true,
+        }, {
+            parent: this,
+        });
+
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/simpleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/simpleComponent.ts
@@ -18,5 +18,6 @@ export class SimpleComponent extends pulumi.ComponentResource {
             parent: this,
         });
 
+        this.registerOutputs();
     }
 }


### PR DESCRIPTION
# Description

 - NodeJS program-gen implementation for component resources: generating components in seperate files and referencing them from where they are used. 
 - PCL binder extended to allow for nested components
 - Dotnet program-gen implements nested components 

Fixes #12416

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
