### PR TITLE
ci-lint: Upgrade to golangci-lint v1.52

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.51
+  GOLANGCI_LINT_VERSION: v1.52
 
 jobs:
   golangci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,13 @@ issues:
     - linters: [revive]
       text: 'empty-block: this block is empty, you can remove it'
 
+    # We *frequently* use the term 'new' in the context of properties
+    # (new and old properties),
+    # and we rarely use the 'new' built-in function.
+    # It's fine to ignore these cases.
+    - linters: [revive]
+      text: 'redefines-builtin-id: redefinition of the built-in function new'
+
   exclude:
     # https://github.com/pulumi/pulumi/issues/9469
     - 'Name is deprecated: Name returns the variable or declaration name of the resource'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,13 @@ issues:
     - linters: [revive]
       text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
 
+    # staticcheck already has smarter checks for empty blocks.
+    # revive's empty-block linter has false positives.
+    # For example, as of writing this, the following is not allowed.
+    #   for foo() { }
+    - linters: [revive]
+      text: 'empty-block: this block is empty, you can remove it'
+
   exclude:
     # https://github.com/pulumi/pulumi/issues/9469
     - 'Name is deprecated: Name returns the variable or declaration name of the resource'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,12 @@ linters-settings:
     allow-unused: true
 
 issues:
