### PR TITLE
Fix config set-all saving secret provider configuration

### DIFF
--- a/changelog/pending/20230411--cli-config--fix-config-set-all-not-saving-secret-provider-configuration.yaml
+++ b/changelog/pending/20230411--cli-config--fix-config-set-all-not-saving-secret-provider-configuration.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix config set-all not saving secret provider configuration.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -185,13 +186,13 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				// fallback on snapshot SecretsManager
+			// Use the current snapshot secrets manager, if there is one, as the fallback secrets manager.
+			var sm secrets.Manager
+			if snap != nil {
 				sm = snap.SecretsManager
 			}
 
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -633,12 +633,7 @@ func newImportCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-			}
-
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -70,12 +70,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return fmt.Errorf("getting secrets manager: %w", err)
-			}
-
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -171,12 +171,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-			}
-
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -174,12 +174,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-			}
-
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -52,9 +52,22 @@ This command displays data about previous updates for a stack.`,
 			}
 			var decrypter config.Decrypter
 			if showSecrets {
-				crypter, err := getStackDecrypter(s)
+				project, _, err := readProject()
+				if err != nil {
+					return fmt.Errorf("loading project: %w", err)
+				}
+				ps, err := loadProjectStack(project, s)
+				if err != nil {
+					return fmt.Errorf("getting stack config: %w", err)
+				}
+				crypter, needsSave, err := getStackDecrypter(s, ps)
 				if err != nil {
 					return fmt.Errorf("decrypting secrets: %w", err)
+				}
+				if needsSave {
+					if err = saveProjectStack(s, ps); err != nil {
+						return fmt.Errorf("saving stack config: %w", err)
+					}
 				}
 				decrypter = crypter
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -104,12 +104,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
 
-		sm, err := getStackSecretsManager(s)
-		if err != nil {
-			return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-		}
-
-		cfg, err := getStackConfiguration(ctx, s, proj, sm)
+		cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 		if err != nil {
 			return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 		}
@@ -308,7 +303,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Prompt for config values (if needed) and save.
-		if err = handleConfig(ctx, s, templateNameOrURL, template, configArray, yes, path, opts.Display); err != nil {
+		if err = handleConfig(ctx, proj, s, templateNameOrURL, template, configArray, yes, path, opts.Display); err != nil {
 			return result.FromError(err)
 		}
 
@@ -331,12 +326,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
 
-		sm, err := getStackSecretsManager(s)
-		if err != nil {
-			return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-		}
-
-		cfg, err := getStackConfiguration(ctx, s, proj, sm)
+		cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 		if err != nil {
 			return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 		}
@@ -648,6 +638,7 @@ func validatePolicyPackConfig(policyPackPaths []string, policyPackConfigPaths []
 // handleConfig handles prompting for config values (as needed) and saving config.
 func handleConfig(
 	ctx context.Context,
+	project *workspace.Project,
 	s backend.Stack,
 	templateNameOrURL string,
 	template workspace.Template,
@@ -686,7 +677,7 @@ func handleConfig(
 		}
 
 		// Prompt for config as needed.
-		c, err = promptForConfig(ctx, s, template.Config, commandLineConfig, stackConfig, yes, opts)
+		c, err = promptForConfig(ctx, project, s, template.Config, commandLineConfig, stackConfig, yes, opts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -213,7 +213,13 @@ func createSecretsManager(
 	}
 
 	// Handle if the configuration changed any of EncryptedKey, etc
-	return saveProjectStackAfterSecretManger(stack, oldConfig, ps)
+	if needsSaveProjectStackAfterSecretManger(stack, oldConfig, ps) {
+		if err = workspace.SaveProjectStack(stack.Ref().Name().Q(), ps); err != nil {
+			return fmt.Errorf("saving stack config: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // createStack creates a stack with the given name, and optionally selects it as the current.

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -522,36 +522,12 @@ func readProjectForUpdate(clientAddress string) (*workspace.Project, string, err
 // project is successfully detected and read, it is returned along with the path to its containing
 // directory, which will be used as the root of the project's Pulumi program.
 func readProject() (*workspace.Project, string, error) {
-	proj, path, err := readProjectWithPath()
+	proj, path, err := workspace.DetectProjectAndPath()
 	if err != nil {
 		return nil, "", err
 	}
 
 	return proj, filepath.Dir(path), nil
-}
-
-// readProjectWithPath attempts to detect and read a Pulumi project for the current workspace. If
-// the project is successfully detected and read, it is returned along with the path to the project
-// file, which will be used as the root of the project's Pulumi program.
-//
-// If a project is not found while searching and no other error occurs, workspace.ErrProjectNotFound
-// is returned.
-func readProjectWithPath() (*workspace.Project, string, error) {
-	pwd, err := os.Getwd()
-	if err != nil {
-		return nil, "", err
-	}
-	// Now that we got here, we have a path, so we will try to load it.
-	path, err := workspace.DetectProjectPathFrom(pwd)
-	if err != nil {
-		return nil, "", err
-	}
-	proj, err := workspace.LoadProject(path)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to load Pulumi project located at %q: %w", path, err)
-	}
-
-	return proj, path, nil
 }
 
 // readPolicyProject attempts to detect and read a Pulumi PolicyPack project for the current

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -109,12 +109,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
-			}
-
-			cfg, err := getStackConfiguration(ctx, s, proj, sm)
+			cfg, sm, err := getStackConfiguration(ctx, s, proj, nil)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Clean up some more hidden loading of config files in `getStackEncrypter`/`getStackDecrypter` that could cause the config file to change due to secret provider initialization. Importantly this was missed in `config set-all` where we would load the config file, then later on call `getStackEncrypter` which would initialize the secrets config and save it to disk, but not return that information back up to "set-all" which then overwrote it with the config structure that it had been building. This could result in secret values written to the config file but without saving their salt meaning they could never correctly be decrypted.

Fixes https://github.com/pulumi/pulumi/issues/12632.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
