### PR TITLE
Remove outdated comments

### DIFF
--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -1047,9 +1047,7 @@ func addNextFileToZIP(r ArchiveReader, zw *zip.Writer, seenFiles map[string]bool
 
 	// Set a nonzero -- but constant -- modification time. Otherwise, some agents (e.g. Azure
 	// websites) can't extract the resulting archive. The date is comfortably after 1980 because
-	// the ZIP format includes a date representation that starts at 1980. Use `SetModTime` to
-	// remain compatible with Go 1.9.
-	//nolint:megacheck
+	// the ZIP format includes a date representation that starts at 1980.
 	fh.Modified = time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 	fw, err := zw.CreateHeader(fh)


### PR DESCRIPTION
The call to `SetModTime` was removed in #11002 but the comment stayed around. The `nolint` directive had been added in #1494 to excuse the (now-removed) use of `SetModTime`.
