### PR TITLE
backend/filestate: Re-add project support

### DIFF
--- a/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
+++ b/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: feat
+  scope: backend/filestate
+  description: |
+    Add support for project-scoped stacks.
+    Newly initialized storage will automatically use this mode.
+    This mode needs write access to the root of the .pulumi directory;
+    if you're using a cloud storage, be sure to update your ACLs.

--- a/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
+++ b/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
@@ -4,5 +4,6 @@ changes:
   description: |
     Add support for project-scoped stacks.
     Newly initialized storage will automatically use this mode.
+    Set PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT=1 to opt-out of this.
     This mode needs write access to the root of the .pulumi directory;
     if you're using a cloud storage, be sure to update your ACLs.

--- a/changelog/pending/20230328--backend-filestate--print-a-warning-if-a-project-scoped-storage-has-non-project-stacks-in-it.yaml
+++ b/changelog/pending/20230328--backend-filestate--print-a-warning-if-a-project-scoped-storage-has-non-project-stacks-in-it.yaml
@@ -1,0 +1,6 @@
+changes:
+- type: chore
+  scope: backend/filestate
+  description: |
+    Print a warning if a project-scoped storage has non-project stacks in it.
+    Disable this warning by setting PULUMI_SELF_MANAGED_STATE_NO_LEGACY_WARNING=1.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -74,7 +74,7 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
-	// Fully qualified name of the stack.
+	// Fully qualified name of the stack, including any organization, project, or other information.
 	FullyQualifiedName() tokens.QName
 }
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -80,6 +80,13 @@ var (
 	// to disable the warning printed by the filestate backend
 	// when it detects that the state has both, project-scoped and legacy stacks.
 	PulumiFilestateNoLegacyWarningEnvVar = env.SelfManagedStateNoLegacyWarning.Var().Name()
+
+	// PulumiFilestateLegacyLayoutEnvVar is the name of an environment variable
+	// that can be set to force the use of the legacy layout
+	// when initializing an empty bucket for filestate.
+	//
+	// This opt-out is intended to be removed in a future release.
+	PulumiFilestateLegacyLayoutEnvVar = env.SelfManagedStateLegacyLayout.Var().Name()
 )
 
 // Backend extends the base backend interface with specific information about local backends.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -91,29 +91,65 @@ type localBackend struct {
 	currentProject atomic.Pointer[workspace.Project]
 
 	// The store controls the layout of stacks in the backend.
