### PR TITLE
pkg/deploytest: Don't zero CustomTimeouts < 1 minute

### DIFF
--- a/changelog/pending/20230414--pkg-testing--deploytest-fix-custom-timeouts-smaller-than-a-minute-being-ignored.yaml
+++ b/changelog/pending/20230414--pkg-testing--deploytest-fix-custom-timeouts-smaller-than-a-minute-being-ignored.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg/testing
+  description: "deploytest: Fix nil custom timeouts and timeouts smaller than a minute being ignored."


### PR DESCRIPTION
deploytest.ResourceMonitor currently zeroes out any custom timeout value
smaller than 60 seconds because it does integer division on it.
Further, it alawys uses a non-nil CustomTimeouts
even when the input was nil.
This causes undesirable breaks in unit tests that use this type.

This change fixes both issues in CustomTimeouts. Now:

- The RegisterResourceRequest.CustomTimeouts field is non-nil
  only if the input CustomTimeouts was non-nil
- time.Duration and float divison is used to accurately format
  the specified duration as a string

Encountered while writing tests for #12154
