### PR TITLE
[sdk/go] Fix hang due to component children cycles

### DIFF
--- a/changelog/pending/20230327--sdk-go--fix-hang-due-to-component-children-cycles.yaml
+++ b/changelog/pending/20230327--sdk-go--fix-hang-due-to-component-children-cycles.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix hang due to component children cycles

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1657,7 +1657,7 @@ func (ctx *Context) getOpts(
 	if opts.DependsOn != nil {
 		depSet := urnSet{}
 		for _, ds := range opts.DependsOn {
-			if err := ds.addURNs(ctx.ctx, depSet); err != nil {
+			if err := ds.addURNs(ctx.ctx, depSet, res); err != nil {
 				return resourceOpts{}, err
 			}
 		}


### PR DESCRIPTION
When a resource depends on a local component resource, rather than setting the component resource itself as a dependency, each of the component's descendants is added as a dependency. This can lead to hangs when cycles are introduced.

For example, consider the following parent/child hierarchy, where `ComponentA` is the parent of `ComponentB` and `ComponentB` is the parent of `CustomC`:

```
ComponentA
    |
ComponentB
    |
 CustomC
```

If `ComponentB` specifies it has a dependency on `ComponentA`, the following takes place as part determining the full set of transitive dependencies:

1. `ComponentA`  is a component resource so it isn't added as a dependency, its children are.
2. `ComponentA` has one child: `ComponentB`
3. `ComponentB`  is a component resource so it isn't added as a dependency, its children are.
4. `ComponentB` has one child: `CustomC`, a custom resource.
5. Since `CustomC` is a custom resource, it is added to the set of dependencies.
6. We try to await its URN, but we'll never get it because `RegisterResource` hasn't yet been called for it. And we hang waiting.

To address this, skip looking at a component's children if it is the component from which the dependency is being added.

In the case of the example, at step 3 the dependency expansion will stop: we won't look at `ComponentB`'s children because we're adding the dependency from `ComponentB`.

Part of #12032

Related to #12462
Related to #12515