### PR TITLE
Bump pulumi-yaml to v1.1.0

### DIFF
--- a/changelog/pending/20230406--yaml--updates-pulumi-yaml-to-v1-1-0.yaml
+++ b/changelog/pending/20230406--yaml--updates-pulumi-yaml-to-v1-1-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: yaml
+  description: Updates Pulumi YAML to v1.1.0.

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/pulumi/pulumi-java/pkg v0.9.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.34.1-0.20221214173921-8e65b1f9fdd5
-	github.com/pulumi/pulumi-yaml v1.0.4
+	github.com/pulumi/pulumi-yaml v1.1.0
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1630,8 +1630,8 @@ github.com/pulumi/pulumi-java/pkg v0.9.0 h1:8KQG7AJVtVBoPE3+Psmhv/lvGHI8RL3/E5uT
 github.com/pulumi/pulumi-java/pkg v0.9.0/go.mod h1:eHpNTbf4n5X3YvqoDI/+cbVIkQaycBFdsvQb/24ykpc=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.34.1-0.20221214173921-8e65b1f9fdd5 h1:cdFbwsev+ihDexxfxYeS4B5rfiBZErMwaBk86CGl9lo=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.34.1-0.20221214173921-8e65b1f9fdd5/go.mod h1:ba1dLETCVZnmdavrrVfg9goz5CjhsqgRfF/NPkLTr28=
-github.com/pulumi/pulumi-yaml v1.0.4 h1:p+989rW3AqkkxbzxtxccHKAN4xCJi3K2cRpvA2K84tw=
-github.com/pulumi/pulumi-yaml v1.0.4/go.mod h1:Szj8ud4Vqyq3oO1n3kzIUfaP3AiCjYZM4FYjOVWwJn8=
+github.com/pulumi/pulumi-yaml v1.1.0 h1:Rm2TOS8/ZLRsgx1IOkiId7bwimbxcfPpAzSH0Tp7ePQ=
+github.com/pulumi/pulumi-yaml v1.1.0/go.mod h1:SIu26o/xRupOoZgrPjgmbUn6dS7FT74pTions9CSSfU=
 github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Dik4Qe/+xguB8JagPyXNlbOnRiXGmq/PSPQTGunYnTk=


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR bumps pulumi-yaml from v1.0.4 to v1.1.0.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12611 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
