### PR TITLE
filestate: Plumb context through constructor

### DIFF
--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -144,9 +144,9 @@ func makeUntypedDeployment(name tokens.QName, phrase, state string) (*apitype.Un
 func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
@@ -204,9 +204,9 @@ func TestDrillError(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Get a non-existent stack and expect a nil error because it won't be found.
 	stackRef, err := b.ParseStackReference("dev")
@@ -222,9 +222,9 @@ func TestCancel(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Check that trying to cancel a stack that isn't created yet doesn't error
 	aStackRef, err := b.ParseStackReference("a")
@@ -260,7 +260,7 @@ func TestCancel(t *testing.T) {
 	assert.False(t, lockExists)
 
 	// Make another filestate backend which will have a different lockId
-	ob, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	ob, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	otherBackend, ok := ob.(*localBackend)
 	assert.True(t, ok)
@@ -283,9 +283,9 @@ func TestRemoveMakesBackups(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Grab the bucket interface to test with
 	lb, ok := b.(*localBackend)
@@ -326,9 +326,9 @@ func TestRenameWorks(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Grab the bucket interface to test with
 	lb, ok := b.(*localBackend)
@@ -393,7 +393,8 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 	t.Parallel()
 
 	fakeDir := "file://" + filepath.ToSlash(os.TempDir()) + "/non-existing"
-	b, err := New(diagtest.LogSink(t), fakeDir, nil)
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), fakeDir, nil)
 	assert.Error(t, err)
 	assert.Nil(t, b)
 }
@@ -444,9 +445,9 @@ func TestHtmlEscaping(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
 	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
 
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -32,7 +32,8 @@ func TestWrappedBucket(t *testing.T) {
 
 	// Initialize a filestate backend, using the default Pulumi directory.
 	cloudURL := FilePathPrefix + "~"
-	b, err := New(nil, cloudURL, nil)
+	ctx := context.Background()
+	b, err := New(ctx, nil, cloudURL, nil)
 	if err != nil {
 		t.Fatalf("Initializing new filestate backend: %v", err)
 	}
@@ -46,7 +47,6 @@ func TestWrappedBucket(t *testing.T) {
 		t.Fatalf("localBackend.bucket wasn't of type wrappedBucket?")
 	}
 
-	ctx := context.Background()
 	// Perform basic file operations using wrappedBucket and verify that it will
 	// successfully handle both "/" and "\" as file separators. (And probably fail in
 	// exciting ways if you try to give it a file on a system that supports "\" or "/" as

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -142,7 +142,7 @@ func newLoginCmd() *cobra.Command {
 
 			var be backend.Backend
 			if filestate.IsFileStateBackendURL(cloudURL) {
-				be, err = filestate.Login(cmdutil.Diag(), cloudURL, project)
+				be, err = filestate.Login(ctx, cmdutil.Diag(), cloudURL, project)
 				if defaultOrg != "" {
 					return fmt.Errorf("unable to set default org for this type of backend")
 				}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -129,7 +129,7 @@ func nonInteractiveCurrentBackend(ctx context.Context, project *workspace.Projec
 	}
 
 	if filestate.IsFileStateBackendURL(url) {
-		return filestate.New(cmdutil.Diag(), url, project)
+		return filestate.New(ctx, cmdutil.Diag(), url, project)
 	}
 	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url, project, workspace.GetCloudInsecure(url))
 }
@@ -145,7 +145,7 @@ func currentBackend(ctx context.Context, project *workspace.Project, opts displa
 	}
 
 	if filestate.IsFileStateBackendURL(url) {
-		return filestate.New(cmdutil.Diag(), url, project)
+		return filestate.New(ctx, cmdutil.Diag(), url, project)
 	}
 	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, project, workspace.GetCloudInsecure(url), opts)
 }


### PR DESCRIPTION
Instead of using context.TODO everywhere,
plumb context.Context into filestate.New and filestate.Login,
and through that into other operations.

Change extracted from #12134