+	// We use different layouts based on the version of the backend
+	// specified in the metadata file.
+	// If the metadata file is missing, we use the legacy layout.
 	store referenceStore
 }
 
 type localBackendReference struct {
-	name tokens.Name
+	name    tokens.Name
+	project tokens.Name
+
+	// A thread-safe way to get the current project.
+	// The function reference or the pointer returned by the function may be nil.
+	currentProject func() *workspace.Project
 
 	// referenceStore that created this reference.
+	//
+	// This is necessary because
+	// the referenceStore for a backend may change over time,
+	// but the store for this reference should not.
 	store referenceStore
 }
 
 func (r *localBackendReference) String() string {
-	return string(r.name)
+	// If project is blank this is a legacy non-project scoped stack reference, just return the name.
+	if r.project == "" {
+		return string(r.name)
+	}
+
+	if r.currentProject != nil {
+		proj := r.currentProject()
+		// For project scoped references when stringifying backend references,
+		// we take the current project (if present) into account.
+		// If the project names match, we can elide them.
+		if proj != nil && string(r.project) == string(proj.Name) {
+			return string(r.name)
+		}
+	}
+
+	// Else return a new style fully qualified reference.
+	return fmt.Sprintf("organization/%s/%s", r.project, r.name)
 }
 
 func (r *localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
+func (r *localBackendReference) Project() tokens.Name {
+	return r.project
+}
+
 func (r *localBackendReference) FullyQualifiedName() tokens.QName {
-	return r.Name().Q()
+	if r.project == "" {
+		return r.name.Q()
+	}
+	return tokens.QName(fmt.Sprintf("organization/%s/%s", r.project, r.name))
 }
 
 // Helper methods that delegate to the underlying referenceStore.
+func (r *localBackendReference) Validate() error       { return r.store.ValidateReference(r) }
 func (r *localBackendReference) StackBasePath() string { return r.store.StackBasePath(r) }
 func (r *localBackendReference) HistoryDir() string    { return r.store.HistoryDir(r) }
 func (r *localBackendReference) BackupDir() string     { return r.store.BackupDir(r) }
@@ -129,6 +165,10 @@ func IsFileStateBackendURL(urlstr string) bool {
 
 const FilePathPrefix = "file://"
 
+// New constructs a new filestate backend,
+// using the given URL as the root for storage.
+// The URL must use one of the schemes supported by the go-cloud blob package.
+// Thes inclue: file, s3, gs, azblob.
 func New(ctx context.Context, d diag.Sink, originalURL string, project *workspace.Project) (Backend, error) {
 	if !IsFileStateBackendURL(originalURL) {
 		return nil, fmt.Errorf("local URL %s has an illegal prefix; expected one of: %s",
@@ -190,17 +230,23 @@ func New(ctx context.Context, d diag.Sink, originalURL string, project *workspac
 		bucket:      wbucket,
 		lockID:      lockID.String(),
 		gzip:        gzipCompression,
-		store:       newLegacyReferenceStore(wbucket),
 	}
 	backend.currentProject.Store(project)
 
 	// Read the Pulumi state metadata
 	// and ensure that it is compatible with this version of the CLI.
+	// The version in the metadata file informs which store we use.
 	meta, err := ensurePulumiMeta(ctx, wbucket)
 	if err != nil {
 		return nil, err
 	}
-	if meta.Version != 0 {
+
+	switch meta.Version {
+	case 0:
+		backend.store = newLegacyReferenceStore(wbucket)
+	case 1:
+		backend.store = newProjectReferenceStore(wbucket, backend.currentProject.Load)
+	default:
 		return nil, fmt.Errorf(
 			"state store unsupported: 'meta.yaml' version (%d) is not supported "+
 				"by this version of the Pulumi CLI", meta.Version)
@@ -267,7 +313,7 @@ func (b *localBackend) getReference(ref backend.StackReference) (*localBackendRe
 	if !ok {
 		return nil, fmt.Errorf("bad stack reference type")
 	}
-	return stackRef, nil
+	return stackRef, stackRef.Validate()
 }
 
 func (b *localBackend) local() {}
@@ -330,8 +376,54 @@ func (b *localBackend) ValidateStackName(stackRef string) error {
 }
 
 func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {
-	// Local backends don't really have multiple projects, so just return false here.
+	projStore, ok := b.store.(*projectReferenceStore)
+	if !ok {
+		// Legacy stores don't have projects
+		// so the project does not exist.
+		return false, nil
+	}
+
+	// TODO[pulumi/pulumi#12547]:
+	// This could be faster if we list "$project/" instead of all projects.
+	projects, err := projStore.ListProjects()
+	if err != nil {
+		return false, err
+	}
+
+	for _, project := range projects {
+		if string(project) == projectName {
+			return true, nil
+		}
+	}
+
 	return false, nil
+}
+
+// Confirm the specified stack's project doesn't contradict the meta.yaml of the current project.
+// If the CWD is not in a Pulumi project, does not contradict.
+// If the project name in Pulumi.yaml is "foo", a stack with a name of bar/foo should not work.
+func currentProjectContradictsWorkspace(stack *localBackendReference) bool {
+	contract.Requiref(stack != nil, "stack", "is nil")
+
+	if stack.project == "" {
+		return false
+	}
+
+	projPath, err := workspace.DetectProjectPath()
+	if err != nil {
+		return false
+	}
+
+	if projPath == "" {
+		return false
+	}
+
+	proj, err := workspace.LoadProject(projPath)
+	if err != nil {
+		return false
+	}
+
+	return proj.Name.String() != stack.project.String()
 }
 
 func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackReference,
@@ -351,6 +443,10 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 		return nil, err
 	}
 	defer b.Unlock(ctx, stackRef)
+
+	if currentProjectContradictsWorkspace(localStackRef) {
+		return nil, fmt.Errorf("provided project name %q doesn't match Pulumi.yaml", localStackRef.project)
+	}
 
 	stackName := localStackRef.FullyQualifiedName()
 	if stackName == "" {
@@ -615,6 +711,10 @@ func (b *localBackend) apply(
 	localStackRef, err := b.getReference(stackRef)
 	if err != nil {
 		return nil, nil, result.FromError(err)
+	}
+
+	if currentProjectContradictsWorkspace(localStackRef) {
+		return nil, nil, result.Errorf("provided project name %q doesn't match Pulumi.yaml", localStackRef.project)
 	}
 
 	stackName := stackRef.FullyQualifiedName()

--- a/pkg/backend/filestate/backend_legacy_test.go
+++ b/pkg/backend/filestate/backend_legacy_test.go
@@ -1,0 +1,374 @@
+package filestate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+)
+
+// This file contains copies of old backend tests
+// that were upgraded to run with project support.
+// This duplicates those tests to run with legacy, non-project state,
+// validating that the legacy behavior is preserved.
+
+//nolint:paralleltest // mutates environment variables
+func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Create stack "a" and import a checkpoint with a secret
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	defer func() {
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
+		_, err := b.RemoveStack(ctx, aStack, true)
+		assert.NoError(t, err)
+	}()
+	deployment, err := makeUntypedDeployment("a", "abc123",
+		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
+	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
+	err = b.ImportDeployment(ctx, aStack, deployment)
+	assert.NoError(t, err)
+
+	// Create stack "b" and import a checkpoint with a secret
+	bStackRef, err := b.ParseStackReference("b")
+	assert.NoError(t, err)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, bStack)
+	defer func() {
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
+		_, err := b.RemoveStack(ctx, bStack, true)
+		assert.NoError(t, err)
+	}()
+	deployment, err = makeUntypedDeployment("b", "123abc",
+		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
+	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
+	err = b.ImportDeployment(ctx, bStack, deployment)
+	assert.NoError(t, err)
+
+	// Remove the config passphrase so that we can no longer deserialize the checkpoints
+	err = os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	assert.NoError(t, err)
+
+	// Ensure that we can list the stacks we created even without a passphrase
+	stacks, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
+	assert.NoError(t, err)
+	assert.Nil(t, outContToken)
+	assert.Len(t, stacks, 2)
+	for _, stack := range stacks {
+		assert.NotNil(t, stack.ResourceCount())
+		assert.Equal(t, 1, *stack.ResourceCount())
+	}
+}
+
+func TestDrillError_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Get a non-existent stack and expect a nil error because it won't be found.
+	stackRef, err := b.ParseStackReference("dev")
+	if err != nil {
+		t.Fatalf("unexpected error %v when parsing stack reference", err)
+	}
+	_, err = b.GetStack(ctx, stackRef)
+	assert.Nil(t, err)
+}
+
+func TestCancel_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Check that trying to cancel a stack that isn't created yet doesn't error
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	err = b.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+
+	// Check that trying to cancel a stack that isn't locked doesn't error
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	err = b.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+
+	// Locking and lock checks are only part of the internal interface
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Lock the stack and check CancelCurrentUpdate deletes the lock file
+	err = lb.Lock(ctx, aStackRef)
+	assert.NoError(t, err)
+	// check the lock file exists
+	lockExists, err := lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, lockExists)
+	// Call CancelCurrentUpdate
+	err = lb.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+	// Now check the lock file no longer exists
+	lockExists, err = lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, lockExists)
+
+	// Make another filestate backend which will have a different lockId
+	ob, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+	otherBackend, ok := ob.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Lock the stack with this new backend, then check that checkForLocks on the first backend now errors
+	err = otherBackend.Lock(ctx, aStackRef)
+	assert.NoError(t, err)
+	err = lb.checkForLock(ctx, aStackRef)
+	assert.Error(t, err)
+	// Now call CancelCurrentUpdate and check that checkForLocks no longer errors
+	err = lb.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+	err = lb.checkForLock(ctx, aStackRef)
+	assert.NoError(t, err)
+}
+
+func TestRemoveMakesBackups_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Grab the bucket interface to test with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Check that creating a new stack doesn't make a backup file
+	aStackRef, err := lb.parseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+
+	// Check the stack file now exists, but the backup file doesn't
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	assert.NoError(t, err)
+	assert.False(t, backupFileExists)
+
+	// Now remove the stack
+	removed, err := b.RemoveStack(ctx, aStack, false)
+	assert.NoError(t, err)
+	assert.False(t, removed)
+
+	// Check the stack file is now gone, but the backup file exists
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	assert.NoError(t, err)
+	assert.True(t, backupFileExists)
+}
+
+func TestRenameWorks_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Grab the bucket interface to test with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Create a new stack
+	aStackRef, err := lb.parseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+
+	// Check the stack file now exists
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+
+	// Fake up some history
+	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
+	assert.NoError(t, err)
+	// And pollute the history folder
+	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
+	assert.NoError(t, err)
+
+	// Rename the stack
+	bStackRefI, err := b.RenameStack(ctx, aStack, "b")
+	assert.NoError(t, err)
+	assert.Equal(t, "b", bStackRefI.String())
+	bStackRef := bStackRefI.(*localBackendReference)
+
+	// Check the new stack file now exists and the old one is gone
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+
+	// Rename again
+	bStack, err := b.GetStack(ctx, bStackRef)
+	assert.NoError(t, err)
+	cStackRefI, err := b.RenameStack(ctx, bStack, "c")
+	assert.NoError(t, err)
+	assert.Equal(t, "c", cStackRefI.String())
+	cStackRef := cStackRefI.(*localBackendReference)
+
+	// Check the new stack file now exists and the old one is gone
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+
+	// Check we can still get the history
+	history, err := b.GetHistory(ctx, cStackRef, 10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/10439
+func TestHtmlEscaping_legacy(t *testing.T) {
+	t.Parallel()
+
+	sm := b64.NewBase64SecretsManager()
+	resources := []*resource.State{
+		{
+			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "name"),
+			Type: "a:b:c",
+			Inputs: resource.PropertyMap{
+				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
+			},
+		},
+	}
+
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+
+	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
+	assert.NoError(t, err)
+
+	data, err := encoding.JSON.Marshal(sdep)
+	assert.NoError(t, err)
+
+	// Ensure data has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
+	// ImportDeployment below should not modify the data
+	assert.Contains(t, string(data), "<html@tags>")
+
+	udep := &apitype.UntypedDeployment{
+		Version:    3,
+		Deployment: json.RawMessage(data),
+	}
+
+	// Login to a temp dir filestate backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Create stack "a" and import a checkpoint with a secret
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	err = b.ImportDeployment(ctx, aStack, udep)
+	assert.NoError(t, err)
+
+	// Ensure the file has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
+
+	// Grab the bucket interface to read the file with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	chkpath := lb.stackPath(aStackRef.(*localBackendReference))
+	bytes, err := lb.bucket.ReadAll(context.Background(), chkpath)
+	assert.NoError(t, err)
+	state := string(bytes)
+	assert.Contains(t, state, "<html@tags>")
+}
+
+func TestLocalBackendRejectsStackInitOptions_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Here, we provide options that illegally specify a team on a
+	// backend that does not support teams. We expect this to create
+	// an error later when we call CreateStack.
+	illegalOptions := &backend.CreateStackOptions{Teams: []string{"red-team"}}
+
+	// • Create a mock local backend
+	tmpDir := markLegacyStore(t, t.TempDir())
+	dirURI := fmt.Sprintf("file://%s", filepath.ToSlash(tmpDir))
+	local, err := New(context.Background(), diagtest.LogSink(t), dirURI, nil)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	// • Simulate `pulumi stack init`, passing non-nil init options
+	fakeStackRef, err := local.ParseStackReference("foobar")
+	assert.NoError(t, err)
+	_, err = local.CreateStack(ctx, fakeStackRef, "", illegalOptions)
+	assert.ErrorIs(t, err, backend.ErrTeamsNotSupported)
+}
+
+// markLegacyStore marks the given directory as a legacy store.
+// This is done by dropping a single file into the bookkeeping directory.
+// ensurePulumiMeta will treat this as a legacy store if the directory exists.
+//
+// Returns the directory that was marked.
+func markLegacyStore(t *testing.T, dir string) string {
+	metaPath := filepath.Join(dir, pulumiMetaPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0o755))
+	require.NoError(t, os.WriteFile(metaPath, []byte(`version: 0`), 0o600))
+	return dir
+}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -553,6 +553,24 @@ func TestLegacyFolderStructure(t *testing.T) {
 	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "b.json"))
 }
 
