### PR TITLE
[pcl/binder] Allow using option(T) in range expressions

### DIFF
--- a/changelog/pending/20230421--programgen--allow-using-option-t-in-range-expressions.yaml
+++ b/changelog/pending/20230421--programgen--allow-using-option-t-in-range-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Allow using option(T) in range expressions

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -330,11 +330,8 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 	collection, collectionDiags := b.bindExpression(syntax.CollExpr)
 	diagnostics = append(diagnostics, collectionDiags...)
 
-	// Poke through any eventual and optional types that may wrap the collection type.
-	collectionType := unwrapIterableSourceType(collection.Type())
-
 	// TODO(pdg): handle union types.
-	keyType, valueType, kvDiags := GetCollectionTypes(collectionType, syntax.CollExpr.Range())
+	keyType, valueType, kvDiags := GetCollectionTypes(collection.Type(), syntax.CollExpr.Range())
 	diagnostics = append(diagnostics, kvDiags...)
 
 	// Push a scope for the key and value variables and define these vars.

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -760,10 +760,7 @@ func (x *ForExpression) typecheck(typecheckCollection, typecheckOperands bool) h
 	}
 
 	if typecheckCollection {
-		// Poke through any eventual and optional types that may wrap the collection type.
-		collectionType := unwrapIterableSourceType(x.Collection.Type())
-
-		keyType, valueType, kvDiags := GetCollectionTypes(collectionType, rng)
+		keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng)
 		diagnostics = append(diagnostics, kvDiags...)
 
 		if x.KeyVariable != nil {
@@ -1193,8 +1190,7 @@ func (x *IndexExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 		rng = x.Syntax.Collection.Range()
 	}
 
-	collectionType := unwrapIterableSourceType(x.Collection.Type())
-	keyType, valueType, kvDiags := GetCollectionTypes(collectionType, rng)
+	keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng)
 	diagnostics = append(diagnostics, kvDiags...)
 	x.keyType = keyType
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -258,6 +258,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Test python reserved words aren't used",
 		Skip:        allProgLanguages.Except("python"),
 	},
+	{
+		Directory:   "iterating-optional-range-expressions",
+		Description: "Test that we can iterate over range expression that are option(iterator)",
+		// TODO: the example doesn't generate correct code because we iterate over a range which is an output
+		Skip: allProgLanguages,
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/iterating-optional-range-expressions.pp
+++ b/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/iterating-optional-range-expressions.pp
@@ -1,0 +1,18 @@
+resource "vpc" "aws:ec2/vpc:Vpc" {
+  cidrBlock          = "10.0.0.0/16"
+  enableDnsHostnames = true
+  enableDnsSupport   = true
+  tags = {
+    Name = "Example VPC"
+  }
+}
+
+resource "gateway" "aws:ec2/internetGateway:InternetGateway" {
+  options {
+    range = vpc.tags
+  }
+  vpcId = "${vpc.id}"
+  tags = {
+    Name = "${range.key} ${range.value}"
+  }
+}


### PR DESCRIPTION
Right now when using an `option(T)` in range expressions where `T` is an iterator like maps or lists, the binder fails when it is unable to figure out the underlying iterator type. This PR fixes the issue by reducing `option(T)` to `T`

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
