### PR TITLE
sdk/workspace/DownloadToFile: Fix multiplied and off-by-one retries

### DIFF
--- a/changelog/pending/20230325--sdk--fix-multiplied-retries-when-downloading-plugins.yaml
+++ b/changelog/pending/20230325--sdk--fix-multiplied-retries-when-downloading-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk
+  description: Fix multiplied retries when downloading plugins.

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -952,5 +952,5 @@ func TestLoadProvider_missingError(t *testing.T) {
 		"Could not automatically download and install resource plugin 'pulumi-resource-myplugin' at version v1.2.3")
 	assert.ErrorContains(t, err,
 		fmt.Sprintf("install the plugin using `pulumi plugin install resource myplugin v1.2.3 --server %s`", srv.URL))
-	assert.Equal(t, 6, count)
+	assert.Equal(t, 5, count)
 }

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -952,7 +952,5 @@ func TestLoadProvider_missingError(t *testing.T) {
 		"Could not automatically download and install resource plugin 'pulumi-resource-myplugin' at version v1.2.3")
 	assert.ErrorContains(t, err,
 		fmt.Sprintf("install the plugin using `pulumi plugin install resource myplugin v1.2.3 --server %s`", srv.URL))
-	// TODO[pulumi/pulumi#12456]: This should probably be 5, but we're currently retrying in
-	// getHTTPResponse as well as DownloadToFile.
-	assert.Equal(t, 30, count)
+	assert.Equal(t, 6, count)
 }

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1045,134 +1045,155 @@ func (spec PluginSpec) Install(tgz io.ReadCloser, reinstall bool) error {
 	return spec.InstallWithContext(context.Background(), tarPlugin{tgz}, reinstall)
 }
 
