### PR TITLE
go/common: Make DefaultSink thread-safe

### DIFF
--- a/changelog/pending/20230323--sdk--make-default-logger-thread-safe.yaml
+++ b/changelog/pending/20230323--sdk--make-default-logger-thread-safe.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk
+  description: Make default logger thread-safe.

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -65,11 +66,34 @@ type FormatOptions struct {
 func DefaultSink(stdout io.Writer, stderr io.Writer, opts FormatOptions) Sink {
 	contract.Requiref(stdout != nil, "stdout", "must not be nil")
 	contract.Requiref(stderr != nil, "stderr", "must not be nil")
+
+	stdoutMu := &sync.Mutex{}
+	stderrMu := &sync.Mutex{}
+	func() {
+		defer func() {
+			// The == check below can panic if stdout and stderr are not comparable.
+			// If that happens, ignore the panic and use separate mutexes.
+			_ = recover()
+		}()
+
+		if stdout == stderr {
+			// If stdout and stderr point to the same stream,
+			// use the same mutex for them.
+			stderrMu = stdoutMu
+		}
+	}()
+
+	// Wrap the stdout and stderr writers in a mutex
+	// to ensure that we don't interleave output.
+	stdout = &syncWriter{Writer: stdout, mu: stdoutMu}
+	stderr = &syncWriter{Writer: stderr, mu: stderrMu}
+
 	// Discard debug output by default unless requested.
 	debug := io.Discard
 	if opts.Debug {
 		debug = stdout
 	}
+
 	return newDefaultSink(opts, map[Severity]io.Writer{
 		Debug:   debug,
 		Info:    stdout,
@@ -129,7 +153,7 @@ func (d *defaultSink) Debugf(diag *Diag, args ...interface{}) {
 	if logging.V(9) {
 		logging.V(9).Infof("defaultSink::Debug(%v)", msg[:len(msg)-1])
 	}
-	fmt.Fprint(d.writers[Debug], msg)
+	d.print(Debug, msg)
 }
 
 func (d *defaultSink) Infof(diag *Diag, args ...interface{}) {
@@ -137,7 +161,7 @@ func (d *defaultSink) Infof(diag *Diag, args ...interface{}) {
 	if logging.V(5) {
 		logging.V(5).Infof("defaultSink::Info(%v)", msg[:len(msg)-1])
 	}
-	fmt.Fprint(d.writers[Info], msg)
+	d.print(Info, msg)
 }
 
 func (d *defaultSink) Infoerrf(diag *Diag, args ...interface{}) {
@@ -145,7 +169,7 @@ func (d *defaultSink) Infoerrf(diag *Diag, args ...interface{}) {
 	if logging.V(5) {
 		logging.V(5).Infof("defaultSink::Infoerr(%v)", msg[:len(msg)-1])
 	}
-	fmt.Fprint(d.writers[Infoerr], msg)
+	d.print(Infoerr, msg)
 }
 
 func (d *defaultSink) Errorf(diag *Diag, args ...interface{}) {
@@ -153,7 +177,7 @@ func (d *defaultSink) Errorf(diag *Diag, args ...interface{}) {
 	if logging.V(5) {
 		logging.V(5).Infof("defaultSink::Error(%v)", msg[:len(msg)-1])
 	}
-	fmt.Fprint(d.writers[Error], msg)
+	d.print(Error, msg)
 }
 
 func (d *defaultSink) Warningf(diag *Diag, args ...interface{}) {
@@ -161,7 +185,11 @@ func (d *defaultSink) Warningf(diag *Diag, args ...interface{}) {
 	if logging.V(5) {
 		logging.V(5).Infof("defaultSink::Warning(%v)", msg[:len(msg)-1])
 	}
-	fmt.Fprint(d.writers[Warning], msg)
+	d.print(Warning, msg)
+}
+
+func (d *defaultSink) print(sev Severity, msg string) {
+	fmt.Fprint(d.writers[sev], msg)
 }
 
 func (d *defaultSink) Stringify(sev Severity, diag *Diag, args ...interface{}) (string, string) {
@@ -202,4 +230,18 @@ func (d *defaultSink) Stringify(sev Severity, diag *Diag, args ...interface{}) (
 
 	// If colorization was requested, compile and execute the directives now.
 	return d.opts.Color.Colorize(prefix.String()), d.opts.Color.Colorize(filtered)
+}
+
+// syncWriter wraps an io.Writer and ensures that all writes are synchronized
+// with a mutex.
+type syncWriter struct {
+	io.Writer
+
+	mu *sync.Mutex
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.Writer.Write(p)
 }


### PR DESCRIPTION
diag.DefaultSink is not safe for concurrent use.
Whether we use it with os.File or with a bytes.Buffer,
both targets do not synchronize their writes,
so this leaves room for interleaving of messages.
Making diag.DefaultSink thread-safe is generally desirable,
but is also a requirement for #12438
so that it can run upgrades concurrently
and print warnings as tasks fail.

This makes the result of DefaultSink thread-safe
by adding a mutex around the targeted stdout and stderr.

Note:
As a special case, when stdout and stderr are the same
we want to use the same mutex for them.
This matches the behavior of [os/exec.Cmd][1]

    // If Stdout and Stderr are the same writer, and have a type that can
    // be compared with ==, at most one goroutine at a time will call Write.
    Stdout io.Writer
    Stderr io.Writer

  [1]: https://pkg.go.dev/os/exec#Cmd

A writer implementation can be anything,
and is not guaranteed to be comparable with `==`.
When that happens, the `==` will panic.
To prevent regressions, we have to handle that case
and treat uncomparable writers as different.
This is also similar to how os/exec does it:
https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/os/exec/exec.go;l=475
