### PR TITLE
Remove experimentalWorkspaceModule from vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,8 +13,6 @@
         ],
         // Uses https://github.com/mvdan/gofumpt for formatting.
         "formatting.gofumpt": true,
-        // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
-        "experimentalWorkspaceModule": true,
     },
 
     "python.testing.pytestArgs": [


### PR DESCRIPTION
This has always been experimental, and is due for removal now that go workspaces are a thing. Turning it on is probably detrimental to gopls performance as well due to the number of go.mod files in this repo, most of which aren't interesting for day-to-day work.