-// DownloadToFile downloads the given PluginInfo to a temporary file and returns that temporary file.
+// pluginDownloader is responsible for downloading plugins from PluginSpecs.
+//
+// It allows hooking into various stages of the download process
+// to allow for custom behavior and progress reporting.
+//
+// All fields are optional.
+type pluginDownloader struct {
+	// WrapStream wraps the stream returned by the plugin source.
+	// This is useful for things like reporting progress.
+	WrapStream func(stream io.ReadCloser, size int64) io.ReadCloser
+
+	// OnRetry receives a notification when a download fails
+	// and is about to be retried.
+	// err is the error that caused the retry.
+	// attempt is the number of the attempt that failed (starting at 1).
+	// limit is the maximum number of attempts.
+	// delay is the amount of time that will be slept before the next attempt.
+	// DO NOT sleep in this function. It's for observation only.
+	OnRetry func(err error, attempt int, limit int, delay time.Duration)
+}
+
+// copyBuffer copies from src to dst until either EOF is reached on src or an error occurs.
+//
+// This is an internal helper that's pretty much just a copy of io.Copy except it returns read and
+// write errors separately. We only want to retry if the read (i.e. download) fails, if the write
+// fails thats probably due to file permissions or space limitations and there's no point retrying.
+func (d *pluginDownloader) copyBuffer(dst io.Writer, src io.Reader) (written int64, readErr error, writeErr error) {
+	size := 32 * 1024
+	if l, ok := src.(*io.LimitedReader); ok && int64(size) > l.N {
+		if l.N < 1 {
+			size = 1
+		} else {
+			size = int(l.N)
+		}
+	}
+	buf := make([]byte, size)
+
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw < 0 || nr < nw {
+				nw = 0
+				if ew == nil {
+					ew = errors.New("invalid write result")
+				}
+			}
+			written += int64(nw)
+			if ew != nil {
+				return written, nil, ew
+			}
+			if nr != nw {
+				return written, nil, io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				er = nil
+			}
+			return written, er, nil
+		}
+	}
+}
+
+func (d *pluginDownloader) tryDownload(pkgPlugin PluginSpec, dst io.WriteCloser) (error, error) {
+	defer dst.Close()
+	tarball, expectedByteCount, err := pkgPlugin.Download()
+	if err != nil {
+		return err, nil
+	}
+	if d.WrapStream != nil {
+		tarball = d.WrapStream(tarball, expectedByteCount)
+	}
+	defer tarball.Close()
+	copiedByteCount, readErr, writerErr := d.copyBuffer(dst, tarball)
+	if readErr != nil || writerErr != nil {
+		return readErr, writerErr
+	}
+	if copiedByteCount != expectedByteCount {
+		return nil, fmt.Errorf("expected %d bytes but copied %d when downloading plugin %s",
+			expectedByteCount, copiedByteCount, pkgPlugin)
+	}
+	return nil, nil
+}
+
+func (d *pluginDownloader) tryDownloadToFile(pkgPlugin PluginSpec) (string, error, error) {
+	file, err := os.CreateTemp("" /* default temp dir */, "pulumi-plugin-tar")
+	if err != nil {
+		return "", nil, err
+	}
+	readErr, writeErr := d.tryDownload(pkgPlugin, file)
+	if readErr != nil || writeErr != nil {
+		err2 := os.Remove(file.Name())
+		if err2 != nil {
+			// only one of readErr or writeErr will be set
+			err := readErr
+			if err == nil {
+				err = writeErr
+			}
+
+			return "", nil, fmt.Errorf("error while removing tempfile: %v. Context: %w", err2, err)
+		}
+		return "", readErr, writeErr
+	}
+	return file.Name(), nil, nil
+}
+
+func (d *pluginDownloader) downloadToFileWithRetry(pkgPlugin PluginSpec) (string, error) {
+	delay := 80 * time.Millisecond
+	for attempt := 0; ; attempt++ {
+		tempFile, readErr, writeErr := d.tryDownloadToFile(pkgPlugin)
+		if readErr == nil && writeErr == nil {
+			return tempFile, nil
+		}
+		if writeErr != nil {
+			return "", writeErr
+		}
+
+		// If the readErr is a checksum error don't retry
+		var checksumErr *checksumError
+		if errors.As(readErr, &checksumErr) {
+			return "", readErr
+		}
+
+		// Don't retry, since the request was processed and rejected.
+		var downloadErr *downloadError
+		if errors.As(readErr, &downloadErr) && (downloadErr.code == 404 || downloadErr.code == 403) {
+			return "", readErr
+		}
+
+		// Don't attempt more than 5 times
+		attempts := 5
+		if readErr != nil && attempt >= attempts {
+			return "", readErr
+		}
+		if d.OnRetry != nil {
+			d.OnRetry(readErr, attempt+1, attempts, delay)
+		}
+		time.Sleep(delay)
+		delay = delay * 2
+	}
+}
+
+// DownloadToFile downloads the given PluginSpec to a temporary file
+// and returns that temporary file.
+//
 // This has some retry logic to re-attempt the download if it errors for any reason.
