### PR TITLE
Only warn about version upgrade once a day

### DIFF
--- a/changelog/pending/20230412--cli--dont-warn-about-the-cli-version-being-out-of-date-on-every-run-the-cli-will-now-only-warn-once-a-day-when-it-queries-for-the-latest-version.yaml
+++ b/changelog/pending/20230412--cli--dont-warn-about-the-cli-version-being-out-of-date-on-every-run-the-cli-will-now-only-warn-once-a-day-when-it-queries-for-the-latest-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Don't warn about the CLI version being out of date on every run. The CLI will now only warn once a day, when it queries for the latest version.

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -14,10 +14,18 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsDevVersion(t *testing.T) {
@@ -36,4 +44,76 @@ func TestIsDevVersion(t *testing.T) {
 	assert.True(t, isDevVersion(alphaVer))
 	assert.True(t, isDevVersion(betaVer))
 	assert.True(t, isDevVersion(rcVer))
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate(t *testing.T) {
+	realVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = realVersion
+	})
+	version.Version = "v1.0.0"
+
+	// Cached version information is stored in PULUMI_HOME.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	// If the cached version is missing or outdated,
+	// the HTTP server receives a request.
+	var requestCounter int // number of requests
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			requestCounter++
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("PULUMI_API", srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	msg := checkForUpdate(ctx)
+	require.NotNil(t, msg)
+	assert.Contains(t, msg.Message, "A new version of Pulumi is available")
+	assert.Contains(t, msg.Message, "upgrade from version '1.0.0' to '1.2.3'")
+	assert.Equal(t, 1, requestCounter,
+		"expected exactly one request to the HTTP server")
+
+	t.Run("cached", func(t *testing.T) {
+		// Once we have cached version information,
+		// we will not warn the user again until the cache expires.
+		requestCounter = 0
+		require.Nil(t, checkForUpdate(ctx))
+		assert.Equal(t, 0, requestCounter,
+			"no requests are expected to the HTTP server")
+	})
+
+	t.Run("cache expired", func(t *testing.T) {
+		// Expire the cached version information
+		// and verify that we query the server again.
+
+		versionCachePath, err := workspace.GetCachedVersionFilePath()
+		require.NoError(t, err)
+
+		expiredTime := time.Now().Add(-25 * time.Hour)
+		require.NoError(t,
+			os.Chtimes(versionCachePath, expiredTime, expiredTime))
+
+		requestCounter = 0
+		require.NotNil(t, checkForUpdate(ctx))
+		assert.Equal(t, 1, requestCounter)
+	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12659.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
