### PR TITLE
testing/ProgramTest: Don't always fail write package.json

### DIFF
--- a/changelog/pending/20230418--pkg-testing--fix-failure-in-writing-a-package-json-for-test-overrides.yaml
+++ b/changelog/pending/20230418--pkg-testing--fix-failure-in-writing-a-package-json-for-test-overrides.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg/testing
+  description: Fix failure in writing a package.json for test overrides.

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2052,8 +2052,10 @@ func writePackageJSON(pathToPackage string, metadata map[string]interface{}) err
 	encoder := json.NewEncoder(f)
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
-
-	return fmt.Errorf("writing package.json: %w", encoder.Encode(metadata))
+	if err := encoder.Encode(metadata); err != nil {
+		return fmt.Errorf("writing package.json: %w", err)
+	}
+	return nil
 }
 
 // preparePythonProject runs setup necessary to get a Python project ready for `pulumi` commands.


### PR DESCRIPTION
The function `writePackageJSON` used by ProgramTest
always returns a non-nil error--even when encode succeded
because it unconditionally wraps the result with an error.
