### PR TITLE
sdk/cmdutil: Support bailing from RunFunc

### DIFF
--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -15,9 +15,8 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 
 	"github.com/spf13/cobra"
 
@@ -41,12 +40,12 @@ func newCancelCmd() *cobra.Command {
 			"\n" +
 			"After this command completes successfully, the stack will be ready for further\n" +
 			"updates.",
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {
-					return result.Error("only one of --stack or argument stack name may be specified, not both")
+					return errors.New("only one of --stack or argument stack name may be specified, not both")
 				}
 
 				stack = args[0]
@@ -58,7 +57,7 @@ func newCancelCmd() *cobra.Command {
 
 			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			// Ensure the user really wants to do this.
@@ -66,12 +65,12 @@ func newCancelCmd() *cobra.Command {
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
 			if cmdutil.Interactive() && (!yes && !confirmPrompt(prompt, stackName, opts)) {
 				fmt.Println("confirmation declined")
-				return result.Bail()
+				return cmdutil.ErrBail
 			}
 
 			// Cancel the update.
 			if err := s.Backend().CancelCurrentUpdate(ctx, s.Ref()); err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			msg := fmt.Sprintf(

--- a/pkg/cmd/pulumi/env.go
+++ b/pkg/cmd/pulumi/env.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 func newEnvCmd() *cobra.Command {
@@ -39,7 +38,7 @@ func newEnvCmd() *cobra.Command {
 		// unhide once most existing variables are using the new env var framework and
 		// show up here.
 		Hidden: !env.Experimental.Value(),
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			table := cmdutil.Table{
 				Headers: []string{"Variable", "Description", "Value"},
 			}
@@ -52,7 +51,8 @@ func newEnvCmd() *cobra.Command {
 			}
 			cmdutil.PrintTable(table)
 			if foundError {
-				return result.Error("Invalid environmental variables found")
+				cmdutil.Diag().Errorf(diag.Message("", "Invalid environmental variables found"))
+				return cmdutil.ErrBail
 			}
 			return nil
 		}),

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
 )
 
@@ -34,13 +33,13 @@ func newPolicyRmCmd() *cobra.Command {
 		Short: "Removes a Policy Pack from a Pulumi organization",
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			policyPack, err := requirePolicyPack(ctx, args[0])
 			if err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			var version *string
@@ -55,7 +54,7 @@ func newPolicyRmCmd() *cobra.Command {
 			prompt := fmt.Sprintf("This will permanently remove the '%s' policy!", args[0])
 			if !yes && !confirmPrompt(prompt, args[0], opts) {
 				fmt.Println("confirmation declined")
-				return result.Bail()
+				return cmdutil.ErrBail
 			}
 
 			// Attempt to remove the Policy Pack.
@@ -63,7 +62,7 @@ func newPolicyRmCmd() *cobra.Command {
 				VersionTag: version, Scopes: cancellationScopes,
 			})
 			if err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -15,10 +15,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 
 	"github.com/spf13/cobra"
 
@@ -45,13 +46,13 @@ func newStackRmCmd() *cobra.Command {
 			"`destroy` command for removing a resources, as this is a distinct operation.\n" +
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {
-					return result.Error("only one of --stack or argument stack name may be specified, not both")
+					return errors.New("only one of --stack or argument stack name may be specified, not both")
 				}
 				stack = args[0]
 			}
@@ -62,33 +63,34 @@ func newStackRmCmd() *cobra.Command {
 
 			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
 			if !yes && !confirmPrompt(prompt, s.Ref().String(), opts) {
 				fmt.Println("confirmation declined")
-				return result.Bail()
+				return cmdutil.ErrBail
 			}
 
 			hasResources, err := s.Remove(ctx, force)
 			if err != nil {
 				if hasResources {
-					return result.Errorf(
+					cmdutil.Diag().Errorf(diag.Message("",
 						"'%s' still has resources; removal rejected. Possible actions:\n"+
 							"- Make sure that '%[1]s' is the stack that you want to destroy\n"+
 							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`\n"+
-							"- Run `pulumi stack rm --force` to override this error", s.Ref())
+							"- Run `pulumi stack rm --force` to override this error"), s.Ref())
+					return cmdutil.ErrBail
 				}
-				return result.FromError(err)
+				return err
 			}
 
 			if !preserveConfig {
 				// Blow away stack specific settings if they exist. If we get an ENOENT error, ignore it.
 				if _, path, err := workspace.DetectProjectStackPath(s.Ref().Name().Q()); err == nil {
 					if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
-						return result.FromError(err)
+						return err
 					}
 				}
 			}

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -28,6 +28,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
+// ErrBail indicates that the command failed,
+// but has already printed its error message.
+//
+// If a command returns ErrBail,
+// we will exit the program with a non-zero exit code
+// but will not print an error message.
+var ErrBail = result.ErrBail
+
 // DetailedError extracts a detailed error message, including stack trace, if there is one.
 func DetailedError(err error) string {
 	msg := errorMessage(err)
@@ -91,6 +99,9 @@ func runPostCommandHooks(c *cobra.Command, args []string) error {
 // callstack which might prohibit reaping of child processes, resources, etc.  And we wish to avoid
 // the default Cobra unhandled error behavior, because it is formatted incorrectly and needlessly
 // prints usage.
+//
+// If run returns [ErrBail], we will not print an error message,
+// but will still be a non-zero exit code.
 func RunFunc(run func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) {
 	return RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 		if err := run(cmd, args); err != nil {

--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -31,7 +31,7 @@ func TestRunFunc_Bail(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := exec.Command(exe, "-test.run=^TestFakeCommand$")
-	cmd.Env = []string{"TEST_FAKE=1"}
+	cmd.Env = append(os.Environ(), "TEST_FAKE=1")
 
 	// Write output to the buffer and to the test logger.
 	var buff bytes.Buffer

--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -1,0 +1,69 @@
+package cmdutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunFunc_Bail(t *testing.T) {
+	t.Parallel()
+
+	// Verifies that a use of RunFunc that returns ErrBail
+	// will cause the program to exit with a non-zero exit code
+	// without printing an error message.
+	//
+	// Unfortunately, we can't test this directly,
+	// because the `os.Exit` call in RunResultFunc.
+	//
+	// Instead, we'll re-run the test binary,
+	// and have it run TestFakeCommand.
+	// We'll verify the output of that binary instead.
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cmd := exec.Command(exe, "-test.run=^TestFakeCommand$")
+	cmd.Env = []string{"TEST_FAKE=1"}
+
+	// Write output to the buffer and to the test logger.
+	var buff bytes.Buffer
+	output := io.MultiWriter(&buff, iotest.LogWriter(t))
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Run()
+	require.Error(t, err)
+	if exitErr := new(exec.ExitError); assert.ErrorAs(t, err, &exitErr) {
+		assert.NotZero(t, exitErr.ExitCode())
+	}
+
+	assert.Empty(t, buff.String())
+}
+
+//nolint:paralleltest // not a real test
+func TestFakeCommand(t *testing.T) {
+	if os.Getenv("TEST_FAKE") != "1" {
+		// This is not a real test.
+		// It's a fake test that we'll run as a subprocess
+		// to verify that the RunFunc function works correctly.
+		// See TestRunFunc_Bail for more details.
+		return
+	}
+
+	cmd := &cobra.Command{
+		Run: RunFunc(func(cmd *cobra.Command, args []string) error {
+			return ErrBail
+		}),
+	}
+	err := cmd.Execute()
+	// Unreachable: RunFunc should have called os.Exit.
+	assert.Fail(t, "unreachable", "RunFunc should have called os.Exit: %v", err)
+}

--- a/sdk/go/common/util/result/result_test.go
+++ b/sdk/go/common/util/result/result_test.go
@@ -1,0 +1,84 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromError(t *testing.T) {
+	t.Parallel()
+
+	errSimilarToBail := errors.New("bail")
+	errSadness := errors.New("great sadness")
+
+	tests := []struct {
+		desc string
+		give error
+
+		// Properties of the Result:
+		wantIsBail bool
+		wantErr    error
+	}{
+		{
+			desc:       "bail",
+			give:       ErrBail,
+			wantIsBail: true,
+			wantErr:    nil,
+		},
+		{
+			// an error with the same message as ErrBail
+			// should not be considered a bail.
+			desc:    "similar to bail",
+			give:    errSimilarToBail,
+			wantErr: errSimilarToBail,
+		},
+		{
+			desc:       "wraps bail",
+			give:       fmt.Errorf("wraps bail: %w", ErrBail),
+			wantIsBail: true,
+			wantErr:    nil,
+		},
+		{
+			desc:       "other error",
+			give:       errSadness,
+			wantIsBail: false,
+			wantErr:    errSadness,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res := FromError(tt.give)
+			assert.Equal(t, tt.wantIsBail, res.IsBail(), "Result.IsBail")
+			assert.ErrorIs(t, res.Error(), tt.wantErr, "Result.Error")
+		})
+	}
+}
+
+func TestFromError_nil(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		FromError(nil)
+	})
+}


### PR DESCRIPTION
**Background**

The result.Result type is used by our CLI implementation
to communicate how we want to exit the program.

Most `result.Result` values (build from errors with `result.FromError`)
cause the program to print the message to stderr
and exit the program with exit code -1.
The exception is `result.Bail()`,
which indicates that we've already printed the error message,
and we simply need to `exit(-1)` now.

Our CLI command implementation use `cmdutil.RunResultFunc`
which takes a `func(...) result.Result` to implement this logic.

`cmdutil` additionally includes a `cmdutil.RunFunc`
which takes a `func(...) error` and wraps it in `RunResultFunc`,
relying on `result.FromError` for the conversion:

    func RunFunc(run func(...) error) func(...) {
        return RunResultFunc(func(...) result.Result {
            if err := run(...); err != nil {
                return result.FromError(err)
            }
            return nil
        })
    }

**Problem**

In CLI contexts where we're using an `error`,
and we want to print an error message to the user and exit,
it's desirable to use diag.Sink to print the message to the user
with the appropriate level (error, warning, etc.)
and exit without printing anything else.

However, the only way to do that currently is
by converting that function to return `result.Result`,
turn all error returns to `result.FromError`,
and then return `result.Bail()`.

**Solution**

This change introduces a `result.ErrBail` error
that gets converted into a `result.Bail()`
when it passes through `result.FromError`.

It allows commands implementations that use `error`
to continue returning errors and still provide an ideal CLI experience.

It relies on `errors.Is` for matching, so even if an intermediate layer
wraps the error with `fmt.Errorf("..: %w", ErrBail)`,
we'll recognize the request to bail.

This includes an alias to `result.ErrBail` in `cmdutil.ErrBail`
for convenience.
Some packages can omit importing `result.Result` entirely.

**Testing**

Besides unit tests, this includes an end-to-end test
for using RunResultFunc with ErrBail.
The test operates by putting the mock behavior in a fake test,
and re-running the test binary to execute *just that test*.

**Demonstration**

This change also ports the following commands to use ErrBail:
cancel, convert, env, policy rm, stack rm.

These command implementations are simple
and were able to switch easily,
without bubbling into a change to a bunch of other code.

For a couple of the commands,
this also lets us put the multi-line, formatted error message
in an error log entry with cmdutil.Diag().Errorf,
and bail cleanly.
This will give us a nice color-coded message for those cases.
