### PR TITLE
[pcl/program-gen] Fix nodejs component config types

### DIFF
--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -403,11 +403,9 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program) error {
 func componentElementType(pclType model.Type) string {
 	switch pclType {
 	case model.BoolType:
-		return "bool"
-	case model.IntType:
-		return "int"
-	case model.NumberType:
-		return "double"
+		return "boolean"
+	case model.IntType, model.NumberType:
+		return "number"
 	case model.StringType:
 		return "string"
 	default:
@@ -417,7 +415,7 @@ func componentElementType(pclType model.Type) string {
 			return fmt.Sprintf("%s[]", elementType)
 		case *model.MapType:
 			elementType := componentElementType(pclType.ElementType)
-			return fmt.Sprintf("{ [k: string]: %s }", elementType)
+			return fmt.Sprintf("Record<string, pulumi.Input<%s>>", elementType)
 		case *model.OutputType:
 			// something is already an output
 			// get only the element type because we are wrapping these in Output<T> anyway

--- a/pkg/codegen/testing/test/testdata/components-pp/components.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/components.pp
@@ -2,6 +2,11 @@ component simpleComponent "./simpleComponent" {}
 
 component exampleComponent "./exampleComponent" {
     input = "doggo"
+    ipAddress = [127, 0, 0, 1]
+    cidrBlocks = {
+        "one" = "uno"
+        "two" = "dos"
+    }
 }
 
 output result {

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -8,6 +8,10 @@ namespace Components
     {
         [Input("input")]
         public Input<string> Input { get; set; } = null!;
+        [Input("cidrBlocks")]
+        public InputMap<string> CidrBlocks { get; set; } = null!;
+        [Input("ipAddress")]
+        public InputList<int> IpAddress { get; set; } = null!;
     }
 
     public class ExampleComponent : global::Pulumi.ComponentResource

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -8,6 +8,18 @@ return await Deployment.RunAsync(() =>
     var exampleComponent = new Components.ExampleComponent("exampleComponent", new()
     {
         Input = "doggo",
+        IpAddress = new[]
+        {
+            127,
+            0,
+            0,
+            1,
+        },
+        CidrBlocks = 
+        {
+            { "one", "uno" },
+            { "two", "dos" },
+        },
     });
 
     return new Dictionary<string, object?>

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -1,5 +1,8 @@
-config input string {
-}
+config input string { }
+
+config cidrBlocks "map(string)" { }
+
+config ipAddress "list(int)" { }
 
 resource password "random:index/randomPassword:RandomPassword" {
   length = 16

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -3,5 +3,17 @@ import { ExampleComponent } from "./exampleComponent";
 import { SimpleComponent } from "./simpleComponent";
 
 const simpleComponent = new SimpleComponent("simpleComponent");
-const exampleComponent = new ExampleComponent("exampleComponent", {input: "doggo"});
+const exampleComponent = new ExampleComponent("exampleComponent", {
+    input: "doggo",
+    ipAddress: [
+        127,
+        0,
+        0,
+        1,
+    ],
+    cidrBlocks: {
+        one: "uno",
+        two: "dos",
+    },
+});
 export const result = exampleComponent.result;

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -4,6 +4,8 @@ import { SimpleComponent } from "./simpleComponent";
 
 interface ExampleComponentArgs {
     input: pulumi.Input<string>,
+    cidrBlocks: pulumi.Input<Record<string, pulumi.Input<string>>>,
+    ipAddress: pulumi.Input<number[]>,
 }
 
 export class ExampleComponent extends pulumi.ComponentResource {


### PR DESCRIPTION
For nodejs PCL components, the config types were not entirely correct, now they are: `int` -> `number`, `bool` -> `boolean` and `{ [k: string]: Input<T> }` has now been refactored to `Record<string, Input<T>>`

Also added tests coverage for correctly binding types of `ConfigVariable` nodes in PCL components (examples of type `map` and `list`) also added more program bind tests to ensure config types are bound correctly

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
