### PR TITLE
[auto/nodejs] Add `excludeProtected` option for `destroy`

### DIFF
--- a/changelog/pending/20230424--auto-nodejs--add-excludeprotected-option-for-destroy.yaml
+++ b/changelog/pending/20230424--auto-nodejs--add-excludeprotected-option-for-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add `excludeProtected` option for `destroy`

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -478,6 +478,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.targetDependents) {
                 args.push("--target-dependents");
             }
+            if (opts.excludeProtected) {
+                args.push("--exclude-protected");
+            }
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
             }
@@ -929,6 +932,10 @@ export interface DestroyOptions extends GlobalOpts {
     color?: "always" | "never" | "raw" | "auto";
     // Include secrets in the DestroySummary
     showSecrets?: boolean;
+    /**
+     * Do not destroy protected resources.
+     */
+    excludeProtected?: boolean;
 }
 
 const execKind = {


### PR DESCRIPTION
This change adds an `excludeProtected` option for `destroy`.

Part of #12733