### PR TITLE
pkg/backend: Delete SupportsTeams methods

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -143,9 +143,6 @@ type Backend interface {
 	// SupportsOrganizations tells whether a user can belong to multiple organizations in this backend.
 	SupportsOrganizations() bool
 
-	// SupportsTeams tells whether a stack can have granular team permissions assigned to it.
-	SupportsTeams() bool
-
 	// ParseStackReference takes a string representation and parses it to a reference which may be used for other
 	// methods in this backend.
 	ParseStackReference(s string) (StackReference, error)
@@ -363,6 +360,10 @@ func (c *backendClient) GetStackResourceOutputs(
 	return pm, nil
 }
 
+// ErrTeamsNotSupported is returned by backends
+// which do not support the teams feature.
+var ErrTeamsNotSupported = errors.New("teams are not supported")
+
 // CreateStackOptions provides options for stack creation.
 // At present, options only apply to the Service.
 type CreateStackOptions struct {
@@ -370,5 +371,8 @@ type CreateStackOptions struct {
 	// the newly created stack.
 	// This option is only appropriate for backends
 	// which support teams (i.e. the Pulumi Service).
+	//
+	// The backend may return ErrTeamsNotSupported
+	// if Teams is specified but not supported.
 	Teams []string
 }

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -295,11 +295,6 @@ func (b *localBackend) GetPolicyPack(ctx context.Context, policyPack string,
 	return nil, fmt.Errorf("File state backend does not support resource policy")
 }
 
-// Teams are only supported in the Service backend.
-func (b *localBackend) SupportsTeams() bool {
-	return false
-}
-
 func (b *localBackend) ListPolicyGroups(ctx context.Context, orgName string, _ backend.ContinuationToken) (
 	apitype.ListPolicyGroupsResponse, backend.ContinuationToken, error,
 ) {
@@ -342,11 +337,9 @@ func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string)
 func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackReference,
 	root string, opts *backend.CreateStackOptions,
 ) (backend.Stack, error) {
-	// Before locking the stack, validate that the options provided are valid.
-	contract.Requiref(
-		opts == nil || len(opts.Teams) == 0,
-		"opts.Teams", "must be empty: filestate doesn't support teams",
-	)
+	if opts != nil && len(opts.Teams) > 0 {
+		return nil, backend.ErrTeamsNotSupported
+	}
 
 	localStackRef, err := b.getReference(stackRef)
 	if err != nil {

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -507,15 +507,8 @@ func TestLocalBackendRejectsStackInitOptions(t *testing.T) {
 	// • Simulate `pulumi stack init`, passing non-nil init options
 	fakeStackRef, err := local.ParseStackReference("foobar")
 	assert.NoError(t, err)
-	assert.Panics(t, func() {
-		// • Expect a panic because the options provided illegally
-		//   include a team.
-		_, err := local.CreateStack(ctx, fakeStackRef, "", illegalOptions)
-		assert.Fail(t, "This statement should be unreachable.")
-		// The linter complains if we don't check this error, even though
-		// the code should be unreachable.
-		assert.NoError(t, err)
-	})
+	_, err = local.CreateStack(ctx, fakeStackRef, "", illegalOptions)
+	assert.ErrorIs(t, err, backend.ErrTeamsNotSupported)
 }
 
 func TestNew_unsupportedStoreVersion(t *testing.T) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -570,10 +570,6 @@ func (b *cloudBackend) SupportsTags() bool {
 	return true
 }
 
-func (b *cloudBackend) SupportsTeams() bool {
-	return true
-}
-
 func (b *cloudBackend) SupportsOrganizations() bool {
 	return true
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -40,7 +40,6 @@ type MockBackend struct {
 	GetPolicyPackF         func(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 	SupportsTagsF          func() bool
 	SupportsOrganizationsF func() bool
-	SupportsTeamsF         func() bool
 	ParseStackReferenceF   func(s string) (StackReference, error)
 	ValidateStackNameF     func(s string) error
 	DoesProjectExistF      func(context.Context, string) (bool, error)
@@ -125,13 +124,6 @@ func (be *MockBackend) GetPolicyPack(
 func (be *MockBackend) SupportsTags() bool {
 	if be.SupportsTagsF != nil {
 		return be.SupportsTagsF()
-	}
-	panic("not implemented")
-}
-
-func (be *MockBackend) SupportsTeams() bool {
-	if be.SupportsTeamsF != nil {
-		return be.SupportsTeamsF()
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -168,14 +168,12 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		return projectErr
 	}
 
-	// Backend-specific config options. Currently only applicable to the HTTP backend.
-	createOpts, err := validateCreateStackOpts(cmd.stackName, b, cmd.teams)
-	if err != nil {
-		return err
-	}
-
+	createOpts := newCreateStackOptions(cmd.teams)
 	newStack, err := createStack(ctx, b, stackRef, root, createOpts, !cmd.noSelect, cmd.secretsProvider)
 	if err != nil {
+		if errors.Is(err, backend.ErrTeamsNotSupported) {
+			return newTeamsUnsupportedError(cmd.stackName, b.Name())
+		}
 		return err
 	}
 
@@ -207,30 +205,21 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 	return nil
 }
 
-// This function constructs a createStackOptions object if
-// valid, otherwise returning nil. Most backends expect nil
-// options, and error if options are non-nil.
-func validateCreateStackOpts(stackName string, b backend.Backend, teams []string) (*backend.CreateStackOptions, error) {
-	// • If the user provided teams but the backend doesn't support them,
-	//   return an error.
-	if len(teams) > 0 && !b.SupportsTeams() {
-		return nil, newTeamsUnsupportedError(stackName, b.Name())
-	}
-	// • Otherwise, validate the teams and pass them along.
-	//   Remove any strings from the list that are empty or just whitespace.
-	validatedTeams := teams[:0] // reuse storage.
+// newCreateStackOptions constructs a backend.CreateStackOptions object
+// from the provided options.
+func newCreateStackOptions(teams []string) *backend.CreateStackOptions {
+	// Remove any strings from the list that are empty or just whitespace.
+	validTeams := teams[:0] // reuse storage.
 	for _, team := range teams {
-		teamStr := strings.TrimSpace(team)
-		if len(teamStr) > 0 {
-			validatedTeams = append(validatedTeams, teamStr)
+		team = strings.TrimSpace(team)
+		if len(team) > 0 {
+			validTeams = append(validTeams, team)
 		}
 	}
 
-	// • We can return stack options that contain the provided teams.
-	//   since this will be zerod for non-Service backends.
 	return &backend.CreateStackOptions{
-		Teams: validatedTeams,
-	}, nil
+		Teams: validTeams,
+	}
 }
 
 // TeamsUnsupportedError is the error returned when the --teams

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -172,7 +172,8 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 	newStack, err := createStack(ctx, b, stackRef, root, createOpts, !cmd.noSelect, cmd.secretsProvider)
 	if err != nil {
 		if errors.Is(err, backend.ErrTeamsNotSupported) {
-			return newTeamsUnsupportedError(cmd.stackName, b.Name())
+			return fmt.Errorf("stack %s uses the %s backend: "+
+				"%s does not support --teams", cmd.stackName, b.Name(), b.Name())
 		}
 		return err
 	}
@@ -220,30 +221,4 @@ func newCreateStackOptions(teams []string) *backend.CreateStackOptions {
 	return &backend.CreateStackOptions{
 		Teams: validTeams,
 	}
-}
-
-// TeamsUnsupportedError is the error returned when the --teams
-// flag is provided on a backend that doesn't support teams.
-type teamsUnsupportedError struct {
-	stackName   string
-	backendType string
-}
-
-// NewTeamsUnsupportedError constructs an error for when users provide the --teams flag
-// for non-Service backends, or when options with teams are incorrectly provided to
-// a backend during stack creation.
-func newTeamsUnsupportedError(stackName, backendType string) *teamsUnsupportedError {
-	return &teamsUnsupportedError{
-		stackName:   stackName,
-		backendType: backendType,
-	}
-}
-
-func (err teamsUnsupportedError) Error() string {
-	return fmt.Sprintf(
-		"stack %s uses the %s backend: %s does not support --teams",
-		err.stackName,
-		err.backendType,
-		err.backendType,
-	)
 }


### PR DESCRIPTION
This deletes the SupportsTeams method added in #11974.
It came up during review that we want to avoid too many new
"SupportsFoo" methods.

Instead, we'll let each backend report whether it supports teams
by returning ErrTeamsNotSupported.

As a result of this change, validateCreateStackOpts cannot error,
so it's been renamed to newCreateStackOptions.

Testing:
There's already a test (added in the #12499 refactor)
that verifies that we report the appropriate error
when the backend doesn't support --teams.
This updates the mock in that test.
