### PR TITLE
test(go/host): GetRequiredPlugins and GetProgramDependencies

### DIFF
--- a/sdk/go/pulumi-language-go/testdata/sample/dep/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/dep/go.mod
@@ -1,0 +1,7 @@
+module example.com/dep
+
+go 1.18
+
+replace example.com/indirect-dep/v2 => ../indirect-dep
+
+require example.com/indirect-dep/v2 v2.1.0

--- a/sdk/go/pulumi-language-go/testdata/sample/dep/plug.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/dep/plug.go
@@ -1,0 +1,8 @@
+package dep
+
+import indirect "example.com/indirect-dep/v2"
+
+func Bar() string {
+	indirect.Baz()
+	return "bar"
+}

--- a/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/go.mod
@@ -1,0 +1,3 @@
+module example.com/indirect-dep/v2
+
+go 1.18

--- a/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/indirect.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/indirect.go
@@ -1,0 +1,3 @@
+package indirect
+
+func Baz() {}

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/go.mod
@@ -1,0 +1,3 @@
+module example.com/plugin
+
+go 1.18

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/plug.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/plug.go
@@ -1,0 +1,5 @@
+package plugin
+
+func Foo() string {
+	return "foo"
+}

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/pulumi-plugin.json
@@ -1,0 +1,5 @@
+{
+  "resource": true,
+  "name": "example",
+  "server": "example.com/download"
+}

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: prog
+description: A program with a few dependencies.
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/go.mod
@@ -1,0 +1,16 @@
+module example.com/prog
+
+go 1.18
+
+replace (
+	example.com/dep => ../dep
+	example.com/indirect-dep/v2 => ../indirect-dep
+	example.com/plugin => ../plugin
+)
+
+require (
+	example.com/dep v1.5.0
+	example.com/plugin v1.2.3
+)
+
+require example.com/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"example.com/dep"
+	"example.com/plugin"
+)
+
+func main() {
+	plugin.Foo()
+	dep.Bar()
+}


### PR DESCRIPTION
Adds a test that sets up a Go module with a few dependencies
and queries its plugins and dependencies with the Go language host.
This test passes today because we're running in module mode.

A sibling test will be added for vendor mode
to verify the fix for #12526, where this same check would fail
if we vendor the dependencies into the Pulumi program.

NOTE:
The test does not run in parallel because we need to change the
working directory. This is resolved in a follow-up.
