### PR TITLE
[pcl/program-gen] Implement description as comments or docstring for config variables

### DIFF
--- a/changelog/pending/20230321--programgen-dotnet-go-nodejs-python--implement-description-as-comments-or-docstring-for-config-variables-in-program-gen.yaml
+++ b/changelog/pending/20230321--programgen-dotnet-go-nodejs-python--implement-description-as-comments-or-docstring-for-config-variables-in-program-gen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Implement description as comments or docstring for config variables in program-gen

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -517,6 +517,13 @@ func (g *generator) genComponentPreamble(w io.Writer, componentName string, comp
 			g.Indented(func() {
 				for _, configVar := range configVars {
 					inputType := componentInputType(configVar.Type())
+					if configVar.Description != "" {
+						g.Fgenf(w, "%s/// <summary>\n", g.Indent)
+						for _, line := range strings.Split(configVar.Description, "\n") {
+							g.Fgenf(w, "%s/// %s\n", g.Indent, line)
+						}
+						g.Fgenf(w, "%s/// </summary>\n", g.Indent)
+					}
 					g.Fprintf(w, "%s[Input(\"%s\")]\n", g.Indent, configVar.LogicalName())
 					g.Fprintf(w, "%spublic %s %s { get; set; } = ",
 						g.Indent,
@@ -1149,6 +1156,12 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	getOrRequire := "Get"
 	if v.DefaultValue == nil {
 		getOrRequire = "Require"
+	}
+
+	if v.Description != "" {
+		for _, line := range strings.Split(v.Description, "\n") {
+			g.Fgenf(w, "%s// %s\n", g.Indent, line)
+		}
 	}
 
 	name := makeValidIdentifier(v.Name())

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -891,6 +891,12 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 		getOrRequire = "Require"
 	}
 
+	if v.Description != "" {
+		for _, line := range strings.Split(v.Description, "\n") {
+			g.Fgenf(w, "%s// %s\n", g.Indent, line)
+		}
+	}
+
 	name := makeValidIdentifier(v.Name())
 	if v.DefaultValue == nil {
 		g.Fgenf(w, "%s := cfg.%s%s(\"%s\")\n", name, getOrRequire, getType, v.LogicalName())

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -464,6 +464,13 @@ func (g *generator) genComponentResourceDefinition(w io.Writer, componentName st
 				if configVar.DefaultValue == nil {
 					optional = ""
 				}
+				if configVar.Description != "" {
+					g.Fgenf(w, "%s/**\n", g.Indent)
+					for _, line := range strings.Split(configVar.Description, "\n") {
+						g.Fgenf(w, "%s * %s\n", g.Indent, line)
+					}
+					g.Fgenf(w, "%s */\n", g.Indent)
+				}
 
 				g.Fgenf(w, "%s", g.Indent)
 				typeName := componentInputType(configVar.Type())
@@ -944,6 +951,12 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	getOrRequire := "get"
 	if v.DefaultValue == nil {
 		getOrRequire = "require"
+	}
+
+	if v.Description != "" {
+		for _, line := range strings.Split(v.Description, "\n") {
+			g.Fgenf(w, "%s// %s\n", g.Indent, line)
+		}
 	}
 
 	name := makeValidIdentifier(v.Name())

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -333,6 +333,19 @@ func getStringAttrValue(attr *model.Attribute) (string, *hcl.Diagnostic) {
 	}
 }
 
+// Returns the value of constant boolean attribute
+func getBooleanAttributeValue(attr *model.Attribute) (bool, *hcl.Diagnostic) {
+	switch lit := attr.Syntax.Expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		if lit.Val.Type() != cty.Bool {
+			return false, boolAttributeError(attr)
+		}
+		return lit.Val.True(), nil
+	default:
+		return false, boolAttributeError(attr)
+	}
+}
+
 // declareNode declares a single top-level node. If a node with the same name has already been declared, it returns an
 // appropriate diagnostic.
 func (b *binder) declareNode(name string, n Node) hcl.Diagnostics {

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -119,6 +119,25 @@ func (b *binder) bindConfigVariable(node *ConfigVariable) hcl.Diagnostics {
 			node.logicalName = logicalName
 		}
 	}
+
+	if descriptionAttr, ok := block.Body.Attribute("description"); ok {
+		description, diags := getStringAttrValue(descriptionAttr)
+		if diags != nil {
+			diagnostics = diagnostics.Append(diags)
+		} else {
+			node.Description = description
+		}
+	}
+
+	if nullableAttr, ok := block.Body.Attribute("nullable"); ok {
+		nullable, diags := getBooleanAttributeValue(nullableAttr)
+		if diags != nil {
+			diagnostics = diagnostics.Append(diags)
+		} else {
+			node.Nullable = nullable
+		}
+	}
+
 	node.Definition = block
 	return diagnostics
 }

--- a/pkg/codegen/pcl/config.go
+++ b/pkg/codegen/pcl/config.go
@@ -32,7 +32,9 @@ type ConfigVariable struct {
 	Definition *model.Block
 	// The default value for the config variable, if any.
 	DefaultValue model.Expression
-
+	Description  string
+	// Whether the config variable is nullable
+	Nullable bool
 	// The name visible to API calls related to the config. Used as the argument when
 	// fetching config variables. Must not be modified during code generation to ensure
 	// that valid config calls don't become invalid.

--- a/pkg/codegen/pcl/diagnostics.go
+++ b/pkg/codegen/pcl/diagnostics.go
@@ -80,3 +80,7 @@ func duplicateBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
 func stringAttributeError(attr *model.Attribute) *hcl.Diagnostic {
 	return errorf(attr.Syntax.Expr.Range(), "attribute %v must be a string literal", attr.Name)
 }
+
+func boolAttributeError(attr *model.Attribute) *hcl.Diagnostic {
+	return errorf(attr.Syntax.Expr.Range(), "attribute %v must be a boolean literal", attr.Name)
+}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -568,6 +568,11 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	}
 	g.genTemps(w, temps)
 
+	if v.Description != "" {
+		for _, line := range strings.Split(v.Description, "\n") {
+			g.Fgenf(w, "%s# %s\n", g.Indent, line)
+		}
+	}
 	name := PyName(v.Name())
 	g.Fgenf(w, "%s%s = config.%s%s(\"%s\")\n", g.Indent, name, getOrRequire, getType, v.LogicalName())
 	if defaultValue != nil {

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/azure-sa.pp
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/azure-sa.pp
@@ -1,7 +1,9 @@
 config storageAccountNameParam string {
+    description = "The name of the storage account"
 }
 
 config resourceGroupNameParam string {
+    description = "The name of the resource group"
 }
 
 resourceGroupVar = invoke("azure:core/getResourceGroup:getResourceGroup", {

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/dotnet/azure-sa.cs
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/dotnet/azure-sa.cs
@@ -5,7 +5,9 @@ using Azure = Pulumi.Azure;
 return await Deployment.RunAsync(() => 
 {
     var config = new Config();
+    // The name of the storage account
     var storageAccountNameParam = config.Require("storageAccountNameParam");
+    // The name of the resource group
     var resourceGroupNameParam = config.Require("resourceGroupNameParam");
     var resourceGroupVar = Azure.Core.GetResourceGroup.Invoke(new()
     {

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/go/azure-sa.go
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/go/azure-sa.go
@@ -10,7 +10,9 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		cfg := config.New(ctx, "")
+		// The name of the storage account
 		storageAccountNameParam := cfg.Require("storageAccountNameParam")
+		// The name of the resource group
 		resourceGroupNameParam := cfg.Require("resourceGroupNameParam")
 		resourceGroupVar, err := core.LookupResourceGroup(ctx, &core.LookupResourceGroupArgs{
 			Name: resourceGroupNameParam,

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/nodejs/azure-sa.ts
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/nodejs/azure-sa.ts
@@ -2,7 +2,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
 
 const config = new pulumi.Config();
+// The name of the storage account
 const storageAccountNameParam = config.require("storageAccountNameParam");
+// The name of the resource group
 const resourceGroupNameParam = config.require("resourceGroupNameParam");
 const resourceGroupVar = azure.core.getResourceGroup({
     name: resourceGroupNameParam,

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/python/azure-sa.py
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/python/azure-sa.py
@@ -2,7 +2,9 @@ import pulumi
 import pulumi_azure as azure
 
 config = pulumi.Config()
+# The name of the storage account
 storage_account_name_param = config.require("storageAccountNameParam")
+# The name of the resource group
 resource_group_name_param = config.require("resourceGroupNameParam")
 resource_group_var = azure.core.get_resource_group(name=resource_group_name_param)
 location_param = config.get("locationParam")

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -13,6 +13,7 @@ namespace Components
         public Input<string> Input { get; set; } = null!;
         /// <summary>
         /// The main CIDR blocks for the VPC
+        /// It is a map of strings
         /// </summary>
         [Input("cidrBlocks")]
         public InputMap<string> CidrBlocks { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -6,8 +6,14 @@ namespace Components
 {
     public class ExampleComponentArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// A simple input
+        /// </summary>
         [Input("input")]
         public Input<string> Input { get; set; } = null!;
+        /// <summary>
+        /// The main CIDR blocks for the VPC
+        /// </summary>
         [Input("cidrBlocks")]
         public InputMap<string> CidrBlocks { get; set; } = null!;
         [Input("ipAddress")]

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -1,6 +1,10 @@
-config input string { }
+config input string {
+    description = "A simple input"
+}
 
-config cidrBlocks "map(string)" { }
+config cidrBlocks "map(string)" {
+    description = "The main CIDR blocks for the VPC"
+}
 
 config ipAddress "list(int)" { }
 

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -3,7 +3,7 @@ config input string {
 }
 
 config cidrBlocks "map(string)" {
-    description = "The main CIDR blocks for the VPC"
+    description = "The main CIDR blocks for the VPC\nIt is a map of strings"
 }
 
 config ipAddress "list(int)" { }

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -9,6 +9,7 @@ interface ExampleComponentArgs {
     input: pulumi.Input<string>,
     /**
      * The main CIDR blocks for the VPC
+     * It is a map of strings
      */
     cidrBlocks: pulumi.Input<Record<string, pulumi.Input<string>>>,
     ipAddress: pulumi.Input<number[]>,

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -3,7 +3,13 @@ import * as random from "@pulumi/random";
 import { SimpleComponent } from "./simpleComponent";
 
 interface ExampleComponentArgs {
+    /**
+     * A simple input
+     */
     input: pulumi.Input<string>,
+    /**
+     * The main CIDR blocks for the VPC
+     */
     cidrBlocks: pulumi.Input<Record<string, pulumi.Input<string>>>,
     ipAddress: pulumi.Input<number[]>,
 }


### PR DESCRIPTION
# Description

This PR adds support for the `description` field to be provided for `ConfigVariable` PCL nodes. This allows 1:1 mapping from terraform's [Input Variable Documentation](https://developer.hashicorp.com/terraform/language/values/variables#input-variable-documentation)

 - For main/root program config variables (all languages): the description becomes a comment above the config declaration
 - For component args (dotnet / nodejs) the description becomes a doc string 

> Also adding `nullable` field but not using it in program-gen yet!

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
