### PR TITLE
Check if Plugin is bundled before installing

### DIFF
--- a/changelog/pending/20230331--cli-plugin--improve-error-pulumi-plugin-install.yaml
+++ b/changelog/pending/20230331--cli-plugin--improve-error-pulumi-plugin-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Improve error message during `pulumi plugin install` if the plugin is bundled with Pulumi

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -23,28 +24,20 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-
 	"github.com/blang/semver"
-
-	"github.com/spf13/cobra"
-
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
 )
 
 func newPluginInstallCmd() *cobra.Command {
-	var serverURL string
-	var exact bool
-	var file string
-	var reinstall bool
-	var checksum string
-
+	var picmd pluginInstallCmd
 	cmd := &cobra.Command{
 		Use:   "install [KIND NAME [VERSION]]",
 		Args:  cmdutil.MaximumNArgs(3),
@@ -62,161 +55,179 @@ func newPluginInstallCmd() *cobra.Command {
 			"the plugin, though the result is not guaranteed.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
-			displayOpts := display.Options{
-				Color: cmdutil.GetGlobalColorization(),
-			}
-
-			// Parse the kind, name, and version, if specified.
-			var installs []workspace.PluginSpec
-			if len(args) > 0 {
-				if !workspace.IsPluginKind(args[0]) {
-					return fmt.Errorf("unrecognized plugin kind: %s", args[0])
-				} else if len(args) < 2 {
-					return errors.New("missing plugin name argument")
-				}
-
-				var version *semver.Version
-				if len(args) == 3 {
-					parsedVersion, err := semver.ParseTolerant(args[2])
-					version = &parsedVersion
-					if err != nil {
-						return fmt.Errorf("invalid plugin semver: %w", err)
-					}
-				}
-				if len(args) < 3 && file != "" {
-					return errors.New("missing plugin version argument, this is required if installing from a file")
-				}
-
-				var checksums map[string][]byte
-				if checksum != "" {
-					checksumBytes, err := hex.DecodeString(checksum)
-					if err != nil {
-						return fmt.Errorf("--checksum was not a valid hex string: %w", err)
-					}
-					checksums = map[string][]byte{
-						runtime.GOOS + "-" + runtime.GOARCH: checksumBytes,
-					}
-				}
-
-				pluginSpec := workspace.PluginSpec{
-					Kind:              workspace.PluginKind(args[0]),
-					Name:              args[1],
-					Version:           version,
-					PluginDownloadURL: serverURL, // If empty, will use default plugin source.
-					Checksums:         checksums,
-				}
-
-				// Try and set known plugin download URLs
-				if urlSet := util.SetKnownPluginDownloadURL(&pluginSpec); urlSet {
-					cmdutil.Diag().Infof(
-						diag.Message("", "Plugin download URL set to %s"), pluginSpec.PluginDownloadURL)
-				}
-
-				// If we don't have a version try to look one up
-				if version == nil {
-					latestVersion, err := pluginSpec.GetLatestVersion()
-					if err != nil {
-						return err
-					}
-					pluginSpec.Version = latestVersion
-				}
-
-				installs = append(installs, pluginSpec)
-			} else {
-				if file != "" {
-					return errors.New("--file (-f) is only valid if a specific package is being installed")
-				}
-				if checksum != "" {
-					return errors.New("--checksum is only valid if a specific package is being installed")
-				}
-
-				// If a specific plugin wasn't given, compute the set of plugins the current project needs.
-				plugins, err := getProjectPlugins()
-				if err != nil {
-					return err
-				}
-				for _, plugin := range plugins {
-					// Skip language plugins; by definition, we already have one installed.
-					// TODO[pulumi/pulumi#956]: eventually we will want to honor and install these in the usual way.
-					if plugin.Kind != workspace.LanguagePlugin {
-						installs = append(installs, plugin)
-					}
-				}
-			}
-
-			// Now for each kind, name, version pair, download it from the release website, and install it.
-			for _, install := range installs {
-				label := fmt.Sprintf("[%s plugin %s]", install.Kind, install)
-
-				// If the plugin already exists, don't download it unless --reinstall was passed.  Note that
-				// by default we accept plugins with >= constraints, unless --exact was passed which requires ==.
-				if !reinstall {
-					if exact {
-						if workspace.HasPlugin(install) {
-							logging.V(1).Infof("%s skipping install (existing == match)", label)
-							continue
-						}
-					} else {
-						if has, _ := workspace.HasPluginGTE(install); has {
-							logging.V(1).Infof("%s skipping install (existing >= match)", label)
-							continue
-						}
-					}
-				}
-
-				cmdutil.Diag().Infoerrf(
-					diag.Message("", "%s installing"), label)
-
-				// If we got here, actually try to do the download.
-				var source string
-				var payload workspace.PluginContent
-				var err error
-				if file == "" {
-					withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
-						return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
-					}
-					retry := func(err error, attempt int, limit int, delay time.Duration) {
-						cmdutil.Diag().Warningf(
-							diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
-					}
-
-					r, err := workspace.DownloadToFile(install, withProgress, retry)
-					if err != nil {
-						return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
-					}
-					defer func() { contract.IgnoreError(os.Remove(r.Name())) }()
-
-					payload = workspace.TarPlugin(r)
-				} else {
-					source = file
-					logging.V(1).Infof("%s opening tarball from %s", label, file)
-					payload, err = getFilePayload(file, install)
-					if err != nil {
-						return err
-					}
-				}
-				logging.V(1).Infof("%s installing tarball ...", label)
-				if err = install.InstallWithContext(ctx, payload, reinstall); err != nil {
-					return fmt.Errorf("installing %s from %s: %w", label, source, err)
-				}
-			}
-
-			return nil
+			return picmd.Run(ctx, args)
 		}),
 	}
 
