### PR TITLE
shorten message after down/destory

### DIFF
--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -264,7 +264,7 @@ func newDestroyCmd() *cobra.Command {
 					" associated with this stack.\n", protectedCount)
 			} else if res == nil && len(*targets) == 0 {
 				if !jsonDisplay && !remove {
-					fmt.Printf("Run `pulumi stack rm %s` to also delete the stack history and configuration\n", s.Ref())
+					fmt.Printf("Run `pulumi stack rm %s` to delete the stack history and configuration\n", s.Ref())
 				} else if remove {
 					_, err = s.Remove(ctx, false)
 					if err != nil {

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -264,9 +264,7 @@ func newDestroyCmd() *cobra.Command {
 					" associated with this stack.\n", protectedCount)
 			} else if res == nil && len(*targets) == 0 {
 				if !jsonDisplay && !remove {
-					fmt.Printf("The resources in the stack have been deleted, but the history and configuration "+
-						"associated with the stack are still maintained. \nIf you want to remove the stack "+
-						"completely, run `pulumi stack rm %s`.\n", s.Ref())
+					fmt.Printf("Run `pulumi stack rm %s` to also delete the stack history and configuration\n", s.Ref())
 				} else if remove {
 					_, err = s.Remove(ctx, false)
 					if err != nil {


### PR DESCRIPTION
i noticed this long message thats difficult to scan and understand quickly
proposing a shorter version which puts the command first
and connects the command and the consequence together into a single sentence

very open to feedback!