### PR TITLE
Fix convert pcl copy

### DIFF
--- a/pkg/util/afero/afero.go
+++ b/pkg/util/afero/afero.go
@@ -16,6 +16,7 @@ package afero
 
 import (
 	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
@@ -25,6 +26,10 @@ import (
 func CopyDir(fs afero.Fs, src, dst string) error {
 	entries, err := afero.ReadDir(fs, src)
 	if err != nil {
+		return err
+	}
+	err = fs.Mkdir(dst, 0o755)
+	if err != nil && !os.IsExist(err) {
 		return err
 	}
 	for _, entry := range entries {


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Can't write a file if the parent directory isn't first created.

Annoyingly we would have probably missed this in tests using MemFs anyway because it doesn't follow that rule.


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Manually ran convert to check this. We should write some tests here next week, although as above MemFs is buggy in this regard as well.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
