### PR TITLE
{cli, filestate}: Add 'state upgrade' command

### DIFF
--- a/changelog/pending/20230316--cli-state--add-upgrade-subcommand-to-upgrade-a-pulumi-self-managed-state-to-use-project-layout.yaml
+++ b/changelog/pending/20230316--cli-state--add-upgrade-subcommand-to-upgrade-a-pulumi-self-managed-state-to-use-project-layout.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Add 'upgrade' subcommand to upgrade a Pulumi self-managed state to use project layout.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -652,18 +652,27 @@ func isDevVersion(s semver.Version) bool {
 }
 
 func confirmPrompt(prompt string, name string, opts display.Options) bool {
+	out := opts.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	in := opts.Stdin
+	if in == nil {
+		in = os.Stdin
+	}
+
 	if prompt != "" {
-		fmt.Print(
+		fmt.Fprint(out,
 			opts.Color.Colorize(
 				fmt.Sprintf("%s%s%s\n", colors.SpecAttention, prompt, colors.Reset)))
 	}
 
-	fmt.Print(
+	fmt.Fprint(out,
 		opts.Color.Colorize(
 			fmt.Sprintf("%sPlease confirm that this is what you'd like to do by typing `%s%s%s`:%s ",
 				colors.SpecAttention, colors.SpecPrompt, name, colors.SpecAttention, colors.Reset)))
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(in)
 	line, _ := reader.ReadString('\n')
 	return strings.TrimSpace(line) == name
 }

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateDeleteCommand())
 	cmd.AddCommand(newStateUnprotectCommand())
 	cmd.AddCommand(newStateRenameCommand())
+	cmd.AddCommand(newStateUpgradeCommand())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -1,0 +1,105 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	"github.com/spf13/cobra"
+)
+
+func newStateUpgradeCommand() *cobra.Command {
+	var sucmd stateUpgradeCmd
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Migrates the current backend to the latest supported version",
+		Long: `Migrates the current backend to the latest supported version
+
+This only has an effect on self-managed backends.
+`,
+		Args: cmdutil.NoArgs,
+		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			if err := sucmd.Run(commandContext()); err != nil {
+				return result.FromError(err)
+			}
+			return nil
+		}),
+	}
+	return cmd
+}
+
+// stateUpgradeCmd implements the 'pulumi state upgrade' command.
+type stateUpgradeCmd struct {
+	Stdin  io.Reader // defaults to os.Stdin
+	Stdout io.Writer // defaults to os.Stdout
+
+	// Used to mock out the currentBackend function for testing.
+	// Defaults to currentBackend function.
+	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+}
+
+func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
+	if cmd.Stdout == nil {
+		cmd.Stdout = os.Stdout
+	}
+	if cmd.Stdin == nil {
+		cmd.Stdin = os.Stdin
+	}
+
+	if cmd.currentBackend == nil {
+		cmd.currentBackend = currentBackend
+	}
+	currentBackend := cmd.currentBackend // shadow top-level currentBackend
+
+	dopts := display.Options{
+		Color:  cmdutil.GetGlobalColorization(),
+		Stdin:  cmd.Stdin,
+		Stdout: cmd.Stdout,
+	}
+
+	b, err := currentBackend(ctx, nil, dopts)
+	if err != nil {
+		return err
+	}
+
+	lb, ok := b.(filestate.Backend)
+	if !ok {
+		// Only the file state backend supports upgrades,
+		// but we don't want to error out here.
+		// Report the no-op.
+		fmt.Fprintln(cmd.Stdout, "Nothing to do")
+		return nil
+	}
+
+	prompt := "This will upgrade the current backend to the latest supported version.\n" +
+		"Older versions of Pulumi will not be able to read the new format.\n" +
+		"Are you sure you want to proceed?"
+	if !confirmPrompt(prompt, "yes", dopts) {
+		fmt.Fprintln(cmd.Stdout, "Upgrade cancelled")
+		return nil
+	}
+
+	return lb.Upgrade(ctx)
+}

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateUpgradeCommand_parseArgs(t *testing.T) {
+	t.Parallel()
+
+	// Parsing flags with a cobra.Command without running the command
+	// is a bit verbose.
+	// You have to run ParseFlags to parse the flags,
+	// then extract non-flag arguments with cmd.Flags().Args(),
+	// then run ValidateArgs to validate the positional arguments.
+
+	cmd := newStateUpgradeCommand()
+	args := []string{} // no arguments
+
+	require.NoError(t, cmd.ParseFlags(args))
+	args = cmd.Flags().Args() // non flag args
+	require.NoError(t, cmd.ValidateArgs(args))
+}
+
+func TestStateUpgradeCommand_parseArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		give    []string
+		wantErr string
+	}{
+		{
+			desc:    "unknown flag",
+			give:    []string{"--unknown"},
+			wantErr: "unknown flag: --unknown",
+		},
+		// Unfortunately,
+		// our cmdutil.NoArgs validator exits the program,
+		// causing the test to fail.
+		// Until we resolve this, we'll skip this test
+		// and rely on the positive test case
+		// to validate the arguments intead.
+		// {
+		// 	desc: "unexpected argument",
+		// 	give: []string{"arg"},
+		// 	wantErr: `unknown command "arg" for "upgrade"`,
+		// },
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newStateUpgradeCommand()
+			args := tt.give
+
+			// Errors can occur during flag parsing
+			// or argument validation.
+			// If there's no error on ParseFlags,
+			// expect one on ValidateArgs.
+			if err := cmd.ParseFlags(args); err != nil {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			args = cmd.Flags().Args() // non flag args
+			assert.ErrorContains(t, cmd.ValidateArgs(args), tt.wantErr)
+		})
+	}
+}
+
+func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	cmd := stateUpgradeCmd{
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return &stubFileBackend{
+				UpgradeF: func(context.Context) error {
+					called = true
+					return nil
+				},
+			}, nil
+		},
+		Stdin:  strings.NewReader("yes\n"),
+		Stdout: io.Discard,
+	}
+
+	err := cmd.Run(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, called, "Upgrade was never called")
+}
+
+func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
+	t.Parallel()
+
+	cmd := stateUpgradeCmd{
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return &stubFileBackend{
+				UpgradeF: func(context.Context) error {
+					t.Fatal("Upgrade should not be called")
+					return nil
+				},
+			}, nil
+		},
+		Stdin:  strings.NewReader("no\n"),
+		Stdout: io.Discard,
+	}
+
+	err := cmd.Run(context.Background())
+	require.NoError(t, err)
+}
+
+func TestStateUpgradeCommand_Run_unsupportedBackend(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := stateUpgradeCmd{
+		Stdout: &stdout,
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return &backend.MockBackend{}, nil
+		},
+	}
+
+	// Non-filestate backend is already up-to-date.
+	err := cmd.Run(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Nothing to do")
+}
+
+func TestStateUpgradeCmd_Run_backendError(t *testing.T) {
+	t.Parallel()
+
+	giveErr := errors.New("great sadness")
+	cmd := stateUpgradeCmd{
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return nil, giveErr
+		},
+	}
+
+	err := cmd.Run(context.Background())
+	assert.ErrorIs(t, err, giveErr)
+}
+
+type stubFileBackend struct {
+	filestate.Backend
+
+	UpgradeF func(context.Context) error
+}
+
+func (f *stubFileBackend) Upgrade(ctx context.Context) error {
+	return f.UpgradeF(ctx)
+}


### PR DESCRIPTION
Adds a new `pulumi state upgrade` command
that will upgrade the state for the current state storage
to the latest version supported by that format *concurrently*.

This is a no-op for httpstate,
but for filestate, this will migrate from unversioned storage
to the project-based versioned format.

It includes a confirmation message, informing users that
the state will be inaccessible from old CLIs after the upgrade.
They must type 'yes' to accept this.

<img width="428" alt="image" src="https://user-images.githubusercontent.com/41730/225780847-381bc9aa-a2a8-451e-bda1-2a942c4cb687.png">

A note on upgrade order:
We attempt to create the new meta.yaml file before moving the stack files.
This prevents us from leaving the bucket in an unreadable state
if we don't have write permission for the meta.yaml.

Extracted from #12134