-	cmd.PersistentFlags().StringVar(&serverURL,
+	cmd.PersistentFlags().StringVar(&picmd.serverURL,
 		"server", "", "A URL to download plugins from")
-	cmd.PersistentFlags().BoolVar(&exact,
+	cmd.PersistentFlags().BoolVar(&picmd.exact,
 		"exact", false, "Force installation of an exact version match (usually >= is accepted)")
-	cmd.PersistentFlags().StringVarP(&file,
+	cmd.PersistentFlags().StringVarP(&picmd.file,
 		"file", "f", "", "Install a plugin from a binary, folder or tarball, instead of downloading it")
-	cmd.PersistentFlags().BoolVar(&reinstall,
+	cmd.PersistentFlags().BoolVar(&picmd.reinstall,
 		"reinstall", false, "Reinstall a plugin even if it already exists")
-	cmd.PersistentFlags().StringVar(&checksum,
+	cmd.PersistentFlags().StringVar(&picmd.checksum,
 		"checksum", "", "The expected SHA256 checksum for the plugin archive")
 
 	return cmd
+}
+
+type pluginInstallCmd struct {
+	serverURL string
+	exact     bool
+	file      string
+	reinstall bool
+	checksum  string
+
+	diag  diag.Sink
+	color colors.Colorization
+}
+
+func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
+	if cmd.diag == nil {
+		cmd.diag = cmdutil.Diag()
+	}
+	if cmd.color == "" {
+		cmd.color = cmdutil.GetGlobalColorization()
+	}
+
+	// Parse the kind, name, and version, if specified.
+	var installs []workspace.PluginSpec
+	if len(args) > 0 {
+		if !workspace.IsPluginKind(args[0]) {
+			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
+		} else if len(args) < 2 {
+			return errors.New("missing plugin name argument")
+		}
+
+		var version *semver.Version
+		if len(args) == 3 {
+			parsedVersion, err := semver.ParseTolerant(args[2])
+			version = &parsedVersion
+			if err != nil {
+				return fmt.Errorf("invalid plugin semver: %w", err)
+			}
+		}
+		if len(args) < 3 && cmd.file != "" {
+			return errors.New("missing plugin version argument, this is required if installing from a file")
+		}
+
+		var checksums map[string][]byte
+		if cmd.checksum != "" {
+			checksumBytes, err := hex.DecodeString(cmd.checksum)
+			if err != nil {
+				return fmt.Errorf("--checksum was not a valid hex string: %w", err)
+			}
+			checksums = map[string][]byte{
+				runtime.GOOS + "-" + runtime.GOARCH: checksumBytes,
+			}
+		}
+
+		pluginSpec := workspace.PluginSpec{
+			Kind:              workspace.PluginKind(args[0]),
+			Name:              args[1],
+			Version:           version,
+			PluginDownloadURL: cmd.serverURL, // If empty, will use default plugin source.
+			Checksums:         checksums,
+		}
+
+		// Try and set known plugin download URLs
+		if urlSet := util.SetKnownPluginDownloadURL(&pluginSpec); urlSet {
+			cmd.diag.Infof(
+				diag.Message("", "Plugin download URL set to %s"), pluginSpec.PluginDownloadURL)
+		}
+
+		// If we don't have a version try to look one up
+		if version == nil {
+			latestVersion, err := pluginSpec.GetLatestVersion()
+			if err != nil {
+				return err
+			}
+			pluginSpec.Version = latestVersion
+		}
+
+		installs = append(installs, pluginSpec)
+	} else {
+		if cmd.file != "" {
+			return errors.New("--file (-f) is only valid if a specific package is being installed")
+		}
+		if cmd.checksum != "" {
+			return errors.New("--checksum is only valid if a specific package is being installed")
+		}
+
+		// If a specific plugin wasn't given, compute the set of plugins the current project needs.
+		plugins, err := getProjectPlugins()
+		if err != nil {
+			return err
+		}
+		for _, plugin := range plugins {
+			// Skip language plugins; by definition, we already have one installed.
+			// TODO[pulumi/pulumi#956]: eventually we will want to honor and install these in the usual way.
+			if plugin.Kind != workspace.LanguagePlugin {
+				installs = append(installs, plugin)
+			}
+		}
+	}
+
+	// Now for each kind, name, version pair, download it from the release website, and install it.
+	for _, install := range installs {
+		label := fmt.Sprintf("[%s plugin %s]", install.Kind, install)
+
+		// If the plugin already exists, don't download it unless --reinstall was passed.  Note that
+		// by default we accept plugins with >= constraints, unless --exact was passed which requires ==.
+		if !cmd.reinstall {
+			if cmd.exact {
+				if workspace.HasPlugin(install) {
+					logging.V(1).Infof("%s skipping install (existing == match)", label)
+					continue
+				}
+			} else {
+				if has, _ := workspace.HasPluginGTE(install); has {
+					logging.V(1).Infof("%s skipping install (existing >= match)", label)
+					continue
+				}
+			}
+		}
+
+		cmdutil.Diag().Infoerrf(
+			diag.Message("", "%s installing"), label)
+
+		// If we got here, actually try to do the download.
+		var source string
+		var payload workspace.PluginContent
+		var err error
+		if cmd.file == "" {
+			withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
+				return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", cmd.color)
+			}
+			retry := func(err error, attempt int, limit int, delay time.Duration) {
+				cmd.diag.Warningf(
+					diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
+			}
+
+			r, err := workspace.DownloadToFile(install, withProgress, retry)
+			if err != nil {
+				return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
+			}
+			defer func() { contract.IgnoreError(os.Remove(r.Name())) }()
+
+			payload = workspace.TarPlugin(r)
+		} else {
+			source = cmd.file
+			logging.V(1).Infof("%s opening tarball from %s", label, cmd.file)
+			payload, err = getFilePayload(cmd.file, install)
+			if err != nil {
+				return err
+			}
+		}
+		logging.V(1).Infof("%s installing tarball ...", label)
+		if err = install.InstallWithContext(ctx, payload, cmd.reinstall); err != nil {
+			return fmt.Errorf("installing %s from %s: %w", label, source, err)
+		}
+	}
+
+	return nil
 }
 
 func getFilePayload(file string, spec workspace.PluginSpec) (workspace.PluginContent, error) {

--- a/pkg/cmd/pulumi/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin_install_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test for https://github.com/pulumi/pulumi/issues/11703, check we give an error when trying to install a
+// bundled plugin
+func TestBundledError(t *testing.T) {
+	t.Parallel()
+
+	cmd := &pluginInstallCmd{
+		diag: diagtest.LogSink(t),
+		env: env.NewEnv(
+			env.MapStore{"PULUMI_DEV": "false"},
+		),
+	}
+
+	err := cmd.Run(context.Background(), []string{"language", "nodejs"})
+	assert.EqualError(t, err,
+		"the nodejs language plugin is bundled with Pulumi, "+
+			"and cannot be directly installed with this command. "+
+			"If you need to reinstall this plugin, reinstall Pulumi via your package manager or install script.")
+}
+
+// Test for https://github.com/pulumi/pulumi/issues/11703, check we still try to install bundled plugins if
+// PULUMI_DEV is set.
+func TestBundledDev(t *testing.T) {
+	t.Parallel()
+
+	var getLatestVersionCalled bool
+	defer func() {
+		assert.True(t, getLatestVersionCalled, "GetLatestVersion should have been called")
+	}()
+
+	cmd := &pluginInstallCmd{
+		diag: diagtest.LogSink(t),
+		env: env.NewEnv(
+			env.MapStore{"PULUMI_DEV": "true"},
+		),
+		pluginGetLatestVersion: func(ps workspace.PluginSpec) (*semver.Version, error) {
+			getLatestVersionCalled = true
+			assert.Equal(t, "nodejs", ps.Name)
+			assert.Equal(t, workspace.LanguagePlugin, ps.Kind)
+			return nil, fmt.Errorf("404 HTTP error fetching plugin")
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{"language", "nodejs"})
+	assert.ErrorContains(t, err, "404 HTTP error fetching plugin")
+}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1064,8 +1064,8 @@ func TestBundledPluginSearch(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
-	// Create a fake side-by-side plugin next to this executable
-	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-mock")
+	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
+	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
 	err = os.WriteFile(bundledPath, []byte{}, 0o700) //nolint: gosec // we intended to write an executable file here
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -1073,22 +1073,22 @@ func TestBundledPluginSearch(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// Create a fake plugin in the path
+	// Create another copy of the fake plugin in $PATH
 	pathDir := t.TempDir()
 	t.Setenv("PATH", pathDir)
-	ambientPath := filepath.Join(pathDir, "pulumi-language-mock")
+	ambientPath := filepath.Join(pathDir, "pulumi-language-nodejs")
 	err = os.WriteFile(ambientPath, []byte{}, 0o700) //nolint: gosec
 	require.NoError(t, err)
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(LanguagePlugin, "mock", nil, nil)
+	path, err := GetPluginPath(LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(LanguagePlugin, "mock", nil, nil)
+	path, err = GetPluginPath(LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds a check to `pulumi plugin install` to confirm that the plugin is not bundled with Pulumi before performing the download. Without this check, the CLI will produce a 404 error because the language plugins aren't distributable independently of the CLI executable.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11703

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] ~I have added tests that prove my fix is effective or that my feature works~ I have manually checked the relevant CLI commands.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
