### PR TITLE
feat: add json flag to config set all

### DIFF
--- a/changelog/pending/20230329--cli-config--adds-a-json-flag-to-pulumi-config-set-all-this-flag-enables-users-to-set-configs-from-a-json-input.yaml
+++ b/changelog/pending/20230329--cli-config--adds-a-json-flag-to-pulumi-config-set-all-this-flag-enables-users-to-set-configs-from-a-json-input.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Adds a --json flag to pulumi config --set-all, this flag enables users to set configs from a json input

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -599,6 +599,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 	var plaintextArgs []string
 	var secretArgs []string
 	var path bool
+	var rawJsonArgs string
 
 	setCmd := &cobra.Command{
 		Use:   "set-all --plaintext key1=value1 --plaintext key2=value2 --secret key3=value3",
@@ -613,12 +614,19 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			"  - `pulumi config set-all --path --plaintext parent.nested=value --plaintext parent.other=value2` \n" +
 			"    will set the value of `parent` to a map `{nested: value, other: value2}`.\n" +
 			"  - `pulumi config set-all --path --plaintext '[\"parent.name\"].[\"nested.name\"]'=value` will set the \n" +
-			"    value of `parent.name` to a map `nested.name: value`.",
+			"    value of `parent.name` to a map `nested.name: value`." +
+			"The --json flag can be used to set multiple configuration values from a json input, the json input musst be \n"+
+			"in the same format as the output of `pulumi config --json`. \n"+
+			"When using the --json flag it's not possible to use the --plaintext and --secret arguments",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
+			}
+			hasTextArgs := len(plaintextArgs) > 0 || len(secretArgs) > 0 || path
+			if rawJsonArgs != "" && hasTextArgs {
+				return fmt.Errorf("cannot set config from json and text args simultaneously")
 			}
 
 			project, _, err := readProject()
@@ -636,7 +644,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+		
 			for _, ptArg := range plaintextArgs {
 				key, value, err := parseKeyValuePair(ptArg)
 				if err != nil {
@@ -670,6 +678,20 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 					return err
 				}
 			}
+            
+			if rawJsonArgs != "" {
+				configJsonValue, err := parseJsonConfig(rawJsonArgs)
+				
+				if err != nil {
+					return err
+				} 
+			
+				err = setConfigFromJsonValue(ctx,stack,ps,configJsonValue)
+				if err != nil {
+					return err
+				}
+				
+			}
 
 			return saveProjectStack(stack, ps)
 		}),
@@ -684,8 +706,86 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 	setCmd.PersistentFlags().StringArrayVar(
 		&secretArgs, "secret", []string{},
 		"Marks a value as secret to be encrypted")
+	setCmd.PersistentFlags().StringVar(
+		&rawJsonArgs, "json", "",
+		"Parse the keys as from a json input")
 
 	return setCmd
+}
+
+func parseJsonConfig(jsonConfig string) (map[string]configValueJSON,error){
+	config := make(map[string]configValueJSON)
+	err := json.Unmarshal([]byte(jsonConfig),&config)
+	if err != nil {
+		return config,err
+	}
+	return config,nil
+}
+
+func encryptValue(ctx context.Context, stack backend.Stack,value string)(string,error){
+	c, cerr := getStackEncrypter(stack)
+				if cerr != nil {
+					return "",cerr
+				}
+				enc, eerr := c.EncryptValue(ctx, value)
+				if eerr != nil {
+					return "",eerr
+				}
+				return enc,nil
+}
+
+func setKeyValuePairFromJson(ctx context.Context, stack backend.Stack,ps *workspace.ProjectStack,key config.Key,jsonValue configValueJSON)(error){
+	var value config.Value 
+	if jsonValue.ObjectValue != nil {
+		if jsonValue.Secret {
+			enc,err := encryptValue(ctx,stack,*jsonValue.Value)
+			if err != nil {
+				return err
+			}
+            value = config.NewSecureObjectValue(enc)	
+		}else{
+			value = config.NewObjectValue(*jsonValue.Value)
+		}
+		err := ps.Config.Set(key,value,true)
+		if err != nil {
+					return err
+		}
+		return nil
+	}
+	
+	if jsonValue.Secret {
+		enc,err := encryptValue(ctx,stack,*jsonValue.Value)
+			if err != nil {
+				return err
+			}
+	    value = config.NewSecureValue(enc)
+	}else{
+		value = config.NewValue(*jsonValue.Value)
+	}
+	err := ps.Config.Set(key,value,false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setConfigFromJsonValue(ctx context.Context, stack backend.Stack,ps *workspace.ProjectStack,jsonValues map[string]configValueJSON) (error){
+	for keyName, element := range jsonValues {
+		if element.Value == nil {
+			return fmt.Errorf("invalid json input, all config entries must have values")
+		}
+        key,err := parseConfigKey(keyName)
+		if err != nil {
+			return err
+		}
+		
+		err = setKeyValuePairFromJson(ctx,stack,ps,key,element)
+        if err != nil {
+			return err
+		}
+    }
+
+	return nil
 }
 
 func parseKeyValuePair(pair string) (config.Key, string, error) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR sdds a --json flag to pulumi config --set-all, this flag enables users to set configs from a json input, as requested in issue https://github.com/pulumi/pulumi/issues/11872 . With this feature, users can run `pulumi config set-all --json $YOUR_JSON_INPUT`  to set many configuration values, the json inputs should follow the same interface as the output of `pulumi config --json`  

Fixes https://github.com/pulumi/pulumi/issues/11872

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
