### PR TITLE
Prefer BindSpec to ImportSpec in tests

### DIFF
--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -372,8 +372,9 @@ func TestFunctionHeaders(t *testing.T) {
 	dctx := newDocGenContext()
 	testPackageSpec := newTestPackageSpec()
 
-	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "importing spec")
+	schemaPkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "binding spec")
+	assert.False(t, diags.HasErrors(), "binding spec")
 
 	tests := []struct {
 		ExpectedTitleTag string
@@ -424,8 +425,9 @@ func TestResourceDocHeader(t *testing.T) {
 	dctx := newDocGenContext()
 	testPackageSpec := newTestPackageSpec()
 
-	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "importing spec")
+	schemaPkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "binding spec")
+	assert.False(t, diags.HasErrors(), "binding spec")
 
 	tests := []struct {
 		Name             string

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -28,8 +28,9 @@ func TestGeneratePackageTree(t *testing.T) {
 	dctx := newDocGenContext()
 	testPackageSpec := newTestPackageSpec()
 
-	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "importing spec")
+	schemaPkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "binding spec")
+	assert.False(t, diags.HasErrors(), "binding spec")
 
 	dctx.initialize(unitTestTool, schemaPkg)
 	pkgTree, err := dctx.generatePackageTree()

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -62,8 +62,9 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "could not import the test package spec")
+	pkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "could not bind the test package spec")
+	assert.False(t, diags.HasErrors(), "could not bind the test package spec")
 	return pkg
 }
 

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -65,8 +65,9 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "could not import the test package spec")
+	pkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "could not bind the test package spec")
+	assert.False(t, diags.HasErrors(), "could not bind the test package spec")
 	return pkg
 }
 

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -157,9 +157,12 @@ func readSchemaFile(file string) *schema.Package {
 	if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
 		panic(err)
 	}
-	pkg, err := schema.ImportSpec(pkgSpec, map[string]schema.Language{"go": Importer})
+	pkg, diags, err := schema.BindSpec(pkgSpec, nil)
 	if err != nil {
 		panic(err)
+	}
+	if diags.HasErrors() {
+		panic(diags)
 	}
 
 	return pkg
@@ -357,7 +360,7 @@ func TestTokenToResource(t *testing.T) {
 }
 
 func importSpec(t *testing.T, spec schema.PackageSpec) *schema.Package {
-	importedPkg, err := schema.ImportSpec(spec, map[string]schema.Language{})
+	importedPkg, err := schema.ImportSpec(spec, nil)
 	assert.NoError(t, err)
 	return importedPkg
 }

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -64,8 +64,9 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "could not import the test package spec")
+	pkg, diags, err := schema.BindSpec(testPackageSpec, nil)
+	assert.NoError(t, err, "could not bind the test package spec")
+	assert.False(t, diags.HasErrors(), "could not bind the test package spec")
 	return pkg
 }
 

--- a/pkg/codegen/python/gen_resource_mappings_test.go
+++ b/pkg/codegen/python/gen_resource_mappings_test.go
@@ -43,9 +43,13 @@ func TestGenResourceMappingsIsDeterministic(t *testing.T) {
 	}
 
 	generateInitHash := func() string {
-		pkg, err := schema.ImportSpec(pkgSpec, nil)
+		pkg, diags, err := schema.BindSpec(pkgSpec, nil)
 		if err != nil {
 			t.Error(err)
+			return ""
+		}
+		if diags.HasErrors() {
+			t.Error(diags)
 			return ""
 		}
 

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -151,9 +151,12 @@ func TestParseAndRenderDocs(t *testing.T) {
 			if err = json.Unmarshal(contents, &spec); err != nil {
 				t.Fatalf("could not unmarshal package spec: %v", err)
 			}
-			pkg, err := ImportSpec(spec, nil)
+			pkg, diags, err := BindSpec(spec, nil)
 			if err != nil {
-				t.Fatalf("could not import package: %v", err)
+				t.Fatalf("could not bind package: %v", err)
+			}
+			if diags.HasErrors() {
+				t.Fatalf("could not bind package: %v", diags)
 			}
 
 			//nolint:paralleltest // these are large, compute heavy tests. keep them in a single thread

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -553,6 +553,7 @@
             "title": "C# Language Overrides Definition",
             "description": "Describes C# specific settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "compatibility": {
                     "description": "",
@@ -577,6 +578,7 @@
             "title": "Go Language Overrides Definition",
             "description": "Describes Go specific settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "generateExtraInputTypes": {
                     "description": "",
@@ -600,6 +602,7 @@
             "title": "NodeJS Language Overrides Definition",
             "description": "Describes NodeJS specific settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "packageName": {
                     "description": "NPM package name (includes @namespace)",
@@ -644,6 +647,7 @@
             "title": "Python Language Overrides Definition",
             "description": "Describes Python specific settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "packageName": {
                     "description": "NPM package name (includes @namespace)",
@@ -672,6 +676,7 @@
             "title": "Java Language Overrides Definition",
             "description": "Describes Java specific settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "packages": {
                     "$ref": "#/$defs/schemaStringMap"

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -466,8 +466,9 @@ func TestPythonResourceArgs(t *testing.T) {
 	assert.NoError(t, err)
 	var spec schema.PackageSpec
 	assert.NoError(t, json.Unmarshal(schemaBytes, &spec))
-	pkg, err := schema.ImportSpec(spec, nil)
+	pkg, diags, err := schema.BindSpec(spec, nil)
 	assert.NoError(t, err)
+	assert.False(t, diags.HasErrors())
 	files, err := pygen.GeneratePackage("test", pkg, map[string][]byte{})
 	assert.NoError(t, err)
 	outdir := filepath.Join(testdir, "lib")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

BindSpec validates that the schema files match the JSON schema. This will help pick up when we start testing options in tests that haven't been added to the schema files which would cause issues in downstream use.