### PR TITLE
filestate: Introduce referenceStore to control layout

### DIFF
--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -351,7 +351,7 @@ func TestRenameWorks(t *testing.T) {
 	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
 	assert.NoError(t, err)
 	// And pollute the history folder
-	err = lb.bucket.WriteAll(ctx, path.Join(lb.historyDirectory(aStackRef), "randomfile.txt"), []byte{0, 13}, nil)
+	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
 	assert.NoError(t, err)
 
 	// Rename the stack
@@ -405,11 +405,13 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 // an error when the stack name is the empty string.TestParseEmptyStackFails
 func TestParseEmptyStackFails(t *testing.T) {
 	t.Parallel()
-	// ParseStackReference does use the method receiver
-	// (it is a total function disguised as a method.)
-	var b *localBackend
-	stackName := ""
-	_, err := b.ParseStackReference(stackName)
+
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	_, err = b.ParseStackReference("")
 	assert.Error(t, err)
 }
 

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -40,7 +40,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -304,7 +303,7 @@ func (b *localBackend) removeStack(ref *localBackendReference) error {
 	file := b.stackPath(ref)
 	backupTarget(b.bucket, file, false)
 
-	historyDir := b.historyDirectory(ref)
+	historyDir := ref.HistoryDir()
 	return removeAllByPrefix(b.bucket, historyDir)
 }
 
@@ -346,7 +345,7 @@ func (b *localBackend) backupStack(ref *localBackendReference) error {
 	}
 
 	// Get the backup directory.
-	backupDir := b.backupDirectory(ref)
+	backupDir := ref.BackupDir()
 
 	// Write out the new backup checkpoint file.
 	stackFile := filepath.Base(stackPath)
@@ -364,15 +363,14 @@ func (b *localBackend) backupStack(ref *localBackendReference) error {
 }
 
 func (b *localBackend) stackPath(ref *localBackendReference) string {
-	path := filepath.Join(b.StateDir(), workspace.StackDir)
 	if ref == nil {
-		return path
+		return StacksDir
 	}
 
 	// We can't use listBucket here for as we need to do a partial prefix match on filename, while the
 	// "dir" option to listBucket is always suffixed with "/". Also means we don't need to save any
 	// results in a slice.
-	plainPath := filepath.ToSlash(filepath.Join(path, fsutil.NamePath(ref.name)) + ".json")
+	plainPath := filepath.ToSlash(ref.StackBasePath()) + ".json"
 	gzipedPath := plainPath + ".gz"
 
 	bucketIter := b.bucket.List(&blob.ListOptions{
@@ -408,22 +406,12 @@ func (b *localBackend) stackPath(ref *localBackendReference) string {
 	return plainPath
 }
 
-func (b *localBackend) historyDirectory(stack *localBackendReference) string {
-	contract.Requiref(stack != nil, "stack", "must not be nil")
-	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.NamePath(stack.name))
-}
-
-func (b *localBackend) backupDirectory(stack *localBackendReference) string {
-	contract.Requiref(stack != nil, "stack", "must not be nil")
-	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.NamePath(stack.name))
-}
-
 // getHistory returns locally stored update history. The first element of the result will be
 // the most recent update record.
 func (b *localBackend) getHistory(stack *localBackendReference, pageSize int, page int) ([]backend.UpdateInfo, error) {
 	contract.Requiref(stack != nil, "stack", "must not be nil")
 
-	dir := b.historyDirectory(stack)
+	dir := stack.HistoryDir()
 	// TODO: we could consider optimizing the list operation using `page` and `pageSize`.
 	// Unfortunately, this is mildly invasive given the gocloud List API.
 	allFiles, err := listBucket(b.bucket, dir)
@@ -496,8 +484,8 @@ func (b *localBackend) renameHistory(oldName *localBackendReference, newName *lo
 	contract.Requiref(oldName != nil, "oldName", "must not be nil")
 	contract.Requiref(newName != nil, "newName", "must not be nil")
 
-	oldHistory := b.historyDirectory(oldName)
-	newHistory := b.historyDirectory(newName)
+	oldHistory := oldName.HistoryDir()
+	newHistory := newName.HistoryDir()
 
 	allFiles, err := listBucket(b.bucket, oldHistory)
 	if err != nil {
@@ -539,7 +527,7 @@ func (b *localBackend) renameHistory(oldName *localBackendReference, newName *lo
 func (b *localBackend) addToHistory(ref *localBackendReference, update backend.UpdateInfo) error {
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 
-	dir := b.historyDirectory(ref)
+	dir := ref.HistoryDir()
 
 	// Prefix for the update and checkpoint files.
 	pathPrefix := path.Join(dir, fmt.Sprintf("%s-%d", ref.name, time.Now().UnixNano()))

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -1,0 +1,157 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestate
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// These should be constants
+// but we can't make a constant from filepath.Join.
+var (
+	// StacksDir is a path under the state's root directory
+	// where the filestate backend stores stack information.
+	StacksDir = filepath.Join(workspace.BookkeepingDir, workspace.StackDir)
+
+	// HistoriesDir is a path under the state's root directory
+	// where the filestate backend stores histories for all stacks.
+	HistoriesDir = filepath.Join(workspace.BookkeepingDir, workspace.HistoryDir)
+
+	// BackupsDir is a path under the state's root directory
+	// where the filestate backend stores backups of stacks.
+	BackupsDir = filepath.Join(workspace.BookkeepingDir, workspace.BackupDir)
+)
+
+// referenceStore stores and provides access to stack information.
+//
+// Each implementation of referenceStore is a different version of the stack
+// storage format.
+type referenceStore interface {
+	// StackBasePath returns the base path to for the file
+	// where snapshots of this stack are stored.
+	//
+	// This must be under StacksDir.
+	//
+	// This is the path to the file without the extension.
+	// The real file path is StackBasePath + ".json"
+	// or StackBasePath + ".json.gz".
+	StackBasePath(*localBackendReference) string
+
+	// HistoryDir returns the path to the directory
+	// where history for this stack is stored.
+	//
+	// This must be under HistoriesDir.
+	HistoryDir(*localBackendReference) string
+
+	// BackupDir returns the path to the directory
+	// where backups for this stack are stored.
+	//
+	// This must be under BackupsDir.
+	BackupDir(*localBackendReference) string
+
+	// ListReferences lists all stack references in the store.
+	ListReferences() ([]*localBackendReference, error)
+
+	// ParseReference parses a localBackendReference from a string.
+	ParseReference(ref string) (*localBackendReference, error)
+}
+
+// legacyReferenceStore is a referenceStore that stores stack
+// information with the legacy layout that did not support projects.
+//
+// This is the format we used before we introduced versioning.
+type legacyReferenceStore struct {
+	bucket Bucket
+}
+
+var _ referenceStore = (*legacyReferenceStore)(nil)
+
+// newLegacyReferenceStore builds a referenceStore in the legacy format
+// (no project support) backed by the provided bucket.
+func newLegacyReferenceStore(b Bucket) *legacyReferenceStore {
+	return &legacyReferenceStore{
+		bucket: b,
+	}
+}
+
+// newReference builds a new localBackendReference with the provided arguments.
+// This DOES NOT modify the underlying storage.
+func (p *legacyReferenceStore) newReference(name tokens.Name) *localBackendReference {
+	return &localBackendReference{
+		name:  name,
+		store: p,
+	}
+}
+
+func (p *legacyReferenceStore) StackBasePath(ref *localBackendReference) string {
+	return filepath.Join(StacksDir, fsutil.NamePath(ref.name))
+}
+
+func (p *legacyReferenceStore) HistoryDir(stack *localBackendReference) string {
+	return filepath.Join(HistoriesDir, fsutil.NamePath(stack.name))
+}
+
+func (p *legacyReferenceStore) BackupDir(stack *localBackendReference) string {
+	return filepath.Join(BackupsDir, fsutil.NamePath(stack.name))
+}
+
+func (p *legacyReferenceStore) ParseReference(stackRef string) (*localBackendReference, error) {
+	if !tokens.IsName(stackRef) || len(stackRef) > 100 {
+		return nil, fmt.Errorf(
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %q",
+			stackRef)
+	}
+	return p.newReference(tokens.Name(stackRef)), nil
+}
+
+func (p *legacyReferenceStore) ListReferences() ([]*localBackendReference, error) {
+	files, err := listBucket(p.bucket, StacksDir)
+	if err != nil {
+		return nil, fmt.Errorf("error listing stacks: %w", err)
+	}
+	stacks := make([]*localBackendReference, 0, len(files))
+
+	for _, file := range files {
+		if file.IsDir {
+			continue
+		}
+
+		objName := objectName(file)
+		// Skip files without valid extensions (e.g., *.bak files).
+		ext := filepath.Ext(objName)
+		// But accept gzip compression
+		if ext == encoding.GZIPExt {
+			objName = strings.TrimSuffix(objName, encoding.GZIPExt)
+			ext = filepath.Ext(objName)
+		}
+
+		if _, has := encoding.Marshalers[ext]; !has {
+			continue
+		}
+
+		// Read in this stack's information.
+		name := objName[:len(objName)-len(ext)]
+		stacks = append(stacks, p.newReference(tokens.Name(name)))
+	}
+
+	return stacks, nil
+}

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/memblob"
+)
+
+func TestLegacyReferenceStore_referencePaths(t *testing.T) {
+	t.Parallel()
+
+	bucket := memblob.OpenBucket(nil)
+	store := newLegacyReferenceStore(bucket)
+
+	ref, err := store.ParseReference("foo")
+	require.NoError(t, err)
+
+	assert.Equal(t, tokens.Name("foo"), ref.Name())
+	assert.Equal(t, tokens.QName("foo"), ref.FullyQualifiedName())
+	assert.Equal(t, ".pulumi/stacks/foo", ref.StackBasePath())
+	assert.Equal(t, ".pulumi/history/foo", ref.HistoryDir())
+	assert.Equal(t, ".pulumi/backups/foo", ref.BackupDir())
+}
+
+func TestLegacyReferenceStore_ParseReference_errors(t *testing.T) {
+	t.Parallel()
+
+	bucket := memblob.OpenBucket(nil)
+	store := newLegacyReferenceStore(bucket)
+
+	tests := []struct {
+		desc string
+		give string
+	}{
+		{desc: "empty", give: ""},
+		{desc: "invalid name", give: "foo/bar"},
+		{desc: "too many parts", give: "foo/bar/baz"},
+		{
+			desc: "over 100 characters",
+			give: strings.Repeat("a", 101),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := store.ParseReference(tt.give)
+			assert.Error(t, err)
+			// If we ever make error messages here more specific,
+			// we can add assert.ErrorContains here.
+		})
+	}
+}
+
+func TestLegacyReferenceStore_ListReferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+
+		// List of file paths relative to the storage root
+		// that should exist before ListReferences is called.
+		files []string
+
+		// List of fully-qualified stack names that should be returned
+		// by ListReferences.
+		want []tokens.QName
+	}{
+		{
+			desc: "empty",
+			want: []tokens.QName{},
+		},
+		{
+			desc: "json",
+			files: []string{
+				".pulumi/stacks/foo.json",
+			},
+			want: []tokens.QName{"foo"},
+		},
+		{
+			desc: "gzipped",
+			files: []string{
+				".pulumi/stacks/foo.json.gz",
+			},
+			want: []tokens.QName{"foo"},
+		},
+		{
+			desc: "multiple",
+			files: []string{
+				".pulumi/stacks/foo.json",
+				".pulumi/stacks/bar.json.gz",
+				".pulumi/stacks/baz.json",
+			},
+			want: []tokens.QName{"bar", "baz", "foo"},
+		},
+		{
+			desc: "extraneous directories",
+			files: []string{
+				".pulumi/stacks/foo.json",
+				".pulumi/stacks/bar.json/baz.json", // not a file
+			},
+			want: []tokens.QName{"foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			bucket := memblob.OpenBucket(nil)
+			store := newLegacyReferenceStore(bucket)
+
+			ctx := context.Background()
+			for _, f := range tt.files {
+				require.NoError(t, bucket.WriteAll(ctx, f, []byte{}, nil))
+			}
+
+			refs, err := store.ListReferences()
+			require.NoError(t, err)
+
+			got := make([]tokens.QName, len(refs))
+			for i, ref := range refs {
+				got[i] = ref.FullyQualifiedName()
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Adds a referenceStore abstraction to control the layout of the storage,
and a legacyReferenceStore implementation based on the current layout
(that does not support projects).

This allows us to move code to determine file paths of stacks, their
histories, and their backups, all into a single component that we can
swap out for project support.

localBackendReferences keep track of the referenceStore that built them.
The primary reason for this is that when we add support for migrating a
stack state from legacy to project mode, `backend.store` will become
mutable.
For references created before the store for a backend was changed, we
still need to be able to access their original file paths, so we need to
hold onto the original referenceStore.
However, as a side-effect of this,
it's more convenient to acess paths from `ref.Foo()` rather than
`backend.foo(ref)` or `backend.store.Foo(ref)`.

In the future, we may also move stackPath to the store,
since right now the .json/.json.gz logic is duplicated in a couple
places.

Extracted from #12134