### PR TITLE
Don't load providers at startup

### DIFF
--- a/changelog/pending/20230419--engine--provider-plugins-are-now-loaded-as-needed-not-at-startup-based-on-old-state-information.yaml
+++ b/changelog/pending/20230419--engine--provider-plugins-are-now-loaded-as-needed-not-at-startup-based-on-old-state-information.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Provider plugins are now loaded as needed, not at startup based on old state information.

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -757,8 +757,13 @@ func TestDefaultProviderDiff(t *testing.T) {
 	t.Parallel()
 
 	const resName, resBName = "resA", "resB"
+	expect1710 := true
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("0.17.10"), func() (plugin.Provider, error) {
+			// If we don't expect to load this assert if called
+			if !expect1710 {
+				assert.Fail(t, "unexpected call to 0.17.10 provider")
+			}
 			return &deploytest.Provider{}, nil
 		}),
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("0.17.11"), func() (plugin.Provider, error) {
@@ -847,6 +852,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 	// The third update changes the version that the language host reports to the engine. This simulates a scenario in
 	// which a user updates their SDK to a new version of a provider package. In order to simulate side-by-side
 	// packages with different versions, this update requests distinct package versions for resA and resB.
+	expect1710 = false
 	snap = runProgram(snap, "0.17.11", "0.17.12", deploy.OpSame)
 	for _, res := range snap.Resources {
 		switch {

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -493,6 +493,12 @@ func (ex *deploymentExecutor) refresh(callerCtx context.Context, opts Options, p
 	resourceToStep := map[*resource.State]Step{}
 	for _, res := range prev.Resources {
 		if opts.RefreshTargets.Contains(res.URN) {
+			// For each resource we're going to refresh we need to ensure we have a provider for it
+			err := ex.deployment.EnsureProvider(res.Provider)
+			if err != nil {
+				return result.Errorf("could not load provider for resource %v: %w", res.URN, err)
+			}
+
 			step := NewRefreshStep(ex.deployment, res, nil)
 			steps = append(steps, step)
 			resourceToStep[res] = step

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -71,7 +71,7 @@ func NewImportDeployment(ctx *plugin.Context, target *Target, projectName tokens
 	}
 
 	// Produce a map of all old resources for fast access.
-	oldResources, olds, err := buildResourceMap(prev, preview)
+	_, olds, err := buildResourceMap(prev, preview)
 	if err != nil {
 		return nil, err
 	}
@@ -82,10 +82,7 @@ func NewImportDeployment(ctx *plugin.Context, target *Target, projectName tokens
 	builtins := newBuiltinProvider(nil, nil)
 
 	// Create a new provider registry.
-	reg, err := providers.NewRegistry(ctx.Host, oldResources, preview, builtins)
-	if err != nil {
-		return nil, err
-	}
+	reg := providers.NewRegistry(ctx.Host, preview, builtins)
 
 	// Return the prepared deployment.
 	return &Deployment{

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -211,68 +211,15 @@ func loadProvider(pkg tokens.Package, version *semver.Version, downloadURL strin
 	return host.Provider(pkg, version)
 }
 
-// NewRegistry creates a new provider registry using the given host and old resources. Each provider present in the old
-// resources will be loaded, configured, and added to the returned registry under its reference. If any provider is not
-// loadable/configurable or has an invalid ID, this function returns an error.
-func NewRegistry(host plugin.Host, prev []*resource.State, isPreview bool,
-	builtins plugin.Provider,
-) (*Registry, error) {
-	r := &Registry{
+// NewRegistry creates a new provider registry using the given host.
+func NewRegistry(host plugin.Host, isPreview bool, builtins plugin.Provider) *Registry {
+	return &Registry{
 		host:      host,
 		isPreview: isPreview,
 		providers: make(map[Reference]plugin.Provider),
 		builtins:  builtins,
 		aliases:   make(map[resource.URN]resource.URN),
 	}
-
-	for _, res := range prev {
-		urn := res.URN
-		if !IsProviderType(urn.Type()) {
-			logging.V(7).Infof("provider(%v): %v", urn, res.Provider)
-			continue
-		}
-
-		// Ensure that this provider has a known ID.
-		if res.ID == "" || res.ID == UnknownID {
-			return nil, fmt.Errorf("provider '%v' has an unknown ID", urn)
-		}
-
-		// Ensure that we have no duplicates.
-		ref := mustNewReference(urn, res.ID)
-		if _, ok := r.providers[ref]; ok {
-			return nil, fmt.Errorf("duplicate provider found in old state: '%v'", ref)
-		}
-
-		providerPkg := GetProviderPackage(urn.Type())
-
-		// Parse the provider version, then load, configure, and register the provider.
-		version, err := GetProviderVersion(res.Inputs)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse version for %v provider '%v': %v", providerPkg, urn, err)
-		}
-		downloadURL, err := GetProviderDownloadURL(res.Inputs)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse download URL for %v provider '%v': %v", providerPkg, urn, err)
-		}
-		// TODO: We should thread checksums through here.
-		provider, err := loadProvider(providerPkg, version, downloadURL, nil, host, builtins)
-		if err != nil {
-			return nil, fmt.Errorf("could not load plugin for %v provider '%v': %v", providerPkg, urn, err)
-		}
-		if provider == nil {
-			return nil, fmt.Errorf("could not find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
-		}
-		if err := provider.Configure(res.Inputs); err != nil {
-			closeErr := host.CloseProvider(provider)
-			contract.IgnoreError(closeErr)
-			return nil, fmt.Errorf("could not configure provider '%v': %v", urn, err)
-		}
-
-		logging.V(7).Infof("loaded provider %v", ref)
-		r.providers[ref] = provider
-	}
-
-	return r, nil
 }
 
 // GetProvider returns the provider plugin that is currently registered under the given reference, if any.
@@ -431,9 +378,9 @@ func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.Pr
 		// If the provider was not found in the registry under its URN and the Unknown ID, then it must have not have
 		// been subject to a call to `Check`. This can happen when we are diffing a provider's inputs as part of
 		// evaluating the fanout of a delete-before-replace operation. In this case, we can just use the old provider
-		// (which must have been loaded when the registry was created), and we will not unload it.
+		// (which we should have loaded during diff search), and we will not unload it.
 		provider, ok = r.GetProvider(mustNewReference(urn, id))
-		contract.Assertf(ok, "Provider must have been registered by NewRegistry for DBR Diff (%v::%v)", urn, id)
+		contract.Assertf(ok, "Provider must have been registered at some point for DBR Diff (%v::%v)", urn, id)
 
 		diff, err := provider.DiffConfig(urn, olds, news, allowUnknowns, ignoreChanges)
 		if err != nil {
@@ -466,20 +413,58 @@ func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.Pr
 	return diff, nil
 }
 
-// Same executes as part of the "Same" step for a provider that has not changed. It exists solely to allow the registry
-// to point aliases for a provider to the proper object.
-func (r *Registry) Same(ref Reference) {
-	r.m.RLock()
-	defer r.m.RUnlock()
+// Same executes as part of the "Same" step for a provider that has not changed. It configures the provider
+// instance with the given state and fixes up aliases.
+func (r *Registry) Same(res *resource.State) error {
+	urn := res.URN
+	if !IsProviderType(urn.Type()) {
+		return fmt.Errorf("urn %v is not a provider type", urn)
+	}
 
+	// Ensure that this provider has a known ID.
+	if res.ID == "" || res.ID == UnknownID {
+		return fmt.Errorf("provider '%v' has an unknown ID", urn)
+	}
+
+	ref := mustNewReference(urn, res.ID)
 	logging.V(7).Infof("Same(%v)", ref)
 
-	// If this provider is aliased to a different old URN, make sure that it is present under both the old reference and
-	// the new reference.
-	if alias, ok := r.aliases[ref.URN()]; ok {
-		aliasRef := mustNewReference(alias, ref.ID())
-		r.providers[ref] = r.providers[aliasRef]
+	// If this provider is already configured, then we're done.
+	_, ok := r.GetProvider(ref)
+	if ok {
+		return nil
 	}
+
+	providerPkg := GetProviderPackage(urn.Type())
+
+	// Parse the provider version, then load, configure, and register the provider.
+	version, err := GetProviderVersion(res.Inputs)
+	if err != nil {
+		return fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+	}
+	downloadURL, err := GetProviderDownloadURL(res.Inputs)
+	if err != nil {
+		return fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
+	}
+	// TODO: We should thread checksums through here.
+	provider, err := loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
+	if err != nil {
+		return fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
+	}
+	if provider == nil {
+		return fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
+	}
+	if err := provider.Configure(res.Inputs); err != nil {
+		closeErr := r.host.CloseProvider(provider)
+		contract.IgnoreError(closeErr)
+		return fmt.Errorf("configure provider '%v': %v", urn, err)
+	}
+
+	logging.V(7).Infof("loaded provider %v", ref)
+
+	r.setProvider(ref, provider)
+
+	return nil
 }
 
 // Create coonfigures the provider with the given URN using the indicated configuration, assigns it an ID, and
@@ -538,8 +523,8 @@ func (r *Registry) Update(urn resource.URN, id resource.ID, olds, news resource.
 	return news, resource.StatusOK, nil
 }
 
-// Delete unregisters and unloads the provider with the given URN and ID. The provider must have been loaded when the
-// registry was created (i.e. it must have been present in the state handed to NewRegistry).
+// Delete unregisters and unloads the provider with the given URN and ID. If the provider was never loaded
+// this is a no-op.
 func (r *Registry) Delete(urn resource.URN, id resource.ID, props resource.PropertyMap,
 	timeout float64,
 ) (resource.Status, error) {
@@ -547,7 +532,9 @@ func (r *Registry) Delete(urn resource.URN, id resource.ID, props resource.Prope
 
 	ref := mustNewReference(urn, id)
 	provider, has := r.deleteProvider(ref)
-	contract.Assertf(has, "could not find provider to delete (%v)", ref)
+	if !has {
+		return resource.StatusOK, nil
+	}
 
 	closeErr := r.host.CloseProvider(provider)
 	contract.IgnoreError(closeErr)

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -51,10 +51,7 @@ func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client Back
 	// Create a new builtin provider. This provider implements features such as `getStack`.
 	builtins := newBuiltinProvider(client, nil)
 
-	reg, err := providers.NewRegistry(plugctx.Host, nil, false, builtins)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start resource monitor: %w", err)
-	}
+	reg := providers.NewRegistry(plugctx.Host, false, builtins)
 
 	// Allows queryResmon to communicate errors loading providers.
 	providerRegErrChan := make(chan result.Result)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,13 +134,12 @@ func (s *SameStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 	// If the resource is a provider, ensure that it is present in the registry under the appropriate URNs.
 	// We can only do this if the provider is actually a same, not a skipped create.
 	if providers.IsProviderType(s.new.Type) && !s.skippedCreate {
-		ref, err := providers.NewReference(s.new.URN, s.new.ID)
-		if err != nil {
-			return resource.StatusOK, nil,
-				fmt.Errorf("bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
-		}
 		if s.Deployment() != nil {
-			s.Deployment().SameProvider(ref)
+			err := s.Deployment().SameProvider(s.new)
+			if err != nil {
+				return resource.StatusOK, nil,
+					fmt.Errorf("bad provider state for resource %v: %v", s.URN(), err)
+			}
 		}
 	}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1037,6 +1037,13 @@ func (sg *stepGenerator) generateStepsFromDiff(
 					}
 				}
 
+				// We're going to delete the old resource before creating the new one. We need to make sure
+				// that the old provider is loaded.
+				err := sg.deployment.EnsureProvider(old.Provider)
+				if err != nil {
+					return nil, result.Errorf("could not load provider for resource %v: %w", old.URN, err)
+				}
+
 				return append(steps,
 					NewDeleteReplacementStep(sg.deployment, sg.deletes, old, true),
 					NewReplaceStep(sg.deployment, old, new, diff.ReplaceKeys, diff.ChangedKeys, diff.DetailedDiff, false),
@@ -1125,6 +1132,14 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets) ([]Step, result.
 					dels = append(dels, NewDeleteStep(sg.deployment, sg.deletes, res))
 				} else {
 					dels = append(dels, NewRemovePendingReplaceStep(sg.deployment, res))
+				}
+			}
+
+			// We just added a Delete step, so we need to ensure the provider for this resource is available.
+			if sg.deletes[res.URN] {
+				err := sg.deployment.EnsureProvider(res.Provider)
+				if err != nil {
+					return nil, result.Errorf("could not load provider for resource %v: %w", res.URN, err)
 				}
 			}
 		}
@@ -1809,6 +1824,12 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 				return false, nil, result.FromError(err)
 			}
 			if replaceSet[ref.URN()] {
+				// We need to use the old provider configuration to delete this resource so ensure it's loaded.
+				err := sg.deployment.EnsureProvider(r.Provider)
+				if err != nil {
+					return false, nil, result.Errorf("could not load provider for resource %v: %w", r.URN, err)
+				}
+
 				return true, nil, nil
 			}
 		}
@@ -1830,6 +1851,20 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 		// may change and this resource does not need to be replaced.
 		if !hasDependencyInReplaceSet {
 			return false, nil, nil
+		}
+
+		// We're going to have to call diff on this resources provider so ensure that we have it created
+		if !providers.IsProviderType(r.Type) {
+			err := sg.deployment.EnsureProvider(r.Provider)
+			if err != nil {
+				return false, nil, result.Errorf("could not load provider for resource %v: %w", r.URN, err)
+			}
+		} else {
+			// This is a provider itself so load it so that Diff below is possible
+			err := sg.deployment.SameProvider(r)
+			if err != nil {
+				return false, nil, result.Errorf("create provider %v: %w", r.URN, err)
+			}
 		}
 
 		// Otherwise, fetch the resource's provider. Since we have filtered out component resources, this resource must


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This changes the provider registry to no longer load all the providers
from the old state on startup (in `NewRegistry`) instead the load logic
has been moved to the `Same` method. The step_executor and
step_generator have been fixed up to ensure that for cases where a
resource might not have had it's provider created yet (i.e. for DBR'ing
the old version of a resource, for refreshes or deletes) they ask the
`Deployment` to look up the provider in the old state and `Same` it in the
registry.

All of the above means we only load providers we're going to use (even
taking --targets into account).

One fix mot done in this change is to auto-update providers for deletes.
That is given a program state with two resources both using V1 of a
provider, if you run the program to update one of those resource to use
V2 of the provider but to delete the other resource currently we'll
still load V1 to do that delete. It _might_ be possible (although this
is definitly questionable) to see that another resource changed it's
provider from V1 to V2 and to just assume the same change should have
happened to the deleted resource.
This could be helpful for not loading old provider versions at all, but
can be done in two passes now pretty easily. Just run `up` without any
program changes except for the SDK version bump to update all the
provider references to V2 of the provider, then do another `up` that
deletes the second resource.
    
Fixes https://github.com/pulumi/pulumi/issues/12177.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
