### PR TITLE
Remove mutually exclusion between ReturnType and Outputs.

### DIFF
--- a/changelog/pending/20230320--cli-package--fix-bug-in-package-get-schema-subcommand-caused-it-to-bail-on-certain-providers.yaml
+++ b/changelog/pending/20230320--cli-package--fix-bug-in-package-get-schema-subcommand-caused-it-to-bail-on-certain-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix bug in `package get-schema` subcommand caused it to bail on certain providers.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1718,11 +1718,6 @@ func (funcSpec FunctionSpec) marshalFunctionSpec() (map[string]interface{}, erro
 		data["multiArgumentInputs"] = funcSpec.MultiArgumentInputs
 	}
 
-	if funcSpec.ReturnType != nil && funcSpec.Outputs != nil {
-		return nil, fmt.Errorf("cannot specify both Outputs and ReturnType when marshalling FunctionSpec" +
-			" because they are mutually exclusive")
-	}
-
 	if funcSpec.ReturnType != nil {
 		if funcSpec.ReturnType.ObjectTypeSpec != nil {
 			data["outputs"] = funcSpec.ReturnType.ObjectTypeSpec

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -184,28 +184,6 @@ func TestMarshalJSONFunctionSpecWithOutputs(t *testing.T) {
 	assert.Equal(t, expectedJSON, data)
 }
 
-func TestMarshalFunctionSpecErrorsWhenBothOutputsAndReturnTypePopulated(t *testing.T) {
-	t.Parallel()
-	functionSpec := &FunctionSpec{
-		Description: "Test function",
-		ReturnType: &ReturnTypeSpec{
-			TypeSpec: &TypeSpec{Type: "number"},
-		},
-		Outputs: &ObjectTypeSpec{
-			Type: "object",
-			Properties: map[string]PropertySpec{
-				"foo": {
-					TypeSpec: TypeSpec{Type: "string"},
-				},
-			},
-		},
-	}
-
-	_, err := json.Marshal(functionSpec)
-	assert.NotNil(t, err, "Unmarshalling should fail")
-	assert.True(t, strings.Contains(err.Error(), "cannot specify both Outputs and ReturnType"))
-}
-
 func TestMarshalYAMLFunctionSpec(t *testing.T) {
 	t.Parallel()
 	functionSpec := &FunctionSpec{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This commit removes an assertion in schema JSON marshaling that function return types are mutually exclusive with Outputs. This assertion was false; in practice, packages like AWS and DigitalOcean both have functions that provide both ReturnType and Outputs (perhaps inadvisedly). This assertion broke the `package get-schema` subcommand. _e.g._, `pulumi package get-schema aws@5.24.0` or
`pulumi package get-schema digitalocean@4.19.0`. Removing this assertion restored this functionality.
Examples of functions that provide both a ReturnType and Outputs:
* `DigitalOcean.get_account()`
* `DigitalOcean.get_app()`
* `DigitalOcean.get_certificate()`
* `aws.ses.getDomainIdentity()`

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12457

**Question:** Any tips on how to add a regression test to prevent this class of bug again? In this case, any kind of regression test against a major provider would have caught this bug; I don't think many users use `get-schema` but it looks like it was probably broken for about two months without anyone noticing.

Also, I'm not well versed enough in PCL/schemaland to verify the correctness of the initial assertion. This fix could be trivializing a more sophisticated issue. Please let me know if there's a "bigger iceberg" here that I'm missing :) 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
