### PR TITLE
Log that we're falling back to get.pulumi.com

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -610,6 +610,7 @@ func (source *fallbackSource) Download(
 	if err == nil {
 		return resp, length, nil
 	}
+	logging.Infof("Failed to download from GitHub, falling back to get.pulumi.com: %v", err)
 
 	// Fallback to get.pulumi.com
 	pulumi := newGetPulumiSource(source.name, source.kind)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently the "GitHub rate limit exceeded, try again in XmYs." errors look pretty bad because it's not clear that we then fallback got get.pulumi.com for our plugins when hitting this error. Adding this log line so it's a bit clearer what's going on when reading log files back.