### PR TITLE
Closes PulumiCtx in Go AutoAPI during Up.

### DIFF
--- a/changelog/pending/20230322--auto-go--fix-memory-leak-in-stack-up-in-automation-api.yaml
+++ b/changelog/pending/20230322--auto-go--fix-memory-leak-in-stack-up-in-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fix memory leak in stack.Up() in Automation API.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1163,6 +1163,7 @@ func (s *languageRuntimeServer) Run(ctx context.Context, req *pulumirpc.RunReque
 	if err != nil {
 		return nil, err
 	}
+	defer pulumiCtx.Close()
 
 	err = func() (err error) {
 		defer func() {


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds a deferred close call to a PulumiCtx that previously went unclosed. Because it was unclosed, it consistently leaked a Goroutine.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12463

## Evaluation

Because memory leaks are hard to test in an automated fashion, I created a sample program to evaluate the fix. This program runs using the Go Automation API.

```golang
package main

import (
	"bufio"
	"context"
	"fmt"
	"os"
	"runtime"

	"github.com/pulumi/pulumi/sdk/v3/go/auto"
	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
)

func main() {
	// Print the number of Goroutines when we start.
	fmt.Printf("Goroutine Count: %d\n", runtime.NumGoroutine())

	deployFunc := func(ctx *pulumi.Context) error {
		return nil
	}

	ctx := context.Background()
	projectName := "inlineTest"
	stackName := "dev"
	outputFile := "experimental-group.csv"
	stack, err := auto.UpsertStackInlineSource(ctx, stackName, projectName, deployFunc)
	if err != nil {
		fmt.Printf("Error: %v\n", err)
		return
	}
	f, err := os.Create(outputFile)
	if err != nil {
		fmt.Printf("%v\n", err)
		return
	}

	w := bufio.NewWriter(f)
	null, err := os.OpenFile("/dev/null", os.O_APPEND|os.O_WRONLY, 0o644)
	if err != nil {
		fmt.Printf("%v\n", err)
		return
	}

	for i := 1; ; i++ {
		// Print the number of Goroutines again on every
		// 50th iteration.
		if i%5 == 0 {
			iteration := i
			goroutineCount := runtime.NumGoroutine()
			fmt.Printf("Iteration #%d\n", i)
			fmt.Printf("Goroutine Count: %d\n", goroutineCount)
			line := fmt.Sprintf("%d,%d\n", iteration, goroutineCount)
			_, err := w.WriteString(line)
			if err != nil {
				fmt.Printf("%v", err)
				return
			}
			if err = w.Flush(); err != nil {
				fmt.Printf("%v\n", err)
				return
			}
		}
		// Run another empty program in a loop.
		// wire up our update to stream progress to stdout
		stdoutStreamer := optup.ProgressStreams(null)
		// run the update to deploy our s3 website
		_, err := stack.Up(ctx, stdoutStreamer)
		// _, err := stack.Up(ctx, nil)
		if err != nil {
			fmt.Printf("Failed to update stack: %v\n\n", err)
			os.Exit(1)
		}
	}
}
```

Running this program before and after the fix has been applied shows that the number of Goroutines goes from an increasing number to a constant value. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
