### PR TITLE
Fix destroy without project file

### DIFF
--- a/changelog/pending/20230424--cli--fix-destroy-without-project-file.yaml
+++ b/changelog/pending/20230424--cli--fix-destroy-without-project-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix destroy without project file.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -74,6 +74,9 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
+	// Project is the project name that this stack belongs to. For old filestate backends this will be empty.
+	Project() tokens.Name
+
 	// Fully qualified name of the stack, including any organization, project, or other information.
 	FullyQualifiedName() tokens.QName
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -653,7 +653,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 
 	return cloudBackendReference{
 		owner:   qualifiedName.Owner,
-		project: qualifiedName.Project,
+		project: tokens.Name(qualifiedName.Project),
 		name:    tokens.Name(qualifiedName.Name),
 		b:       b,
 	}, nil
@@ -1452,7 +1452,7 @@ func (b *cloudBackend) getCloudStackIdentifier(stackRef backend.StackReference) 
 
 	return client.StackIdentifier{
 		Owner:   cloudBackendStackRef.owner,
-		Project: cleanProjectName(cloudBackendStackRef.project),
+		Project: cleanProjectName(string(cloudBackendStackRef.project)),
 		Stack:   string(cloudBackendStackRef.name),
 	}, nil
 }

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -43,7 +43,7 @@ type Stack interface {
 
 type cloudBackendReference struct {
 	name    tokens.Name
-	project string
+	project tokens.Name
 	owner   string
 	b       *cloudBackend
 }
@@ -53,7 +53,7 @@ func (c cloudBackendReference) String() string {
 	currentProject := c.b.currentProject
 
 	// If the project names match, we can elide them.
-	if currentProject != nil && c.project == string(currentProject.Name) {
+	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
 
 		// Elide owner too, if it is the default owner.
 		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(currentProject)
@@ -76,6 +76,10 @@ func (c cloudBackendReference) String() string {
 
 func (c cloudBackendReference) Name() tokens.Name {
 	return c.name
+}
+
+func (c cloudBackendReference) Project() tokens.Name {
+	return c.project
 }
 
 func (c cloudBackendReference) FullyQualifiedName() tokens.QName {
@@ -103,7 +107,7 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 	return &cloudStack{
 		ref: cloudBackendReference{
 			owner:   apistack.OrgName,
-			project: apistack.ProjectName,
+			project: tokens.Name(apistack.ProjectName),
 			name:    tokens.Name(apistack.StackName.String()),
 			b:       b,
 		},
@@ -214,7 +218,7 @@ func (css cloudStackSummary) Name() backend.StackReference {
 
 	return cloudBackendReference{
 		owner:   css.summary.OrgName,
-		project: css.summary.ProjectName,
+		project: tokens.Name(css.summary.ProjectName),
 		name:    tokens.Name(css.summary.StackName),
 		b:       css.b,
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -521,6 +521,7 @@ func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets
 type MockStackReference struct {
 	StringV             string
 	NameV               tokens.Name
+	ProjectV            tokens.Name
 	FullyQualifiedNameV tokens.QName
 }
 
@@ -536,6 +537,13 @@ func (r *MockStackReference) String() string {
 func (r *MockStackReference) Name() tokens.Name {
 	if r.NameV != "" {
 		return r.NameV
+	}
+	panic("not implemented")
+}
+
+func (r *MockStackReference) Project() tokens.Name {
+	if r.ProjectV != "" {
+		return r.ProjectV
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -170,7 +171,9 @@ func newDestroyCmd() *cobra.Command {
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				logging.Warningf("failed to find current Pulumi project, continuing with an empty project"+
 					"using stack %v from backend %v", s.Ref().Name(), s.Backend().Name())
-				proj = &workspace.Project{}
+				proj = &workspace.Project{
+					Name: tokens.PackageName(s.Ref().Project()),
+				}
 				root = ""
 			} else if err != nil {
 				return result.FromError(err)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12714

The empty project created for destroy operations when no Pulumi.yaml is found still needs to have it's name filled in so that project name consistency checks work.

Our tests didn't pick this up because for filestate we were still searching from the working directory for consistency checks rather than checking the backends current project. I've also fixed that up as part of this change.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
