### PR TITLE
sdk/go: Propagate more resource options from provider.Construct

### DIFF
--- a/changelog/pending/20230418--sdk-go--support-new-options-on-packaged-components.yaml
+++ b/changelog/pending/20230418--sdk-go--support-new-options-on-packaged-components.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: >-
+    Support new options on packaged components (MLCs), including:
+    AdditionalSecretOutputs, Timeouts, DeletedWith, DeleteBeforeReplace,
+    IgnoreChanges, ReplaceOnChanges, and RetainOnDelete.

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -116,6 +116,22 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 		ro.Protect = req.GetProtect()
 		ro.Providers = providers
 		ro.Parent = parent
+
+		ro.AdditionalSecretOutputs = append(ro.AdditionalSecretOutputs, req.GetAdditionalSecretOutputs()...)
+		if t := req.CustomTimeouts; t != nil {
+			ro.CustomTimeouts = &CustomTimeouts{
+				Create: t.GetCreate(),
+				Update: t.GetUpdate(),
+				Delete: t.GetDelete(),
+			}
+		}
+		if urn := req.DeletedWith; urn != "" {
+			ro.DeletedWith = pulumiCtx.newDependencyResource(URN(urn))
+		}
+		ro.DeleteBeforeReplace = req.GetDeleteBeforeReplace()
+		ro.IgnoreChanges = append(ro.IgnoreChanges, req.GetIgnoreChanges()...)
+		ro.ReplaceOnChanges = append(ro.ReplaceOnChanges, req.GetReplaceOnChanges()...)
+		ro.RetainOnDelete = req.GetRetainOnDelete()
 	})
 
 	urn, state, err := constructF(pulumiCtx, req.GetType(), req.GetName(), inputs, opts)

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -1826,4 +1826,111 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 		})
 		assert.NotNil(t, snap.Parent, "parent was not set")
 	})
+
+	t.Run("AdditionalSecretOutputs", func(t *testing.T) {
+		t.Parallel()
+
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			AdditionalSecretOutputs: []string{"foo"},
+		})
+		assert.Equal(t, []string{"foo"}, snap.AdditionalSecretOutputs)
+	})
+
+	t.Run("CustomTimeouts", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			give *pulumirpc.ConstructRequest_CustomTimeouts
+			want *CustomTimeouts
+		}{
+			{
+				name: "Create",
+				give: &pulumirpc.ConstructRequest_CustomTimeouts{Create: "1m"},
+				want: &CustomTimeouts{Create: "1m"},
+			},
+			{
+				name: "Update",
+				give: &pulumirpc.ConstructRequest_CustomTimeouts{Update: "2m"},
+				want: &CustomTimeouts{Update: "2m"},
+			},
+			{
+				name: "Delete",
+				give: &pulumirpc.ConstructRequest_CustomTimeouts{Delete: "3m"},
+				want: &CustomTimeouts{Delete: "3m"},
+			},
+			{
+				name: "all",
+				give: &pulumirpc.ConstructRequest_CustomTimeouts{
+					Create: "1m",
+					Update: "2m",
+					Delete: "3m",
+				},
+				want: &CustomTimeouts{
+					Create: "1m",
+					Update: "2m",
+					Delete: "3m",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+					CustomTimeouts: tt.give,
+				})
+
+				assert.Equal(t, tt.want, snap.CustomTimeouts)
+			})
+		}
+	})
+
+	t.Run("DeletedWith", func(t *testing.T) {
+		t.Parallel()
+
+		urn := resource.NewURN("mystack", "myproject", "", "foo:bar:Baz", "qux")
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			DeletedWith: string(urn),
+		})
+		assert.NotNil(t, snap.DeletedWith, "deletedWith was not set")
+	})
+
+	t.Run("DeleteBeforeReplace", func(t *testing.T) {
+		t.Parallel()
+
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			DeleteBeforeReplace: true,
+		})
+		assert.True(t, snap.DeleteBeforeReplace, "deleteBeforeReplace was not set")
+	})
+
+	t.Run("IgnoreChanges", func(t *testing.T) {
+		t.Parallel()
+
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			IgnoreChanges: []string{"foo"},
+		})
+		assert.Equal(t, []string{"foo"}, snap.IgnoreChanges)
+	})
+
+	t.Run("ReplaceOnChanges", func(t *testing.T) {
+		t.Parallel()
+
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			ReplaceOnChanges: []string{"foo"},
+		})
+		assert.Equal(t, []string{"foo"}, snap.ReplaceOnChanges)
+	})
+
+	t.Run("RetainOnDelete", func(t *testing.T) {
+		t.Parallel()
+
+		snap := snapshotFromRequest(t, &pulumirpc.ConstructRequest{
+			RetainOnDelete: true,
+		})
+		assert.True(t, snap.RetainOnDelete, "retainOnDelete was not set")
+	})
 }

