### PR TITLE
[sdk/python] Fix hang due to component children cycles

### DIFF
--- a/changelog/pending/20230327--sdk-python--fix-hang-due-to-component-children-cycles.yaml
+++ b/changelog/pending/20230327--sdk-python--fix-hang-due-to-component-children-cycles.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix hang due to component children cycles

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -1115,7 +1115,15 @@ async def _add_dependency(
 
     from .. import ComponentResource  # pylint: disable=import-outside-toplevel
 
+    # Local component resources act as aggregations of their descendents.
+    # Rather than adding the component resource itself, each child resource
+    # is added as a dependency.
     if isinstance(res, ComponentResource) and not res._remote:
+        # If `res` is the same as `from_resource`, exit early to avoid depending on
+        # children that haven't been registered yet.
+        if res is from_resource:
+            return
+
         # Copy the set before iterating so that any concurrent child additions during
         # the dependency computation (which is async, so can be interleaved with other
         # operations including child resource construction which adds children to this

--- a/sdk/python/lib/test/langhost/component_dependencies/__main__.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/__main__.py
@@ -39,3 +39,8 @@ resG = MyResource("resG", {"propA": comp1})
 resH = MyResource("resH", {"propA": comp2})
 resI = MyResource("resI", {"propA": resG})
 resJ = MyResource("resJ", {}, ResourceOptions(depends_on=[comp2]))
+
+first = MyComponent("first")
+firstChild = MyResource("firstChild", {}, ResourceOptions(parent=first))
+second = MyComponent("second", ResourceOptions(parent=first, depends_on=[first]))
+myresource = MyResource("myresource", {}, ResourceOptions(parent=second))

--- a/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
@@ -20,7 +20,7 @@ class ComponentDependenciesTest(LanghostTest):
     def test_component_dependencies(self):
         self.run_test(
             program=path.join(self.base_path(), "component_dependencies"),
-            expected_resource_count=12)
+            expected_resource_count=16)
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
@@ -59,6 +59,8 @@ class ComponentDependenciesTest(LanghostTest):
         elif name == "resJ":
             self.assertListEqual(_dependencies, ["resD", "resE"], msg=f"{name}._dependencies")
             self.assertDictEqual(_property_deps, {}, msg=f"{name}._property_deps")
+        elif name == "second":
+            self.assertListEqual(_dependencies, ["firstChild"], msg=f"{name}._dependencies")
 
         return {
             "urn": name,

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -203,3 +203,22 @@ class MergeResourceOptions(unittest.TestCase):
         assert opts2.protect is True
         opts3 = ResourceOptions.merge(opts2, ResourceOptions())
         assert opts3.protect is True
+
+# Regression test for https://github.com/pulumi/pulumi/issues/12032
+@pulumi.runtime.test
+def test_parent_and_depends_on_are_the_same_12032():
+    mocks.set_mocks(MinimalMocks())
+
+    parent = pulumi.ComponentResource("pkg:index:first", "first")
+    child = pulumi.ComponentResource(
+        "pkg:index:second",
+        "second",
+        opts=pulumi.ResourceOptions(parent=parent, depends_on=[parent]),
+    )
+
+    # This would freeze before the fix.
+    pulumi.CustomResource(
+        "foo:bar:baz",
+        "myresource",
+        opts=pulumi.ResourceOptions(parent=child),
+    )


### PR DESCRIPTION
When a resource depends on a local component resource, rather than setting the component resource itself as a dependency, each of the component's descendants is added as a dependency. This can lead to hangs when cycles are introduced.

For example, consider the following parent/child hierarchy, where `ComponentA` is the parent of `ComponentB` and `ComponentB` is the parent of `CustomC`:

```
ComponentA
    |
ComponentB
    |
 CustomC
```

If `ComponentB` specifies it has a dependency on `ComponentA`, the following takes place as part determining the full set of transitive dependencies:

1. `ComponentA`  is a component resource so it isn't added as a dependency, its children are.
2. `ComponentA` has one child: `ComponentB`
3. `ComponentB`  is a component resource so it isn't added as a dependency, its children are.
4. `ComponentB` has one child: `CustomC`, a custom resource.
5. Since `CustomC` is a custom resource, it is added to the set of dependencies.
6. We try to await its URN, but we'll never get it because `RegisterResource` hasn't yet been called for it. And we hang waiting.

To address this, skip looking at a component's children if it is the component from which the dependency is being added.

In the example, with the fix, at step 3 the dependency expansion will stop: we won't look at `ComponentB`'s children because we're adding the dependency from `ComponentB`.

Fixes #12032

Related to #12515
Related to #12516