-func DownloadToFile(
-	pkgPlugin PluginSpec,
-	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
-	retry func(err error, attempt int, limit int, delay time.Duration),
-) (*os.File, error) {
-	// This is an internal helper that's pretty much just a copy of io.Copy except it returns read and
-	// write errors separately. We only want to retry if the read (i.e. download) fails, if the write
-	// fails thats probably due to file permissions or space limitations and there's no point retrying.
-	copyBuffer := func(dst io.Writer, src io.Reader) (written int64, readErr error, writeErr error) {
-		size := 32 * 1024
-		if l, ok := src.(*io.LimitedReader); ok && int64(size) > l.N {
-			if l.N < 1 {
-				size = 1
-			} else {
-				size = int(l.N)
-			}
-		}
-		buf := make([]byte, size)
-
-		for {
-			nr, er := src.Read(buf)
-			if nr > 0 {
-				nw, ew := dst.Write(buf[0:nr])
-				if nw < 0 || nr < nw {
-					nw = 0
-					if ew == nil {
-						ew = errors.New("invalid write result")
-					}
-				}
-				written += int64(nw)
-				if ew != nil {
-					return written, nil, ew
-				}
-				if nr != nw {
-					return written, nil, io.ErrShortWrite
-				}
-			}
-			if er != nil {
-				if er == io.EOF {
-					er = nil
-				}
-				return written, er, nil
-			}
-		}
-	}
-
-	tryDownload := func(dst io.WriteCloser) (error, error) {
-		defer dst.Close()
-		tarball, expectedByteCount, err := pkgPlugin.Download()
-		if err != nil {
-			return err, nil
-		}
-		if wrapper != nil {
-			tarball = wrapper(tarball, expectedByteCount)
-		}
-		defer tarball.Close()
-		copiedByteCount, readErr, writerErr := copyBuffer(dst, tarball)
-		if readErr != nil || writerErr != nil {
-			return readErr, writerErr
-		}
-		if copiedByteCount != expectedByteCount {
-			return nil, fmt.Errorf("expected %d bytes but copied %d when downloading plugin %s",
-				expectedByteCount, copiedByteCount, pkgPlugin)
-		}
-		return nil, nil
-	}
-
-	tryDownloadToFile := func() (string, error, error) {
-		file, err := os.CreateTemp("" /* default temp dir */, "pulumi-plugin-tar")
-		if err != nil {
-			return "", nil, err
-		}
-		readErr, writeErr := tryDownload(file)
-		if readErr != nil || writeErr != nil {
-			err2 := os.Remove(file.Name())
-			if err2 != nil {
-				// only one of readErr or writeErr will be set
-				err := readErr
-				if err == nil {
-					err = writeErr
-				}
-
-				return "", nil, fmt.Errorf("error while removing tempfile: %v. Context: %w", err2, err)
-			}
-			return "", readErr, writeErr
-		}
-		return file.Name(), nil, nil
-	}
-
-	downloadToFileWithRetry := func() (string, error) {
-		delay := 80 * time.Millisecond
-		for attempt := 0; ; attempt++ {
-			tempFile, readErr, writeErr := tryDownloadToFile()
-			if readErr == nil && writeErr == nil {
-				return tempFile, nil
-			}
-			if writeErr != nil {
-				return "", writeErr
-			}
-
-			// If the readErr is a checksum error don't retry
-			var checksumErr *checksumError
-			if errors.As(readErr, &checksumErr) {
-				return "", readErr
-			}
-
-			// Don't retry, since the request was processed and rejected.
-			var downloadErr *downloadError
-			if errors.As(readErr, &downloadErr) && (downloadErr.code == 404 || downloadErr.code == 403) {
-				return "", readErr
-			}
-
-			// Don't attempt more than 5 times
-			attempts := 5
-			if readErr != nil && attempt >= attempts {
-				return "", readErr
-			}
-			if retry != nil {
-				retry(readErr, attempt+1, attempts, delay)
-			}
-			time.Sleep(delay)
-			delay = delay * 2
-		}
-	}
-
-	tarball, err := downloadToFileWithRetry()
+func (d *pluginDownloader) DownloadToFile(pkgPlugin PluginSpec) (*os.File, error) {
+	tarball, err := d.downloadToFileWithRetry(pkgPlugin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download plugin: %s: %w", pkgPlugin, err)
 	}
@@ -1181,6 +1202,19 @@ func DownloadToFile(
 		return nil, fmt.Errorf("failed to open downloaded plugin: %s: %w", pkgPlugin, err)
 	}
 	return reader, nil
+}
+
+// DownloadToFile downloads the given PluginInfo to a temporary file and returns that temporary file.
+// This has some retry logic to re-attempt the download if it errors for any reason.
+func DownloadToFile(
+	pkgPlugin PluginSpec,
+	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
+	retry func(err error, attempt int, limit int, delay time.Duration),
+) (*os.File, error) {
+	return (&pluginDownloader{
+		WrapStream: wrapper,
+		OnRetry:    retry,
+	}).DownloadToFile(pkgPlugin)
 }
 
 type PluginContent interface {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -943,18 +943,13 @@ func TestDownloadToFile_retries(t *testing.T) {
 	// while numRetries is the number of times the retry function is called.
 	// These should match--the function is called on all failures.
 	var numRetries int
-	_, err := DownloadToFile(
-		spec,
-		func(stream io.ReadCloser, size int64) io.ReadCloser {
-			// wrapper: no-op
-			return stream
-		},
-		func(err error, attempt, limit int, delay time.Duration) {
+	_, err := (&pluginDownloader{
+		OnRetry: func(err error, attempt, limit int, delay time.Duration) {
 			assert.Equal(t, 5, limit, "unexpected retry limit")
 			numRetries++
 			assert.Equal(t, numRetries, attempt, "unexpected attempt number")
 		},
-	)
+	}).DownloadToFile(spec)
 	assert.ErrorContains(t, err, "failed to download plugin: myplugin-1.0.0")
 	assert.Equal(t, numRequests, numRetries)
 }

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
@@ -896,6 +898,65 @@ func TestParsePluginDownloadURLOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDownloadToFile_retries(t *testing.T) {
+	t.Parallel()
+
+	// Verifies that DownloadToFile retries on transient errors
+	// when trying to download plugins,
+	// and that it calls the wrapper and retry functions as expected.
+	//
+	// Regression test for https://github.com/pulumi/pulumi/issues/12456.
+
+	var numRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "expected GET request")
+		assert.Regexp(t, `/pulumi-language-myplugin-v1.0.0-\S+\.tar\.gz`, r.URL.Path,
+			"unexpected URL path")
+
+		// Fails all requests with a 500 error.
+		// This will cause every download attempt to fail
+		// and be retried.
+		w.WriteHeader(http.StatusInternalServerError)
+
+		numRequests++
+	}))
+	t.Cleanup(server.Close)
+	defer func() {
+		assert.Equal(t, 5, numRequests,
+			"server received more requests than expected")
+	}()
+
+	// Create a fake plugin.
+	version := semver.MustParse("1.0.0")
+	spec := PluginSpec{
+		Name:              "myplugin",
+		Kind:              LanguagePlugin,
+		Version:           &version,
+		PluginDownloadURL: server.URL,
+		PluginDir:         t.TempDir(),
+	}
+
+	// numRetries is tracked separately from numRequests.
+	// numRequests is the number of requests received by the server,
+	// while numRetries is the number of times the retry function is called.
+	// These should match--the function is called on all failures.
+	var numRetries int
+	_, err := DownloadToFile(
+		spec,
+		func(stream io.ReadCloser, size int64) io.ReadCloser {
+			// wrapper: no-op
+			return stream
+		},
+		func(err error, attempt, limit int, delay time.Duration) {
+			assert.Equal(t, 5, limit, "unexpected retry limit")
+			numRetries++
+			assert.Equal(t, numRetries, attempt, "unexpected attempt number")
+		},
+	)
+	assert.ErrorContains(t, err, "failed to download plugin: myplugin-1.0.0")
+	assert.Equal(t, numRequests, numRetries)
 }
 
 //nolint:paralleltest // changes directory for process


### PR DESCRIPTION
**The commits in this PR are meant to be reviewed individually.**

---

This PR fixes two issues in the workspace.DownloadToFile retry logic:

- an off-by-one error that caused it to make 6 attempts, not 5
- a double-retry bug downstream, that caused 5 times as many requests
  as intended

The net effect of this was that we made 30 attempts to download plugins
instead of the intended 5.

The fix required some amount of refactoring,
and is therefore split into N different commits.

In order, the commits are:

- Add a failing test case that verifies the total number of requests
  as well as correct reporting to the `retry` callback
  that is used to report progress to users.
- Refactor without changing any logic
  so that we can redefine `time.After` later.
- Fix double retry bug.
  This brings the number of attempts down from 30 to 6.
- Fix off-by-one bug by re-using util/retry's retryer.

Resolves #12456
