### PR TITLE
Fix emission of dup types breaking Go compilation when chunking >500 …

### DIFF
--- a/changelog/pending/20230323--sdkgen-go--fixes-emission-of-dup-types-breaking-go-compilation-when-chunking-500-helper-types.yaml
+++ b/changelog/pending/20230323--sdkgen-go--fixes-emission-of-dup-types-breaking-go-compilation-when-chunking-500-helper-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fixes emission of dup types breaking Go compilation when chunking >500 helper types

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3817,8 +3817,14 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			}
 			types = types[len(chunk):]
 
+			// To avoid duplicating collection types into every chunk, only pass known to chunk i=0.
+			known := sortedKnownTypes
+			if i != 0 {
+				known = nil
+			}
+
 			buffer := &bytes.Buffer{}
-			err := generateTypes(buffer, pkg, chunk, sortedKnownTypes)
+			err := generateTypes(buffer, pkg, chunk, known)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -419,6 +419,7 @@ func TestTitle(t *testing.T) {
 }
 
 func TestRegressTypeDuplicatesInChunking(t *testing.T) {
+	t.Parallel()
 	pkgSpec := schema.PackageSpec{
 		Name:      "test",
 		Version:   "0.0.1",

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
 )
 
@@ -415,4 +416,110 @@ func TestTitle(t *testing.T) {
 	assert.Equal("WaldoThudFred", Title("waldo-ThudFred"))
 	assert.Equal("WaldoThud_Fred", Title("waldo-Thud_Fred"))
 	assert.Equal("WaldoThud_Fred", Title("waldo-thud_Fred"))
+}
+
+func TestRegressTypeDuplicatesInChunking(t *testing.T) {
+	pkgSpec := schema.PackageSpec{
+		Name:      "test",
+		Version:   "0.0.1",
+		Resources: make(map[string]schema.ResourceSpec),
+		Types: map[string]schema.ComplexTypeSpec{
+			"test:index:PolicyStatusAutogenRules": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"imageExtractors": {
+							TypeSpec: schema.TypeSpec{
+								Type: "object",
+								AdditionalProperties: &schema.TypeSpec{
+									Type: "array",
+									Items: &schema.TypeSpec{
+										Type: "object",
+										Ref:  "#/types/test:index:Im",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"test:index:Im": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"path": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{"path"},
+				},
+			},
+		},
+	}
+
+	// Need to ref PolicyStatusAutogenRules in input position to trigger the code path.
+	pkgSpec.Resources["test:index:Res"] = schema.ResourceSpec{
+		InputProperties: map[string]schema.PropertySpec{
+			"a": {
+				TypeSpec: schema.TypeSpec{
+					Ref: "#/types/test:index:PolicyStatusAutogenRules",
+				},
+			},
+		},
+	}
+
+	// Need to have N>500 but N<1000 to obtain 2 chunks.
+	for i := 0; i < 750; i++ {
+		ttok := fmt.Sprintf("test:index:Typ%d", i)
+		pkgSpec.Types[ttok] = schema.ComplexTypeSpec{
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Type:     "object",
+				Required: []string{"x"},
+				Properties: map[string]schema.PropertySpec{
+					"x": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		}
+	}
+
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	pkg, diags, err := schema.BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	t.Logf("%v", diags.Error())
+	require.False(t, diags.HasErrors())
+
+	fs, err := GeneratePackage("tests", pkg)
+	require.NoError(t, err)
+
+	for f := range fs {
+		t.Logf("Generated %v", f)
+	}
+
+	// Expect to see two chunked files (chunking at n=500).
+	assert.Contains(t, fs, "test/pulumiTypes.go")
+	assert.Contains(t, fs, "test/pulumiTypes1.go")
+	assert.NotContains(t, fs, "test/pulumiTypes2.go")
+
+	// The types defined in the chunks should be mutually exclusive.
+	typedefs := func(s string) []string {
+		var types []string
+		for _, line := range strings.Split(s, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "type") {
+				types = append(types, line)
+			}
+		}
+		sort.Strings(types)
+		return types
+	}
+
+	typedefs1 := typedefs(string(fs["test/pulumiTypes.go"]))
+	typedefs2 := typedefs(string(fs["test/pulumiTypes1.go"]))
+
+	for _, typ := range typedefs1 {
+		assert.NotContains(t, typedefs2, typ)
+	}
+
+	for _, typ := range typedefs2 {
+		assert.NotContains(t, typedefs1, typ)
+	}
 }


### PR DESCRIPTION
…helper types

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description


Fixes https://github.com/pulumi/crd2pulumi/issues/108


Fix emission of dup types breaking Go compilation when chunking >500 helper types.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
