### PR TITLE
fix data race in `plugin.Context`

### DIFF
--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextRequest_race(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := NewContext(
+		diagtest.LogSink(t), // The diagnostics sink to use for messages.
+		diagtest.LogSink(t), // The diagnostics sink to use for status messages.
+		nil,                 // the host that can be used to fetch providers.
+		nil,                 // configSource
+		t.TempDir(),         // the working directory to spawn all plugins in.
+		nil,                 // runtimeOptions
+		false,               // disableProviderPreview
+		mocktracer.New().StartSpan("root"),
+	)
+	require.NoError(t, err)
+
+	// Run 10 goroutines that all call context.Request() concurrently to trigger the race detector.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx.Request()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This PR fixes a data race `plugin.Context` that was detected by the Go race detector.
```
==================
WARNING: DATA RACE
Read at 0x00c000630430 by goroutine 3223:
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*Context).Request()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/context.go:116 +0xf1
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*provider).requestContext()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/provider_plugin.go:300 +0x564
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*provider).Create()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/provider_plugin.go:898 +0x565
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*CreateStep).Apply()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step.go:246 +0x219
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).executeStep()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:300 +0x238
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).executeChain()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:250 +0x138
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).worker.func1()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:437 +0x108

Previous write at 0x00c000630430 by goroutine 3221:
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*Context).Request()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/context.go:116 +0x18f
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*provider).requestContext()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/provider_plugin.go:300 +0x564
  github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.(*provider).Create()
      /home/kdixler/go/src/github.com/pulumi/pulumi/sdk/go/common/resource/plugin/provider_plugin.go:898 +0x565
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*CreateStep).Apply()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step.go:246 +0x219
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).executeStep()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:300 +0x238
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).executeChain()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:250 +0x138
  github.com/pulumi/pulumi/pkg/v3/resource/deploy.(*stepExecutor).worker.func1()
      /home/kdixler/go/src/github.com/pulumi/pulumi/pkg/resource/deploy/step_executor.go:437 +0x108

```
