### PR TITLE
Fix documentation of valid schema type strings

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1403,7 +1403,7 @@ func (m *RawMessage) UnmarshalYAML(node *yaml.Node) error {
 
 // TypeSpec is the serializable form of a reference to a type.
 type TypeSpec struct {
-	// Type is the primitive or composite type, if any. May be "bool", "integer", "number", "string", "array", or
+	// Type is the primitive or composite type, if any. May be "boolean", "string", "integer", "number", "array", or
 	// "object".
 	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	// Ref is a reference to a type in this or another document. For example, the built-in Archive, Asset, and Any


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fix inline documentation of valid schema type strings. 

- "bool" is not a valid value
- Re-order to match defined values in switch statement ~80 lines above

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
