### PR TITLE
display: Switch "Open in Browser" to "View in Browser"

### DIFF
--- a/changelog/pending/20230308--cli-display--add-an-open-in-browser-shortcut-to-the-interactive-display.yaml
+++ b/changelog/pending/20230308--cli-display--add-an-open-in-browser-shortcut-to-the-interactive-display.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/display
-  description: Add an open in browser shortcut to the interactive display
+  description: Add a view in browser shortcut to the interactive display.

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -33,17 +33,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
-// printViewLive prints an update's permalink prefaced with `View Live: `. This message is printed in non-interactive
-// scenarios in order to maintain backwards compatibility with older versions of the Automation API, the message is
-// not changed for non-interactive scenarios.
-func printViewLive(out io.Writer, opts Options, permalink string) {
+// printPermalinkNonInteractive prints an update's permalink prefaced with `View Live: `.
+// This message is printed in non-interactive scenarios.
+// In order to maintain backwards compatibility with older versions of the Automation API,
+// the message is not changed for non-interactive scenarios.
+func printPermalinkNonInteractive(out io.Writer, opts Options, permalink string) {
 	printPermalink(out, opts, "View Live", permalink)
 }
 
-// printOpenInBrowser print's an update's permalink prefaced with `Open in Browser (Ctrl+O): `. This is printed in
-// interactive scenarios that use the tree renderer.
-func printOpenInBrowser(term terminal.Terminal, opts Options, permalink string) {
-	printPermalink(term, opts, "Open in Browser (Ctrl+O)", permalink)
+// printPermalinkInteractive prints an update's permalink prefaced with `View in Browser (Ctrl+O): `.
+// This is printed in interactive scenarios that use the tree renderer.
+func printPermalinkInteractive(term terminal.Terminal, opts Options, permalink string) {
+	printPermalink(term, opts, "View in Browser (Ctrl+O)", permalink)
 }
 
 func printPermalink(out io.Writer, opts Options, message, permalink string) {
@@ -78,7 +79,7 @@ func ShowEvents(
 	}
 
 	if opts.Type != DisplayProgress {
-		printViewLive(os.Stdout, opts, permalink)
+		printPermalinkNonInteractive(os.Stdout, opts, permalink)
 	}
 
 	switch opts.Type {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -246,10 +246,10 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Name,
 
 	var renderer progressRenderer
 	if isInteractive {
-		printOpenInBrowser(term, opts, permalink)
+		printPermalinkInteractive(term, opts, permalink)
 		renderer = newInteractiveRenderer(term, permalink, opts)
 	} else {
-		printViewLive(stdout, opts, permalink)
+		printPermalinkNonInteractive(stdout, opts, permalink)
 		renderer = newNonInteractiveRenderer(stdout, op, opts)
 	}
 

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-100x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-100x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-200x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-200x80-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-200x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-200x80.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24-cooked.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 13%}><{%bold%}>Open in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
+<{%fg 13%}><{%bold%}>View in Browser (Ctrl+O): <{%underline%}><{%fg 12%}>link<{%reset%}>
 
      <{%underline%}><{%fg 12%}>Type<{%reset%}>                 <{%underline%}><{%fg 12%}>Name<{%reset%}>           <{%underline%}><{%fg 12%}>Status<{%reset%}>     <{%underline%}><{%fg 12%}>Info<{%reset%}>[K
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack  project-stack  <{%bold%}><{%reset%}><{%reset%}>           <{%reset%}>Configuration:<{%reset%}>[K


### PR DESCRIPTION
Switch this to "View in Browser" per discussion
which is closer to the old "View Live" message.

sdk/go/auto doesn't need an update because the regex there
is still using "View in Browser".
