### PR TITLE
Fix Download Pulumi Cron workflow

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -37,7 +37,7 @@ jobs:
         id: vars
         run: |
           echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
-          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >>" ${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - run: command -v pulumi
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}


### PR DESCRIPTION
The "Install Pulumi via script on macOS" job keeps failing with:

```
Run echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
  echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
  echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >>" ${GITHUB_OUTPUT}"
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
/Users/runner/work/_temp/fc2ea067-d0b7-4c2a-8d41-a190f04de3b6.sh: line 2:  /Users/runner/work/_temp/_runner_file_commands/set_output_021331ce-28c1-4ad9-b493-f4d0f88b5042: No such file or directory
```

Looks like it's due to an incorrect placement of a space character, which this change fixes.

Fixes #12384