### PR TITLE
Add more details to `pulumi stack history` to provide more context.

### DIFF
--- a/changelog/pending/20230331--backend-filestate-service--add-more-environment-metadata-to-updateinfo-update-cli-args-environment-variables-pulumi-version-os-architecture.yaml
+++ b/changelog/pending/20230331--backend-filestate-service--add-more-environment-metadata-to-updateinfo-update-cli-args-environment-variables-pulumi-version-os-architecture.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/filestate,service
+  description: Add more information to `pulumi stack history` (Update CLI Args, Environment Variables, Pulumi Version, OS, Architecture).

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -176,7 +176,7 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
 			if err != nil {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -628,7 +628,7 @@ func newImportCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
 			if err != nil {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -166,7 +166,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "")
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
 			if err != nil {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -169,7 +169,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, execAgent, false)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())
 			if err != nil {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -83,7 +83,7 @@ func newUpCmd() *cobra.Command {
 	var planFilePath string
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
-	upWorkingDirectory := func(ctx context.Context, opts backend.UpdateOptions) result.Result {
+	upWorkingDirectory := func(ctx context.Context, opts backend.UpdateOptions, cmd *cobra.Command) result.Result {
 		s, err := requireStack(ctx, stackName, stackOfferNew, opts.Display)
 		if err != nil {
 			return result.FromError(err)
@@ -99,7 +99,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "")
+		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
 		if err != nil {
 			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
@@ -192,7 +192,7 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is a template name or a URL to a template.
 	upTemplateNameOrURL := func(ctx context.Context,
-		templateNameOrURL string, opts backend.UpdateOptions,
+		templateNameOrURL string, opts backend.UpdateOptions, cmd *cobra.Command,
 	) result.Result {
 		// Retrieve the template repo.
 		repo, err := workspace.RetrieveTemplates(templateNameOrURL, false, workspace.TemplateKindPulumiProject)
@@ -321,7 +321,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "")
+		m, err := getUpdateMetadata(message, root, execKind, execAgent, planFilePath != "", cmd.Flags())
 		if err != nil {
 			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
@@ -483,10 +483,10 @@ func newUpCmd() *cobra.Command {
 			}
 
 			if len(args) > 0 {
-				return upTemplateNameOrURL(ctx, args[0], opts)
+				return upTemplateNameOrURL(ctx, args[0], opts, cmd)
 			}
 
-			return upWorkingDirectory(ctx, opts)
+			return upWorkingDirectory(ctx, opts, cmd)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -104,7 +104,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */, false)
+			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */, false, cmd.Flags())
 			if err != nil {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
After running an update, it's not necessarily clear what envvars or flags were set. This can make it unclear how an update was performed and can make reproductions of issues more difficult.

As a user, I set aliases to set flags, export PULUMI envvars in my `.zshrc`, and upgrade pulumi and when looking at an updates that ran successfully a month ago on one machine and may not run successfully on my current machine, I'd like to know this context that performed the update to enable better root cause analysis of the error.

To address this, this PR augments the existing Update Metadata to track the:
- CLI flags set (name only)
- `PULUMI_` Environment Variables set (name and truthiness `true` otherwise `set`)
- Version of Pulumi used
- Operating System and CPU Architecture (runtime.GOOS, runtime.GOARCH)


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
