### PR TITLE
Escape import names for python

### DIFF
--- a/changelog/pending/20230316--programgen-python--fix-handling-of-reserved-words-in-imports.yaml
+++ b/changelog/pending/20230316--programgen-python--fix-handling-of-reserved-words-in-imports.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Fix handling of reserved words in imports.

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -256,7 +256,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 		}
 		control := importSet[pkg]
 		if control.ImportAs {
-			imports = append(imports, fmt.Sprintf("import %s as %s", pkg, control.Pkg))
+			imports = append(imports, fmt.Sprintf("import %s as %s", pkg, EnsureKeywordSafe(control.Pkg)))
 		} else {
 			imports = append(imports, fmt.Sprintf("import %s", pkg))
 		}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -245,6 +245,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "throw-not-implemented",
 		Description: "Function notImplemented is compiled to a runtime error at call-site",
 	},
+	{
+		Directory:   "python-reserved",
+		Description: "Test python reserved words aren't used",
+		Skip:        allProgLanguages.Except("python"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/lambda-0.1.0.json
+++ b/pkg/codegen/testing/test/testdata/lambda-0.1.0.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "lambda",
+  "version": "0.1.0",
+  "//": "Test schema for checking python codegen when packages, modules and types have reserved names.",
+  "resources": {
+    "lambda:lambda:Lambda": {
+      "properties": {
+        "lambda": {
+          "type": "string"
+        }
+      },
+      "inputProperties": {
+        "lambda": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/python-reserved-pp/python-reserved.pp
+++ b/pkg/codegen/testing/test/testdata/python-reserved-pp/python-reserved.pp
@@ -1,0 +1,7 @@
+resource assert "lambda:lambda:Lambda" {
+    lambda = "dns"
+}
+
+output global {
+    value = assert.lambda
+}

--- a/pkg/codegen/testing/test/testdata/python-reserved-pp/python/python-reserved.py
+++ b/pkg/codegen/testing/test/testdata/python-reserved-pp/python/python-reserved.py
@@ -1,0 +1,5 @@
+import pulumi
+import pulumi_lambda as lambda_
+
+assert_ = lambda_.lambda_.Lambda("assert", lambda_="dns")
+pulumi.export("global", assert_.lambda_)

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -79,5 +79,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 
 		SchemaProvider{"other", "0.1.0"},
 		SchemaProvider{"synthetic", "1.0.0"},
+		SchemaProvider{"lambda", "0.1.0"},
 	)
 }


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/896

Adds a test that reserved words in schemas and PCL are handled correctly by python codegen.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
