### PR TITLE
Skip tests on .version changes.

### DIFF
--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -10,8 +10,8 @@ name: Pull Request
 on:
   pull_request:
     paths:
-      - '!.version'
-
+      - '**' # Run if any file changes…
+      - '!.version' # …except if only this file changes and nothing else.
 jobs:
   no-op:
     name: Skip CI on .version changes

--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -1,0 +1,21 @@
+# This file fires for the same events as `on-pr.yml`,
+# except where `on-pr.yml` skips over changes in paths-ignore,
+# this event fires on the inverse.
+# This is an officially blessed pattern for handling skipped but
+# required status checks. See 
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+# for more information.
+name: Pull Request
+
+on:
+  pull_request:
+    paths:
+      - '!.version'
+
+jobs:
+  no-op:
+    name: Skip CI on .version changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip CI on .version changes
+        run: echo 'No need to run CI tests when only .version changes'

--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -9,8 +9,8 @@ name: Pull Request
 
 on:
   pull_request:
-    paths:
-      - '**' # Run if any file changes…
+    paths-ignore:
+      - '**' # Skip all files…
       - '!.version' # …except if only this file changes and nothing else.
 jobs:
   no-op:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -10,7 +10,8 @@ permissions:
 
 on:
   pull_request:
-
+    paths-ignore:
+      - '.version'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

I noticed it can take some time to cut a minor version release because we have to wait for CI four times.
1. PR to bump `.version` to the intended minor version.
2. Once approved and CI is successful, wait for bors.
3. Freeze the version with another change to `.version`, waiting for CI to approve the PR.
4. Once approved, wait for bors to merge it.

This change skips status checks for PRs that only change `.version` while also side-stepping the "required status checks" rule for branch protection. I've tested this out in a personal repo to confirm it won't become a release blocker next week. 

After this PR, we will skip steps 1 and 3, reducing release time by about 52 minutes on average.

Once this is merged, we can double-check this works by making a test PR modifying the `.version` file.