### PR TITLE
[pcl/program-gen] Support object-typed config variables for PCL components

### DIFF
--- a/changelog/pending/20230323--programgen-dotnet-nodejs--object-typed-config-variables-for-components.yaml
+++ b/changelog/pending/20230323--programgen-dotnet-nodejs--object-typed-config-variables-for-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,nodejs
+  description: Object-typed config variables for components

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -375,7 +375,7 @@ type programUsings struct {
 }
 
 func (g *generator) usingStatements(program *pcl.Program) programUsings {
-	systemUsings := codegen.NewStringSet("System.Collections.Generic")
+	systemUsings := codegen.NewStringSet("System.Linq", "System.Collections.Generic")
 	pulumiUsings := codegen.NewStringSet()
 	preambleHelperMethods := codegen.NewStringSet()
 	for _, n := range program.Nodes {

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -447,11 +447,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				g.genRange(w, call, true)
 				return
 			}
-			g.Fgenf(w, "%.20v.Select((v, k)", expr.Args[0])
+			g.Fgenf(w, "%.20v.Select((v, k) => new { Key = k, Value = v })", expr.Args[0])
 		case *model.MapType, *model.ObjectType:
-			g.genNYI(w, "MapOrObjectEntries")
+			g.Fgenf(w, "%.20v.Select(pair => new { pair.Key, pair.Value })", expr.Args[0])
 		}
-		g.Fgenf(w, " => new { Key = k, Value = v })")
 	case "fileArchive":
 		g.Fgenf(w, "new FileArchive(%.v)", expr.Args[0])
 	case "remoteArchive":

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -664,6 +664,18 @@ func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 }
 
 func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) {
+	switch argType := expr.Type().(type) {
+	case *model.ObjectType:
+		if len(argType.Annotations) > 0 {
+			if configMetadata, ok := argType.Annotations[0].(*ObjectTypeFromConfigMetadata); ok {
+				fullTypeName := fmt.Sprintf("Components.%sArgs.%s",
+					configMetadata.ComponentName,
+					configMetadata.TypeName)
+				g.genObjectConsExpressionWithTypeName(w, expr, fullTypeName, false, nil)
+				return
+			}
+		}
+	}
 	g.genObjectConsExpression(w, expr, expr.Type())
 }
 
@@ -822,6 +834,7 @@ func (g *generator) withinFunctionInvoke(run func()) {
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
+	rootName := makeValidIdentifier(expr.RootName)
 	if g.isComponent {
 		configVars := map[string]*pcl.ConfigVariable{}
 		for _, configVar := range g.program.ConfigVariables() {
@@ -830,13 +843,11 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 		if _, isConfig := configVars[expr.RootName]; isConfig {
 			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
-				g.Fgenf(w, "args.%s", Title(expr.RootName))
-				return
+				rootName = fmt.Sprintf("args.%s", Title(expr.RootName))
 			}
 		}
 	}
 
-	rootName := makeValidIdentifier(expr.RootName)
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"
 	}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -496,14 +496,14 @@ func (g *generator) genComponentResourceDefinition(w io.Writer, componentName st
 				g.Fgenf(w, "%s", g.Indent)
 				switch configVarType := configVar.Type().(type) {
 				case *model.ObjectType:
-					// generate pulumi.Input<{...}>
+					// generate {...}
 					g.Fgenf(w, "%s%s: ", configVar.Name(), optional)
 					g.genObjectTypedConfig(w, configVarType)
 					g.Fgen(w, ",\n")
 				case *model.ListType:
 					switch elementType := configVarType.ElementType.(type) {
 					case *model.ObjectType:
-						// generate pulumi.Input<{...}[]>
+						// generate {...}[]
 						g.Fgenf(w, "%s%s: ", configVar.Name(), optional)
 						g.genObjectTypedConfig(w, elementType)
 						g.Fgen(w, "[],\n")
@@ -514,7 +514,7 @@ func (g *generator) genComponentResourceDefinition(w io.Writer, componentName st
 				case *model.MapType:
 					switch elementType := configVarType.ElementType.(type) {
 					case *model.ObjectType:
-						// generate pulumi.Input<Record<string, {...}>>
+						// generate Record<string, {...}>
 						g.Fgenf(w, "%s%s: Record<string, ", configVar.Name(), optional)
 						g.genObjectTypedConfig(w, elementType)
 						g.Fgen(w, ">,\n")

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -656,6 +656,7 @@ func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.Rela
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
+	rootName := makeValidIdentifier(expr.RootName)
 	if g.isComponent {
 		if expr.RootName == "this" {
 			// special case for parent: this
@@ -670,13 +671,11 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 		if _, isConfig := configVars[expr.RootName]; isConfig {
 			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
-				g.Fgenf(w, "args.%s", expr.RootName)
-				return
+				rootName = fmt.Sprintf("args.%s", expr.RootName)
 			}
 		}
 	}
 
-	rootName := makeValidIdentifier(expr.RootName)
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"
 	}

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -169,11 +169,13 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 	})
 	if err != nil {
 		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), err.Error()))
