### PR TITLE
[pcl] Fixes the type signature of function "entries" to return list of key-value pair objects

### DIFF
--- a/changelog/pending/20230405--programgen-nodejs-python--fixes-the-type-signature-of-pcl-function-entries-to-return-list-of-key-value-pair-objects.yaml
+++ b/changelog/pending/20230405--programgen-nodejs-python--fixes-the-type-signature-of-pcl-function-entries-to-return-list-of-key-value-pair-objects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs,python
+  description: Fixes the type signature of PCL function "entries" to return list of key-value pair objects

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -179,7 +179,7 @@ func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 		// TODO(pdg): grouping
 		g.Fgenf(w, ".reduce((__obj, %s) => { ...__obj, [%.v]: %.v })", reduceParams, expr.Key, expr.Value)
 	} else {
-		g.Fgenf(w, ".map(%s => %.v)", fnParams, expr.Value)
+		g.Fgenf(w, ".map(%s => (%.v))", fnParams, expr.Value)
 	}
 }
 

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -36,7 +36,11 @@ func getEntriesSignature(args []model.Expression) (model.StaticFunctionSignature
 		keyType, valueType, diagnostics = keyT, valueT, append(diagnostics, diags...)
 	}
 
-	signature.ReturnType = model.NewListType(model.NewTupleType(keyType, valueType))
+	elementType := model.NewObjectType(map[string]model.Type{
+		"key":   keyType,
+		"value": valueType,
+	})
+	signature.ReturnType = model.NewListType(elementType)
 	return signature, diagnostics
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -238,6 +238,14 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages.Except("dotnet").Except("nodejs"),
 	},
 	{
+		Directory:   "entries-function",
+		Description: "Using the entries function",
+		// go and dotnet do not support GenForExpression yet
+		// Todo: https://github.com/pulumi/pulumi/issues/12606
+		Skip:        allProgLanguages.Except("nodejs").Except("python"),
+		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
+	},
+	{
 		Directory:   "retain-on-delete",
 		Description: "Generate RetainOnDelete option",
 	},

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/entries-function.pp
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/entries-function.pp
@@ -1,0 +1,4 @@
+data = [for entry in entries([1,2,3]) : {
+    usingKey: entry.key
+    usingValue: entry.value
+}]

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/nodejs/entries-function.ts
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/nodejs/entries-function.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const data = [
+    1,
+    2,
+    3,
+].map((v, k) => ({key: k, value: v})).map(entry => ({
+    usingKey: entry.key,
+    usingValue: entry.value,
+}));

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/python/entries-function.py
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/python/entries-function.py
@@ -1,0 +1,10 @@
+import pulumi
+
+data = [{
+    "usingKey": entry["key"],
+    "usingValue": entry["value"],
+} for entry in [{"key": k, "value": v} for k, v in [
+    1,
+    2,
+    3,
+]]]


### PR DESCRIPTION
# Description

The `entries` function in PCL had a return type of `list(tuple(keyT, valueT))` but program-gen in nodejs and python generates an expression which returns `list(object({ key = keyT, value = valueT }))` as it should. This PR fixes the type signature and adds a test case for it

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
