### PR TITLE
Fix providers created during updates with `--target` with uncreated parents

### DIFF
--- a/changelog/pending/20230418--engine--fix-bug-where-providers-are-created-even-when-not-specified-as-a-target.yaml
+++ b/changelog/pending/20230418--engine--fix-bug-where-providers-are-created-even-when-not-specified-as-a-target.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: Fix bug where providers are created even when not specified as a target.
+  description: Fix bug where non-default providers are created even when not specified as a target.

--- a/changelog/pending/20230418--engine--fix-bug-where-providers-are-created-even-when-not-specified-as-a-target.yaml
+++ b/changelog/pending/20230418--engine--fix-bug-where-providers-are-created-even-when-not-specified-as-a-target.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix bug where providers are created even when not specified as a target.

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -514,6 +515,61 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTarget(t *testin
 	p.Run(t, nil)
 }
 
+func TestCreateDuringTargetedUpdate_UntargetedProviderReferencedByTarget(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CheckF: func(urn resource.URN, olds, news resource.PropertyMap, randomSeed []byte,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					assert.Fail(t, "Check shouldn't be called because the provider shouldn't be created")
+					return nil, nil, fmt.Errorf("should not be called")
+				},
+				CreateF: func(urn resource.URN, inputs resource.PropertyMap, timeout float64, preview bool,
+				) (resource.ID, resource.PropertyMap, resource.Status, error) {
+					assert.Fail(t, "Create shouldn't be called because the provider shouldn't be created")
+					return "", nil, resource.StatusUnknown, fmt.Errorf("should not be called")
+				},
+			}, nil
+		}),
+	}
+
+	// Create a resource A with --target but don't create its explicit provider.
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
+		assert.NoError(t, err)
+
+		if provID == "" {
+			provID = providers.UnknownID
+		}
+
+		provRef, err := providers.NewReference(provURN, provID)
+		assert.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Provider: provRef.String(),
+		})
+		assert.NoError(t, err)
+		return nil
+	})
+	host1 := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host1},
+	}
+
+	resA := p.NewURN("pkgA:m:typA", "resA", "")
+
+	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
+	p.Steps = []TestStep{{
+		Op:            Update,
+		ExpectFailure: true,
+	}}
+	p.Run(t, nil)
+}
+
 func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUntargetedCreate(t *testing.T) {
 	t.Parallel()
 
@@ -913,4 +969,51 @@ func newResource(urn, parent resource.URN, id resource.ID, provider string, depe
 		Provider:             provider,
 		Parent:               parent,
 	}
+}
+
+// TestTargetedDoesNotCreateProvider checks that an update that targets a resource does not create the default
+// provider if not targeted.
+func TestTargetedDoesNotCreateProvider(t *testing.T) {
+	t.Parallel()
+
+	host := func() plugin.Host {
+		loaders := []*deploytest.ProviderLoader{
+			deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+				return &deploytest.Provider{}, nil
+			}),
+		}
+
+		program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
+			assert.NoError(t, err)
+
+			return nil
+		})
+
+		host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+		return host
+	}()
+
+	p := &TestPlan{}
+
+	project := p.GetProject()
+
+	// Check that update fails because the default provider is not created (as it is not targeted).
+	_, res := TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
+		Host: host,
+		UpdateTargets: deploy.NewUrnTargets([]string{
+			"urn:pulumi:test::test::pkgA:m:typA::resA",
+		}),
+	}, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+
+	// Check that update succeeds when the default provider is also targeted.
+	_, res = TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
+		Host: host,
+		UpdateTargets: deploy.NewUrnTargets([]string{
+			"urn:pulumi:test::test::pkgA:m:typA::resA",
+			"urn:pulumi:test::test::pulumi:providers:pkgA::default",
+		}),
+	}, false, p.BackendClient, nil)
+	assert.Nil(t, res)
 }

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1640,3 +1640,79 @@ func TestPlannedUpdateWithDependentDelete(t *testing.T) {
 	assert.NotNil(t, snap)
 	assert.Nil(t, res)
 }
