### PR TITLE
Allow for setting runtime config without it being added to the config file

### DIFF
--- a/changelog/pending/20230403--cli-config--adds-runtime-config-flag-to-pulumi-preview-and-pulumi-up-this-flag-enables-users-to-specify-command-line-configurations-values-without-persisting-to-local-config-file.yaml
+++ b/changelog/pending/20230403--cli-config--adds-runtime-config-flag-to-pulumi-preview-and-pulumi-up-this-flag-enables-users-to-specify-command-line-configurations-values-without-persisting-to-local-config-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Adds --runtime-config flag to pulumi preview and pulumi up, this flag enables users to specify command line configurations values without persisting to local config file

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -42,6 +42,7 @@ func newPreviewCmd() *cobra.Command {
 	var execAgent string
 	var stackName string
 	var configArray []string
+	var runtimeConfigArray []string
 	var configPath bool
 	var client string
 	var planFilePath string
@@ -196,6 +197,11 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
+			err = applyRuntimeConfigValues(cfg.Config, runtimeConfigArray, configPath)
+			if err != nil {
+				return result.FromError(fmt.Errorf("applying runtime config values: %w", err))
+			}
+
 			targetURNs := []string{}
 			targetURNs = append(targetURNs, targets...)
 
@@ -290,6 +296,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the preview")
+	cmd.PersistentFlags().StringArrayVar(
+		&runtimeConfigArray, "runtime-config", []string{},
+		"Config used at runtime without persisting to the local config file")
 	cmd.PersistentFlags().BoolVar(
 		&configPath, "config-path", false,
 		"Config keys contain a path to a property in a map or list to set")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -52,6 +52,7 @@ func newUpCmd() *cobra.Command {
 	var execAgent string
 	var stackName string
 	var configArray []string
+	var runtimeConfigArray []string
 	var path bool
 	var client string
 
@@ -123,6 +124,11 @@ func newUpCmd() *cobra.Command {
 		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(stackName, proj, cfg.Config, decrypter)
 		if configErr != nil {
 			return result.FromError(fmt.Errorf("validating stack config: %w", configErr))
+		}
+
+		err = applyRuntimeConfigValues(cfg.Config, runtimeConfigArray, path)
+		if err != nil {
+			return result.FromError(fmt.Errorf("applying runtime config values: %w", err))
 		}
 
 		targetURNs, replaceURNs := []string{}, []string{}
@@ -515,6 +521,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the update")
+	cmd.PersistentFlags().StringArrayVar(
+		&runtimeConfigArray, "runtime-config", []string{},
+		"Config used at runtime without persisting to the local config file")
 	cmd.PersistentFlags().BoolVar(
 		&path, "config-path", false,
 		"Config keys contain a path to a property in a map or list to set")

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -486,16 +486,40 @@ func chooseStack(ctx context.Context,
 // parseAndSaveConfigArray parses the config array and saves it as a config for
 // the provided stack.
 func parseAndSaveConfigArray(s backend.Stack, configArray []string, path bool) error {
-	if len(configArray) == 0 {
-		return nil
-	}
-	commandLineConfig, err := parseConfig(configArray, path)
+	commandLineConfig, err := parseConfigArray(configArray, path)
 	if err != nil {
 		return err
 	}
 
 	if err = saveConfig(s, commandLineConfig); err != nil {
 		return fmt.Errorf("saving config: %w", err)
+	}
+	return nil
+}
+
+// parseConfigArray parses the config array
+// returns empty config if configArray argument is empty
+func parseConfigArray(configArray []string, path bool) (config.Map, error) {
+	if len(configArray) == 0 {
+		return config.Map{}, nil
+	}
+	commandLineConfig, err := parseConfig(configArray, path)
+	if err != nil {
+		return nil, err
+	}
+	return commandLineConfig, nil
+}
+
+// applyRuntimeConfigValues overrides config with provided runtime-only values
+func applyRuntimeConfigValues(configMap config.Map, runtimeConfigArray []string, path bool) error {
+	commandLineRuntimeConfig, err := parseConfigArray(runtimeConfigArray, path)
+	if err != nil {
+		return err
+	}
+	for key, value := range commandLineRuntimeConfig {
+		if err = configMap.Set(key, value, path); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Allow for setting runtime config without it being added to the config file 

Fixes #11884 

## Checklist
I couldn't find tests which cover similar scenarious and if you can point me where to add  / or have any suggestions on how to implement tests for this, it would be nice.
<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
