### PR TITLE
refactor(language-go): Extract global state into a struct

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -85,28 +85,62 @@ func compileProgram(programDirectory string, outfile string) (string, error) {
 	return outfile, nil
 }
 
-// Launches the language host, which in turn fires up an RPC server implementing the LanguageRuntimeServer endpoint.
-func main() {
-	var tracing string
-	var binary string
-	var buildTarget string
-	var root string
-	flag.StringVar(&tracing, "tracing", "", "Emit tracing to a Zipkin-compatible tracing endpoint")
-	flag.StringVar(&binary, "binary", "", "Look on path for a binary executable with this name")
-	flag.StringVar(&buildTarget, "buildTarget", "", "Path to use to output the compiled Pulumi Go program")
-	flag.StringVar(&root, "root", "", "Project root path to use")
+// runParams defines the command line arguments accepted by this program.
+type runParams struct {
+	tracing       string
+	binary        string
+	buildTarget   string
+	root          string
+	engineAddress string
+}
 
-	flag.Parse()
-	args := flag.Args()
-	logging.InitLogging(false, 0, false)
-	cmdutil.InitTracing("pulumi-language-go", "pulumi-language-go", tracing)
+// parseRunParams parses the given arguments into a runParams structure,
+// using the provided FlagSet.
+func parseRunParams(flag *flag.FlagSet, args []string) (*runParams, error) {
+	var p runParams
+	flag.StringVar(&p.tracing, "tracing", "", "Emit tracing to a Zipkin-compatible tracing endpoint")
+	flag.StringVar(&p.binary, "binary", "", "Look on path for a binary executable with this name")
+	flag.StringVar(&p.buildTarget, "buildTarget", "", "Path to use to output the compiled Pulumi Go program")
+	flag.StringVar(&p.root, "root", "", "Project root path to use")
+
+	if err := flag.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if p.binary != "" && p.buildTarget != "" {
+		return nil, errors.New("binary and buildTarget cannot both be specified")
+	}
 
 	// Pluck out the engine so we can do logging, etc.
+	args = flag.Args()
 	if len(args) == 0 {
-		cmdutil.Exit(errors.New("missing required engine RPC address argument"))
+		return nil, errors.New("missing required engine RPC address argument")
 	}
-	engineAddress := args[0]
+	p.engineAddress = args[0]
 
+	return &p, nil
+}
+
+// Launches the language host, which in turn fires up an RPC server implementing the LanguageRuntimeServer endpoint.
+func main() {
+	p, err := parseRunParams(flag.CommandLine, os.Args[1:])
+	if err != nil {
+		cmdutil.Exit(err)
+	}
+
+	cmd := mainCmd{
+		Stdout: os.Stdout,
+	}
+	if err := cmd.Run(p); err != nil {
+		cmdutil.Exit(err)
+	}
+}
+
+type mainCmd struct {
+	Stdout io.Writer // == os.Stdout
+}
+
+func (cmd *mainCmd) Run(p *runParams) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	// map the context Done channel to the rpcutil boolean cancel channel
 	cancelChannel := make(chan bool)
@@ -114,36 +148,34 @@ func main() {
 		<-ctx.Done()
 		close(cancelChannel)
 	}()
-	err := rpcutil.Healthcheck(ctx, engineAddress, 5*time.Minute, cancel)
+	err := rpcutil.Healthcheck(ctx, p.engineAddress, 5*time.Minute, cancel)
 	if err != nil {
-		cmdutil.Exit(fmt.Errorf("could not start health check host RPC server: %w", err))
-	}
-
-	if binary != "" && buildTarget != "" {
-		cmdutil.Exit(fmt.Errorf("binary and buildTarget cannot both be specified"))
+		return fmt.Errorf("could not start health check host RPC server: %w", err)
 	}
 
 	// Fire up a gRPC server, letting the kernel choose a free port.
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: cancelChannel,
 		Init: func(srv *grpc.Server) error {
-			host := newLanguageHost(engineAddress, tracing, binary, buildTarget)
+			host := newLanguageHost(p.engineAddress, p.tracing, p.binary, p.buildTarget)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
 		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
-		cmdutil.Exit(fmt.Errorf("could not start language host RPC server: %w", err))
+		return fmt.Errorf("could not start language host RPC server: %w", err)
 	}
 
 	// Otherwise, print out the port so that the spawner knows how to reach us.
-	fmt.Printf("%d\n", handle.Port)
+	fmt.Fprintf(cmd.Stdout, "%d\n", handle.Port)
 
 	// And finally wait for the server to stop serving.
 	if err := <-handle.Done; err != nil {
-		cmdutil.Exit(fmt.Errorf("language host RPC stopped serving: %w", err))
+		return fmt.Errorf("language host RPC stopped serving: %w", err)
 	}
+
+	return nil
 }
 
 // goLanguageHost implements the LanguageRuntimeServer interface for use as an API endpoint.

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -15,14 +15,104 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestParseRunParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		give    []string
+		want    runParams
+		wantErr string // non-empty if we expect an error
+	}{
+		{
+			desc:    "no arguments",
+			wantErr: "missing required engine RPC address argument",
+		},
+		{
+			desc: "no options",
+			give: []string{"localhost:1234"},
+			want: runParams{
+				engineAddress: "localhost:1234",
+			},
+		},
+		{
+			desc:    "binary buildTarget exclusivity",
+			give:    []string{"-binary", "foo", "-buildTarget=bar"},
+			wantErr: "binary and buildTarget cannot both be specified",
+		},
+		{
+			desc: "tracing",
+			give: []string{"-tracing", "foo.trace", "localhost:1234"},
+			want: runParams{
+				tracing:       "foo.trace",
+				engineAddress: "localhost:1234",
+			},
+		},
+		{
+			desc: "binary",
+			give: []string{"-binary", "foo", "localhost:1234"},
+			want: runParams{
+				binary:        "foo",
+				engineAddress: "localhost:1234",
+			},
+		},
+		{
+			desc: "buildTarget",
+			give: []string{"-buildTarget", "foo", "localhost:1234"},
+			want: runParams{
+				buildTarget:   "foo",
+				engineAddress: "localhost:1234",
+			},
+		},
+		{
+			desc: "root",
+			give: []string{"-root", "path/to/root", "localhost:1234"},
+			want: runParams{
+				root:          "path/to/root",
+				engineAddress: "localhost:1234",
+			},
+		},
+		{
+			desc:    "unknown option",
+			give:    []string{"-unknown-option", "bar", "localhost:1234"},
+			wantErr: "flag provided but not defined: -unknown-option",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Use a FlagSet with ContinueOnError for each case
+			// instead of using the global flag set.
+			//
+			// The global flag set uses flag.ExitOnError,
+			// so it cannot validate error cases during tests.
+			fset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+			fset.SetOutput(iotest.LogWriter(t))
+
+			got, err := parseRunParams(fset, tt.give)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, &tt.want, got)
+			}
+		})
+	}
+}
 
 func TestGetPlugin(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Refactors the Go language host plugin
to extract global state (e.g. stdout, command line args)
into a mainCmd struct.
The command line parsing logic is placed into a separate,
independently tested function.

This change does not modify any behavior.
