### PR TITLE
Fixed panic in display on narrow terminals

### DIFF
--- a/changelog/pending/20230330--cli-display--fixes-a-bug-in-the-interactive-update-tree-display-where-small-terminals-would-cause-pulumi-to-panic.yaml
+++ b/changelog/pending/20230330--cli-display--fixes-a-bug-in-the-interactive-update-tree-display-where-small-terminals-would-cause-pulumi-to-panic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fixes a bug in the interactive update tree display where small terminals would cause the Pulumi CLI to panic.

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -266,6 +266,10 @@ func (r *treeRenderer) frame(locked, done bool) {
 			r.treeTableOffset = r.maxTreeTableOffset
 		}
 
+		if treeTableHeight <= 0 {
+			// Ensure that the treeTableHeight is at least 1 to avoid going out of bounds.
+			treeTableHeight = 1
+		}
 		treeTableRows = treeTableRows[r.treeTableOffset : r.treeTableOffset+treeTableHeight-1]
 
 		totalHeight = treeTableHeight + systemMessagesHeight + statusMessageHeight + 1
@@ -292,6 +296,12 @@ func (r *treeRenderer) frame(locked, done bool) {
 			statusMessageHeight, statusMessage = 0, ""
 		}
 
+		if padding < 0 {
+			// Padding can potentially go negative on very small terminals.
+			// This will cause a panic. To avoid this, we clamp the padding to 0.
+			// The user won't be able to see anything anyway.
+			padding = 0
+		}
 		treeTableFooter = r.opts.Color.Colorize(prefix + strings.Repeat(" ", padding) + footer)
 
 		if systemMessagesHeight > 0 {

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+// Table Test using different terminal widths and heights to ensure that the display does not panic.
+func TestTreeFrameSize(t *testing.T) {
+	t.Parallel()
+
+	// Table Test using different terminal widths and heights
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"narrow", 1, 100},
+		{"short", 100, 1},
+		{"small", 1, 1},
+		{"normal", 100, 100},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			term := terminal.NewMockTerminal(&buf, tt.width, tt.height, true)
+			treeRenderer := newInteractiveRenderer(term, "this-is-a-fake-permalink", Options{
+				Color: colors.Always,
+			}).(*treeRenderer)
+
+			// Fill the renderer with too many rows of strings to fit in the terminal.
+			for i := 0; i < 1000; i++ {
+				// Fill the renderer with strings that are too long to fit in the terminal.
+				treeRenderer.systemMessages = append(treeRenderer.systemMessages, strings.Repeat("a", 1000))
+			}
+			treeRenderer.treeTableRows = treeRenderer.systemMessages
+
+			// Required to get the frame to render.
+			treeRenderer.dirty = true
+
+			// This should not panic.
+			treeRenderer.frame(false /* locked */, false /* done */)
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR fixes 2 panics in the interactive update display code where a small terminal would cause panics when:
- calculation of the displayed rows to yield a negative index
- strings.Repeat() would go negative

Fixes #12545 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
