### PR TITLE
sdk/go: Don't use Provider for type if package doesn't match

### DIFF
--- a/changelog/pending/20230314--sdk-go--fixes-use-of-provider-option-from-parent-resources-with-mismatched-packages.yaml
+++ b/changelog/pending/20230314--sdk-go--fixes-use-of-provider-option-from-parent-resources-with-mismatched-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fixes use of Provider option from parent resources with mismatched packages.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1062,8 +1062,8 @@ func (ctx *Context) mergeProviders(t string, parent Resource, provider ProviderR
 
 // getProvider gets the provider for the resource.
 func getProvider(t string, provider ProviderResource, providers map[string]ProviderResource) ProviderResource {
-	if provider == nil {
-		pkg := getPackage(t)
+	pkg := getPackage(t)
+	if provider == nil || provider.getPackage() != pkg {
 		provider = providers[pkg]
 	}
 	return provider


### PR DESCRIPTION
In #12296, we started correctly interpreting the Provider argument
per other SDKs. but this introduced a regression:
the Provider field is now set for resources with mismatched types.

This results in a scenario where a provider foo for package X
is passed to a resource bar with package Y,
with the intent of plumbing it to bar's descendants,
but bar attempts to incorrectly use the provider directly.

    foo := NewXProvider()
    bar := NewYThing("bar", Provider(foo))
    // ...
    baz := NewXThing("baz", Parent(bar)) // should use foo

This worked previously, but with #12296, this fails
because NewYThing attempts to use Provider foo directly.

To fix this, we need to prevent NewYThing from using a provider
that does not match the package that it belongs to.
We had to make a similar change to the Python SDK in #12292.

https://github.com/pulumi/pulumi/blob/477e0c97660bdbeb28a142057899792d52e63a0b/sdk/python/lib/pulumi/resource.py#L925-L927

The regression test is specific to remote component resources
per #12430, but the issue would be caused even for normal component
resources before this.

Resolves #12430