+
+// TestResourcesTargeted checks that a plan created with targets specified captures only those targets.
+// It checks that trying to construct a new resource that was not targeted in the plan fails and that the
+// update with the same --targets specified is compatible with the plan (roundtripped).
+func TestResoucesTargeted(t *testing.T) {
+	t.Parallel()
+
+	host := func() plugin.Host {
+		loaders := []*deploytest.ProviderLoader{
+			deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+				return &deploytest.Provider{}, nil
+			}),
+		}
+
+		program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+				Inputs: resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+				},
+			})
+			assert.NoError(t, err)
+
+			_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+				Inputs: resource.PropertyMap{
+					"foo": resource.NewStringProperty("bar"),
+				},
+			})
+			assert.NoError(t, err)
+
+			return nil
+		})
+
+		host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+		return host
+	}()
+
+	p := &TestPlan{}
+
+	project := p.GetProject()
+
+	// Create the update plan with only targeted resources.
+	plan, res := TestOp(Update).Plan(project, p.GetTarget(t, nil), UpdateOptions{
+		Host:         host,
+		Experimental: true,
+		GeneratePlan: true,
+		UpdateTargets: deploy.NewUrnTargets([]string{
+			"urn:pulumi:test::test::pkgA:m:typA::resB",
+			"urn:pulumi:test::test::pulumi:providers:pkgA::default",
+		}),
+	}, p.BackendClient, nil)
+	assert.Nil(t, res)
+	assert.NotNil(t, plan)
+
+	// Check that running an update with everything targeted fails due to our plan being constrained
+	// to the resource and default provider.
+	_, res = TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
+		// Clone the plan as the plan will be mutated by the engine and useless in future runs.
+		Plan:         plan.Clone(),
+		Host:         host,
+		Experimental: true,
+	}, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+
+	// Check that running an update with the same UpdateTargets as the Plan succeeds.
+	_, res = TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
+		// Clone the plan as the plan will be mutated by the engine and useless in future runs.
+		Plan:         plan.Clone(),
+		Host:         host,
+		Experimental: true,
+		UpdateTargets: deploy.NewUrnTargets([]string{
+			"urn:pulumi:test::test::pkgA:m:typA::resB",
+			"urn:pulumi:test::test::pulumi:providers:pkgA::default",
+		}),
+	}, false, p.BackendClient, nil)
+	assert.Nil(t, res)
+}

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1641,9 +1641,9 @@ func TestPlannedUpdateWithDependentDelete(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-// TestResourcesTargeted checks that a plan created with targets specified captures only those targets.
-// It checks that trying to construct a new resource that was not targeted in the plan fails and that the
-// update with the same --targets specified is compatible with the plan (roundtripped).
+// TestResourcesTargeted checks that a plan created with targets specified captures only those targets and
+// default providers. It checks that trying to construct a new resource that was not targeted in the plan
+// fails and that the update with the same --targets specified is compatible with the plan (roundtripped).
 func TestResoucesTargeted(t *testing.T) {
 	t.Parallel()
 
@@ -1687,14 +1687,13 @@ func TestResoucesTargeted(t *testing.T) {
 		GeneratePlan: true,
 		UpdateTargets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resB",
-			"urn:pulumi:test::test::pulumi:providers:pkgA::default",
 		}),
 	}, p.BackendClient, nil)
 	assert.Nil(t, res)
 	assert.NotNil(t, plan)
 
 	// Check that running an update with everything targeted fails due to our plan being constrained
-	// to the resource and default provider.
+	// to the resource.
 	_, res = TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
 		// Clone the plan as the plan will be mutated by the engine and useless in future runs.
 		Plan:         plan.Clone(),
@@ -1711,7 +1710,6 @@ func TestResoucesTargeted(t *testing.T) {
 		Experimental: true,
 		UpdateTargets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resB",
-			"urn:pulumi:test::test::pulumi:providers:pkgA::default",
 		}),
 	}, false, p.BackendClient, nil)
 	assert.Nil(t, res)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -132,7 +132,8 @@ func (s *SameStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 	s.new.Outputs = s.old.Outputs
 
 	// If the resource is a provider, ensure that it is present in the registry under the appropriate URNs.
-	if providers.IsProviderType(s.new.Type) {
+	// We can only do this if the provider is actually a same, not a skipped create.
+	if providers.IsProviderType(s.new.Type) && !s.skippedCreate {
 		ref, err := providers.NewReference(s.new.URN, s.new.ID)
 		if err != nil {
 			return resource.StatusOK, nil,

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -80,6 +80,11 @@ func (sg *stepGenerator) isTargetedUpdate() bool {
 // `--target-dependents`. `targetDependentsForUpdate` should probably be called if this function
 // returns true.
 func (sg *stepGenerator) isTargetedForUpdate(res *resource.State) bool {
+	// Default providers are marked always targeted. Default providers are under Pulumi's control
+	// and changes or creations should be invisible to the user.
+	if providers.IsDefaultProvider(res.URN) {
+		return true
+	}
 	if sg.updateTargetsOpt.Contains(res.URN) {
 		return true
 	} else if !sg.opts.TargetDependents {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Provider resources are now skipped if not targeted for creation.

Fixes #12621 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