+		node.VariableType = model.DynamicType
 		return diagnostics
 	}
 
 	if programDiags.HasErrors() || componentProgram == nil {
 		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), programDiags.Error()))
+		node.VariableType = model.DynamicType
 		return diagnostics
 	}
 

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -57,7 +57,7 @@ func componentInputs(program *Program) map[string]componentInput {
 		switch node := node.(type) {
 		case *ConfigVariable:
 			inputs[node.LogicalName()] = componentInput{
-				required: node.DefaultValue == nil,
+				required: node.DefaultValue == nil && !node.Nullable,
 				key:      node.LogicalName(),
 			}
 		}

--- a/pkg/codegen/testing/test/testdata/components-pp/components.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/components.pp
@@ -7,6 +7,23 @@ component exampleComponent "./exampleComponent" {
         "one" = "uno"
         "two" = "dos"
     }
+    githubApp = {
+        id = "example id"
+        keyBase64 = "base64 encoded key"
+        webhookSecret = "very important secret"
+    }
+    servers = [
+        { name = "First" },
+        { name = "Second" }
+    ]
+    deploymentZones = {
+        "first" = {
+            zone = "First zone"
+        }, 
+        "second" = {
+            zone = "Second zone"
+        }
+    }
 }
 
 output result {

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -6,6 +6,28 @@ namespace Components
 {
     public class ExampleComponentArgs : global::Pulumi.ResourceArgs
     {
+        public class GithubAppArgs : global::Pulumi.ResourceArgs
+        {
+            [Input("webhookSecret")]
+            public Input<string>? WebhookSecret { get; set; }
+            [Input("id")]
+            public Input<string>? Id { get; set; }
+            [Input("keyBase64")]
+            public Input<string>? KeyBase64 { get; set; }
+        }
+
+        public class ServersArgs : global::Pulumi.ResourceArgs
+        {
+            [Input("name")]
+            public Input<string>? Name { get; set; }
+        }
+
+        public class DeploymentZonesArgs : global::Pulumi.ResourceArgs
+        {
+            [Input("zone")]
+            public Input<string>? Zone { get; set; }
+        }
+
         /// <summary>
         /// A simple input
         /// </summary>
@@ -17,6 +39,21 @@ namespace Components
         /// </summary>
         [Input("cidrBlocks")]
         public InputMap<string> CidrBlocks { get; set; } = null!;
+        /// <summary>
+        /// GitHub app parameters, see your github app. Ensure the key is the base64-encoded `.pem` file (the output of `base64 app.private-key.pem`, not the content of `private-key.pem`).
+        /// </summary>
+        [Input("githubApp")]
+        public GithubAppArgs GithubApp { get; set; } = null!;
+        /// <summary>
+        /// A list of servers
+        /// </summary>
+        [Input("servers")]
+        public InputList<ServersArgs> Servers { get; set; } = null!;
+        /// <summary>
+        /// A map between for zones
+        /// </summary>
+        [Input("deploymentZones")]
+        public InputMap<DeploymentZonesArgs> DeploymentZones { get; set; } = null!;
         [Input("ipAddress")]
         public InputList<int> IpAddress { get; set; } = null!;
     }
@@ -33,6 +70,16 @@ namespace Components
                 Length = 16,
                 Special = true,
                 OverrideSpecial = args.Input,
+            }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            var githubPassword = new Random.RandomPassword($"{name}-githubPassword", new()
+            {
+                Length = 16,
+                Special = true,
+                OverrideSpecial = args.GithubApp.WebhookSecret,
             }, new CustomResourceOptions
             {
                 Parent = this,

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Random = Pulumi.Random;
 
@@ -85,6 +86,35 @@ namespace Components
                 Parent = this,
             });
 
+            // Example of iterating a list of objects
+            var serverPasswords = new List<Random.RandomPassword>();
+            for (var rangeIndex = 0; rangeIndex < args.Servers.Length; rangeIndex++)
+            {
+                var range = new { Value = rangeIndex };
+                serverPasswords.Add(new Random.RandomPassword($"{name}-serverPasswords-{range.Value}", new()
+                {
+                    Length = 16,
+                    Special = true,
+                    OverrideSpecial = args.Servers[range.Value].Name,
+                }, new CustomResourceOptions
+                {
+                    Parent = this,
+                }));
+            }
+            // Example of iterating a map of objects
+            var zonePasswords = new List<Random.RandomPassword>();
+            foreach (var range in args.DeploymentZones.Select(pair => new { pair.Key, pair.Value }))
+            {
+                zonePasswords.Add(new Random.RandomPassword($"{name}-zonePasswords-{range.Key}", new()
+                {
+                    Length = 16,
+                    Special = true,
+                    OverrideSpecial = range.Value.Zone,
+                }, new CustomResourceOptions
+                {
+                    Parent = this,
+                }));
+            }
             var simpleComponent = new Components.SimpleComponent($"{name}-simpleComponent", new ComponentResourceOptions
             {
                 Parent = this,

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -8,12 +8,12 @@ namespace Components
     {
         public class GithubAppArgs : global::Pulumi.ResourceArgs
         {
-            [Input("webhookSecret")]
-            public Input<string>? WebhookSecret { get; set; }
             [Input("id")]
             public Input<string>? Id { get; set; }
             [Input("keyBase64")]
             public Input<string>? KeyBase64 { get; set; }
+            [Input("webhookSecret")]
+            public Input<string>? WebhookSecret { get; set; }
         }
 
         public class ServersArgs : global::Pulumi.ResourceArgs
@@ -48,12 +48,12 @@ namespace Components
         /// A list of servers
         /// </summary>
         [Input("servers")]
-        public InputList<ServersArgs> Servers { get; set; } = null!;
+        public ServersArgs[] Servers { get; set; } = null!;
         /// <summary>
         /// A map between for zones
         /// </summary>
         [Input("deploymentZones")]
-        public InputMap<DeploymentZonesArgs> DeploymentZones { get; set; } = null!;
+        public Dictionary<string, DeploymentZonesArgs> DeploymentZones { get; set; } = null!;
         [Input("ipAddress")]
         public InputList<int> IpAddress { get; set; } = null!;
     }

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/SimpleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/SimpleComponent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Random = Pulumi.Random;
 

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 
 return await Deployment.RunAsync(() => 

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -20,6 +20,34 @@ return await Deployment.RunAsync(() =>
             { "one", "uno" },
             { "two", "dos" },
         },
+        GithubApp = new Components.ExampleComponentArgs.GithubAppArgs
+        {
+            Id = "example id",
+            KeyBase64 = "base64 encoded key",
+            WebhookSecret = "very important secret",
+        },
+        Servers = new[]
+        {
+            new Components.ExampleComponentArgs.ServersArgs
+            {
+                Name = "First",
+            },
+            new Components.ExampleComponentArgs.ServersArgs
+            {
+                Name = "Second",
+            },
+        },
+        DeploymentZones = 
+        {
+            { "first", new Components.ExampleComponentArgs.DeploymentZonesArgs
+            {
+                Zone = "First zone",
+            } },
+            { "second", new Components.ExampleComponentArgs.DeploymentZonesArgs
+            {
+                Zone = "Second zone",
+            } },
+        },
     });
 
     return new Dictionary<string, object?>

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -6,12 +6,33 @@ config cidrBlocks "map(string)" {
     description = "The main CIDR blocks for the VPC\nIt is a map of strings"
 }
 
+config "githubApp" "object({id=string, keyBase64=string,webhookSecret=string})" {
+  description = "GitHub app parameters, see your github app. Ensure the key is the base64-encoded `.pem` file (the output of `base64 app.private-key.pem`, not the content of `private-key.pem`)."
+  nullable = true
+}
+
+config "servers" "list(object({name=string}))" {
+  description = "A list of servers"
+  nullable = true
+}
+
+config "deploymentZones" "map(object({ zone = string }))" {
+  description = "A map between for zones"
+  nullable = true
+}
+
 config ipAddress "list(int)" { }
 
 resource password "random:index/randomPassword:RandomPassword" {
   length = 16
   special = true
   overrideSpecial = input
+}
+
+resource githubPassword "random:index/randomPassword:RandomPassword" {
+  length = 16
+  special = true
+  overrideSpecial = githubApp.webhookSecret
 }
 
 component simpleComponent "../simpleComponent" {}

--- a/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/exampleComponent/main.pp
@@ -35,6 +35,22 @@ resource githubPassword "random:index/randomPassword:RandomPassword" {
   overrideSpecial = githubApp.webhookSecret
 }
 
+# Example of iterating a list of objects
+resource serverPasswords "random:index/randomPassword:RandomPassword" {
+   options { range = length(servers) }
+   length = 16
+   special = true
+   overrideSpecial = servers[range.value].name
+}
+
+# Example of iterating a map of objects
+resource zonePasswords "random:index/randomPassword:RandomPassword" {
+   options { range = deploymentZones }
+   length = 16
+   special = true
+   overrideSpecial = range.value.zone
+}
+
 component simpleComponent "../simpleComponent" {}
 
 output result {

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -15,5 +15,26 @@ const exampleComponent = new ExampleComponent("exampleComponent", {
         one: "uno",
         two: "dos",
     },
+    githubApp: {
+        id: "example id",
+        keyBase64: "base64 encoded key",
+        webhookSecret: "very important secret",
+    },
+    servers: [
+        {
+            name: "First",
+        },
+        {
+            name: "Second",
+        },
+    ],
+    deploymentZones: {
+        first: {
+            zone: "First zone",
+        },
+        second: {
+            zone: "Second zone",
+        },
+    },
 });
 export const result = exampleComponent.result;

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -55,6 +55,30 @@ export class ExampleComponent extends pulumi.ComponentResource {
             parent: this,
         });
 
+        // Example of iterating a list of objects
+        const serverPasswords: random.RandomPassword[] = [];
+        for (const range = {value: 0}; range.value < args.servers.length; range.value++) {
+            serverPasswords.push(new random.RandomPassword(`${name}-serverPasswords-${range.value}`, {
+                length: 16,
+                special: true,
+                overrideSpecial: args.servers[range.value].name,
+            }, {
+            parent: this,
+        }));
+        }
+
+        // Example of iterating a map of objects
+        const zonePasswords: random.RandomPassword[] = [];
+        for (const range of Object.entries(args.deploymentZones).map(([k, v]) => ({key: k, value: v}))) {
+            zonePasswords.push(new random.RandomPassword(`${name}-zonePasswords-${range.key}`, {
+                length: 16,
+                special: true,
+                overrideSpecial: range.value.zone,
+            }, {
+            parent: this,
+        }));
+        }
+
         const simpleComponent = new SimpleComponent(`${name}-simpleComponent`, {
             parent: this,
         });

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/exampleComponent.ts
@@ -12,6 +12,26 @@ interface ExampleComponentArgs {
      * It is a map of strings
      */
     cidrBlocks: pulumi.Input<Record<string, pulumi.Input<string>>>,
+    /**
+     * GitHub app parameters, see your github app. Ensure the key is the base64-encoded `.pem` file (the output of `base64 app.private-key.pem`, not the content of `private-key.pem`).
+     */
+    githubApp: {
+        id?: pulumi.Input<string>,
+        keyBase64?: pulumi.Input<string>,
+        webhookSecret?: pulumi.Input<string>,
+    },
+    /**
+     * A list of servers
+     */
+    servers: {
+        name?: pulumi.Input<string>,
+    }[],
+    /**
+     * A map between for zones
+     */
+    deploymentZones: Record<string, {
+        zone?: pulumi.Input<string>,
+    }>,
     ipAddress: pulumi.Input<number[]>,
 }
 
@@ -23,6 +43,14 @@ export class ExampleComponent extends pulumi.ComponentResource {
             length: 16,
             special: true,
             overrideSpecial: args.input,
+        }, {
+            parent: this,
+        });
+
+        const githubPassword = new random.RandomPassword(`${name}-githubPassword`, {
+            length: 16,
+            special: true,
+            overrideSpecial: args.githubApp.webhookSecret,
         }, {
             parent: this,
         });

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/dotnet/discriminated-union.cs
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/dotnet/discriminated-union.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using AzureNative = Pulumi.AzureNative;
 

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/dotnet/retain-on-delete.cs
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/dotnet/retain-on-delete.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Random = Pulumi.Random;
 

--- a/pkg/codegen/testing/test/testdata/throw-not-implemented-pp/dotnet/throw-not-implemented.cs
+++ b/pkg/codegen/testing/test/testdata/throw-not-implemented-pp/dotnet/throw-not-implemented.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 
 	

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/dotnet/traverse-union-repro.cs
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/dotnet/traverse-union-repro.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Pulumi;
 using Aws = Pulumi.Aws;
 


### PR DESCRIPTION
# Description

This PR implements object-typed config variables for PCL components for both dotnet and nodejs. 

This will support types of the shape `T`, `list(T)` and `map(T)` where `T` is an object type. 

The PR implements how these variables are defined and consumed and includes examples of each
   - dotnet: objects are generated as seperate classes, their types are tracked through "annotations" (this was really annoying) and their traversals are fixed
   - nodejs: objects are implemented as inline definitions (very nice in TS), traversals are fixed 

It is worth noting that the _containers_ of the `list(T)` and `map(T)` are _plain_! only their underlying values are _inputty_. This is because we need to be able to directly iterate over the container in the component constructor. 


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
