### PR TITLE
Unpin Node back to 19.x

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -124,7 +124,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
     "go": "1.20.x",
-    "nodejs": "19.7.x",
+    "nodejs": "19.x",
     "python": "3.10.x",
 }
 


### PR DESCRIPTION
Node v19.8.1 was just released with the upstream fix for the internal assert we were hitting. This change unpins us back to 19.x.

Fixes #12434