### PR TITLE
pkg/filestate: Plumb context

### DIFF
--- a/changelog/pending/20230410--backend-filestate--propagate-request-context-to-external-call-sites.yaml
+++ b/changelog/pending/20230410--backend-filestate--propagate-request-context-to-external-call-sites.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend/filestate
+  description: Propagate request context to external call sites.

--- a/pkg/backend/filestate/backend_legacy_test.go
+++ b/pkg/backend/filestate/backend_legacy_test.go
@@ -187,10 +187,10 @@ func TestRemoveMakesBackups_legacy(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists, but the backup file doesn't
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef)+".bak")
 	assert.NoError(t, err)
 	assert.False(t, backupFileExists)
 
@@ -200,10 +200,10 @@ func TestRemoveMakesBackups_legacy(t *testing.T) {
 	assert.False(t, removed)
 
 	// Check the stack file is now gone, but the backup file exists
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
-	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef)+".bak")
 	assert.NoError(t, err)
 	assert.True(t, backupFileExists)
 }
@@ -230,12 +230,12 @@ func TestRenameWorks_legacy(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
 
 	// Fake up some history
-	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
+	err = lb.addToHistory(ctx, aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
 	assert.NoError(t, err)
 	// And pollute the history folder
 	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
@@ -248,10 +248,10 @@ func TestRenameWorks_legacy(t *testing.T) {
 	bStackRef := bStackRefI.(*localBackendReference)
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, bStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -264,10 +264,10 @@ func TestRenameWorks_legacy(t *testing.T) {
 	cStackRef := cStackRefI.(*localBackendReference)
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, cStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, bStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -332,7 +332,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, lb)
 
-	chkpath := lb.stackPath(aStackRef.(*localBackendReference))
+	chkpath := lb.stackPath(ctx, aStackRef.(*localBackendReference))
 	bytes, err := lb.bucket.ReadAll(context.Background(), chkpath)
 	assert.NoError(t, err)
 	state := string(bytes)

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -321,10 +321,10 @@ func TestRemoveMakesBackups(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists, but the backup file doesn't
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef)+".bak")
 	assert.NoError(t, err)
 	assert.False(t, backupFileExists)
 
@@ -334,10 +334,10 @@ func TestRemoveMakesBackups(t *testing.T) {
 	assert.False(t, removed)
 
 	// Check the stack file is now gone, but the backup file exists
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
-	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef)+".bak")
 	assert.NoError(t, err)
 	assert.True(t, backupFileExists)
 }
@@ -364,12 +364,12 @@ func TestRenameWorks(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
 
 	// Fake up some history
-	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
+	err = lb.addToHistory(ctx, aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
 	assert.NoError(t, err)
 	// And pollute the history folder
 	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
@@ -382,10 +382,10 @@ func TestRenameWorks(t *testing.T) {
 	bStackRef := bStackRefI.(*localBackendReference)
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, bStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -398,10 +398,10 @@ func TestRenameWorks(t *testing.T) {
 	cStackRef := cStackRefI.(*localBackendReference)
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, cStackRef))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, bStackRef))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -489,7 +489,7 @@ func TestHtmlEscaping(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, lb)
 
-	chkpath := lb.stackPath(aStackRef.(*localBackendReference))
+	chkpath := lb.stackPath(ctx, aStackRef.(*localBackendReference))
 	bytes, err := lb.bucket.ReadAll(context.Background(), chkpath)
 	assert.NoError(t, err)
 	state := string(bytes)
@@ -877,7 +877,7 @@ func TestLegacyUpgrade(t *testing.T) {
 	// Check that a has been moved
 	aStackRef, err := lb.parseStackReference("organization/project/a")
 	require.NoError(t, err)
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(ctx, aStackRef))
 	require.NoError(t, err)
 	assert.True(t, stackFileExists)
 
