### PR TITLE
filestate: Don't write metadata for legacy layouts

### DIFF
--- a/changelog/pending/20230328--backend-filestate--dont-write-a-state-layout-file-for-legacy-layouts.yaml
+++ b/changelog/pending/20230328--backend-filestate--dont-write-a-state-layout-file-for-legacy-layouts.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: fix
+  scope: backend/filestate
+  description: |
+    Don't write a state metadata file for legacy layouts.
+    This should prevent permissioning issues for users
+    with tight access control to the storage backend.

--- a/pkg/backend/filestate/meta_test.go
+++ b/pkg/backend/filestate/meta_test.go
@@ -16,10 +16,13 @@ package filestate
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/fileblob"
 	"gocloud.dev/blob/memblob"
 )
 
@@ -44,6 +47,13 @@ func TestEnsurePulumiMeta(t *testing.T) {
 				".pulumi/Pulumi.yaml": `version: 0`,
 			},
 			want: pulumiMeta{Version: 0},
+		},
+		{
+			desc: "future version",
+			give: map[string]string{
+				".pulumi/Pulumi.yaml": `version: 42`,
+			},
+			want: pulumiMeta{Version: 42},
 		},
 	}
 
@@ -103,4 +113,60 @@ func TestEnsurePulumiMeta_corruption(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+// Writes a metadata file to the bucket and reads it back.
+func TestMeta_roundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give pulumiMeta
+	}{
+		{desc: "zero", give: pulumiMeta{Version: 0}},
+		{desc: "future", give: pulumiMeta{Version: 42}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			b := memblob.OpenBucket(nil)
+			ctx := context.Background()
+			require.NoError(t, tt.give.WriteTo(ctx, b))
+
+			got, err := ensurePulumiMeta(ctx, b)
+			require.NoError(t, err)
+			assert.Equal(t, &tt.give, got)
+		})
+	}
+}
+
+// Verifies that we don't write a metadata file with version 0.
+func TestMeta_WriteTo_zero(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	bucket, err := fileblob.OpenBucket(tmpDir, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, (&pulumiMeta{
+		Version: 0,
+	}).WriteTo(ctx, bucket))
+
+	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "Pulumi.yaml"))
+}
+
+// Verify that we don't create a metadata file with version 0 in new buckets.
+func TestNew_noMetaOnInit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+	_, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "Pulumi.yaml"))
 }


### PR DESCRIPTION
In #12472, we added a new file to filestate backends:
.pulumi/Pulumi.yaml.
This file is intended to store metadata about the layout
in anticipation of support for project-scoped stacks.

This had the unintended side-effect of breaking users
who use tight access control on their S3 buckets:
users don't get write access outside specific stack directories
so they get an error like the following:

    error: write ".pulumi/Pulumi.yaml": blob (key ".pulumi/Pulumi.yaml") (code=Unknown): AccessDenied: Access Denied

This changes filestate.New to never write the file
if the version is zero
so users that don't currently have write access to that directory
will continue to be able to use the backend.

Resolves #12534
