### PR TITLE
[pcl/python] Implemented python program-gen for PCL components

### DIFF
--- a/changelog/pending/20230329--programgen-python--impleneted-python-program-gen-for-pcl-components.yaml
+++ b/changelog/pending/20230329--programgen-python--impleneted-python-program-gen-for-pcl-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/python
+  description: Impleneted python program-gen for PCL components

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -420,6 +420,14 @@ func componentElementType(pclType model.Type) string {
 			// something is already an output
 			// get only the element type because we are wrapping these in Output<T> anyway
 			return componentElementType(pclType.ElementType)
+		case *model.UnionType:
+			if len(pclType.ElementTypes) == 2 && pclType.ElementTypes[0] == model.NoneType {
+				return componentElementType(pclType.ElementTypes[1])
+			} else if len(pclType.ElementTypes) == 2 && pclType.ElementTypes[1] == model.NoneType {
+				return componentElementType(pclType.ElementTypes[0])
+			} else {
+				return "any"
+			}
 		default:
 			return "any"
 		}

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -236,3 +236,13 @@ func GenerateMultiArguments(
 		}
 	}
 }
+
+func SortedStringKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0)
+	for propertyName := range m {
+		keys = append(keys, propertyName)
+	}
+
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -565,6 +565,19 @@ func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.Rela
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
 	rootName := PyName(expr.RootName)
+	if g.isComponent {
+		configVars := map[string]*pcl.ConfigVariable{}
+		for _, configVar := range g.program.ConfigVariables() {
+			configVars[configVar.Name()] = configVar
+		}
+
+		if _, isConfig := configVars[expr.RootName]; isConfig {
+			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
+				rootName = fmt.Sprintf("args[\"%s\"]", expr.RootName)
+			}
+		}
+	}
+
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"
 	}

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -52,7 +52,10 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 		keyVal, objectKey := key.AsString(), false
 
 		receiver := parts[i]
