### PR TITLE
update cli docs service -> clouds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,10 +17,10 @@ User-facing changes require a CHANGELOG entry.
 -->
 - [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
 <!--
-If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
+If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
 then the service should honor older versions of the CLI where this change would not exist.
 You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
 it to the service.
 -->
-- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
+- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
   <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -92,8 +92,8 @@ func newConsoleCmd() *cobra.Command {
 				return nil
 			}
 			fmt.Println("This command is not available for your backend. " +
-				"To migrate to the Pulumi Service backend, " +
-				"please see https://www.pulumi.com/docs/intro/concepts/state/#adopting-the-pulumi-service-backend")
+				"To migrate to the Pulumi Cloud backend, " +
+				"please see https://www.pulumi.com/docs/intro/concepts/state/#pulumi-cloud-backend")
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -39,28 +39,28 @@ func newLoginCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login [<url>]",
-		Short: "Log in to the Pulumi service",
-		Long: "Log in to the Pulumi service.\n" +
+		Short: "Log in to the Pulumi Cloud",
+		Long: "Log in to the Pulumi Cloud.\n" +
 			"\n" +
-			"The service manages your stack's state reliably. Simply run\n" +
+			"The Pulumi Cloud manages your stack's state reliably. Simply run\n" +
 			"\n" +
 			"    $ pulumi login\n" +
 			"\n" +
 			"and this command will prompt you for an access token, including a way to launch your web browser to\n" +
 			"easily obtain one. You can script by using `PULUMI_ACCESS_TOKEN` environment variable.\n" +
 			"\n" +
-			"By default, this will log in to the managed Pulumi service backend.\n" +
-			"If you prefer to log in to a self-hosted Pulumi service backend, specify a URL. For example, run\n" +
+			"By default, this will log in to the managed Pulumi Cloud backend.\n" +
+			"If you prefer to log in to a self-hosted Pulumi Cloud backend, specify a URL. For example, run\n" +
 			"\n" +
 			"    $ pulumi login https://api.pulumi.acmecorp.com\n" +
 			"\n" +
-			"to log in to a self-hosted Pulumi service running at the api.pulumi.acmecorp.com domain.\n" +
+			"to log in to a self-hosted Pulumi Cloud running at the api.pulumi.acmecorp.com domain.\n" +
 			"\n" +
-			"For `https://` URLs, the CLI will speak REST to a service that manages state and concurrency control.\n" +
-			"You can specify a default org to use when logging into the Pulumi service backend or a " +
-			"self-hosted Pulumi service.\n" +
+			"For `https://` URLs, the CLI will speak REST to a Pulumi Cloud that manages state and concurrency control.\n" +
+			"You can specify a default org to use when logging into the Pulumi Cloud backend or a " +
+			"self-hosted Pulumi Cloud.\n" +
 			"\n" +
-			"[PREVIEW] If you prefer to operate Pulumi independently of a service, and entirely local to your computer,\n" +
+			"[PREVIEW] If you prefer to operate Pulumi independently of a Pulumi Cloud, and entirely local to your computer,\n" +
 			"pass `file://<path>`, where `<path>` will be where state checkpoints will be stored. For instance,\n" +
 			"\n" +
 			"    $ pulumi login file://~\n" +
