### PR TITLE
golangci: Drop goconst

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   enable:
     - errcheck
     - prealloc
-    - goconst
     - gofumpt
     - revive
     - gosec

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package display
 
 import (

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package display
 
 import (
@@ -1031,7 +1030,6 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 			case deploy.OpDeleteReplaced:
 				opText = "deleted original"
 			case deploy.OpRead:
-				//nolint:goconst
 				opText = "read"
 			case deploy.OpReadReplacement:
 				opText = "read for replacement"
@@ -1097,7 +1095,6 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 	case deploy.OpDeleteReplaced:
 		return "delete original"
 	case deploy.OpRead:
-		//nolint:goconst
 		return "read"
 	case deploy.OpReadReplacement:
 		return "read for replacement"
@@ -1133,7 +1130,6 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 		deploy.OpDiscardReplaced:
 		return "replace"
 	case deploy.OpRead:
-		//nolint:goconst
 		return "read"
 	case deploy.OpRefresh:
 		return "refresh"

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package display
 
 import (

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -176,11 +176,11 @@ func runConvert(
 		projectGenerator = gogen.GenerateProject
 	case "typescript":
 		projectGenerator = nodejs.GenerateProject
-	case "python": //nolint:goconst
+	case "python":
 		projectGenerator = python.GenerateProject
-	case "java": //nolint:goconst
+	case "java":
 		projectGenerator = javagen.GenerateProject
-	case "yaml": //nolint:goconst
+	case "yaml":
 		projectGenerator = yamlgen.GenerateProject
 	case "pulumi", "pcl":
 		if e.GetBool(env.Dev) {

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -60,7 +60,6 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 	oldConfig := deepcopy.Copy(ps).(*workspace.ProjectStack)
 
 	var sm secrets.Manager
-	//nolint:goconst
 	if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
 		sm, err = cloud.NewCloudSecretsManager(
 			ps, ps.SecretsProvider, false /* rotateSecretsProvider */)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -127,7 +127,6 @@ func newDestroyCmd() *cobra.Command {
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
 			// which we pass as 'false'
-			//nolint:goconst
 			if suppressPermalink == "true" {
 				opts.Display.SuppressPermalink = true
 			} else {
@@ -157,7 +156,6 @@ func newDestroyCmd() *cobra.Command {
 
 			// by default, we are going to suppress the permalink when using self-managed backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
-			//nolint:goconst
 			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermalink = true
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -541,11 +541,11 @@ func newImportCmd() *cobra.Command {
 
 			var programGenerator programGeneratorFunc
 			switch proj.Runtime.Name() {
-			case "dotnet": //nolint:goconst
+			case "dotnet":
 				programGenerator = dotnet.GenerateProgram
 			case "go":
 				programGenerator = gogen.GenerateProgram
-			case "nodejs": //nolint:goconst
+			case "nodejs":
 				programGenerator = nodejs.GenerateProgram
 			case "python":
 				programGenerator = python.GenerateProgram

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package main
 
 import (

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -95,7 +95,7 @@ func genSDK(language, out string, pkg *schema.Package, overlays string) error {
 		}
 	case "nodejs":
 		f = nodejs.GeneratePackage
-	case "python": //nolint:goconst
+	case "python":
 		f = python.GeneratePackage
 	case "java":
 		f = javagen.GeneratePackage

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -85,7 +85,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 		namespaces:    d.Namespaces,
 		rootNamespace: info.GetRootNamespace(),
 	}
-	qualifier := "Inputs" //nolint:goconst
+	qualifier := "Inputs"
 	if !input {
 		qualifier = "Outputs"
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -176,7 +176,6 @@ func (g *generator) genSafeEnum(w io.Writer, to *model.EnumType) func(member *sc
 }
 
 func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionCallExpression) {
-	//nolint:goconst
 	switch expr.Name {
 	case pcl.IntrinsicConvert:
 		from := expr.Args[0]

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package pcl
 
 import (

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package pcl
 
 import (

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package python
 
 import (

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -449,7 +449,6 @@ func (t *types) externalPackage() PackageReference {
 	return t.pkg.Reference()
 }
 
-//nolint:goconst
 func (t *types) bindPrimitiveType(path, name string) (Type, hcl.Diagnostics) {
 	switch name {
 	case "boolean":
@@ -886,7 +885,6 @@ func (t *types) bindTypeSpec(path string, spec TypeSpec,
 		return t.bindTypeSpecOneOf(path, spec, inputShape)
 	}
 
-	//nolint:goconst
 	switch spec.Type {
 	case "boolean", "integer", "number", "string":
 		typ, typDiags := t.bindPrimitiveType(path+"/type", spec.Type)

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -53,7 +53,6 @@ const (
 	jsonType    primitiveType = 8
 )
 
-//nolint:goconst
 func (t primitiveType) String() string {
 	switch t {
 	case boolType:

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -170,7 +170,6 @@ type TestPlan struct {
 	Steps          []TestStep
 }
 
-//nolint:goconst
 func (p *TestPlan) getNames() (stack tokens.Name, project tokens.PackageName, runtime string) {
 	project = tokens.PackageName(p.Project)
 	if project == "" {

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package lifecycletest
 
 import (

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -117,7 +117,7 @@ func NewBlindingDecrypter() Decrypter {
 type blindingCrypter struct{}
 
 func (b blindingCrypter) DecryptValue(ctx context.Context, _ string) (string, error) {
-	return "[secret]", nil //nolint:goconst
+	return "[secret]", nil
 }
 
 func (b blindingCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {

--- a/sdk/go/common/resource/resource_id_test.go
+++ b/sdk/go/common/resource/resource_id_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:goconst
 package resource
 
 import (

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst
 package pulumi
 
 import (


### PR DESCRIPTION
golangci-lint: Drop goconst

Per team discussion, drop goconst.
The number of false positives with this linter is too high.
Whether or not something should be a constant
is the author and the reviewer's decision.

Also drops the nolint:goconst directives.
