### PR TITLE
[pcl] Do not panic when attribute type or resource variable type isn't fully bound

### DIFF
--- a/changelog/pending/20230412--programgen--do-not-panic-when-attribute-type-or-resource-variable-type-isnt-fully-bound.yaml
+++ b/changelog/pending/20230412--programgen--do-not-panic-when-attribute-type-or-resource-variable-type-isnt-fully-bound.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Do not panic when PCL attribute type or PCL resource variable type isn't fully bound

--- a/pkg/codegen/hcl2/model/attribute.go
+++ b/pkg/codegen/hcl2/model/attribute.go
@@ -66,6 +66,10 @@ func (a *Attribute) print(w io.Writer, p *printer) {
 }
 
 func (a *Attribute) Type() Type {
+	if a == nil || a.Value == nil {
+		return DynamicType
+	}
+
 	return a.Value.Type()
 }
 

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -98,6 +98,10 @@ func (r *Resource) VisitExpressions(pre, post model.ExpressionVisitor) hcl.Diagn
 }
 
 func (r *Resource) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	if r == nil || r.VariableType == nil {
+		return model.DynamicType.Traverse(traverser)
+	}
+
 	return r.VariableType.Traverse(traverser)
 }
 


### PR DESCRIPTION
# Description

Sometimes during program binding, when an attribute isn't fully bound, its type would be `nil`. Later on when the attribute is used and its type needs to be type-checked, it panics. Here we resort to using `model.DynamicType` when the type isn't known. The same for the `VariableType` of resources.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
