### PR TITLE
Expose Context for plugin providers

### DIFF
--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/go/common/resource/plugin/provider_context.go
+++ b/sdk/go/common/resource/plugin/provider_context.go
@@ -1,0 +1,242 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// A version of Provider interface that is enhanced by giving access to the request Context.
+type ProviderWithContext interface {
+	io.Closer
+
+	PkgWithContext(ctx context.Context) tokens.Package
+
+	GetSchemaWithContext(ctx context.Context, version int) ([]byte, error)
+
+	CheckConfigWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
+		allowUnknowns bool) (resource.PropertyMap, []CheckFailure, error)
+
+	DiffConfigWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
+		allowUnknowns bool, ignoreChanges []string) (DiffResult, error)
+
+	ConfigureWithContext(ctx context.Context, inputs resource.PropertyMap) error
+
+	CheckWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
+		allowUnknowns bool, randomSeed []byte) (resource.PropertyMap, []CheckFailure, error)
+
+	DiffWithContext(ctx context.Context, urn resource.URN, id resource.ID, olds resource.PropertyMap,
+		news resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (DiffResult, error)
+
+	CreateWithContext(ctx context.Context, urn resource.URN, news resource.PropertyMap, timeout float64,
+		preview bool) (resource.ID, resource.PropertyMap, resource.Status, error)
+
+	ReadWithContext(ctx context.Context, urn resource.URN, id resource.ID,
+		inputs, state resource.PropertyMap) (ReadResult, resource.Status, error)
+
+	UpdateWithContext(ctx context.Context, urn resource.URN, id resource.ID,
+		olds resource.PropertyMap, news resource.PropertyMap, timeout float64,
+		ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, error)
+
+	DeleteWithContext(ctx context.Context, urn resource.URN, id resource.ID,
+		props resource.PropertyMap, timeout float64) (resource.Status, error)
+
+	ConstructWithContext(ctx context.Context, info ConstructInfo, typ tokens.Type, name tokens.QName,
+		parent resource.URN, inputs resource.PropertyMap,
+		options ConstructOptions) (ConstructResult, error)
+
+	InvokeWithContext(ctx context.Context, tok tokens.ModuleMember,
+		args resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
+
+	StreamInvokeWithContext(
+		ctx context.Context,
+		tok tokens.ModuleMember,
+		args resource.PropertyMap,
+		onNext func(resource.PropertyMap) error) ([]CheckFailure, error)
+
+	CallWithContext(ctx context.Context, tok tokens.ModuleMember, args resource.PropertyMap, info CallInfo,
+		options CallOptions) (CallResult, error)
+
+	GetPluginInfoWithContext(ctx context.Context) (workspace.PluginInfo, error)
+
+	SignalCancellationWithContext(ctx context.Context) error
+
+	GetMappingWithContext(ctx context.Context, key string) ([]byte, string, error)
+}
+
+func toProviderWithContext(prov Provider) ProviderWithContext {
+	if p, ok := prov.(ProviderWithContext); ok {
+		return p
+	}
+	return &providerWithDiscardedContext{prov}
+}
+
+type providerWithDiscardedContext struct {
+	p Provider
+}
+
+func (p *providerWithDiscardedContext) Close() error {
+	return p.p.Close()
+}
+
+func (p *providerWithDiscardedContext) PkgWithContext(_ context.Context) tokens.Package {
+	return p.p.Pkg()
+}
+
+func (p *providerWithDiscardedContext) GetSchemaWithContext(_ context.Context, version int) ([]byte, error) {
+	return p.p.GetSchema(version)
+}
+
+func (p *providerWithDiscardedContext) CheckConfigWithContext(
+	_x context.Context,
+	urn resource.URN,
+	olds, news resource.PropertyMap,
+	allowUnknowns bool,
+) (resource.PropertyMap, []CheckFailure, error) {
+	return p.p.CheckConfig(urn, olds, news, allowUnknowns)
+}
+
+func (p *providerWithDiscardedContext) DiffConfigWithContext(
+	_ context.Context,
+	urn resource.URN,
+	olds, news resource.PropertyMap,
+	allowUnknowns bool,
+	ignoreChanges []string,
+) (DiffResult, error) {
+	return p.p.DiffConfig(urn, olds, news, allowUnknowns, ignoreChanges)
+}
+
+func (p *providerWithDiscardedContext) ConfigureWithContext(_ context.Context, inputs resource.PropertyMap) error {
+	return p.p.Configure(inputs)
+}
+
+func (p *providerWithDiscardedContext) CheckWithContext(
+	_ context.Context,
+	urn resource.URN,
+	olds, news resource.PropertyMap,
+	allowUnknowns bool,
+	randomSeed []byte,
+) (resource.PropertyMap, []CheckFailure, error) {
+	return p.p.Check(urn, olds, news, allowUnknowns, randomSeed)
+}
+
+func (p *providerWithDiscardedContext) DiffWithContext(
+	_ context.Context,
+	urn resource.URN,
+	id resource.ID,
+	olds, news resource.PropertyMap,
+	allowUnknowns bool,
+	ignoreChanges []string,
+) (DiffResult, error) {
+	return p.p.Diff(urn, id, olds, news, allowUnknowns, ignoreChanges)
+}
+
+func (p *providerWithDiscardedContext) CreateWithContext(
+	_ context.Context,
+	urn resource.URN,
+	news resource.PropertyMap,
+	timeout float64,
+	preview bool,
+) (resource.ID, resource.PropertyMap, resource.Status, error) {
+	return p.p.Create(urn, news, timeout, preview)
+}
+
+func (p *providerWithDiscardedContext) ReadWithContext(
+	_ context.Context,
+	urn resource.URN,
+	id resource.ID,
+	inputs, state resource.PropertyMap,
+) (ReadResult, resource.Status, error) {
+	return p.p.Read(urn, id, inputs, state)
+}
+
+func (p *providerWithDiscardedContext) UpdateWithContext(
+	_ context.Context,
+	urn resource.URN,
+	id resource.ID,
+	olds resource.PropertyMap,
+	news resource.PropertyMap,
+	timeout float64,
+	ignoreChanges []string,
+	preview bool,
+) (resource.PropertyMap, resource.Status, error) {
+	return p.p.Update(urn, id, olds, news, timeout, ignoreChanges, preview)
+}
+
+func (p *providerWithDiscardedContext) DeleteWithContext(
+	_ context.Context,
+	urn resource.URN,
+	id resource.ID,
+	props resource.PropertyMap,
+	timeout float64,
+) (resource.Status, error) {
+	return p.p.Delete(urn, id, props, timeout)
+}
+
+func (p *providerWithDiscardedContext) ConstructWithContext(
+	_ context.Context,
+	info ConstructInfo,
+	typ tokens.Type,
+	name tokens.QName,
+	parent resource.URN,
+	inputs resource.PropertyMap,
+	options ConstructOptions,
+) (ConstructResult, error) {
+	return p.p.Construct(info, typ, name, parent, inputs, options)
+}
+
+func (p *providerWithDiscardedContext) InvokeWithContext(
+	_ context.Context,
+	tok tokens.ModuleMember,
+	args resource.PropertyMap,
+) (resource.PropertyMap, []CheckFailure, error) {
+	return p.p.Invoke(tok, args)
+}
+
+func (p *providerWithDiscardedContext) StreamInvokeWithContext(
+	_ context.Context,
+	tok tokens.ModuleMember,
+	args resource.PropertyMap,
+	onNext func(resource.PropertyMap) error,
+) ([]CheckFailure, error) {
+	return p.p.StreamInvoke(tok, args, onNext)
+}
+
+func (p *providerWithDiscardedContext) CallWithContext(
+	_ context.Context,
+	tok tokens.ModuleMember,
+	args resource.PropertyMap,
+	info CallInfo,
+	options CallOptions,
+) (CallResult, error) {
+	return p.p.Call(tok, args, info, options)
+}
+
+func (p *providerWithDiscardedContext) GetPluginInfoWithContext(_ context.Context) (workspace.PluginInfo, error) {
+	return p.p.GetPluginInfo()
+}
+
+func (p *providerWithDiscardedContext) SignalCancellationWithContext(_ context.Context) error {
+	return p.p.SignalCancellation()
+}
+
+func (p *providerWithDiscardedContext) GetMappingWithContext(_ context.Context, key string) ([]byte, string, error) {
+	return p.p.GetMapping(key)
+}

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -41,6 +41,10 @@ func NewProviderServer(provider Provider) pulumirpc.ResourceProviderServer {
 	return &providerServer{provider: toProviderWithContext(provider)}
 }
 
+func NewProviderServerWithContext(provider ProviderWithContext) pulumirpc.ResourceProviderServer {
+	return &providerServer{provider: provider}
+}
+
 func (p *providerServer) unmarshalOptions(label string) MarshalOptions {
 	return MarshalOptions{
 		Label:         label,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As a provider author, I may want to access request Context while continuing to use plugin.NewProviderServer to create a pulumirpc.ResourceProviderServer while coding to a higher-level API than raw gRPC. The request context has cancellation and metadata that might be relevant. For example, as a provider author I may want to add tracing spans to internal operations and have them tied to the parent span coming through gRPC and the request context.

Before this PR it wasn't quite possible to do this, and I'd have to drop to coding at pulumirpc.ResourceProviderServer level directly to recover the Context.

This PR introduces a new interface PluginWithContext that I can code against as provider author that gives back the request Context in every method. The change is slightly duplicative but non-breaking.
 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
