### PR TITLE
sdk/common: Add testing/diagtest package

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -350,7 +350,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 	}
 
 	stack := newStack(stackRef, file, nil, b)
-	fmt.Printf("Created stack '%s'\n", stack.Ref())
+	b.d.Infof(diag.Message("", "Created stack '%s'"), stack.Ref())
 
 	return stack, nil
 }

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func TestMassageBlobPath(t *testing.T) {
@@ -144,7 +144,7 @@ func makeUntypedDeployment(name tokens.QName, phrase, state string) (*apitype.Un
 func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -204,7 +204,7 @@ func TestDrillError(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -222,7 +222,7 @@ func TestCancel(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -260,7 +260,7 @@ func TestCancel(t *testing.T) {
 	assert.False(t, lockExists)
 
 	// Make another filestate backend which will have a different lockId
-	ob, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	ob, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	otherBackend, ok := ob.(*localBackend)
 	assert.True(t, ok)
@@ -283,7 +283,7 @@ func TestRemoveMakesBackups(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -326,7 +326,7 @@ func TestRenameWorks(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -393,7 +393,7 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 	t.Parallel()
 
 	fakeDir := "file://" + filepath.ToSlash(os.TempDir()) + "/non-existing"
-	b, err := New(cmdutil.Diag(), fakeDir, nil)
+	b, err := New(diagtest.LogSink(t), fakeDir, nil)
 	assert.Error(t, err)
 	assert.Nil(t, b)
 }
@@ -444,7 +444,7 @@ func TestHtmlEscaping(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
+	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/require"
 )
 
 func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {
 	cwd, err := os.Getwd()
 	require.NoError(b, err)
-	sink := cmdutil.Diag()
+	sink := diagtest.LogSink(b)
 	ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -78,9 +78,9 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 	}
 }
 
-func newTestPluginContext(program deploytest.ProgramFunc) (*plugin.Context, error) {
-	sink := cmdutil.Diag()
-	statusSink := cmdutil.Diag()
+func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin.Context, error) {
+	sink := diagtest.LogSink(t)
+	statusSink := diagtest.LogSink(t)
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
 	return plugin.NewContext(sink, statusSink, host, nil, "", nil, false, nil)
@@ -207,7 +207,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 	}
 
 	// Create and iterate an eval source.
-	ctx, err := newTestPluginContext(fixedProgram(steps))
+	ctx, err := newTestPluginContext(t, fixedProgram(steps))
 	assert.NoError(t, err)
 
 	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
@@ -290,7 +290,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 	}
 
 	// Create and iterate an eval source.
-	ctx, err := newTestPluginContext(fixedProgram(steps))
+	ctx, err := newTestPluginContext(t, fixedProgram(steps))
 	assert.NoError(t, err)
 
 	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
@@ -403,7 +403,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	}
 
 	// Create and iterate an eval source.
-	ctx, err := newTestPluginContext(program)
+	ctx, err := newTestPluginContext(t, program)
 	assert.NoError(t, err)
 
 	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
@@ -476,7 +476,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 	}
 
 	// Create and iterate an eval source.
-	ctx, err := newTestPluginContext(program)
+	ctx, err := newTestPluginContext(t, program)
 	assert.NoError(t, err)
 
 	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
@@ -655,7 +655,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 			}
 
 			// Create and iterate an eval source.
-			ctx, err := newTestPluginContext(program)
+			ctx, err := newTestPluginContext(t, program)
 			assert.NoError(t, err)
 
 			iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)

--- a/sdk/go/common/testing/diagtest/sink.go
+++ b/sdk/go/common/testing/diagtest/sink.go
@@ -1,0 +1,41 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diagtest provides testing utilities
+// for code that uses the common/diag package.
+package diagtest
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
+)
+
+// LogSink builds a diagnostic sink that logs to the given testing.TB.
+//
+// Messages are prefixed with [stdout] or [stderr]
+// to indicate which stream they were written to.
+func LogSink(t testing.TB) diag.Sink {
+	return diag.DefaultSink(
+		iotest.LogWriterPrefixed(t, "[stdout] "),
+		iotest.LogWriterPrefixed(t, "[stderr] "),
+		diag.FormatOptions{
+			// Don't colorize test output.
+			Color: colors.Never,
+			Debug: true,
+		},
+	)
+}

--- a/sdk/go/common/testing/diagtest/sink_test.go
+++ b/sdk/go/common/testing/diagtest/sink_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagtest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogSink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+
+		// Reference to the diag.Sink method to call.
+		// This is an unbound method reference.
+		// Use the syntax "($T).$method" to get an unbound method reference.
+		fn   func(diag.Sink, *diag.Diag, ...any)
+		want string
+	}{
+		{
+			desc: "debug",
+			fn:   (diag.Sink).Debugf,
+			want: "[stdout] debug: msg",
+		},
+		{
+			desc: "info",
+			fn:   (diag.Sink).Infof,
+			want: "[stdout] msg",
+		},
+		{
+			desc: "infoerr",
+			fn:   (diag.Sink).Infoerrf,
+			want: "[stderr] msg",
+		},
+		{
+			desc: "warning",
+			fn:   (diag.Sink).Warningf,
+			want: "[stderr] warning: msg",
+		},
+		{
+			desc: "error",
+			fn:   (diag.Sink).Errorf,
+			want: "[stderr] error: msg",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			fakeT := fakeT{TB: t}
+			sink := LogSink(&fakeT)
+
+			tt.fn(sink, diag.Message("", "msg"))
+			fakeT.runCleanup()
+
+			require.Len(t, fakeT.msgs, 1)
+			assert.Equal(t, tt.want, fakeT.msgs[0])
+		})
+	}
+}
+
+// Wraps a testing.TB and intercepts log messages.
+type fakeT struct {
+	testing.TB
+
+	msgs     []string
+	cleanups []func()
+}
+
+func (t *fakeT) Logf(msg string, args ...interface{}) {
+	t.msgs = append(t.msgs, fmt.Sprintf(msg, args...))
+}
+
+func (t *fakeT) Cleanup(f func()) {
+	t.cleanups = append(t.cleanups, f)
+}
+
+func (t *fakeT) runCleanup() {
+	// cleanup functions are called in reverse order.
+	for i := len(t.cleanups) - 1; i >= 0; i-- {
+		t.cleanups[i]()
+	}
+}


### PR DESCRIPTION
Adds a testing/diagtest package similar to
the previously added iotest package (#12377)
which writes log messages to a testing.TB's log stream.

This makes tests less noisy and helps associate error messages
with the exact test cases they came from.

diagtest, unlike iotest, prefixes each message with stdout or stderr.
To reuse iotest.LogWriter for this, we add support to iotest.LogWriter
to specify an optional prefix string.

This also updates all tests that use cmdutil.Diag directly
(because these write to the test process' stdout/stderr)
and instead use diagtest.Sink to have them write
to the test's logger.
