### PR TITLE
Pin Node to 18.x temporarily

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -124,7 +124,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
     "go": "1.20.x",
-    "nodejs": "19.7.x",
+    "nodejs": "18.x",
     "python": "3.10.x",
 }
 


### PR DESCRIPTION
Installing 19.7.0 is taking a long time and timing out in CI. See if using the latest 18.x release is any better. We temporarily lose coverage running on 19.x, but should get it back soon as a fix for the assert we're hitting on 19.x is being fast tracked.