### PR TITLE
[macOS] cli: Suggest brew update in upgrade message

### DIFF
--- a/changelog/pending/20230323--cli--improve-cli-upgrade-instructions-for-macos.yaml
+++ b/changelog/pending/20230323--cli--improve-cli-upgrade-instructions-for-macos.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Improve CLI upgrade instructions for macOS.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -535,7 +535,7 @@ func getUpgradeCommand() string {
 		logging.V(3).Infof("error determining if the running executable was installed with brew: %s", err)
 	}
 	if isBrew {
-		return "$ brew upgrade pulumi"
+		return "$ brew update && brew upgrade pulumi"
 	}
 
 	if filepath.Dir(exe) != filepath.Join(curUser.HomeDir, workspace.BookkeepingDir, "bin") {


### PR DESCRIPTION
On macOS, the message informing users
that a new version of Pulumi is available
takes the form:

```
warning: A new version of Pulumi is available. To upgrade from version '3.58.0' to '3.59.0', run
   $ brew upgrade pulumi
```

If the user has not run `brew update` in a while,
this will not actually perform the upgrade.

Make the command more copy-paste friendly
by also suggesting a `brew update`.