--- a/tests/integration/construct_component_resource_options/go/main.go
+++ b/tests/integration/construct_component_resource_options/go/main.go
@@ -33,6 +33,34 @@ func main() {
 			return err
 		}
 
+		_, err = newComponent("AdditionalSecretOutputs", pulumi.AdditionalSecretOutputs([]string{"foo"}))
+		if err != nil {
+			return err
+		}
+
+		_, err = newComponent("CustomTimeouts", pulumi.Timeouts(&pulumi.CustomTimeouts{
+			Create: ("1m"),
+			Update: ("2m"),
+			Delete: ("3m"),
+		}))
+		if err != nil {
+			return err
+		}
+
+		getDeletedWithMe, err := newComponent("getDeletedWithMe")
+		if err != nil {
+			return err
+		}
+		_, err = newComponent("DeletedWith", pulumi.DeletedWith(getDeletedWithMe))
+		if err != nil {
+			return err
+		}
+
+		_, err = newComponent("RetainOnDelete", pulumi.RetainOnDelete(true))
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -806,6 +806,24 @@ func testConstructResourceOptions(t *testing.T, dir string, deps []string) {
 				wantDeps := []resource.URN{urns["Dep1"], urns["Dep2"]}
 				assert.ElementsMatch(t, wantDeps, res.Dependencies,
 					"DependsOn(%s)", name)
+
+			case "AdditionalSecretOutputs":
+				assert.Equal(t,
+					[]resource.PropertyKey{"foo"}, res.AdditionalSecretOutputs,
+					"AdditionalSecretOutputs(%s)", name)
+
+			case "CustomTimeouts":
+				if ct := res.CustomTimeouts; assert.NotNil(t, ct, "CustomTimeouts(%s)", name) {
+					assert.Equal(t, float64(60), ct.Create, "CustomTimeouts.Create(%s)", name)
+					assert.Equal(t, float64(120), ct.Update, "CustomTimeouts.Update(%s)", name)
+					assert.Equal(t, float64(180), ct.Delete, "CustomTimeouts.Delete(%s)", name)
+				}
+
+			case "DeletedWith":
+				assert.Equal(t, urns["getDeletedWithMe"], res.DeletedWith, "DeletedWith(%s)", name)
+
+			case "RetainOnDelete":
+				assert.True(t, res.RetainOnDelete, "RetainOnDelete(%s)", name)
 			}
 		}
 	}


### PR DESCRIPTION
`provider.Construct` is used to build MLCs in Go.
It receives a pulumirpc.ConstructRequest
and turns that into a standard Go SDK ResourceOption.

In #12682, we added a few new fields to pulumirpc.ConstructRequest.
This updates the Go SDK to pick up these new options
and pass them on for the resource to pick up
(and eventually send back to the engine as a RegisterResource call).

Testing:
This change includes unit tests to verify mapping of ConstructRequests
to options, which are then interpreted with NewResourceOptions.

On top of that, it builds upon the integration test added in #12699
to verify options that are saved in snapshots.
Note that this integration test does not test for the following options:
IgnoreChanges, ReplaceOnChanges, and DeleteBeforeReplace.
These options are not stored in state snapshots,
so we can't validate them just by looking at that.

Refs #12154
