### PR TITLE
CONTRIBUTING: Require a supported version of Go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Finally, please limit your pull requests to contain only one feature at a time. 
 
 You'll want to install the following on your machine:
 
-- [Go 1.18 or later](https://go.dev/dl/)
+- [Go](https://go.dev/dl/) (a [supported version](https://go.dev/doc/devel/release#policy))
 - [NodeJS 14.X.X or later](https://nodejs.org/en/download/)
 - [Python 3.6 or later](https://www.python.org/downloads/)
 - [.NET](https://dotnet.microsoft.com/download)


### PR DESCRIPTION
Pulumi supports the same versions of Go as upstream.
Instead of updating the CONTRIBUTING.md with every Go releas,
specify that contributors should install "a supported version",
which will normally be one of the two most recent minor releases.

Resolves #12664
