### PR TITLE
Pulumi check version message is now printed as info rather than a warning

### DIFF
--- a/changelog/pending/20230310--cli-display--changes-the-check-version-warning-to-an-info-message.yaml
+++ b/changelog/pending/20230310--cli-display--changes-the-check-version-warning-to-an-info-message.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Changes the check version warning to an info message.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -247,7 +247,7 @@ func NewPulumiCmd() *cobra.Command {
 
 			checkVersionMsg, ok := <-updateCheckResult
 			if ok && checkVersionMsg != nil && !isJSON {
-				cmdutil.Diag().Warningf(checkVersionMsg)
+				cmdutil.Diag().Infoerrf(checkVersionMsg)
 			}
 
 			logging.Flush()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Pulumi check version message is now printed as info rather than a warning.

New:
[![asciicast](https://asciinema.org/a/Zy5mzN5bvvaaiunBU96VqmEaM.svg)](https://asciinema.org/a/Zy5mzN5bvvaaiunBU96VqmEaM)

Old:
[![asciicast](https://asciinema.org/a/s1B18mVMQvPX2DxfKPkxSMCUG.svg)](https://asciinema.org/a/s1B18mVMQvPX2DxfKPkxSMCUG)

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10578 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
