### PR TITLE
sdk/common/retry: Add tests, fix extra backoff

### DIFF
--- a/changelog/pending/20230324--sdk--fix-extraneous-backoff-during-retries.yaml
+++ b/changelog/pending/20230324--sdk--fix-extraneous-backoff-during-retries.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk
+  description: "common: Fix extraneous backoff during retries."

--- a/sdk/go/common/util/retry/until.go
+++ b/sdk/go/common/util/retry/until.go
@@ -89,8 +89,6 @@ func (r *Retryer) Until(ctx context.Context, acceptor Acceptor) (bool, interface
 	// Loop until the condition is accepted or the context expires, whichever comes first.
 	try := 0
 	for {
-		// Compute the next retry time so the callback can access it.
-		delay = time.Duration(float64(delay) * backoff)
 		if delay > maxDelay {
 			delay = maxDelay
 		}
@@ -109,6 +107,7 @@ func (r *Retryer) Until(ctx context.Context, acceptor Acceptor) (bool, interface
 			return false, nil, nil
 		}
 
+		delay = time.Duration(float64(delay) * backoff)
 		try++
 	}
 }

--- a/sdk/go/common/util/retry/until.go
+++ b/sdk/go/common/util/retry/until.go
@@ -26,10 +26,15 @@ type Acceptor struct {
 	MaxDelay *time.Duration // an optional maximum delay duration.
 }
 
