### PR TITLE
Revert "sdk/py/ComponentResource: Propagate provider to children"

### DIFF
--- a/changelog/pending/20230327--sdk-python--revert-12292-to-unbreak-some-users.yaml
+++ b/changelog/pending/20230327--sdk-python--revert-12292-to-unbreak-some-users.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: "Revert #12292 to unbreak some users."

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -920,25 +920,16 @@ class Resource:
             Optional[ProviderResource], opts.parent and opts.parent.get_provider(t)
         )
 
-        provider = ambient_provider or parent_provider
-        if opts.provider:
-            # If an explicit provider was passed in,
-            # its package may or may not match the package we're looking for.
-            provider_pkg = opts.provider.package
-            if pkg == provider_pkg:
-                # Explicit provider takes precedence over parent or ambient providers.
-                provider = opts.provider
+        provider = opts.provider or ambient_provider or parent_provider
 
-            # Regardless of whether it matches,
-            # we still want to keep the provider in the
-            # providers map, so that it can be used for child resources.
-            if provider_pkg in opts_providers:
-                message = f"There is a conflict between the `provider` field ({provider_pkg}) and a member of the `providers` map"
+        if pkg and opts.provider:
+            if pkg in opts_providers:
+                message = f"There is a conflict between the `provider` field ({pkg}) and a member of the `providers` map"
                 depreciation = "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details"
                 warnings.warn(f"{message} for resource {t}. " + depreciation)
                 log.warn(f"{message}. {depreciation}", resource=self)
             else:
-                opts_providers[provider_pkg] = opts.provider
+                opts_providers[pkg] = opts.provider
 
         # opts_providers takes priority over self._providers
         providers = {**self._providers, **opts_providers}

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -129,46 +129,6 @@ def test_depends_on_typing_variations(dep_tracker) -> None:
     ])
 
 
-@pulumi.runtime.test
-def test_component_resource_propagates_provider() -> None:
-    mocks.set_mocks(MinimalMocks())
-
-    provider = pulumi.ProviderResource('test', 'prov', {})
-    component = pulumi.ComponentResource(
-        "custom:foo:Component",
-        "comp",
-        opts=pulumi.ResourceOptions(provider=provider),
-    )
-    custom = pulumi.CustomResource(
-        "test:index:Resource",
-        "res",
-        opts=pulumi.ResourceOptions(parent=component),
-    )
-
-    assert provider == custom._provider, \
-        "Failed to propagate provider to child resource"
-
-
-@pulumi.runtime.test
-def test_component_resource_propagates_providers_list() -> None:
-    mocks.set_mocks(MinimalMocks())
-
-    provider = pulumi.ProviderResource('test', 'prov', {})
-    component = pulumi.ComponentResource(
-        "custom:foo:Component",
-        "comp",
-        opts=pulumi.ResourceOptions(providers=[provider]),
-    )
-    custom = pulumi.CustomResource(
-        "test:index:Resource",
-        "res",
-        opts=pulumi.ResourceOptions(parent=component),
-    )
-
-    assert provider == custom._provider, \
-        "Failed to propagate provider to child resource"
-
-
 def output_depending_on_resource(r: pulumi.Resource, isKnown: bool) -> pulumi.Output[None]:
     """Returns an output that depends on the given resource."""
     o = pulumi.Output.from_input(None)


### PR DESCRIPTION
This reverts commit db4c071f61958661031b467d19d696689e7c5452 (#12292).

This appears to have broken some customers.
Reverting to unblock.

Reopens #12161
Refs #12520
