### PR TITLE
Pass PULUMI_CONFIG through to provider plugins

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -127,7 +127,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}
 		pwd, program, pluginContext, err := engine.ProjectInfoContext(
-			projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
+			projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 		if err != nil {
 			addError(err, "Failed to create plugin context")
 		} else {

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -291,7 +291,7 @@ func runConvert(
 		}
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
-		pwd, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
+		pwd, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 		if err != nil {
 			return result.FromError(err)
 		}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -318,6 +318,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			cmdutil.Diag(),
 			false,
 			span,
+			nil,
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -120,7 +120,7 @@ func schemaFromSchemaSource(packageSource string) (*schema.Package, error) {
 	// No file separators, so we try to look up the schema
 	// On unix, these checks are identical. On windows, filepath.Separator is '\\'
 	if !strings.ContainsRune(pkg, filepath.Separator) && !strings.ContainsRune(pkg, '/') {
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil)
+		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +150,7 @@ func schemaFromSchemaSource(packageSource string) (*schema.Package, error) {
 		return nil, fmt.Errorf("plugin at path %q not executable", pkg)
 	}
 
-	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil)
+	host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -58,7 +58,7 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	}
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	pwd, main, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
+	pwd, main, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 	}
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	_, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
+	_, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -204,6 +204,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 			cmdutil.Diag(),
 			false,
 			span,
+			nil,
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -83,7 +83,7 @@ func newPolicyPublishCmd() *cobra.Command {
 			}
 
 			plugctx, err := plugin.NewContextWithRoot(cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
-				projinfo.Proj.Runtime.Options(), false, nil, nil)
+				projinfo.Proj.Runtime.Options(), false, nil, nil, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -315,7 +315,7 @@ func newUpCmd() *cobra.Command {
 		// Install dependencies.
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
-		pwd, _, pctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
+		pwd, _, pctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 		if err != nil {
 			return result.FromError(fmt.Errorf("building project context: %w", err))
 		}

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -71,7 +71,7 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
 	contract.Assertf(proj != nil, "query project cannot be nil")
 
 	pwd, main, plugctx, err := ProjectInfoContext(&Projinfo{Proj: proj, Root: q.GetRoot()},
-		opts.Host, diag, statusDiag, false, tracingSpan)
+		opts.Host, diag, statusDiag, false, tracingSpan, nil)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -73,13 +74,13 @@ func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
 
 	root := ""
 	return NewContextWithRoot(d, statusD, host, pwd, root, runtimeOptions,
-		disableProviderPreview, parentSpan, plugins)
+		disableProviderPreview, parentSpan, plugins, nil)
 }
 
 // NewContextWithRoot is a variation of NewContext that also sets known project Root. Additionally accepts Plugins
 func NewContextWithRoot(d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
-	parentSpan opentracing.Span, plugins *workspace.Plugins,
+	parentSpan opentracing.Span, plugins *workspace.Plugins, config map[config.Key]string,
 ) (*Context, error) {
 	if d == nil {
 		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
@@ -98,7 +99,7 @@ func NewContextWithRoot(d, statusD diag.Sink, host Host,
 		cancelLock:      &sync.Mutex{},
 	}
 	if host == nil {
-		h, err := NewDefaultHost(ctx, runtimeOptions, disableProviderPreview, plugins)
+		h, err := NewDefaultHost(ctx, runtimeOptions, disableProviderPreview, plugins, config)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -128,7 +128,7 @@ func (p *pluginConfigPromise) Fulfill(cfg pluginConfig, err error) {
 // NewProvider attempts to bind to a given package's resource plugin and then creates a gRPC connection to it.  If the
 // plugin could not be found, or an error occurs while creating the child process, an error is returned.
 func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Version,
-	options map[string]interface{}, disableProviderPreview bool,
+	options map[string]interface{}, disableProviderPreview bool, jsonConfig string,
 ) (Provider, error) {
 	// See if this is a provider we just want to attach to
 	var plug *plugin
@@ -180,6 +180,9 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		env := os.Environ()
 		for k, v := range options {
 			env = append(env, fmt.Sprintf("PULUMI_RUNTIME_%s=%v", strings.ToUpper(k), v))
+		}
+		if jsonConfig != "" {
+			env = append(env, fmt.Sprintf("PULUMI_CONFIG=%s", jsonConfig))
 		}
 		plug, err = newPlugin(ctx, ctx.Pwd, path, prefix,
 			workspace.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, pkg, ""))

--- a/tests/integration/dynamic/nodejs-pulumi-config/Pulumi.yaml
+++ b/tests/integration/dynamic/nodejs-pulumi-config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nodejs_resource_type_name
+runtime: nodejs
+description: A simple Nodejs program that uses dynamic providers with custom resource type name.

--- a/tests/integration/dynamic/nodejs-pulumi-config/index.ts
+++ b/tests/integration/dynamic/nodejs-pulumi-config/index.ts
@@ -1,0 +1,21 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+import * as pulumi from '@pulumi/pulumi'
+
+class CustomResource extends pulumi.dynamic.Resource {
+  constructor (name: string, opts?: pulumi.ResourceOptions) {
+    super(new DummyResourceProvider(), name, {}, opts, "custom-provider", "CustomResource")
+  }
+}
+
+class DummyResourceProvider implements pulumi.dynamic.ResourceProvider {
+  async create (props: any): Promise<pulumi.dynamic.CreateResult> {
+    var config = JSON.parse(process.env.PULUMI_CONFIG)
+
+    return { id: config["id"], outs: {} }
+  }
+}
+
+const resource = new CustomResource('resource-name')
+
+export const rid = resource.id

--- a/tests/integration/dynamic/nodejs-pulumi-config/package.json
+++ b/tests/integration/dynamic/nodejs-pulumi-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nodejs-resource-type-name",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^4.5.4",
+    "@types/node": "^14.11.6"
+  },
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1347,3 +1347,19 @@ func TestRegression12301Node(t *testing.T) {
 		},
 	})
 }
+
+// Tests provider config is passed through to provider processes.
+func TestPulumiConfig(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("dynamic", "nodejs-pulumi-config"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Config: map[string]string{
+			"pulumi-nodejs:id": "testing123",
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.Len(t, stack.Outputs, 1)
+			assert.Contains(t, stack.Outputs, "rid")
+			assert.Equal(t, "testing123", stack.Outputs["rid"].(string))
+		},
+	})
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Some users wish to experiment with merging stack provider config with explicit provider config. It's not clear this is something we want to fully support/expose yet, so this change forwards the stack config to provider binaries via the PULUMI_CONFIG environment variable. 

Users wishing to experiment with this in their providers can grab and JSON decode that variable and do their merging as wanted, without this affecting others users generally.

At some point we may remove this in favor of a better system that makes itself evident from these experiments.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works 
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