-// Acceptance is meant to accept a condition.  It returns true when this condition has succeeded, and false otherwise
-// (to which the retry framework responds by waiting and retrying after a certain period of time).  If a non-nil error
-// is returned, retrying halts.  The interface{} data may be used to return final values to the caller.
-type Acceptance func(try int, nextRetryTime time.Duration) (bool, interface{}, error)
+// Acceptance is meant to accept a condition.
+// It returns true when this condition has succeeded, and false otherwise
+// (to which we respond by waiting and retrying after a certain period of time).
+// If a non-nil error is returned, retrying halts.
+// The interface{} data may be used to return final values to the caller.
+//
+// Try specifies the attempt number,
+// zero indicating that this is the first attempt with no retries.
+type Acceptance func(try int, nextRetryTime time.Duration) (success bool, result interface{}, err error)
 
 const (
 	DefaultDelay    time.Duration = 100 * time.Millisecond // by default, delay by 100ms
@@ -37,10 +42,30 @@ const (
 	DefaultMaxDelay time.Duration = 5 * time.Second        // by default, no more than 5 seconds
 )
 
-// Until waits until the acceptor accepts the current condition, or the context expires, whichever comes first.  A
-// return boolean of true means the acceptor eventually accepted; a non-nil error means the acceptor returned an error.
-// If an acceptor accepts a condition after the context has expired, we ignore the expiration and return the condition.
-func Until(ctx context.Context, acceptor Acceptor) (bool, interface{}, error) {
+// Retryer provides the ability to run and retry a fallible operation
+// with exponential backoff.
+type Retryer struct {
+	// Returns a channel that will send the time after the duration elapses.
+	//
+	// Defaults to time.After.
+	After func(time.Duration) <-chan time.Time
+}
+
+// Until runs the provided acceptor until one of the following conditions is met:
+//
+//   - the operation succeeds: returns true and the result
+//   - the context expires: returns false and no result or errors
+//   - the operation returns an error: returns an error
+//
+// Note that the number of attempts is not limited.
+// The Acceptance function is responsible for determining
+// when to stop retrying.
+func (r *Retryer) Until(ctx context.Context, acceptor Acceptor) (bool, interface{}, error) {
+	timeAfter := time.After
+	if r.After != nil {
+		timeAfter = r.After
+	}
+
 	// Prepare our delay and backoff variables.
 	var delay time.Duration
 	if acceptor.Delay == nil {
@@ -78,7 +103,7 @@ func Until(ctx context.Context, acceptor Acceptor) (bool, interface{}, error) {
 
 		// Wait for delay or timeout.
 		select {
-		case <-time.After(delay):
+		case <-timeAfter(delay):
 			// Continue on.
 		case <-ctx.Done():
 			return false, nil, nil
@@ -86,6 +111,15 @@ func Until(ctx context.Context, acceptor Acceptor) (bool, interface{}, error) {
 
 		try++
 	}
+}
+
+// Until waits until the acceptor accepts the current condition, or the context expires, whichever comes first.  A
+// return boolean of true means the acceptor eventually accepted; a non-nil error means the acceptor returned an error.
+// If an acceptor accepts a condition after the context has expired, we ignore the expiration and return the condition.
+//
+// This uses [Retryer] with the default settings.
+func Until(ctx context.Context, acceptor Acceptor) (bool, interface{}, error) {
+	return (&Retryer{}).Until(ctx, acceptor)
 }
 
 // UntilDeadline creates a child context with the given deadline, and then invokes the above Until function.

--- a/sdk/go/common/util/retry/until_test.go
+++ b/sdk/go/common/util/retry/until_test.go
@@ -39,10 +39,10 @@ func TestUntil_exhaustAttempts(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, errTooManyTries)
 	assert.Equal(t, []time.Duration{
+		1 * time.Second,
 		2 * time.Second,
 		4 * time.Second,
 		8 * time.Second,
-		16 * time.Second,
 	}, afterRec.Sleeps)
 	assert.Equal(t, 4, attempts)
 }

--- a/sdk/go/common/util/retry/until_test.go
+++ b/sdk/go/common/util/retry/until_test.go
@@ -1,0 +1,130 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUntil_exhaustAttempts(t *testing.T) {
+	t.Parallel()
+
+	// Make the math for the test easy.
+	delay := time.Second
+	backoff := 2.0
+	maxDelay := 100 * time.Second
+
+	ctx := context.Background()
+	errTooManyTries := errors.New("too many tries")
+	afterRec := newAfterRecorder(time.Now())
+
+	var attempts int
+	_, _, err := (&Retryer{
+		After: afterRec.After,
+	}).Until(ctx, Acceptor{
+		Delay:    &delay,
+		Backoff:  &backoff,
+		MaxDelay: &maxDelay,
+		Accept: func(try int, delay time.Duration) (bool, interface{}, error) {
+			if try > 3 {
+				return false, nil, errTooManyTries
+			}
+			attempts++
+			return false, nil, nil // operation failed
+		},
+	})
+	assert.ErrorIs(t, err, errTooManyTries)
+	assert.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+	}, afterRec.Sleeps)
+	assert.Equal(t, 4, attempts)
+}
+
+func TestUntil_contextExpired(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ok, _, _ := (&Retryer{
+		After: newAfterRecorder(time.Now()).After,
+	}).Until(ctx, Acceptor{
+		Accept: func(try int, delay time.Duration) (bool, interface{}, error) {
+			if try > 2 {
+				cancel()
+			}
+			return false, nil, nil
+		},
+	})
+	assert.False(t, ok, "should not have succeeded")
+	// This is surprising behavior (no error instead of ctx.Err())
+	// but it's risky to change it right now.
+	// Ideally, the assertion here would be:
+	//   assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestUntil_maxDelay(t *testing.T) {
+	t.Parallel()
+
+	// Make the math for the test easy.
+	delay := time.Second
+	backoff := 2.0
+	maxDelay := 10 * time.Second
+
+	ctx := context.Background()
+	afterRec := newAfterRecorder(time.Now())
+	ok, _, err := (&Retryer{
+		After: afterRec.After,
+	}).Until(ctx, Acceptor{
+		Delay:    &delay,
+		Backoff:  &backoff,
+		MaxDelay: &maxDelay,
+		Accept: func(try int, delay time.Duration) (bool, interface{}, error) {
+			// 100 tries should be enough to reach maxDelay.
+			if try < 100 {
+				return false, nil, nil
+			}
+			return true, nil, nil
+		},
+	})
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	assert.Len(t, afterRec.Sleeps, 100)
+	for _, d := range afterRec.Sleeps {
+		assert.LessOrEqual(t, d, maxDelay)
+	}
+}
+
+// afterRecorder implements a time.After variant
+// that records all requested sleeps,
+// and advances the current time instantly.
+type afterRecorder struct {
+	mu  sync.Mutex
+	now time.Time
+
+	// Sleeps is the list of all sleeps requested.
+	Sleeps []time.Duration
+}
+
+func newAfterRecorder(now time.Time) *afterRecorder {
+	return &afterRecorder{
+		now: now,
+	}
+}
+
+func (r *afterRecorder) After(d time.Duration) <-chan time.Time {
+	r.mu.Lock()
+	r.Sleeps = append(r.Sleeps, d)
+	r.now = r.now.Add(d)
+	r.mu.Unlock()
+
+	afterc := make(chan time.Time, 1)
+	afterc <- r.now
+	return afterc
+}


### PR DESCRIPTION
This extracts the core logic in the retry package into a Retryer struct.
The Retryer struct supports an optional "After" field,
which allows injecting a custom time.After implementation.

With this, we're able to write tests for this package
without actually sleeping (and slowing down the test suite).

The tests exposed two surprising behaviors:

- If the context times out or expires, we correctly return `false`,
  but we return a nil error instead of `ctx.Err()`.
  I've chosen to not change this at this time
  because we don't know what that might break downstream.
- The initial delay is never used. We start with `delay*backoff`.
  This was fixed by moving the delay update down
  after the first attempt.
  The fix is available in its own commit.
