### PR TITLE
[tests] Consolidate methods integration test

### DIFF
--- a/tests/integration/construct_component_methods/nodejs/index.ts
+++ b/tests/integration/construct_component_methods/nodejs/index.ts
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
+import * as pulumi from "@pulumi/pulumi";
 import { Component } from "./component";
 
 const component = new Component("component", {
@@ -10,3 +11,14 @@ const component = new Component("component", {
 const result = component.getMessage({ name: "Alice" });
 
 export const message = result.message;
+
+export const messagedeps = getDeps(message);
+
+async function getDeps(o: pulumi.Output<string>): Promise<string[]> {
+    const resources: Set<pulumi.Resource> = await (message as any).allResources()
+    const urns: string[] = [];
+    for (const res of resources) {
+        urns.push(await (res.urn as any).promise());
+    }
+    return urns;
+}

--- a/tests/integration/construct_component_methods/python/__main__.py
+++ b/tests/integration/construct_component_methods/python/__main__.py
@@ -6,5 +6,12 @@ from component import Component
 
 component = Component("component", first="Hello", second="World")
 result = component.get_message("Alice")
+message = result.message
 
-pulumi.export("message", result.message)
+pulumi.export("message", message)
+
+async def get_deps(o: pulumi.Output[str]):
+    resources = await o.resources()
+    return [await res.urn.future() for res in resources]
+
+pulumi.export("messagedeps", get_deps(message))

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -574,58 +574,7 @@ func TestConstructUnknownGo(t *testing.T) {
 }
 
 func TestConstructMethodsGo(t *testing.T) {
-	t.Parallel()
-
-	testDir := "construct_component_methods"
-	runComponentSetup(t, testDir)
-
-	tests := []struct {
-		componentDir string
-		env          []string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.componentDir, func(t *testing.T) {
-			localProvider := integration.LocalDependency{
-				Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir),
-			}
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Env: test.env,
-				Dir: filepath.Join(testDir, "go"),
-				Dependencies: []string{
-					"github.com/pulumi/pulumi/sdk/v3",
-				},
-				LocalProviders: []integration.LocalDependency{localProvider},
-				Quick:          true,
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
-
-					// TODO[pulumi/pulumi#12471]: Only the Go SDK has been fixed such that rehydrated
-					// components are kept as dependencies. So only check this for the provider written
-					// in Go. Once the other SDKs are fixed, we can test the other providers as well.
-					if test.componentDir == "testcomponent-go" {
-						var componentURN string
-						for _, res := range stackInfo.Deployment.Resources {
-							if res.URN.Name() == "component" {
-								componentURN = string(res.URN)
-							}
-						}
-						assert.Contains(t, stackInfo.Outputs["messagedeps"], componentURN)
-					}
-				},
-			})
-		})
-	}
+	testConstructMethods(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 func TestConstructMethodsUnknownGo(t *testing.T) {

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -911,41 +911,7 @@ func TestConstructUnknownNode(t *testing.T) {
 
 // Test methods on remote components.
 func TestConstructMethodsNode(t *testing.T) {
-	t.Parallel()
-
-	testDir := "construct_component_methods"
-	runComponentSetup(t, testDir)
-
-	tests := []struct {
-		componentDir string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.componentDir, func(t *testing.T) {
-			localProvider := integration.LocalDependency{
-				Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir),
-			}
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Dir:            filepath.Join(testDir, "nodejs"),
-				Dependencies:   []string{"@pulumi/pulumi"},
-				LocalProviders: []integration.LocalDependency{localProvider},
-				Quick:          true,
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructMethods(t, "nodejs", "@pulumi/pulumi")
 }
 
 func TestConstructMethodsUnknownNode(t *testing.T) {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -652,43 +652,7 @@ func TestConstructUnknownPython(t *testing.T) {
 
 // Test methods on remote components.
 func TestConstructMethodsPython(t *testing.T) {
-	t.Parallel()
-
-	testDir := "construct_component_methods"
-	runComponentSetup(t, testDir)
-
-	tests := []struct {
-		componentDir string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.componentDir, func(t *testing.T) {
-			localProvider := integration.LocalDependency{
-				Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir),
-			}
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Dir: filepath.Join(testDir, "python"),
-				Dependencies: []string{
-					filepath.Join("..", "..", "sdk", "python", "env", "src"),
-				},
-				LocalProviders: []integration.LocalDependency{localProvider},
-				Quick:          true,
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructMethods(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 func TestConstructMethodsUnknownPython(t *testing.T) {


### PR DESCRIPTION
Update the Node.js and Python programs of the `construct_component_methods` integration test to match the Go program, and consolidate the test into one shared implementation.