### PR TITLE
Fix whitespace in generated .csproj files

### DIFF
--- a/changelog/pending/20230331--sdkgen-dotnet--fix-a-whitespace-error-in-generated-csproj-files.yaml
+++ b/changelog/pending/20230331--sdkgen-dotnet--fix-a-whitespace-error-in-generated-csproj-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet
+  description: Fix a whitespace error in generated .csproj files.

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -164,7 +164,7 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -40,7 +40,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -40,7 +40,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/Pulumi.Std.csproj
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/Pulumi.Std.csproj
@@ -39,7 +39,7 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
-   <ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="pulumi-plugin.json" />
     <None Include="pulumi-plugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

There was a stray space character before `<ItemGroup>` in the generated .csproj files.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