@@ -900,7 +900,7 @@ func TestLegacyUpgrade(t *testing.T) {
 	// Check that b has been moved
 	bStackRef, err := lb.parseStackReference("organization/other-project/b")
 	require.NoError(t, err)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(ctx, bStackRef))
 	require.NoError(t, err)
 	assert.True(t, stackFileExists)
 }

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -63,7 +63,7 @@ func (b *wrappedBucket) Exists(ctx context.Context, key string) (bool, error) {
 }
 
 // listBucket returns a list of all files in the bucket within a given directory. go-cloud sorts the results by key
-func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
+func listBucket(ctx context.Context, bucket Bucket, dir string) ([]*blob.ListObject, error) {
 	bucketIter := bucket.List(&blob.ListOptions{
 		Delimiter: "/",
 		Prefix:    dir + "/",
@@ -71,7 +71,6 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 
 	files := []*blob.ListObject{}
 
-	ctx := context.TODO()
 	for {
 		file, err := bucketIter.Next(ctx)
 		if err == io.EOF {
@@ -95,14 +94,14 @@ func objectName(obj *blob.ListObject) string {
 }
 
 // removeAllByPrefix deletes all objects with a given prefix (i.e. filepath)
-func removeAllByPrefix(bucket Bucket, dir string) error {
-	files, err := listBucket(bucket, dir)
+func removeAllByPrefix(ctx context.Context, bucket Bucket, dir string) error {
+	files, err := listBucket(ctx, bucket, dir)
 	if err != nil {
 		return fmt.Errorf("unable to list bucket objects for removal: %w", err)
 	}
 
 	for _, file := range files {
-		err = bucket.Delete(context.TODO(), file.Key)
+		err = bucket.Delete(ctx, file.Key)
 		if err != nil {
 			logging.V(5).Infof("error deleting object: %v (%v) skipping", file.Key, err)
 		}

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -86,7 +86,7 @@ func TestWrappedBucket(t *testing.T) {
 
 		// Verify it is found. NOTE: This requires that any files created
 		// during other tests have successfully been cleaned up too.
-		objects, err := listBucket(wrappedBucket, `.pulumi\bucket-test`)
+		objects, err := listBucket(ctx, wrappedBucket, `.pulumi\bucket-test`)
 		mustNotHaveError(t, "listBucket", err)
 		if len(objects) != len(filenames) {
 			assert.Equal(t, 3, len(objects), "listBucket returned unexpected number of objects.")

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -60,7 +60,7 @@ func newLockContent() (*lockContent, error) {
 // checkForLock looks for any existing locks for this stack, and returns a helpful diagnostic if there is one.
 func (b *localBackend) checkForLock(ctx context.Context, stackRef backend.StackReference) error {
 	stackName := stackRef.FullyQualifiedName()
-	allFiles, err := listBucket(b.bucket, stackLockDir(stackName))
+	allFiles, err := listBucket(ctx, b.bucket, stackLockDir(stackName))
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -15,6 +15,8 @@
 package filestate
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 )
@@ -22,6 +24,10 @@ import (
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
 // to disk on the local machine.
 type localSnapshotPersister struct {
+	// TODO[pulumi/pulumi#12593]:
+	// Remove this once SnapshotPersister is updated to take a context.
+	ctx context.Context
+
 	ref     *localBackendReference
 	backend *localBackend
 	sm      secrets.Manager
@@ -32,10 +38,14 @@ func (sp *localSnapshotPersister) SecretsManager() secrets.Manager {
 }
 
 func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	_, err := sp.backend.saveStack(sp.ref, snapshot, sp.sm)
+	_, err := sp.backend.saveStack(sp.ctx, sp.ref, snapshot, sp.sm)
 	return err
 }
 
-func (b *localBackend) newSnapshotPersister(ref *localBackendReference, sm secrets.Manager) *localSnapshotPersister {
-	return &localSnapshotPersister{ref: ref, backend: b, sm: sm}
+func (b *localBackend) newSnapshotPersister(
+	ctx context.Context,
+	ref *localBackendReference,
+	sm secrets.Manager,
+) *localSnapshotPersister {
+	return &localSnapshotPersister{ctx: ctx, ref: ref, backend: b, sm: sm}
 }

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -74,7 +74,7 @@ type referenceStore interface {
 	BackupDir(*localBackendReference) string
 
 	// ListReferences lists all stack references in the store.
-	ListReferences() ([]*localBackendReference, error)
+	ListReferences(context.Context) ([]*localBackendReference, error)
 
 	// ParseReference parses a localBackendReference from a string.
 	ParseReference(ref string) (*localBackendReference, error)
@@ -204,10 +204,10 @@ func (p *projectReferenceStore) ValidateReference(ref *localBackendReference) er
 	return nil
 }
 
-func (p *projectReferenceStore) ListProjects() ([]tokens.Name, error) {
+func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name, error) {
 	path := StacksDir
 
-	files, err := listBucket(p.bucket, path)
+	files, err := listBucket(ctx, p.bucket, path)
 	if err != nil {
 		return nil, fmt.Errorf("error listing stacks: %w", err)
 	}
@@ -232,10 +232,9 @@ func (p *projectReferenceStore) ListProjects() ([]tokens.Name, error) {
 	return projects, nil
 }
 
-func (p *projectReferenceStore) ListReferences() ([]*localBackendReference, error) {
+func (p *projectReferenceStore) ListReferences(ctx context.Context) ([]*localBackendReference, error) {
 	// The first level of the bucket is the project name.
 	// The second level of the bucket is the stack name.
-	ctx := context.TODO()
 	prefix := filepath.ToSlash(StacksDir) + "/"
 	iter := p.bucket.List(&blob.ListOptions{
 		Prefix: prefix,
@@ -353,8 +352,8 @@ func (p *legacyReferenceStore) ValidateReference(ref *localBackendReference) err
 	return nil
 }
 
-func (p *legacyReferenceStore) ListReferences() ([]*localBackendReference, error) {
-	files, err := listBucket(p.bucket, StacksDir)
+func (p *legacyReferenceStore) ListReferences(ctx context.Context) ([]*localBackendReference, error) {
+	files, err := listBucket(ctx, p.bucket, StacksDir)
 	if err != nil {
 		return nil, fmt.Errorf("error listing stacks: %w", err)
 	}

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -277,7 +277,7 @@ func TestLegacyReferenceStore_ListReferences(t *testing.T) {
 				require.NoError(t, bucket.WriteAll(ctx, f, []byte{}, nil))
 			}
 
-			refs, err := store.ListReferences()
+			refs, err := store.ListReferences(ctx)
 			require.NoError(t, err)
 
 			got := make([]tokens.QName, len(refs))
@@ -373,7 +373,7 @@ func TestProjectReferenceStore_List(t *testing.T) {
 			t.Run("Projects", func(t *testing.T) {
 				t.Parallel()
 
-				projects, err := store.ListProjects()
+				projects, err := store.ListProjects(ctx)
 				require.NoError(t, err)
 
 				assert.Equal(t, tt.projects, projects)
@@ -382,7 +382,7 @@ func TestProjectReferenceStore_List(t *testing.T) {
 			t.Run("References", func(t *testing.T) {
 				t.Parallel()
 
-				refs, err := store.ListReferences()
+				refs, err := store.ListReferences(ctx)
 				require.NoError(t, err)
 
 				got := make([]tokens.QName, len(refs))


### PR DESCRIPTION
The filestate backend implementation drops context in many places
instead opting to use context.TODO.
context.TODO is a TODO--something intended to be addressed.
context.Backgruond is appropriate for process-scoped operations.

In this case, we can resolve the issues and drop all uses of
context.TODO by plumbing the received contexts appropriately.

For localSnapshotPersister, we add a new `ctx` field
because the interface doesn't yet accept a context argument.
This is tracked in #12637.

Result:

```
% rg context.TODO pkg/backend/filestate
[empty]
```

Resolves #12594