-		if _, ok := pcl.GetSchemaForType(model.GetTraversableType(receiver)); ok {
+		_, hasSchema := pcl.GetSchemaForType(model.GetTraversableType(receiver))
+		_, isComponent := receiver.(*pcl.Component)
+
+		if hasSchema || isComponent {
 			objectKey, keyVal = true, PyName(keyVal)
 			switch t := traverser.(type) {
 			case hcl.TraverseAttr:

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -234,8 +234,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "components",
 		Description: "Components",
-		Skip:        allProgLanguages.Except("dotnet").Except("nodejs"),
-		SkipCompile: allProgLanguages.Except("dotnet").Except("nodejs"),
+		Skip:        codegen.NewStringSet("go"),
+		SkipCompile: codegen.NewStringSet("go"),
 	},
 	{
 		Directory:   "retain-on-delete",

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/ExampleComponent.cs
@@ -7,6 +7,12 @@ namespace Components
 {
     public class ExampleComponentArgs : global::Pulumi.ResourceArgs
     {
+        public class DeploymentZonesArgs : global::Pulumi.ResourceArgs
+        {
+            [Input("zone")]
+            public Input<string>? Zone { get; set; }
+        }
+
         public class GithubAppArgs : global::Pulumi.ResourceArgs
         {
             [Input("id")]
@@ -21,12 +27,6 @@ namespace Components
         {
             [Input("name")]
             public Input<string>? Name { get; set; }
-        }
-
-        public class DeploymentZonesArgs : global::Pulumi.ResourceArgs
-        {
-            [Input("zone")]
-            public Input<string>? Zone { get; set; }
         }
 
         /// <summary>

--- a/pkg/codegen/testing/test/testdata/components-pp/python/components.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/components.py
@@ -1,0 +1,39 @@
+import pulumi
+from .exampleComponent import ExampleComponent
+from .simpleComponent import SimpleComponent
+
+simple_component = SimpleComponent("simpleComponent")
+example_component = ExampleComponent("exampleComponent", {
+    'input': "doggo", 
+    'ipAddress': [
+        127,
+        0,
+        0,
+        1,
+    ], 
+    'cidrBlocks': {
+        "one": "uno",
+        "two": "dos",
+    }, 
+    'githubApp': {
+        "id": "example id",
+        "keyBase64": "base64 encoded key",
+        "webhookSecret": "very important secret",
+    }, 
+    'servers': [
+        {
+            "name": "First",
+        },
+        {
+            "name": "Second",
+        },
+    ], 
+    'deploymentZones': {
+        "first": {
+            "zone": "First zone",
+        },
+        "second": {
+            "zone": "Second zone",
+        },
+    }})
+pulumi.export("result", example_component.result)

--- a/pkg/codegen/testing/test/testdata/components-pp/python/exampleComponent.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/exampleComponent.py
@@ -1,0 +1,65 @@
+import pulumi
+from .simpleComponent import SimpleComponent
+from pulumi import Input
+from typing import Optional, Dict, TypedDict, Any
+import pulumi_random as random
+
+class DeploymentZones(TypedDict, total=False):
+    zone: Input[str]
+
+class GithubApp(TypedDict, total=False):
+    id: Input[str]
+    keyBase64: Input[str]
+    webhookSecret: Input[str]
+
+class Servers(TypedDict, total=False):
+    name: Input[str]
+
+class ExampleComponentArgs(TypedDict, total=False):
+    input: Input[str]
+    cidrBlocks: Input[Dict[str, str]]
+    githubApp: Input[GithubApp]
+    servers: Input[list(Servers)]
+    deploymentZones: Input[Dict[str, DeploymentZones]]
+    ipAddress: Input[list[int]]
+
+class ExampleComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, args: ExampleComponentArgs, opts:Optional[pulumi.ResourceOptions] = None):
+        super().__init__("components:index:ExampleComponent", name, args, opts)
+
+        password = random.RandomPassword(f"{name}-password",
+            length=16,
+            special=True,
+            override_special=args["input"],
+            opts=pulumi.ResourceOptions(parent=self))
+
+        github_password = random.RandomPassword(f"{name}-githubPassword",
+            length=16,
+            special=True,
+            override_special=args["githubApp"]["webhookSecret"],
+            opts=pulumi.ResourceOptions(parent=self))
+
+        # Example of iterating a list of objects
+        server_passwords = []
+        for range in [{"value": i} for i in range(0, len(args["servers"]))]:
+            server_passwords.append(random.RandomPassword(f"{name}-serverPasswords-{range['value']}",
+                length=16,
+                special=True,
+                override_special=args["servers"][range["value"]]["name"],
+                opts=pulumi.ResourceOptions(parent=self)))
+
+        # Example of iterating a map of objects
+        zone_passwords = []
+        for range in [{"key": k, "value": v} for [k, v] in enumerate(args["deploymentZones"])]:
+            zone_passwords.append(random.RandomPassword(f"{name}-zonePasswords-{range['key']}",
+                length=16,
+                special=True,
+                override_special=range["value"]["zone"],
+                opts=pulumi.ResourceOptions(parent=self)))
+
+        simple_component = SimpleComponent(f"{name}-simpleComponent", opts=pulumi.ResourceOptions(parent=self))
+
+        self.result = password.result
+        self.register_outputs({
+            'result': password.result
+        })

--- a/pkg/codegen/testing/test/testdata/components-pp/python/simpleComponent.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/simpleComponent.py
@@ -1,0 +1,20 @@
+import pulumi
+from pulumi import Input
+from typing import Optional, Dict, TypedDict, Any
+import pulumi_random as random
+
+class SimpleComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("components:index:SimpleComponent", name, {}, opts)
+
+        first_password = random.RandomPassword(f"{name}-firstPassword",
+            length=16,
+            special=True,
+            opts=pulumi.ResourceOptions(parent=self))
+
+        second_password = random.RandomPassword(f"{name}-secondPassword",
+            length=16,
+            special=True,
+            opts=pulumi.ResourceOptions(parent=self))
+
+        self.register_outputs()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Implements python program-gen for components

Still todo:

 - [x] worked out correct types for component arguments
 - [x] fixed component scope traversals
 - [x] made object-typed component variables optional by default

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
