### PR TITLE
Test and fix component->custom->component lifecycle

### DIFF
--- a/changelog/pending/20230330--engine--fix-updating-a-resource-from-a-component-to-custom-resource.yaml
+++ b/changelog/pending/20230330--engine--fix-updating-a-resource-from-a-component-to-custom-resource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix updating a resource from a component to custom resource.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1424,7 +1424,14 @@ func (sg *stepGenerator) providerChanged(urn resource.URN, old, new *resource.St
 	}
 
 	logging.V(stepExecutorLogLevel).Infof("sg.diffProvider(%s, ...): observed provider diff", urn)
-	logging.V(stepExecutorLogLevel).Infof("sg.diffProvider(%s, ...): %s => %s", urn, old.Provider, new.Provider)
+	logging.V(stepExecutorLogLevel).Infof("sg.diffProvider(%s, ...): %v => %v", urn, old.Provider, new.Provider)
+
+	// If we're changing from a component resource to a non-component resource, there is no old provider to
+	// diff against and trigger a delete but we need to Create the new custom resource. If we're changing from
+	// a custom resource to a component resource, we should always trigger a replace.
+	if old.Provider == "" || new.Provider == "" {
+		return true, nil
+	}
 
 	oldRef, err := providers.ParseReference(old.Provider)
 	if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12550

If we're updating a resource from a component to custom resource (or vice versa) we always mark it as a provider diff and so trigger a replace.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
