### PR TITLE
Support map(any) in config/output types

### DIFF
--- a/changelog/pending/20230406--programgen--suppport-the-any-type-in-config-and-outputs.yaml
+++ b/changelog/pending/20230406--programgen--suppport-the-any-type-in-config-and-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Suppport the `any` type in config and outputs.

--- a/pkg/codegen/hcl2/model/type_scope.go
+++ b/pkg/codegen/hcl2/model/type_scope.go
@@ -6,6 +6,7 @@ import (
 )
 
 var typeBuiltins = map[string]Type{
+	"any":    DynamicType,
 	"string": StringType,
 	"number": NumberType,
 	"int":    IntType,

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -267,3 +267,18 @@ func TestConfigNodeTypedIntMap(t *testing.T) {
 	assert.True(t, ok, "the type of config is a map type")
 	assert.Equal(t, mapType.ElementType, model.IntType, "the element type is an int")
 }
+
+func TestConfigNodeTypedAnyMap(t *testing.T) {
+	t.Parallel()
+	source := "config names \"map(any)\" { }"
+	program, diags := parseAndBindProgram(t, source, "config.pp")
+	contract.Ignore(diags)
+	assert.NotNil(t, program, "failed to parse and bind program")
+	assert.Equal(t, len(program.Nodes), 1, "there is one node")
+	config, ok := program.Nodes[0].(*pcl.ConfigVariable)
+	assert.True(t, ok, "first node is a config variable")
+	assert.Equal(t, config.Name(), "names")
+	mapType, ok := config.Type().(*model.MapType)
+	assert.True(t, ok, "the type of config is a map type")
+	assert.Equal(t, mapType.ElementType, model.DynamicType, "the element type is a dynamic")
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Encountered while doing terraform conversions, the current binder couldn't handle types like `map(any)`.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
