### PR TITLE
Fix provider_server ID handling in Read

### DIFF
--- a/changelog/pending/20230310--sdk-go--fixes-an-id-handling-bug-in-provider_server-read-implementation.yaml
+++ b/changelog/pending/20230310--sdk-go--fixes-an-id-handling-bug-in-provider_server-read-implementation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fixes an ID handling bug in provider_server Read implementation

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -331,7 +331,7 @@ func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateReques
 }
 
 func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	urn, id := resource.URN(req.GetUrn()), resource.ID(req.GetId())
+	urn, requestID := resource.URN(req.GetUrn()), resource.ID(req.GetId())
 
 	state, err := UnmarshalProperties(req.GetProperties(), p.unmarshalOptions("state"))
 	if err != nil {
@@ -343,7 +343,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 		return nil, err
 	}
 
-	result, _, err := p.provider.Read(urn, id, inputs, state)
+	result, _, err := p.provider.Read(urn, requestID, inputs, state)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 	}
 
 	return &pulumirpc.ReadResponse{
-		Id:         string(id),
+		Id:         string(result.ID),
 		Properties: rpcState,
 		Inputs:     rpcInputs,
 	}, nil

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -45,6 +45,9 @@ func TestProviderServer_Configure_variables(t *testing.T) {
 type stubProvider struct {
 	Provider
 
+	ReadFunc func(urn resource.URN, id resource.ID,
+		inputs, state resource.PropertyMap) (ReadResult, resource.Status, error)
+
 	ConfigureFunc func(resource.PropertyMap) error
 }
 
@@ -53,4 +56,39 @@ func (p *stubProvider) Configure(inputs resource.PropertyMap) error {
 		return p.ConfigureFunc(inputs)
 	}
 	return p.Provider.Configure(inputs)
+}
+
+func (p *stubProvider) Read(urn resource.URN, id resource.ID,
+	inputs, state resource.PropertyMap) (ReadResult, resource.Status, error) {
+	if p.ReadFunc != nil {
+		return p.ReadFunc(urn, id, inputs, state)
+	}
+	return p.Provider.Read(urn, id, inputs, state)
+}
+
+// When importing random passwords, the secret passed as "ID" should not leak in plain text into the final ID.
+func TestProviderServer_Read_respects_ID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	provider := stubProvider{
+		ReadFunc: func(urn resource.URN, id resource.ID,
+			inputs, state resource.PropertyMap) (ReadResult, resource.Status, error) {
+			return ReadResult{
+				ID: resource.ID("none"),
+				Outputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+					"result": resource.NewSecretProperty(&resource.Secret{
+						Element: resource.NewStringProperty(string(id)),
+					}),
+				}),
+			}, resource.StatusOK, nil
+		},
+	}
+	secret := "supersecretpassword"
+	srv := NewProviderServer(&provider)
+	resp, err := srv.Read(ctx, &pulumirpc.ReadRequest{
+		Urn: "urn:pulumi:v2::re::random:index/randomPassword:RandomPassword::newPassword",
+		Id:  secret,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, secret, resp.Id)
 }

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -45,8 +45,10 @@ func TestProviderServer_Configure_variables(t *testing.T) {
 type stubProvider struct {
 	Provider
 
-	ReadFunc func(urn resource.URN, id resource.ID,
-		inputs, state resource.PropertyMap) (ReadResult, resource.Status, error)
+	ReadFunc func(
+		urn resource.URN, id resource.ID,
+		inputs, state resource.PropertyMap,
+	) (ReadResult, resource.Status, error)
 
 	ConfigureFunc func(resource.PropertyMap) error
 }
@@ -58,8 +60,12 @@ func (p *stubProvider) Configure(inputs resource.PropertyMap) error {
 	return p.Provider.Configure(inputs)
 }
 
-func (p *stubProvider) Read(urn resource.URN, id resource.ID,
-	inputs, state resource.PropertyMap) (ReadResult, resource.Status, error) {
+func (p *stubProvider) Read(
+	urn resource.URN,
+	id resource.ID,
+	inputs,
+	state resource.PropertyMap,
+) (ReadResult, resource.Status, error) {
 	if p.ReadFunc != nil {
 		return p.ReadFunc(urn, id, inputs, state)
 	}
@@ -71,8 +77,10 @@ func TestProviderServer_Read_respects_ID(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	provider := stubProvider{
-		ReadFunc: func(urn resource.URN, id resource.ID,
-			inputs, state resource.PropertyMap) (ReadResult, resource.Status, error) {
+		ReadFunc: func(
+			urn resource.URN, id resource.ID,
+			inputs, state resource.PropertyMap,
+		) (ReadResult, resource.Status, error) {
 			return ReadResult{
 				ID: resource.ID("none"),
 				Outputs: resource.NewPropertyMapFromMap(map[string]interface{}{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

There seems to be an issue with provider_server ignoring the inner ID. In the case of importing random passwords, this leaks the secret password in plaintext into the state. 

See also: https://github.com/pulumi/pulumi-terraform-bridge/pull/882

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
