### PR TITLE
refactor(cmd/stack init): Turn into a command struct

### DIFF
--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -519,3 +519,38 @@ func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets
 	}
 	panic("not implemented")
 }
+
+//
+// Mock stack reference
+//
+
+// MockStackReference is a mock implementation of [StackReference].
+// Set the fields on this struct to control the behavior of the mock.
+type MockStackReference struct {
+	StringV             string
+	NameV               tokens.Name
+	FullyQualifiedNameV tokens.QName
+}
+
+var _ StackReference = (*MockStackReference)(nil)
+
+func (r *MockStackReference) String() string {
+	if r.StringV != "" {
+		return r.StringV
+	}
+	panic("not implemented")
+}
+
+func (r *MockStackReference) Name() tokens.Name {
+	if r.NameV != "" {
+		return r.NameV
+	}
+	panic("not implemented")
+}
+
+func (r *MockStackReference) FullyQualifiedName() tokens.QName {
+	if r.FullyQualifiedNameV != "" {
+		return r.FullyQualifiedNameV
+	}
+	panic("not implemented")
+}

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -73,30 +73,18 @@ func newContToken(s string) backend.ContinuationToken {
 	return &s
 }
 
-// mockStackSummary implements the backend.StackReference interface.
-type mockStackReference struct {
-	name string
-}
-
-func (msr *mockStackReference) Name() tokens.Name {
-	return tokens.Name(msr.name)
-}
-
-func (msr *mockStackReference) FullyQualifiedName() tokens.QName {
-	return msr.Name().Q()
-}
-
-func (msr *mockStackReference) String() string {
-	return msr.name
-}
-
 // mockStackSummary implements the backend.StackSummary interface.
 type mockStackSummary struct {
 	name string
 }
 
 func (mss *mockStackSummary) Name() backend.StackReference {
-	return &mockStackReference{mss.name}
+	name := tokens.Name(mss.name)
+	return &backend.MockStackReference{
+		NameV:               name,
+		FullyQualifiedNameV: name.Q(),
+		StringV:             name.String(),
+	}
 }
 
 func (mss *mockStackSummary) LastUpdate() *time.Time {


### PR DESCRIPTION
This refactors the `pulumi stack init` command implementation
in the same vein as #12400 and #11951.

In short, this moves
flags and global dependencies are moved to a stackInitCmd struct,
and the command implementation into a Run method on that struct.

Doing so allows direct testing of the command implementation.
As demonstration, this includes a variant of the
"--teams is not supported" test directly against the command.
This test needed a mock StackReference,
so this PR also adds one to the pkg/backend package.

This PR contains no behavior changes for the 'stack init' command.
However, this does move the default value of the --secrets-provider flag
into the Run method instead of being applied by Cobra.
