### PR TITLE
refactor(filestate): Don't use t.Setenv in tests

### DIFF
--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -17,7 +17,6 @@ package filestate
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 
@@ -63,7 +62,7 @@ type pulumiMeta struct {
 // "PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT" to "1".
 // ensurePulumiMeta uses the provided 'getenv' function
 // to read the environment variable.
-func ensurePulumiMeta(ctx context.Context, b Bucket) (*pulumiMeta, error) {
+func ensurePulumiMeta(ctx context.Context, b Bucket, getenv func(string) string) (*pulumiMeta, error) {
 	meta, err := readPulumiMeta(ctx, b)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func ensurePulumiMeta(ctx context.Context, b Bucket) (*pulumiMeta, error) {
 	if empty {
 		// Allow opting into legacy mode for new states
 		// by setting the environment variable.
-		v, err := strconv.ParseBool(os.Getenv(PulumiFilestateLegacyLayoutEnvVar))
+		v, err := strconv.ParseBool(getenv(PulumiFilestateLegacyLayoutEnvVar))
 		if err == nil {
 			useLegacy = v
 		}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -258,7 +257,7 @@ func (b *localBackend) saveCheckpoint(
 	logging.V(7).Infof("Saved stack %s checkpoint to: %s (backup=%s)", ref.FullyQualifiedName(), file, backupFile)
 
 	// And if we are retaining historical checkpoint information, write it out again
-	if cmdutil.IsTruthy(os.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
+	if cmdutil.IsTruthy(b.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
 		if err = b.bucket.WriteAll(context.TODO(), fmt.Sprintf("%v.%v", file, time.Now().UnixNano()), byts, nil); err != nil {
 			return backupFile, "", fmt.Errorf("An IO error occurred while writing the new snapshot file: %w", err)
 		}
@@ -334,7 +333,7 @@ func (b *localBackend) backupStack(ref *localBackendReference) error {
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 
 	// Exit early if backups are disabled.
-	if cmdutil.IsTruthy(os.Getenv(DisableCheckpointBackupsEnvVar)) {
+	if cmdutil.IsTruthy(b.Getenv(DisableCheckpointBackupsEnvVar)) {
 		return nil
 	}
 


### PR DESCRIPTION
This is an alternative take on what #12473 was for.
Specifically, the current filestate.New constructor
makes it tedious to inject optional hooks
to control external state like the environment, time, etc.

This introduces a private constructor:

    func newLocalBackend(..., *localBackendOptions) (*localBackendReference, error)

The filestate.New constructor just calls newLocalBackend
with the default options.

The only available option is Getenv: an override for os.Getenv.
We replace all direct uses of os.Getenv with this function reference,
so this allows us to control environment variables in tests
without *actually* changing them with t.Setenv.
That, in turn, allows these tests to run in parallel again.

To further demonstrate the value of doing this,
this change also includes tests for previously untested functionality:
the PULUMI_RETAIN_CHECKPOINTS and PULUMI_SELF_MANAGED_STATE_GZIP
environment variables.

The only remaining uses of t.Setenv are in tests
that cross boundaries to stack.DefaultSecretsProvider.
That dependency is also easy to break with localBackendOptions
in a future change.
