### PR TITLE
sdk/go/common/util cleanup

### DIFF
--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -71,8 +70,8 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 	case tar.TypeDir:
 		// Create any directories as needed.
 		if _, err := os.Stat(path); err != nil {
-			if err = os.MkdirAll(path, 0o700); err != nil {
-				return errors.Wrapf(err, "extracting dir %s", path)
+			if err = os.MkdirAll(path, 0o0700); err != nil {
+				return fmt.Errorf("extracting dir %s: %w", path, err)
 			}
 		}
 	case tar.TypeReg:
@@ -81,25 +80,25 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 		// to create it here.
 		dir := filepath.Dir(path)
 		if _, err := os.Stat(dir); err != nil {
-			if err = os.MkdirAll(dir, 0o700); err != nil {
-				return errors.Wrapf(err, "extracting dir %s", dir)
+			if err = os.MkdirAll(dir, 0o0700); err != nil {
+				return fmt.Errorf("extracting dir %s: %w", dir, err)
 			}
 		}
 
 		// Expand files into the target directory.
 		dst, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 		if err != nil {
-			return errors.Wrapf(err, "opening file %s for extraction", path)
+			return fmt.Errorf("opening file %s for extraction: %w", path, err)
 		}
 		defer contract.IgnoreClose(dst)
 
 		// We're not concerned with potential tarbombs, so disable gosec.
 		//nolint:gosec
 		if _, err = io.Copy(dst, r); err != nil {
-			return errors.Wrapf(err, "untarring file %s", path)
+			return fmt.Errorf("untarring file %s: %w", path, err)
 		}
 	default:
-		return errors.Errorf("unexpected plugin file type %s (%v)", header.Name, header.Typeflag)
+		return fmt.Errorf("unexpected plugin file type %s (%v)", header.Name, header.Typeflag)
 	}
 
 	return nil
@@ -109,7 +108,7 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 func ExtractTGZ(r io.Reader, dir string) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
-		return errors.Wrapf(err, "uncompressing")
+		return fmt.Errorf("uncompressing: %w", err)
 	}
 	tr := tar.NewReader(gzr)
 	for {
@@ -118,7 +117,7 @@ func ExtractTGZ(r io.Reader, dir string) error {
 			if err == io.EOF {
 				return nil
 			}
-			return errors.Wrapf(err, "extracting")
+			return fmt.Errorf("extracting: %w", err)
 		}
 
 		if err = extractFile(tr, header, dir); err != nil {
@@ -143,7 +142,7 @@ func addDirectoryToTar(writer *tar.Writer, root, dir, prefixPathInsideTar string
 
 		ignore, err := newGitIgnoreIgnorer(ignoreFilePath)
 		if err != nil {
-			return errors.Wrapf(err, "could not read ignore file in %v", dir)
+			return fmt.Errorf("could not read ignore file in %v: %w", dir, err)
 		}
 
 		ignores = ignores.Append(ignore)
@@ -161,7 +160,7 @@ func addDirectoryToTar(writer *tar.Writer, root, dir, prefixPathInsideTar string
 
 				ignore, err := newGitIgnoreIgnorer(ignoreFilePath)
 				if err != nil {
-					return errors.Wrapf(err, "could not read ignore file in %v", dir)
+					return fmt.Errorf("could not read ignore file in %v: %w", dir, err)
 				}
 
 				ignores = ignores.Append(ignore)

--- a/sdk/go/common/util/buildutil/semver.go
+++ b/sdk/go/common/util/buildutil/semver.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/semver"
 )
@@ -97,7 +96,7 @@ func PyPiVersionFromNpmVersion(s string) (string, error) {
 		return b.String(), nil
 	}
 
-	return "", errors.Errorf("can not parse version string '%s'", s)
+	return "", fmt.Errorf("can not parse version string '%s'", s)
 }
 
 func captureToMap(r *regexp.Regexp, s string) map[string]string {

--- a/sdk/go/common/util/executable/executable.go
+++ b/sdk/go/common/util/executable/executable.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -23,7 +22,7 @@ func FindExecutable(program string) (string, error) {
 	// look in the same directory
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to get current working directory")
+		return "", fmt.Errorf("unable to get current working directory: %w", err)
 	}
 
 	cwdProgram := filepath.Join(cwd, program)
@@ -59,7 +58,7 @@ func FindExecutable(program string) (string, error) {
 		return fullPath, nil
 	}
 
-	return "", errors.Errorf(unableToFindProgramTemplate, program)
+	return "", fmt.Errorf(unableToFindProgramTemplate, program)
 }
 
 func splitGoPath(goPath string, os string) []string {

--- a/sdk/go/common/util/fsutil/chdir.go
+++ b/sdk/go/common/util/fsutil/chdir.go
@@ -15,9 +15,9 @@
 package fsutil
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -32,7 +32,7 @@ func Chdir(pwd string) (func(), error) {
 		return nil, err
 	}
 	if err = os.Chdir(pwd); err != nil {
-		return nil, errors.Wrapf(err, "could not change to the project working directory")
+		return nil, fmt.Errorf("could not change to the project working directory: %w", err)
 	}
 	return func() {
 		// Restore the working directory after planning completes.

--- a/sdk/go/common/util/goversion/version.go
+++ b/sdk/go/common/util/goversion/version.go
@@ -1,11 +1,11 @@
 package goversion
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
 	goVersion "github.com/hashicorp/go-version"
-	"github.com/pkg/errors"
 )
 
 var minGoVersion = goVersion.Must(goVersion.NewVersion("1.14.0"))
@@ -15,7 +15,7 @@ func CheckMinimumGoVersion(gobin string) error {
 	cmd := exec.Command(gobin, "version")
 	stdout, err := cmd.Output()
 	if err != nil {
-		return errors.Wrap(err, "determining go version")
+		return fmt.Errorf("determining go version: %w", err)
 	}
 
 	return checkMinimumGoVersion(string(stdout))
@@ -26,18 +26,18 @@ func CheckMinimumGoVersion(gobin string) error {
 func checkMinimumGoVersion(goVersionOutput string) error {
 	split := strings.Split(goVersionOutput, " ")
 	if len(split) <= 2 {
-		return errors.Errorf("unexpected format for go version output: \"%s\"", goVersionOutput)
+		return fmt.Errorf("unexpected format for go version output: \"%s\"", goVersionOutput)
 	}
 	version := strings.TrimSpace(split[2])
 	version = strings.TrimPrefix(version, "go")
 
 	currVersion, err := goVersion.NewVersion(version)
 	if err != nil {
-		return errors.Wrap(err, "parsing go version")
+		return fmt.Errorf("parsing go version: %w", err)
 	}
 
 	if currVersion.LessThan(minGoVersion) {
-		return errors.Errorf("go version must be %s or higher (%s detected)", minGoVersion.String(), version)
+		return fmt.Errorf("go version must be %s or higher (%s detected)", minGoVersion.String(), version)
 	}
 	return nil
 }

--- a/sdk/go/common/util/mapper/mapper_decode.go
+++ b/sdk/go/common/util/mapper/mapper_decode.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -240,7 +238,7 @@ func (md *mapper) adjustValueForAssignment(val reflect.Value,
 				val = reflect.ValueOf(target).Elem()
 			} else {
 				return val, NewTypeFieldError(ty, key,
-					errors.Errorf(
+					fmt.Errorf(
 						"Cannot decode Object{} to type %v; it isn't a struct, and no custom decoder exists", to))
 			}
 		} else if val.Type().Kind() == reflect.String {

--- a/sdk/go/common/util/result/result.go
+++ b/sdk/go/common/util/result/result.go
@@ -15,10 +15,10 @@
 package result
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 // Result represents the result of a computation that can fail. The Result type revolves around two
@@ -76,7 +76,7 @@ func Bail() Result {
 // Errorf produces a Result that represents an internal Pulumi error,
 // constructed from the given format string and arguments.
 func Errorf(msg string, args ...interface{}) Result {
-	err := errors.Errorf(msg, args...)
+	err := fmt.Errorf(msg, args...)
 	return FromError(err)
 }
 


### PR DESCRIPTION
Bit more of pkg/errors cleanup. Most of util, skips cmdutil and rpcutil because they're a bit more tricky to untangle.
