### PR TITLE
filestate: Rename Pulumi.yaml to meta.yaml

### DIFF
--- a/changelog/pending/20230328--backend-filestate--rename-internal-state-metadata-file-from-pulumi-yaml-to-meta-yaml-to-avoid-confusion.yaml
+++ b/changelog/pending/20230328--backend-filestate--rename-internal-state-metadata-file-from-pulumi-yaml-to-meta-yaml-to-avoid-confusion.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: chore
+  scope: backend/filestate
+  description: |
+    Rename state metadata file from .pulumi/Pulumi.yaml to .pulumi/meta.yaml.
+    This is an internal detail to the self-managed backend's storage format
+    intended to avoid confusion with Pulumi project files,
+    and should not affect most users.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -202,7 +202,7 @@ func New(ctx context.Context, d diag.Sink, originalURL string, project *workspac
 	}
 	if meta.Version != 0 {
 		return nil, fmt.Errorf(
-			"state store unsupported: 'Pulumi.yaml' version (%d) is not supported "+
+			"state store unsupported: 'meta.yaml' version (%d) is not supported "+
 				"by this version of the Pulumi CLI", meta.Version)
 	}
 

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -528,14 +528,14 @@ func TestNew_unsupportedStoreVersion(t *testing.T) {
 	bucket, err := fileblob.OpenBucket(stateDir, nil)
 	require.NoError(t, err)
 
-	// Set up a Pulumi.yaml "from the future".
+	// Set up a meta.yaml "from the future".
 	ctx := context.Background()
 	require.NoError(t,
-		bucket.WriteAll(ctx, ".pulumi/Pulumi.yaml", []byte("version: 999999999"), nil))
+		bucket.WriteAll(ctx, ".pulumi/meta.yaml", []byte("version: 999999999"), nil))
 
 	_, err = New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(stateDir), nil)
 	assert.ErrorContains(t, err, "state store unsupported")
-	assert.ErrorContains(t, err, "'Pulumi.yaml' version (999999999) is not supported")
+	assert.ErrorContains(t, err, "'meta.yaml' version (999999999) is not supported")
 }
 
 // TestSerializeTimestampRFC3339 captures our expectations that Created and Modified will be serialized to

--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -26,9 +26,9 @@ import (
 )
 
 // Path inside the bucket where we store the metadata file.
-var pulumiMetaPath = filepath.Join(workspace.BookkeepingDir, "Pulumi.yaml")
+var pulumiMetaPath = filepath.Join(workspace.BookkeepingDir, "meta.yaml")
 
-// pulumiMeta holds the contents of the .pulumi/Pulumi.yaml file
+// pulumiMeta holds the contents of the .pulumi/meta.yaml file
 // in a filestate backend.
 //
 // This file specifies metadata for the backend,

--- a/pkg/backend/filestate/meta_test.go
+++ b/pkg/backend/filestate/meta_test.go
@@ -44,14 +44,14 @@ func TestEnsurePulumiMeta(t *testing.T) {
 		{
 			desc: "version 0",
 			give: map[string]string{
-				".pulumi/Pulumi.yaml": `version: 0`,
+				".pulumi/meta.yaml": `version: 0`,
 			},
 			want: pulumiMeta{Version: 0},
 		},
 		{
 			desc: "future version",
 			give: map[string]string{
-				".pulumi/Pulumi.yaml": `version: 42`,
+				".pulumi/meta.yaml": `version: 42`,
 			},
 			want: pulumiMeta{Version: 42},
 		},
@@ -80,23 +80,23 @@ func TestEnsurePulumiMeta_corruption(t *testing.T) {
 
 	tests := []struct {
 		desc    string
-		give    string // contents of Pulumi.yaml
+		give    string // contents of meta.yaml
 		wantErr string
 	}{
 		{
 			desc:    "empty",
 			give:    ``,
-			wantErr: `corrupt store: missing version in ".pulumi/Pulumi.yaml"`,
+			wantErr: `corrupt store: missing version in ".pulumi/meta.yaml"`,
 		},
 		{
 			desc:    "other fields",
 			give:    `foo: bar`,
-			wantErr: `corrupt store: missing version in ".pulumi/Pulumi.yaml"`,
+			wantErr: `corrupt store: missing version in ".pulumi/meta.yaml"`,
 		},
 		{
 			desc:    "corrupt version",
 			give:    `version: foo`,
-			wantErr: `corrupt store: unmarshal ".pulumi/Pulumi.yaml"`,
+			wantErr: `corrupt store: unmarshal ".pulumi/meta.yaml"`,
 		},
 	}
 
@@ -107,7 +107,7 @@ func TestEnsurePulumiMeta_corruption(t *testing.T) {
 
 			b := memblob.OpenBucket(nil)
 			ctx := context.Background()
-			require.NoError(t, b.WriteAll(ctx, ".pulumi/Pulumi.yaml", []byte(tt.give), nil))
+			require.NoError(t, b.WriteAll(ctx, ".pulumi/meta.yaml", []byte(tt.give), nil))
 
 			_, err := ensurePulumiMeta(context.Background(), b)
 			assert.ErrorContains(t, err, tt.wantErr)
@@ -156,7 +156,7 @@ func TestMeta_WriteTo_zero(t *testing.T) {
 		Version: 0,
 	}).WriteTo(ctx, bucket))
 
-	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "Pulumi.yaml"))
+	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "meta.yaml"))
 }
 
 // Verify that we don't create a metadata file with version 0 in new buckets.
@@ -168,5 +168,5 @@ func TestNew_noMetaOnInit(t *testing.T) {
 	_, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	require.NoError(t, err)
 
-	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "Pulumi.yaml"))
+	assert.NoFileExists(t, filepath.Join(tmpDir, ".pulumi", "meta.yaml"))
 }


### PR DESCRIPTION
In #12472, we added a .pulumi/Pulumi.yaml file to filestate backends
to hold metadata about the storage layout format.
It has been brought up multiple times that this is a confusing name,
so we're renaming it to meta.yaml.

Backwards compatibility:
Although we've already shipped #12472,
and have started writing Pulumi.yaml files,
we don't currently use it for anything.
Its first use will be in #12437 when we add project-scoped stacks.
Therefore, this change is completely backwards compatible.

We'll end up leaving the extraneous .pulumi/Pulumi.yaml file behind
if the bucket was initialized with Pulumi v3.59.0 or newer,
before this change was released. This is not a high cost.
I don't think we should go back and delete these files;
I'm reluctant for the backend to perform destructive operations
for files that are technically not managed by it.
