### PR TITLE
Remove the pulumi/templates `trigger-cron` step from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,6 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - name: Templates Smoke Test
-            run-command: pulumictl dispatch -r pulumi/templates -c trigger-cron "${PULUMI_VERSION}"
           - name: Update Templates Version
             run-command: pulumictl dispatch -r pulumi/templates -c update-templates "${PULUMI_VERSION}"
           - name: Examples Templates Version


### PR DESCRIPTION
Today, when we do a release, we dispatch the `trigger-cron` workflow on the pulumi/templates repo, but this workflow consistently fails on new releases because it installs the Pulumi CLI with pulumi/actions, which [relies on pulumi/docs for its list of available versions](https://github.com/pulumi/actions/blob/e50e616f7d8f4c92d3d22abdd8cfd048e6e672de/src/libs/libs/get-version.ts#L23-L45) (a list that doesn't get updated until much later as part of a different process).  As a result, every new release causes a pulumi/templates workflow failure (and alerts us in the #builds channel):

```
> Run pulumi/actions@v4
Configured range: v3.61.1
Error: Could not find a version that satisfied the version range
```

So this PR removes this step from the release workflow. 

It does seem useful to run new releases against the templates repo, however -- so perhaps a better change would be to update pulumi/actions not to rely on the website for the list of available versions? Open to suggestions of course -- the main thing I'm after isn't so much to stop this particular step from happening as to pause it until we can run it in a way that can actually succeed. Thanks!