### PR TITLE
Support WhoAmI in automation api for old CLI versions

### DIFF
--- a/changelog/pending/20230322--auto-go-nodejs-python--fix-calling-whoami-against-pre-3-58-clis.yaml
+++ b/changelog/pending/20230322--auto-go-nodejs-python--fix-calling-whoami-against-pre-3-58-clis.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go,nodejs,python
+  description: Fix calling WhoAmI against pre 3.58 CLIs.

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -289,7 +289,7 @@ export type PulumiFn = () => Promise<Record<string, any> | void>;
  */
 export interface WhoAmIResult {
     user: string;
-    url: string;
+    url?: string;
     organizations?: string[];
 }
 

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -14,12 +14,12 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Callable, Mapping, Any, List, Optional
+from typing import Any, Callable, List, Mapping, Optional
 
-from ._stack_settings import StackSettings
-from ._project_settings import ProjectSettings
 from ._config import ConfigMap, ConfigValue
 from ._output import OutputMap
+from ._project_settings import ProjectSettings
+from ._stack_settings import StackSettings
 from ._tag import TagMap
 
 PulumiFn = Callable[[], None]
@@ -56,11 +56,14 @@ class WhoAmIResult:
     """The currently logged-in Pulumi identity."""
 
     user: str
-    url: str
+    url: Optional[str]
     organizations: Optional[List[str]]
 
     def __init__(
-        self, user: str, url: str, organizations: Optional[List[str]] = None
+        self,
+        user: str,
+        url: Optional[str] = None,
+        organizations: Optional[List[str]] = None,
     ) -> None:
         self.user = user
         self.url = url

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -14,8 +14,7 @@
 
 """The Pulumi Python SDK."""
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 VERSION = "3.0.0"
 
@@ -48,7 +47,7 @@ setup(name='pulumi',
           'grpcio==1.51.3',
           'dill~=0.3',
           'six~=1.12',
-          'semver~=2.8',
+          'semver~=2.13',
           'pyyaml~=6.0'
       ],
       zip_safe=False)

--- a/sdk/python/lib/test/automation/data/testproj/Pulumi.int_test_983828.yaml
+++ b/sdk/python/lib/test/automation/data/testproj/Pulumi.int_test_983828.yaml
@@ -1,0 +1,4 @@
+config:
+  testproj:bar: abc
+  testproj:buzz:
+    secure: AAABAII+gDfUcpoMRLtxD5xT9Nj99gx5gycEreX7Kd0s+XQfUEk=

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,7 +4,7 @@ protobuf~=4.21
 grpcio==1.51.3
 dill~=0.3
 six~=1.12
-semver~=2.8
+semver~=2.13
 pyyaml~=6.0
 
 # Dev packages only needed during development.

--- a/sdk/python/stubs/semver/__init__.pyi
+++ b/sdk/python/stubs/semver/__init__.pyi
@@ -3,9 +3,15 @@ class VersionInfo:
     minor: int
     patch: int
 
+    def __init__(self, major, minor=0, patch=0, prerelease=None, build=None) -> None:
+        ...
+
     def compare(self, other: VersionInfo) -> int:
         ...
 
     @staticmethod
     def parse(version: str) -> VersionInfo:
+        ...
+
+    def __ge__(self, other: VersionInfo) -> bool:
         ...


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix automation `WhoAmI` calls for old versions of the CLI without "--json" support.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
