### PR TITLE
Speed up mapping lookup

### DIFF
--- a/changelog/pending/20230420--cli--speed-up-conversion-mapping-lookups-for-the-common-case-of-pulumi-names-matching-external-ecosystem-names.yaml
+++ b/changelog/pending/20230420--cli--speed-up-conversion-mapping-lookups-for-the-common-case-of-pulumi-names-matching-external-ecosystem-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Speed up conversion mapping lookups for the common case of Pulumi names matching external ecosystem names.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Rather than doing a linear search through all the plugins and asking each in turn for their mapping information, use the heuristic that normally the Pulumi provider name matches the mapped provider name and try that plugin first.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
