### PR TITLE
sdk/go: Don't drop Dependencies in ResourceOptions snapshot for MLCs

### DIFF
--- a/changelog/pending/20230414--sdk-go--fixed-newresourceoptions-dropping-mlc-dependencies-from-the-options-snapshot.yaml
+++ b/changelog/pending/20230414--sdk-go--fixed-newresourceoptions-dropping-mlc-dependencies-from-the-options-snapshot.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fixed NewResourceOptions dropping MLC dependencies from the options preview.

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -419,11 +419,6 @@ func resourceOptionsSnapshot(ro *resourceOptions) *ResourceOptions {
 	)
 	for _, d := range ro.DependsOn {
 		switch d := d.(type) {
-		case urnDependencySet:
-			// There is no user-facing option
-			// to specify URN dependencies directly.
-			// This is only used internally,
-			// so omit this from the snapshot.
 		case resourceDependencySet:
 			dependsOn = append(dependsOn, []Resource(d)...)
 		case *resourceArrayInputDependencySet:
@@ -618,16 +613,6 @@ type dependencySet interface {
 	// Optionally pass the last Resource arg to short-circuit component
 	// children cycles.
 	addURNs(context.Context, urnSet, Resource) error
-}
-
-// urnDependencySet is a dependencySet built from a constant set of URNs.
-type urnDependencySet urnSet
-
-var _ dependencySet = (urnDependencySet)(nil)
-
-func (us urnDependencySet) addURNs(ctx context.Context, urns urnSet, _ Resource) error {
-	urns.union(urnSet(us))
-	return nil
 }
 
 // DependsOn is an optional array of explicit dependencies on other resources.


### PR DESCRIPTION
We recently added a new API, NewResourceOptions to build a preview
of a set of resource options.

    func NewResourceOptions(...ResourceOption) (*ResourceOptions, error)

This currently drops the dependencies of an MLC from the snapshot.
The reason for this is that it used a special type "urnSet"
to represent dependencies for MLCs received over the wire.
This decision was made at the time because the original Resource objects
were not available for these dependencies.

Turns out that that limitation isn't a blocker:
we can use newDependencyResource to create dummy Resource objects
that hold nothing but a URN.

This allows NewResourceOptions to work on options even inside an MLC.
Note that this currently only works for some of the options:
those that are propagated from `construct` into the Go SDK options.
Others will be added as part of #12154.

Testing:
The accompanying test failed for Dependencies without this change.
