### PR TITLE
[pcl] Linearize component resource nodes

### DIFF
--- a/changelog/pending/20230414--programgen-nodejs--linearize-component-resource-nodes.yaml
+++ b/changelog/pending/20230414--programgen-nodejs--linearize-component-resource-nodes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Linearize component resource nodes

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -602,7 +602,7 @@ func (g *generator) genComponentResourceDefinition(w io.Writer, componentName st
 				}
 			}
 
-			for _, node := range component.Program.Nodes {
+			for _, node := range pcl.Linearize(component.Program) {
 				switch node := node.(type) {
 				case *pcl.LocalVariable:
 					g.genLocalVariable(w, node)


### PR DESCRIPTION
Resource declarations in components were not linear before; some resources refer to other resources declared later on in the program. This fixes the issue 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
