### PR TITLE
CI: Node 14 => Node 16

### DIFF
--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -24,7 +24,7 @@ on:
           {
             "dotnet": "6.0.x",
             "go": "1.18.x",
-            "nodejs": "14.x",
+            "nodejs": "16.x",
             "python": "3.9.x"
           }
 

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -47,7 +47,7 @@ on:
           {
             "dotnet": "6.0.x",
             "go": "1.18.x",
-            "nodejs": "14.x",
+            "nodejs": "16.x",
             "python": "3.9.x"
           }
       continue-on-error:

--- a/.github/workflows/ci-test-codegen.yml
+++ b/.github/workflows/ci-test-codegen.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ on:
           {
             "dotnet": "6.0.x",
             "go": "1.18.x",
-            "nodejs": "14.x",
+            "nodejs": "16.x",
             "python": "3.9.x"
           }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Finally, please limit your pull requests to contain only one feature at a time. 
 You'll want to install the following on your machine:
 
 - [Go](https://go.dev/dl/) (a [supported version](https://go.dev/doc/devel/release#policy))
-- [NodeJS 14.X.X or later](https://nodejs.org/en/download/)
+- [NodeJS 16.X.X or later](https://nodejs.org/en/download/)
 - [Python 3.6 or later](https://www.python.org/downloads/)
 - [.NET](https://dotnet.microsoft.com/download)
 - [Golangci-lint](https://github.com/golangci/golangci-lint)

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ details of the core Pulumi CLI and [programming model concepts](https://www.pulu
 
 |    | Language | Status | Runtime |
 | -- | -------- | ------ | ------- |
-| <img src="https://www.pulumi.com/logos/tech/logo-js.png" height=38 />     | [JavaScript](https://www.pulumi.com/docs/intro/languages/javascript/) | Stable  | Node.js 14+  |
-| <img src="https://www.pulumi.com/logos/tech/logo-ts.png" height=38 />     | [TypeScript](https://www.pulumi.com/docs/intro/languages/javascript/) | Stable  | Node.js 14+  |
+| <img src="https://www.pulumi.com/logos/tech/logo-js.png" height=38 />     | [JavaScript](https://www.pulumi.com/docs/intro/languages/javascript/) | Stable  | Node.js 16+  |
+| <img src="https://www.pulumi.com/logos/tech/logo-ts.png" height=38 />     | [TypeScript](https://www.pulumi.com/docs/intro/languages/javascript/) | Stable  | Node.js 16+  |
 | <img src="https://www.pulumi.com/logos/tech/logo-python.svg" height=38 /> | [Python](https://www.pulumi.com/docs/intro/languages/python/)     | Stable  | Python 3.7+ |
 | <img src="https://www.pulumi.com/logos/tech/logo-golang.png" height=38 /> | [Go](https://www.pulumi.com/docs/intro/languages/go/)             | Stable  | Go [supported versions](https://go.dev/doc/devel/release#policy) |
 | <img src="https://www.pulumi.com/logos/tech/dotnet.svg" height=38 />      | [.NET (C#/F#/VB.NET)](https://www.pulumi.com/docs/intro/languages/dotnet/)     | Stable  | .NET Core 3.1+  |

--- a/changelog/pending/20230412--sdk-nodejs--minimum-version-node16.yaml
+++ b/changelog/pending/20230412--sdk-nodejs--minimum-version-node16.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: With Node14 sunset on April 30, the minimum version of Node is now Node 16.

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -116,7 +116,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
     "go": "1.19.x",
-    "nodejs": "14.x",
+    "nodejs": "16.x",
     "python": "3.9.x",
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR migrates our CI/CD to use Node 16 instead of Node 14.
Node 14 will be sunset on April 30, 2023 (less than 3 weeks from the time of writing). This PR moves CI/CD to test and build on Node 16.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12646

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
