### PR TITLE
fix(go/host): Use program directory

### DIFF
--- a/changelog/pending/20230424--sdk-go--ensure-that-dependency-searches-happen-in-the-pulumi-program-directory.yaml
+++ b/changelog/pending/20230424--sdk-go--ensure-that-dependency-searches-happen-in-the-pulumi-program-directory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Ensure that dependency searches happen in the Pulumi program directory.


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/12727#discussion_r1175433156

The GetRequiredPlugins and GetProgramDependencies methods of the Go
language host always operate in the current directory of the plugin.
This is likely unintentional because the request message includes a Pwd
field specifying the program directory.

For comparison:

- The Python host also runs in the plugin directory
- The Node host correctly uses the program directory:
  via the Pwd field for GetProgramDependencies
  and the Program field for GetRequiredPlugins

The existing behavior likely happens to work because the plugin happens
to run inside the program directory, but that's not guaranteed.

This switches the Go language host to run queries inside the program
directory to guard against issues in the future.