+//nolint:paralleltest // uses t.Setenv
+func TestOptIntoLegacyFolderStructure(t *testing.T) {
+	t.Setenv("PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT", "true")
+
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	require.NoError(t, err)
+
+	// Verify that a new stack is created in the legacy location.
+	foo, err := b.ParseStackReference("foo")
+	require.NoError(t, err)
+
+	_, err = b.CreateStack(ctx, foo, "", nil)
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(tmpDir, ".pulumi", "stacks", "foo.json"))
+}
+
 // Verifies that the StackReference.String method
 // takes the current project name into account,
 // even if the current project name changes

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"gocloud.dev/blob"
@@ -87,7 +88,9 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 
 // objectName returns the filename of a ListObject (an object from a bucket).
 func objectName(obj *blob.ListObject) string {
-	_, filename := path.Split(obj.Key)
+	// If obj.Key ends in "/" we want to trim that to get the name just before
+	key := strings.TrimSuffix(obj.Key, "/")
+	_, filename := path.Split(key)
 	return filename
 }
 

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -64,12 +65,16 @@ func (b *localBackend) checkForLock(ctx context.Context, stackRef backend.StackR
 		return err
 	}
 
+	// lockPath may return a path with backslashes (\) on Windows.
+	// We need to convert it to a slash path (/) to compare it to
+	// the keys in the bucket which are always slash paths.
+	wantLock := filepath.ToSlash(b.lockPath(stackRef))
 	var lockKeys []string
 	for _, file := range allFiles {
 		if file.IsDir {
 			continue
 		}
-		if file.Key != b.lockPath(stackRef) {
+		if file.Key != wantLock {
 			lockKeys = append(lockKeys, file.Key)
 		}
 	}

--- a/pkg/backend/filestate/state_test.go
+++ b/pkg/backend/filestate/state_test.go
@@ -1,0 +1,68 @@
+package filestate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/memblob"
+)
+
+func TestIsPulumiDirEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		// List of files that exist in the bucket.
+		files []string
+
+		// Whether the pulumi directory is considered empty.
+		empty bool
+	}{
+		{
+			desc:  "empty",
+			empty: true,
+		},
+		{
+			desc: "non-state files",
+			files: []string{
+				"foo",
+				"bar",
+			},
+			empty: true,
+		},
+		{
+			desc: "state files",
+			files: []string{
+				".pulumi/stacks/foo.json",
+				".pulumi/stacks/bar.json",
+			},
+			empty: false,
+		},
+		{
+			desc: "has pulumi meta file",
+			files: []string{
+				".pulumi/meta.yaml",
+			},
+			empty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			b := memblob.OpenBucket(nil)
+			ctx := context.Background()
+			for _, f := range tt.files {
+				require.NoError(t, b.WriteAll(ctx, f, []byte{}, nil))
+			}
+
+			got, err := isPulumiDirEmpty(ctx, b)
+			require.NoError(t, err)
+			assert.Equal(t, tt.empty, got)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -149,7 +149,8 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
 	// Expect the stack directory to have a checkpoint file for the stack.
-	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
+	_, err = os.Stat(filepath.Join(
+		fileStateDir, workspace.BookkeepingDir, workspace.StackDir, defaultProjectName, stackName+".json"))
 	assert.NoError(t, err)
 
 	b, err = currentBackend(ctx, nil, display.Options{})

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -68,3 +68,9 @@ fail without a --force parameter.`)
 
 var DebugGRPC = env.String("DEBUG_GRPC", `Enables debug tracing of Pulumi gRPC internals.
 The variable should be set to the log file to which gRPC debug traces will be sent.`)
+
+// Environment variables that affect the self-managed backend.
+var (
+	SelfManagedStateNoLegacyWarning = env.Bool("SELF_MANAGED_STATE_NO_LEGACY_WARNING",
+		"Disables the warning about legacy stack files mixed with project-scoped stack files.")
+)

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -73,4 +73,7 @@ The variable should be set to the log file to which gRPC debug traces will be se
 var (
 	SelfManagedStateNoLegacyWarning = env.Bool("SELF_MANAGED_STATE_NO_LEGACY_WARNING",
 		"Disables the warning about legacy stack files mixed with project-scoped stack files.")
+
+	SelfManagedStateLegacyLayout = env.Bool("SELF_MANAGED_STATE_LEGACY_LAYOUT",
+		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.")
 )

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -71,10 +71,14 @@ func TestConfigCommands(t *testing.T) {
 
 		// check that the nested config does not exist because we didn't use path
 		_, stderr := e.RunCommandExpectError("pulumi", "config", "get", "outer")
-		assert.Equal(t, "error: configuration key 'outer' not found for stack 'test'", strings.Trim(stderr, "\r\n"))
+		assert.Equal(t,
+			"error: configuration key 'outer' not found for stack 'test'",
+			strings.Trim(stderr, "\r\n"))
 
 		_, stderr = e.RunCommandExpectError("pulumi", "config", "get", "myList")
-		assert.Equal(t, "error: configuration key 'myList' not found for stack 'test'", strings.Trim(stderr, "\r\n"))
+		assert.Equal(t,
+			"error: configuration key 'myList' not found for stack 'test'",
+			strings.Trim(stderr, "\r\n"))
 
 		// set the nested config using --path
 		e.RunCommand("pulumi", "config", "set-all", "--path",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -531,7 +531,7 @@ func TestDestroyStackRef(t *testing.T) {
 
 	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
 	e.CWD = os.TempDir()
-	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "dev")
+	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "organization/large_resource_js/dev")
 }
 
 //nolint:paralleltest // uses parallel programtest

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -367,7 +367,7 @@ func TestStackBackups(t *testing.T) {
 		const stackName = "imulup"
 
 		// Get the path to the backup directory for this project.
-		backupDir, err := getStackProjectBackupDir(e, stackName)
+		backupDir, err := getStackProjectBackupDir(e, "stack_outputs", stackName)
 		assert.NoError(t, err, "getting stack project backup path")
 		defer func() {
 			if !t.Failed() {
@@ -560,8 +560,8 @@ func TestLocalStateLocking(t *testing.T) {
 
 // stackFileFormatAsserters returns a function to assert that the current file
 // format is for gzip and plain formats respectively.
-func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, stackName string) (func(), func()) {
-	stacksDir := filepath.Join(".pulumi", "stacks")
+func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, projectName, stackName string) (func(), func()) {
+	stacksDir := filepath.Join(".pulumi", "stacks", projectName)
 	pathStack := filepath.Join(stacksDir, stackName+".json")
 	pathStackGzip := pathStack + ".gz"
 	pathStackBak := pathStack + ".bak"
@@ -622,7 +622,7 @@ func TestLocalStateGzip(t *testing.T) { //nolint:paralleltest
 	e.RunCommand("yarn", "install")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
 
-	assertGzipFileFormat, assertPlainFileFormat := stackFileFormatAsserters(t, e, stackName)
+	assertGzipFileFormat, assertPlainFileFormat := stackFileFormatAsserters(t, e, "stack_dependencies", stackName)
 	switchGzipOff := func() { e.Setenv(filestate.PulumiFilestateGzipEnvVar, "0") }
 	switchGzipOn := func() { e.Setenv(filestate.PulumiFilestateGzipEnvVar, "1") }
 	pulumiUp := func() { e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview") }
@@ -691,10 +691,11 @@ func assertBackupStackFile(t *testing.T, stackName string, file os.DirEntry, bef
 	assert.True(t, parsedTime < after, "False: %v < %v", parsedTime, after)
 }
 
-func getStackProjectBackupDir(e *ptesting.Environment, stackName string) (string, error) {
+func getStackProjectBackupDir(e *ptesting.Environment, projectName, stackName string) (string, error) {
 	return filepath.Join(e.RootPath,
 		workspace.BookkeepingDir,
 		workspace.BackupDir,
+		projectName,
 		stackName,
 	), nil
 }


### PR DESCRIPTION
This re-adds project support back to the filestate backend
by implementing a new referenceStore: projectReferenceStore.

We will use this reference store for all new filestate stores.
Existing states will continue to use the legacyReferenceStore.

To accomplish this, and to plan for the future,
we introduce a 'meta.yaml' file inside the .pulumi directory.
This file contains metadata about the storage state.
Currently, this only holds a version number:

    # .pulumi/meta.yaml
    version: 1

Version 1 is the number we've chosen for the initial release
of project support.
If we ever need to make breaking changes to the storage protocol
we can bump the format version.

Notes:

- Stack references produced by filestate will shorten to
  just the stack name if the project name for the stack
  matches the currently selected project.

Testing:
Besides included unit tests,
we duplicate some existing tests that operate on fresh stores
to also run for legacy stores by emulating a pre-existing store.

Environment variables:
This adds two new environment variables that affect behavior:

- PULUMI_SELF_MANAGED_STATE_NO_LEGACY_WARNING:
  Suppresses the warning printed if a bucket contains both,
  project-scoped and legacy stack files.
- PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT:
  Uses the legacy layout for new buckets even if they're empty
  instead of project-scoped stacks.

Extracted from #12134

---

**Commits are split for reviewability.**