@@ -73,7 +73,7 @@ func newLoginCmd() *cobra.Command {
 			"    $ pulumi login --local\n" +
 			"\n" +
 			"[PREVIEW] Additionally, you may leverage supported object storage backends from one of the cloud providers " +
-			"to manage the state independent of the service. For instance,\n" +
+			"to manage the state independent of the Pulumi Cloud. For instance,\n" +
 			"\n" +
 			"AWS S3:\n" +
 			"\n" +
@@ -132,7 +132,7 @@ func newLoginCmd() *cobra.Command {
 				cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") ||
 				strings.HasPrefix(url, "pulumi.com") {
 				return fmt.Errorf("%s is not a valid self-hosted backend, "+
-					"use `pulumi login` without arguments to log into the Pulumi service backend", cloudURL)
+					"use `pulumi login` without arguments to log into the Pulumi Cloud backend", cloudURL)
 			} else {
 				// Ensure we have the correct cloudurl type before logging in
 				if err := validateCloudBackendType(cloudURL); err != nil {

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -34,8 +34,8 @@ func newLogoutCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "logout <url>",
-		Short: "Log out of the Pulumi service",
-		Long: "Log out of the Pulumi service.\n" +
+		Short: "Log out of the Pulumi Cloud",
+		Long: "Log out of the Pulumi Cloud.\n" +
 			"\n" +
 			"This command deletes stored credentials on the local machine for a single login.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -35,7 +35,7 @@ func newPolicyDisableCmd() *cobra.Command {
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := commandContext()
-			// Obtain current PolicyPack, tied to the Pulumi service backend.
+			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			var err error
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -42,7 +42,7 @@ func newPolicyEnableCmd() *cobra.Command {
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := commandContext()
-			// Obtain current PolicyPack, tied to the Pulumi service backend.
+			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -34,8 +34,8 @@ func newPolicyPublishCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "publish [org-name]",
 		Args:  cmdutil.MaximumNArgs(1),
-		Short: "Publish a Policy Pack to the Pulumi service",
-		Long: "Publish a Policy Pack to the Pulumi service\n" +
+		Short: "Publish a Policy Pack to the Pulumi Cloud",
+		Long: "Publish a Policy Pack to the Pulumi Cloud\n" +
 			"\n" +
 			"If an organization name is not specified, the current user account is used.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
@@ -59,7 +59,7 @@ func newPolicyPublishCmd() *cobra.Command {
 			policyPackRef := fmt.Sprintf("%s/", orgName)
 
 			//
-			// Obtain current PolicyPack, tied to the Pulumi service backend.
+			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			//
 
 			policyPack, err := requirePolicyPack(ctx, policyPackRef)
@@ -119,7 +119,7 @@ func requirePolicyPack(ctx context.Context, policyPack string) (backend.PolicyPa
 
 	cloudURL, err := workspace.GetCurrentCloudURL(project)
 	if err != nil {
-		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi service: %w", err)
+		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi Cloud: %w", err)
 	}
 
 	displayOptions := display.Options{

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -37,7 +37,7 @@ func newPolicyRmCmd() *cobra.Command {
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()
-			// Obtain current PolicyPack, tied to the Pulumi service backend.
+			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, args[0])
 			if err != nil {
 				return result.FromError(err)

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -33,7 +33,7 @@ func newPolicyValidateCmd() *cobra.Command {
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := commandContext()
-			// Obtain current PolicyPack, tied to the Pulumi service backend.
+			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -306,7 +306,7 @@ func NewPulumiCmd() *cobra.Command {
 			},
 		},
 		{
-			Name: "Service Commands",
+			Name: "Pulumi Cloud Commands",
 			Commands: []*cobra.Command{
 				newLoginCmd(),
 				newLogoutCmd(),

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -44,7 +44,7 @@ func newStackInitCmd() *cobra.Command {
 			"This command creates an empty stack with the given name.  It has no resources,\n" +
 			"but afterwards it can become the target of a deployment using the `update` command.\n" +
 			"\n" +
-			"To create a stack in an organization when logged in to the Pulumi service,\n" +
+			"To create a stack in an organization when logged in to the Pulumi Cloud,\n" +
 			"prefix the stack name with the organization name and a slash (e.g. 'acmecorp/dev')\n" +
 			"\n" +
 			"By default, a stack created using the pulumi.com backend will use the pulumi.com secrets\n" +

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -53,8 +53,8 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 // out teams consisting exclusively of whitespace. NB: It's not intended
 // to fully validate the correctness of team names. For example, it doesn't
 // check for illegal punctuation, length, or other measures of correctness.
-// To keep the codebase DRY, we pass along team names as-is to the Service,
-// with the exception of trimming whitespace, and allow the Service to
+// To keep the codebase DRY, we pass along team names as-is to the Pulumi Cloud,
+// with the exception of trimming whitespace, and allow the Pulumi Cloud to
 // validate them.
 func TestNewCreateStackOptsFiltersWhitespace(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -176,7 +176,7 @@ func createSecretsManager(
 	// As part of creating the stack, we also need to configure the secrets provider for the stack.
 	// We need to do this configuration step for cases where we will be using with the passphrase
 	// secrets provider or one of the cloud-backed secrets providers.  We do not need to do this
-	// for the Pulumi service backend secrets provider.
+	// for the Pulumi Cloud backend secrets provider.
 	// we have an explicit flag to rotate the secrets manager ONLY when it's a passphrase!
 	isDefaultSecretsProvider := secretsProvider == "" || secretsProvider == "default"
 
@@ -993,8 +993,8 @@ func buildStackName(stackName string) (string, error) {
 	return stackName, nil
 }
 
-// we only want to log a secrets decryption for a service backend project
-// we will allow any secrets provider to be used (service or self managed)
+// we only want to log a secrets decryption for a Pulumi Cloud backend project
+// we will allow any secrets provider to be used (Pulumi Cloud or self managed)
 // we will log the message and not worry about the response. The types
 // of messages we will log here will range from single secret decryption events
 // to requesting a list of secrets in an individual event e.g. stack export
@@ -1003,7 +1003,7 @@ func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, backend back
 	secretName, commandName string,
 ) {
 	if stack, ok := backend.(httpstate.Stack); ok {
-		// we only want to do something if this is a service backend
+		// we only want to do something if this is a Pulumi Cloud backend
 		if be, ok := stack.Backend().(httpstate.Backend); ok {
 			client := be.Client()
 			if client != nil {

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -272,8 +272,8 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 	// Ensure the cloud backend is being used.
 	cb, isCloud := b.(httpstate.Backend)
 	if !isCloud {
-		return result.FromError(errors.New("the Pulumi service backend must be used for remote operations; " +
-			"use `pulumi login` without arguments to log into the Pulumi service backend"))
+		return result.FromError(errors.New("the Pulumi Cloud backend must be used for remote operations; " +
+			"use `pulumi login` without arguments to log into the Pulumi Cloud backend"))
 	}
 
 	stackRef, err := b.ParseStackReference(stack)


### PR DESCRIPTION
# Description

@justinvp i went ahead and did the changes for the cli docs, since it impacts the docs on our website. feel free to close though if you would like someone else to do this changes at another time. also updated the pr template. left all other things alone.

see also
https://github.com/pulumi/registry/pull/2326
https://github.com/pulumi/examples/pull/1412
https://github.com/pulumi/pulumi-hugo/pull/2666

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
