### PR TITLE
refactor(go/host): Inject current working directory

### DIFF
--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -326,8 +326,9 @@ func TestGetPlugin(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // changes current directory
 func TestPluginsAndDependencies_moduleMode(t *testing.T) {
+	t.Parallel()
+
 	root := t.TempDir()
 	require.NoError(t,
 		fsutil.CopyFile(root, filepath.Join("testdata", "sample"), nil),
@@ -345,7 +346,7 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 		assert.NoError(t, os.Chdir(cwd), "restore working directory")
 	}()
 
-	host := newLanguageHost("0.0.0.0:0", "", "", "")
+	host := newLanguageHost("0.0.0.0:0", progDir, "", "", "")
 	ctx := context.Background()
 
 	t.Run("GetRequiredPlugins", func(t *testing.T) {


### PR DESCRIPTION
Refactors the Go language host to inject CWD into it
instead of always using `os.Getwd`.
This allows the test for plugin and dependency behavior
to run in parallel.

NOTE:
Some of the RPCs methods get a Directory or Pwd in the request
but it wasn't being used before so we were running in the directory
where the host was started.
This retains that behvaior for those methods rather than changing it
because it's not clear whether that omission was intentional.