+  exclude-rules:
+    # Don't warn on unused parameters.
+    # Parameter names are useful; replacing them with '_' is undesirable.
+    - linters: [revive]
+      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+
   exclude:
     # https://github.com/pulumi/pulumi/issues/9469
     - 'Name is deprecated: Name returns the variable or declaration name of the resource'

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -39,15 +39,15 @@ import (
 func getIndent(step engine.StepEventMetadata, seen map[resource.URN]engine.StepEventMetadata) int {
 	indent := 0
 	for p := step.Res.Parent; p != ""; {
-		if par, has := seen[p]; !has {
+		par, has := seen[p]
+		if !has {
 			// This can happen during deletes, since we delete children before parents.
 			// TODO[pulumi/pulumi#340]: we need to figure out how best to display this sequence; at the very
 			//     least, it would be ideal to preserve the indentation.
 			break
-		} else {
-			indent++
-			p = par.Res.Parent
 		}
+		indent++
+		p = par.Res.Parent
 	}
 	return indent
 }
@@ -713,8 +713,8 @@ func (p *propertyPrinter) printObjectPropertyDiff(key resource.PropertyKey, maxk
 	titleFunc := propertyTitlePrinter(string(key), maxkey)
 	if add, isadd := diff.Adds[key]; isadd {
 		p.printAdd(add, titleFunc)
-	} else if delete, isdelete := diff.Deletes[key]; isdelete {
-		p.printDelete(delete, titleFunc)
+	} else if del, isdelete := diff.Deletes[key]; isdelete {
+		p.printDelete(del, titleFunc)
 	} else if update, isupdate := diff.Updates[key]; isupdate {
 		p.printPropertyValueDiff(titleFunc, update)
 	} else if same := diff.Sames[key]; !p.summary && shouldPrintPropertyValue(same, p.planning) {
@@ -739,8 +739,8 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 
 			if add, isadd := a.Adds[i]; isadd {
 				elemPrinter.printAdd(add, elemTitleFunc)
-			} else if delete, isdelete := a.Deletes[i]; isdelete {
-				elemPrinter.printDelete(delete, elemTitleFunc)
+			} else if del, isdelete := a.Deletes[i]; isdelete {
+				elemPrinter.printDelete(del, elemTitleFunc)
 			} else if update, isupdate := a.Updates[i]; isupdate {
 				elemPrinter.printPropertyValueDiff(elemTitleFunc, update)
 			} else if same, issame := a.Sames[i]; issame && !p.summary {
@@ -979,7 +979,6 @@ func (p *propertyPrinter) printAssetsDiff(oldAssets, newAssets map[string]interf
 			titleFunc := propertyTitlePrinter("\""+oldName+"\"", maxkey)
 			p.indented(1).printDelete(assetOrArchiveToPropertyValue(oldAssets[oldName]), titleFunc)
 			i++
-			continue
 		} else {
 			contract.Assertf(addNew, "expected to print new asset")
 			newName := newNames[j]

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1811,22 +1811,22 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	for _, entry := range wireLevel {
 		switch entry.Capability {
 		case apitype.DeltaCheckpointUploads:
-			var cap apitype.DeltaCheckpointUploadsConfigV1
-			if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
+			var upcfg apitype.DeltaCheckpointUploadsConfigV1
+			if err := json.Unmarshal(entry.Configuration, &upcfg); err != nil {
 				msg := "decoding DeltaCheckpointUploadsConfig returned %w"
 				return capabilities{}, fmt.Errorf(msg, err)
 			}
 			parsed.deltaCheckpointUpdates = &apitype.DeltaCheckpointUploadsConfigV2{
-				CheckpointCutoffSizeBytes: cap.CheckpointCutoffSizeBytes,
+				CheckpointCutoffSizeBytes: upcfg.CheckpointCutoffSizeBytes,
 			}
 		case apitype.DeltaCheckpointUploadsV2:
 			if entry.Version == 2 {
-				var cap apitype.DeltaCheckpointUploadsConfigV2
-				if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
+				var upcfg apitype.DeltaCheckpointUploadsConfigV2
+				if err := json.Unmarshal(entry.Configuration, &upcfg); err != nil {
 					msg := "decoding DeltaCheckpointUploadsConfigV2 returned %w"
 					return capabilities{}, fmt.Errorf(msg, err)
 				}
-				parsed.deltaCheckpointUpdates = &cap
+				parsed.deltaCheckpointUpdates = &upcfg
 			}
 		default:
 			continue

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -441,22 +441,18 @@ func (pc *Client) Log3rdPartySecretsProviderDecryptionEvent(ctx context.Context,
 	secretName string,
 ) error {
 	req := apitype.Log3rdPartyDecryptionEvent{SecretName: secretName}
-	if err := pc.restCall(ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-decryption"),
-		nil, &req, nil); err != nil {
-		return err
-	}
-	return nil
+	return pc.restCall(
+		ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-decryption"),
+		nil, &req, nil)
 }
 
 func (pc *Client) LogBulk3rdPartySecretsProviderDecryptionEvent(ctx context.Context, stack StackIdentifier,
 	command string,
 ) error {
 	req := apitype.Log3rdPartyDecryptionEvent{CommandName: command}
-	if err := pc.restCall(ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-batch-decryption"), nil,
-		&req, nil); err != nil {
-		return err
-	}
-	return nil
+	return pc.restCall(
+		ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-batch-decryption"),
+		nil, &req, nil)
 }
 
 // BulkDecryptValue decrypts a ciphertext value in the context of the indicated stack.

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -110,11 +110,8 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := workspace.SetBackendConfigDefaultOrg(cloudURL, orgName); err != nil {
-				return err
-			}
 
-			return nil
+			return workspace.SetBackendConfigDefaultOrg(cloudURL, orgName)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -213,11 +213,7 @@ func createSecretsManager(
 	}
 
 	// Handle if the configuration changed any of EncryptedKey, etc
-	if err := saveProjectStackAfterSecretManger(stack, oldConfig, ps); err != nil {
-		return err
-	}
-
-	return nil
+	return saveProjectStackAfterSecretManger(stack, oldConfig, ps)
 }
 
 // createStack creates a stack with the given name, and optionally selects it as the current.

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -425,14 +425,14 @@ func (mod *modContext) withDocGenContext(dctx *docGenContext) *modContext {
 	if mod == nil {
 		return nil
 	}
-	copy := *mod
-	copy.docGenContext = dctx
-	children := make([]*modContext, 0, len(copy.children))
-	for _, c := range copy.children {
+	newctx := *mod
+	newctx.docGenContext = dctx
+	children := make([]*modContext, 0, len(newctx.children))
+	for _, c := range newctx.children {
 		children = append(children, c.withDocGenContext(dctx))
 	}
-	copy.children = children
-	return &copy
+	newctx.children = children
+	return &newctx
 }
 
 func resourceName(r *schema.Resource) string {

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -2148,8 +2148,8 @@ func (x *SplatExpression) GetTrailingTrivia() syntax.TriviaList {
 	if parens := x.Tokens.GetParentheses(); parens.Any() {
 		return parens.GetTrailingTrivia()
 	}
-	if close := x.Tokens.GetClose(); close != nil {
-		return close.TrailingTrivia
+	if closeTok := x.Tokens.GetClose(); closeTok != nil {
+		return closeTok.TrailingTrivia
 	}
 	return x.Tokens.GetStar().TrailingTrivia
 }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1364,13 +1364,13 @@ func (mod *modContext) genType(w io.Writer, obj *schema.ObjectType, input bool, 
 
 			properties = make([]*schema.Property, len(obj.Properties))
 			for i, p := range obj.Properties {
-				copy := *p
+				newp := *p
 				if required.Has(p.Name) {
-					copy.Type = codegen.RequiredType(&copy)
+					newp.Type = codegen.RequiredType(&newp)
 				} else {
-					copy.Type = codegen.OptionalType(&copy)
+					newp.Type = codegen.OptionalType(&newp)
 				}
-				properties[i] = &copy
+				properties[i] = &newp
 			}
 		}
 	}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -133,13 +133,13 @@ func (g *generator) GenConditionalExpression(w io.Writer, expr *model.Conditiona
 }
 
 func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
-	close := "]"
+	closedelim := "]"
 	if expr.Key != nil {
 		// Dictionary comprehension
 		//
 		// TODO(pdg): grouping
 		g.Fgenf(w, "{%.v: %.v", expr.Key, expr.Value)
-		close = "}"
+		closedelim = "}"
 	} else {
 		// List comprehension
 		g.Fgenf(w, "[%.v", expr.Value)
@@ -155,7 +155,7 @@ func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 		g.Fgenf(w, " if %.v", expr.Condition)
 	}
 
-	g.Fprint(w, close)
+	g.Fprint(w, closedelim)
 }
 
 func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {

--- a/pkg/codegen/report/report.go
+++ b/pkg/codegen/report/report.go
@@ -122,11 +122,11 @@ func WrapGen(reporter Reporter, title, language string, files []*syntax.File, f 
 func (r *reporter) Report(title, language string, files []*syntax.File, diags hcl.Diagnostics, err error) {
 	r.m.Lock()
 	defer r.m.Unlock()
-	if panicErr := recover(); panicErr != nil {
-		if panic, ok := panicErr.(error); ok {
-			err = fmt.Errorf("panic: %w", panic)
+	if panicVal := recover(); panicVal != nil {
+		if panicErr, ok := panicVal.(error); ok {
+			err = fmt.Errorf("panic: %w", panicErr)
 		} else {
-			err = fmt.Errorf("panic: %v", panicErr)
+			err = fmt.Errorf("panic: %v", panicVal)
 		}
 	}
 	failed := diags.HasErrors() || err != nil

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -207,9 +207,8 @@ func TestReferenceRenderer(t *testing.T) {
 
 		if _, ok := seenNames[name]; ok {
 			continue
-		} else {
-			seenNames[name] = struct{}{}
 		}
+		seenNames[name] = struct{}{}
 
 		t.Run(f.Name(), func(t *testing.T) {
 			t.Parallel()

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -787,14 +787,14 @@ func (pkg *Package) ImportLanguages(languages map[string]Language) error {
 		pkg.importedLanguages = map[string]struct{}{}
 	}
 
-	any := false
+	found := false
 	for lang := range languages {
 		if _, ok := pkg.importedLanguages[lang]; !ok {
-			any = true
+			found = true
 			break
 		}
 	}
-	if !any {
+	if !found {
 		return nil
 	}
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -503,11 +503,7 @@ func (rp *ResourcePlan) checkOutputs(
 	contract.Assertf(rp.Goal != nil, "resource plan goal must be set")
 
 	// Check that the property diffs meet the constraints set in the plan.
-	if err := checkDiff(oldOutputs, newOutputs, rp.Goal.OutputDiff); err != nil {
-		return err
-	}
-
-	return nil
+	return checkDiff(oldOutputs, newOutputs, rp.Goal.OutputDiff)
 }
 
 func (rp *ResourcePlan) checkGoal(

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -56,9 +56,9 @@ func TestSnapshotWithUpdatedResources(t *testing.T) {
 	assert.Same(t, s, s1)
 
 	s = s1.withUpdatedResources(func(r *resource.State) *resource.State {
-		copy := *r
-		copy.URN += "!"
-		return &copy
+		out := *r
+		out.URN += "!"
+		return &out
 	})
 	assert.NotSame(t, s, s1)
 	assert.Equal(t, s1.Resources[0].URN+"!", s.Resources[0].URN)

--- a/pkg/resource/deploy/state_builder.go
+++ b/pkg/resource/deploy/state_builder.go
@@ -105,9 +105,9 @@ func (sb *stateBuilder) updateURNSlice(
 	if !needsUpdate {
 		return false, slice
 	}
-	copy := make([]resource.URN, len(slice))
+	updated := make([]resource.URN, len(slice))
 	for i, urn := range slice {
-		copy[i] = update(urn)
+		updated[i] = update(urn)
 	}
-	return true, copy
+	return true, updated
 }

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -139,10 +139,10 @@ func (ctx *Context) Close() error {
 //
 // WARNING: Calling this function without ever closing `c` will leak go routines.
 func (ctx *Context) WithCancelChannel(c <-chan struct{}) *Context {
-	copy := *ctx
+	newCtx := *ctx
 	go func() {
 		<-c
-		copy.Close()
+		newCtx.Close()
 	}()
-	return &copy
+	return &newCtx
 }

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -139,24 +139,24 @@ func dialPlugin(portNum int, bin, prefix string, dialOptions []grpc.DialOption) 
 				err = grpc.Invoke(timeout, "", nil, nil, conn)
 				if err == nil {
 					break // successful connect
-				} else {
-					// We have an error; see if it's a known status and, if so, react appropriately.
-					status, ok := status.FromError(err)
-					if ok {
-						switch status.Code() {
-						case codes.Unavailable:
-							// The server is unavailable.  This is the Linux bug.  Wait a little and retry.
-							time.Sleep(time.Millisecond * 10)
-							continue // keep retrying
-						default:
-							// Since we sent "" as the method above, this is the expected response.  Ready to go.
-							break outer
-						}
-					}
-
-					// Unexpected error; get outta dodge.
-					return nil, errors.Wrapf(err, "%v plugin [%v] did not come alive", prefix, bin)
 				}
+
+				// We have an error; see if it's a known status and, if so, react appropriately.
+				status, ok := status.FromError(err)
+				if ok {
+					switch status.Code() {
+					case codes.Unavailable:
+						// The server is unavailable.  This is the Linux bug.  Wait a little and retry.
+						time.Sleep(time.Millisecond * 10)
+						continue // keep retrying
+					default:
+						// Since we sent "" as the method above, this is the expected response.  Ready to go.
+						break outer
+					}
+				}
+
+				// Unexpected error; get outta dodge.
+				return nil, errors.Wrapf(err, "%v plugin [%v] did not come alive", prefix, bin)
 			}
 			break
 		}

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -111,28 +111,28 @@ type ArrayDiff struct {
 
 // Len computes the length of this array, taking into account adds, deletes, sames, and updates.
 func (diff *ArrayDiff) Len() int {
-	len := 0
+	length := 0
 	for i := range diff.Adds {
-		if i+1 > len {
-			len = i + 1
+		if i+1 > length {
+			length = i + 1
 		}
 	}
 	for i := range diff.Deletes {
-		if i+1 > len {
-			len = i + 1
+		if i+1 > length {
+			length = i + 1
 		}
 	}
 	for i := range diff.Sames {
-		if i+1 > len {
-			len = i + 1
+		if i+1 > length {
+			length = i + 1
 		}
 	}
 	for i := range diff.Updates {
-		if i+1 > len {
-			len = i + 1
+		if i+1 > length {
+			length = i + 1
 		}
 	}
-	return len
+	return length
 }
 
 // IgnoreKeyFunc is the callback type for Diff's ignore option.

--- a/sdk/go/common/util/deepcopy/copy.go
+++ b/sdk/go/common/util/deepcopy/copy.go
@@ -24,10 +24,10 @@ func Copy(i interface{}) interface{} {
 	if i == nil {
 		return nil
 	}
-	return copy(reflect.ValueOf(i)).Interface()
+	return deepCopy(reflect.ValueOf(i)).Interface()
 }
 
-func copy(v reflect.Value) reflect.Value {
+func deepCopy(v reflect.Value) reflect.Value {
 	if !v.IsValid() {
 		return v
 	}
@@ -49,14 +49,14 @@ func copy(v reflect.Value) reflect.Value {
 	case reflect.Interface:
 		rv := reflect.New(typ).Elem()
 		if !v.IsNil() {
-			rv.Set(copy(v.Elem()))
+			rv.Set(deepCopy(v.Elem()))
 		}
 		return rv
 	case reflect.Ptr:
 		if v.IsNil() {
 			return reflect.New(typ).Elem()
 		}
-		elem := copy(v.Elem())
+		elem := deepCopy(v.Elem())
 		if elem.CanAddr() {
 			return elem.Addr()
 		}
@@ -66,7 +66,7 @@ func copy(v reflect.Value) reflect.Value {
 	case reflect.Array:
 		rv := reflect.New(typ).Elem()
 		for i := 0; i < v.Len(); i++ {
-			rv.Index(i).Set(copy(v.Index(i)))
+			rv.Index(i).Set(deepCopy(v.Index(i)))
 		}
 		return rv
 	case reflect.Slice:
@@ -74,7 +74,7 @@ func copy(v reflect.Value) reflect.Value {
 		if !v.IsNil() {
 			rv.Set(reflect.MakeSlice(typ, v.Len(), v.Cap()))
 			for i := 0; i < v.Len(); i++ {
-				rv.Index(i).Set(copy(v.Index(i)))
+				rv.Index(i).Set(deepCopy(v.Index(i)))
 			}
 		}
 		return rv
@@ -84,7 +84,7 @@ func copy(v reflect.Value) reflect.Value {
 			rv.Set(reflect.MakeMap(typ))
 			iter := v.MapRange()
 			for iter.Next() {
-				rv.SetMapIndex(copy(iter.Key()), copy(iter.Value()))
+				rv.SetMapIndex(deepCopy(iter.Key()), deepCopy(iter.Value()))
 			}
 		}
 		return rv
@@ -92,7 +92,7 @@ func copy(v reflect.Value) reflect.Value {
 		rv := reflect.New(typ).Elem()
 		for i := 0; i < typ.NumField(); i++ {
 			if f := rv.Field(i); f.CanSet() {
-				f.Set(copy(v.Field(i)))
+				f.Set(deepCopy(v.Field(i)))
 			}
 		}
 		return rv

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -239,11 +239,7 @@ func StoreCredentials(creds Credentials) error {
 		return fmt.Errorf("marshalling credentials object: %w", err)
 	}
 
-	if err := lockedfile.Write(credsFile, bytes.NewReader(raw), 0o600); err != nil {
-		return err
-	}
-
-	return nil
+	return lockedfile.Write(credsFile, bytes.NewReader(raw), 0o600)
 }
 
 type BackendConfig struct {

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -566,11 +566,7 @@ func (host *goLanguageHost) InstallDependencies(
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))
 
-	if err := closer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return closer.Close()
 }
 
 func (host *goLanguageHost) About(ctx context.Context, req *pbempty.Empty) (*pulumirpc.AboutResponse, error) {
@@ -703,9 +699,5 @@ func (host *goLanguageHost) RunPlugin(
 		return err
 	}
 
-	if err := closer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return closer.Close()
 }

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -922,7 +922,7 @@ func TestExportResource(t *testing.T) {
 		},
 	}
 
-	var any Output
+	var anyout Output
 	err := RunErr(func(ctx *Context) error {
 		var res testResource2
 		err := ctx.RegisterResource("test:resource:type", "resA", &testResource2Inputs{
@@ -930,14 +930,14 @@ func TestExportResource(t *testing.T) {
 		}, &res)
 		assert.NoError(t, err)
 
-		any = Any(&res)
+		anyout = Any(&res)
 
-		ctx.Export("any", any)
+		ctx.Export("any", anyout)
 		return nil
 	}, WithMocks("project", "stack", mocks))
 	assert.NoError(t, err)
 
-	state := any.getState()
+	state := anyout.getState()
 	assert.NotNil(t, state.value)
 }
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -775,11 +775,7 @@ func (host *nodeLanguageHost) InstallDependencies(
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))
 
-	if err := closer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return closer.Close()
 }
 
 func (host *nodeLanguageHost) About(ctx context.Context, req *pbempty.Empty) (*pulumirpc.AboutResponse, error) {

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -860,11 +860,7 @@ func (host *pythonLanguageHost) InstallDependencies(
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))
 
-	if err := closer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return closer.Close()
 }
 
 func (host *pythonLanguageHost) About(ctx context.Context, req *pbempty.Empty) (*pulumirpc.AboutResponse, error) {
@@ -1008,9 +1004,5 @@ func (host *pythonLanguageHost) RunPlugin(
 		return fmt.Errorf("problem executing plugin program (could not run language executor): %w", err)
 	}
 
-	if err := closer.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return closer.Close()
 }

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -227,13 +227,13 @@ func InstallDependencies(ctx context.Context, root, venvDir string, showOutput b
 func InstallDependenciesWithWriters(ctx context.Context,
 	root, venvDir string, showOutput bool, infoWriter, errorWriter io.Writer,
 ) error {
-	print := func(message string) {
+	printmsg := func(message string) {
 		if showOutput {
 			fmt.Fprintf(infoWriter, "%s\n", message)
 		}
 	}
 
-	print("Creating virtual environment...")
+	printmsg("Creating virtual environment...")
 
 	// Create the virtual environment by running `python -m venv <venvDir>`.
 	if !filepath.IsAbs(venvDir) {
@@ -251,7 +251,7 @@ func InstallDependenciesWithWriters(ctx context.Context,
 		return fmt.Errorf("creating virtual environment at %s: %w", venvDir, err)
 	}
 
-	print("Finished creating virtual environment")
+	printmsg("Finished creating virtual environment")
 
 	runPipInstall := func(errorMsg string, arg ...string) error {
 		pipCmd := VirtualEnvCommand(venvDir, "python", append([]string{"-m", "pip", "install"}, arg...)...)
@@ -281,14 +281,14 @@ func InstallDependenciesWithWriters(ctx context.Context,
 		return nil
 	}
 
-	print("Updating pip, setuptools, and wheel in virtual environment...")
+	printmsg("Updating pip, setuptools, and wheel in virtual environment...")
 
 	err = runPipInstall("updating pip, setuptools, and wheel", "--upgrade", "pip", "setuptools", "wheel")
 	if err != nil {
 		return err
 	}
 
-	print("Finished updating")
+	printmsg("Finished updating")
 
 	// If `requirements.txt` doesn't exist, exit early.
 	requirementsPath := filepath.Join(root, "requirements.txt")
@@ -296,14 +296,14 @@ func InstallDependenciesWithWriters(ctx context.Context,
 		return nil
 	}
 
-	print("Installing dependencies in virtual environment...")
+	printmsg("Installing dependencies in virtual environment...")
 
 	err = runPipInstall("installing dependencies", "-r", "requirements.txt")
 	if err != nil {
 		return err
 	}
 
-	print("Finished installing dependencies")
+	printmsg("Finished installing dependencies")
 
 	return nil
 }

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -279,12 +279,12 @@ func synchronouslyDo(t testing.TB, lockfile string, timeout time.Duration, fn fu
 			if err := mutex.Lock(); err != nil {
 				time.Sleep(1 * time.Second)
 				continue
-			} else {
-				defer func() {
-					assert.NoError(t, mutex.Unlock())
-				}()
-				break
 			}
+
+			defer func() {
+				assert.NoError(t, mutex.Unlock())
+			}()
+			break
 		}
 
 		// Context may hav expired


### PR DESCRIPTION
The new release pulls in revive 1.3 which changed its default ruleset.
With the new rule set, here are the failures we see:

```
% cat pkg/lint.txt sdk/lint.txt tests/lint.txt | cut -d: -f4 | sort | uniq -c
  39  empty-block
  11  if-return
  67  redefines-builtin-id
   5  superfluous-else
 589  unused-parameter
 ```

This PR upgrades pu/pu to the latest release of golangci-lint,
and either fixes or excludes linters on a case-by-case basis.

Each commit is individually reviewable,
and elaborates on the rationale for disabling linter rules,
but in short:

- unused-parameter: parameter names are useful,
  and the benefit we'd get from fixing 500+ instances of this
  is questionable
- empty-block: revive has undesirable false positives on this
- redefines-builtin-id: we keep this rule except for 'new',
  which we use frequently in the context of 'old' and 'new'
  properties.

The last commit in this PR fixes all issues not ignored above,
and includes the full list of fixed issues in the commit message.
