### PR TITLE
display backend specific messages to the user during updates

### DIFF
--- a/changelog/pending/20230418--cli-display--pulumi-cli-can-now-display-messages-provided-by-the-service.yaml
+++ b/changelog/pending/20230418--cli-display--pulumi-cli-can-now-display-messages-provided-by-the-service.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Pulumi CLI can now display messages provided by the service.

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -70,6 +70,22 @@ type UpdateMetadata struct {
 	Environment map[string]string `json:"environment"`
 }
 
+type MessageSeverity string
+
+const (
+	MessageSeverityWarning MessageSeverity = "warning"
+	MessageSeverityError   MessageSeverity = "error"
+	MessageSeverityInfo    MessageSeverity = "info"
+)
+
+// Message is a message from the backend to be displayed to the user.
+type Message struct {
+	// Severity is the severity of the message.
+	Severity MessageSeverity `json:"severity,omitempty"`
+	// Message is the message to display to the user.
+	Message string `json:"message"`
+}
+
 // UpdateProgramResponse is the result of an update program request.
 type UpdateProgramResponse struct {
 	// UpdateID is the opaque identifier of the requested update. This value is needed to begin an update, as
@@ -78,6 +94,9 @@ type UpdateProgramResponse struct {
 
 	// RequiredPolicies is a list of required Policy Packs to run during the update.
 	RequiredPolicies []RequiredPolicy `json:"requiredPolicies,omitempty"`
+
+	// Messages is a list of messages that should be displayed to the user.
+	Messages []Message `json:"messages,omitempty"`
 }
 
 // StartUpdateRequest requests that an update starts getting applied to a stack.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR enables a backend to supply messages for the CLI to display to the user during Pulumi updates.

Fixes #12598 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
