### PR TITLE
Add test to show errors in dynamic NodeJS providers work

### DIFF
--- a/tests/integration/dynamic/nodejs-error-create/Pulumi.yaml
+++ b/tests/integration/dynamic/nodejs-error-create/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nodejs_resource_type_name
+runtime: nodejs
+description: A simple Nodejs program that uses dynamic providers with custom resource type name.

--- a/tests/integration/dynamic/nodejs-error-create/index.ts
+++ b/tests/integration/dynamic/nodejs-error-create/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+import * as pulumi from '@pulumi/pulumi'
+
+class CustomResource extends pulumi.dynamic.Resource {
+  constructor (name: string, opts?: pulumi.ResourceOptions) {
+    super(new DummyResourceProvider(), name, {}, opts, "custom-provider", "CustomResource")
+  }
+}
+
+class DummyResourceProvider implements pulumi.dynamic.ResourceProvider {
+  async create (props: any): Promise<pulumi.dynamic.CreateResult> {
+    throw new Error("boom!")
+  }
+}
+
+const resource = new CustomResource('resource-name')
+
+export const urn = resource.urn

--- a/tests/integration/dynamic/nodejs-error-create/package.json
+++ b/tests/integration/dynamic/nodejs-error-create/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nodejs-resource-type-name",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^4.5.4"
+  },
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1309,6 +1309,25 @@ func TestCustomResourceTypeNameDynamicNode(t *testing.T) {
 	})
 }
 
+// Tests errors in dynamic provider methods
+func TestErrorCreateDynamicNode(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           filepath.Join("dynamic", "nodejs-error-create"),
+		Dependencies:  []string{"@pulumi/pulumi"},
+		ExpectFailure: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			foundError := false
+			for _, event := range stack.Events {
+				if event.ResOpFailedEvent != nil {
+					foundError = true
+					assert.Equal(t, apitype.OpType("create"), event.ResOpFailedEvent.Metadata.Op)
+				}
+			}
+			assert.True(t, foundError, "Did not see create error")
+		},
+	})
+}
+
 // Regression test for https://github.com/pulumi/pulumi/issues/12301
 func TestRegression12301Node(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
Little test to show errors work in dynamic providers, based on reports from Slack that there might be issues with this.