### PR TITLE
Resources now inherit the `DeletedWith` Resource Option across SDKs

### DIFF
--- a/changelog/pending/20230315--engine--deletedwith-resourceoption-is-now-inherited-from-its-parent-across-sdks.yaml
+++ b/changelog/pending/20230315--engine--deletedwith-resourceoption-is-now-inherited-from-its-parent-across-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: DeletedWith ResourceOption is now inherited from its parent across SDKs.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -54,6 +54,9 @@ type stepGenerator struct {
 	creates  map[resource.URN]bool // set of URNs created in this deployment
 	sames    map[resource.URN]bool // set of URNs that were not changed in this deployment
 
+	// track the resource goals. This is used to set default resource options inherited from the resource's parent.
+	resourceGoals map[resource.URN]*resource.Goal
+
 	// set of URNs that would have been created, but were filtered out because the user didn't
 	// specify them with --target
 	skippedCreates map[resource.URN]bool
@@ -421,22 +424,51 @@ func (sg *stepGenerator) inheritedChildAlias(
 		aliasName)
 }
 
+// configureGoal mutates the passed goal to inherit the correct ResourceOptions from its parent.
+func (sg *stepGenerator) configureGoal(goal *resource.Goal) result.Result {
+	originalParent := goal.Parent
+
+	// Some goal settings are based on the parent settings so make sure our parent is correct.
+	p, res := sg.checkParent(goal.Parent, goal.Type)
+	if res != nil {
+		return res
+	}
+
+	if p != "" {
+		parentGoal, ok := sg.resourceGoals[p]
+		if !ok {
+			return result.Errorf("could not find parent goal %v (originally %v)", p, originalParent)
+		}
+
+		// Make resource goal inherit parent's default resource options if left unset.
+		if goal.DeletedWith == "" {
+			goal.DeletedWith = parentGoal.DeletedWith
+		}
+	}
+
+	goal.Parent = p
+	return nil
+}
+
 func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, result.Result) {
 	var invalid bool // will be set to true if this object fails validation.
 
 	goal := event.Goal()
 
-	// Some goal settings are based on the parent settings so make sure our parent is correct.
-	parent, res := sg.checkParent(goal.Parent, goal.Type)
+	// Configure Goal's parent and inherited ResourceOptions.
+	res := sg.configureGoal(goal)
 	if res != nil {
 		return nil, res
 	}
-	goal.Parent = parent
 
 	urn, res := sg.generateURN(goal.Parent, goal.Type, goal.Name)
 	if res != nil {
 		return nil, res
 	}
+
+	// Store the resource's goal. This is used to determine the parent's resource options to inherit
+	// by child resources.
+	sg.resourceGoals[urn] = goal
 
 	// Generate the aliases for this resource
 	aliases := make(map[resource.URN]struct{}, 0)
@@ -1921,6 +1953,7 @@ func newStepGenerator(
 		replaces:             make(map[resource.URN]bool),
 		updates:              make(map[resource.URN]bool),
 		deletes:              make(map[resource.URN]bool),
+		resourceGoals:        make(map[resource.URN]*resource.Goal),
 		skippedCreates:       make(map[resource.URN]bool),
 		pendingDeletes:       make(map[*resource.State]bool),
 		providers:            make(map[resource.URN]*resource.State),

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -360,3 +360,71 @@ func TestEngineDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceInheritsOptionsFromParent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		parentDeletedWith resource.URN
+		childDeletedWith  resource.URN
+		wantDeletedWith   resource.URN
+	}{
+		{
+			// Children missing DeletedWith should inherit DeletedWith
+			name:              "inherit",
+			parentDeletedWith: "parent-deleted-with",
+			childDeletedWith:  "",
+			wantDeletedWith:   "parent-deleted-with",
+		},
+		{
+			// Children with DeletedWith should not inherit DeletedWith
+			name:              "override",
+			parentDeletedWith: "parent-deleted-with",
+			childDeletedWith:  "this-value-is-set-and-should-not-change",
+			wantDeletedWith:   "this-value-is-set-and-should-not-change",
+		},
+		{
+			// Children with DeletedWith should not inherit empty DeletedWith.
+			name:              "keep",
+			parentDeletedWith: "",
+			childDeletedWith:  "this-value-is-set-and-should-not-change",
+			wantDeletedWith:   "this-value-is-set-and-should-not-change",
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			parentURN := resource.NewURN("a", "proj", "d:e:f", "a:b:c", "parent")
+			parentGoal := &resource.Goal{
+				Parent:      "",
+				Type:        parentURN.Type(),
+				Name:        parentURN.Name(),
+				DeletedWith: test.parentDeletedWith,
+			}
+
+			childURN := resource.NewURN("a", "proj", "d:e:f", "a:b:c", "child")
+			goal := &resource.Goal{
+				Parent:      parentURN,
+				Type:        childURN.Type(),
+				Name:        childURN.Name(),
+				DeletedWith: test.childDeletedWith,
+			}
+
+			sg := stepGenerator{
+				urns: map[resource.URN]bool{
+					parentURN: true,
+				},
+				resourceGoals: map[resource.URN]*resource.Goal{
+					parentURN: parentGoal,
+				},
+			}
+			err := sg.configureGoal(goal)
+
+			assert.Nil(t, err)
+			assert.Equal(t, goal.DeletedWith, test.wantDeletedWith)
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Tracking inheritance of resource options across SDKs is difficult to scale. This PR uses this information to set the `DeletedWith` when it is left unset by the user's program and there is a Parent resource to inherit the value from.

Alternate approach to https://github.com/pulumi/pulumi/pull/12420

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12158 

Needs follow up on: https://github.com/pulumi/pulumi-hugo/issues/2566

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
