### PR TITLE
[pcl] Do not panic when the type of PCL local variable isn't known

### DIFF
--- a/changelog/pending/20230413--programgen--do-not-panic-when-the-type-of-pcl-local-variable-isnt-known.yaml
+++ b/changelog/pending/20230413--programgen--do-not-panic-when-the-type-of-pcl-local-variable-isnt-known.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: programgen
+  description: Do not panic when the type of PCL local variable isn't known

--- a/pkg/codegen/pcl/local.go
+++ b/pkg/codegen/pcl/local.go
@@ -36,6 +36,9 @@ func (lv *LocalVariable) SyntaxNode() hclsyntax.Node {
 }
 
 func (lv *LocalVariable) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	if lv == nil || lv.Type() == nil {
+		return model.DynamicType.Traverse(traverser)
+	}
 	return lv.Type().Traverse(traverser)
 }
 


### PR DESCRIPTION
Another small fix for PCL binding so that we don't panic when the type of a local variable isn't known. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
