### PR TITLE
Allow convert from plugin to pcl to write PCL even if binding fails

### DIFF
--- a/pkg/util/afero/afero.go
+++ b/pkg/util/afero/afero.go
@@ -1,0 +1,67 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+// Copies all file and directories from src to dst
+func CopyDir(fs afero.Fs, src, dst string) error {
+	entries, err := afero.ReadDir(fs, src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(src, entry.Name())
+		destPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := CopyDir(fs, sourcePath, destPath); err != nil {
+				return err
+			}
+		} else {
+			if err := Copy(fs, sourcePath, destPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Copies a file from src to dst
+func Copy(fs afero.Fs, src, dst string) error {
+	out, err := fs.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := fs.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This should help with debugging converter problems as we'll be able to easily run the converter to see what PCL its trying to write for codegen even if that's not valid PCL.

This require's double-binding of tfEject/yamlEject but that shouldn't change correctness and both of those should be changed to converter plugins that just write PCL at some point soon anyway.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - PCL is currently only really intended for internal use.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
