### PR TITLE
Pin CI to Node 19.7.x to avoid hitting assert in 19.8.0

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -124,7 +124,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
     "go": "1.20.x",
-    "nodejs": "19.x",
+    "nodejs": "19.7.x",
     "python": "3.10.x",
 }
 


### PR DESCRIPTION
Node 19.8.0 was released ~5 hours ago and we're hitting an internal assert. Pin to 19.7.x to unblock CI until we understand what's going on with 19.8.0.

Part of #12434