### PR TITLE
Node AutoAPI: Support `preview --refresh`

### DIFF
--- a/changelog/pending/20230425--auto-nodejs--add-refresh-option-for-preview.yaml
+++ b/changelog/pending/20230425--auto-nodejs--add-refresh-option-for-preview.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add `refresh` option for `preview`

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -293,6 +293,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
             }
+            if (opts.refresh) {
+                args.push("--refresh");
+            }
             if (opts.diff) {
                 args.push("--diff");
             }
@@ -885,6 +888,10 @@ export interface PreviewOptions extends GlobalOpts {
     parallel?: number;
     message?: string;
     expectNoChanges?: boolean;
+    /**
+      * Refresh the state of the stack's resources against the cloud provider before running preview.
+      */
+    refresh?: boolean;
     diff?: boolean;
     replace?: string[];
     policyPacks?: string[];

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -889,8 +889,8 @@ export interface PreviewOptions extends GlobalOpts {
     message?: string;
     expectNoChanges?: boolean;
     /**
-      * Refresh the state of the stack's resources against the cloud provider before running preview.
-      */
+     * Refresh the state of the stack's resources against the cloud provider before running preview.
+     */
     refresh?: boolean;
     diff?: boolean;
     replace?: string[];

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -398,10 +398,10 @@ describe("LocalWorkspace", () => {
         const projectName = "inline_node";
         const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
         const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
-        const refresh = true;
         // • First, run Up so we can set the initial state.
         await stack.up({ userAgent });
         // • Next, run preview with refresh and check that the refresh was performed.
+        const refresh = true;
         const previewRes = await stack.preview({ userAgent, refresh });
         assert.match(previewRes.stdout, /refreshing/);
         assert.strictEqual(previewRes.changeSummary.same, 1, "preview expected 1 same (the stack)");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -387,6 +387,34 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
+    it(`refreshes before preview`, async() => {
+        // We create a toggle representing state that we can modify from
+        // within the program. When we call `preview --refresh`, we expect
+        // a change between what we have saved and what we see in state.
+        var toggle = false;
+        const program = async () => {
+            return {
+                toggle,
+            };
+        };
+        const projectName = "inline_node";
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
+        const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
+        const refresh = true;
+        // • First, run Up so we can set the initial state.
+        await stack.up({ userAgent });
+        // • Next, run preview with refres to demonstrate nothing has changed.
+        const previewRes = await stack.preview({ userAgent, refresh });
+        assert.strictEqual(previewRes.changeSummary.same, 1);
+        // • Now, we modify the state and refresh again.
+        // const state = await stack.exportStack();
+        // await stack.importStack(state);
+        toggle = false;
+        const secondPreview = await stack.preview({ userAgent, refresh });
+        assert.strictEqual(secondPreview.changeSummary.same, 0);
+        assert.strictEqual(secondPreview.changeSummary.refresh, 1);        
+        assert.strictEqual(true, false);        
+    });
     it(`destroys an inline program with excludeProtected`, async () => {
         const program = async () => {
             class MyResource extends ComponentResource {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -404,7 +404,7 @@ describe("LocalWorkspace", () => {
         // • Next, run preview with refresh and check that the refresh was performed.
         const previewRes = await stack.preview({ userAgent, refresh });
         assert.match(previewRes.stdout, /refreshing/);
-        assert.strictEqual(previewRes.changeSummary.same, 1, 'preview expected 1 same (the stack)');
+        assert.strictEqual(previewRes.changeSummary.same, 1, "preview expected 1 same (the stack)");
     });
     it(`destroys an inline program with excludeProtected`, async () => {
         const program = async () => {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -388,13 +388,11 @@ describe("LocalWorkspace", () => {
         await stack.workspace.removeStack(stackName);
     });
     it(`refreshes before preview`, async() => {
-        // We create a toggle representing state that we can modify from
-        // within the program. When we call `preview --refresh`, we expect
-        // a change between what we have saved and what we see in state.
-        var toggle = false;
+        // We create a simple program, and scan the output for an indication
+        // that adding refresh: true will perfrom a refresh operation.
         const program = async () => {
             return {
-                toggle,
+                toggle: true,
             };
         };
         const projectName = "inline_node";
@@ -403,17 +401,10 @@ describe("LocalWorkspace", () => {
         const refresh = true;
         // • First, run Up so we can set the initial state.
         await stack.up({ userAgent });
-        // • Next, run preview with refres to demonstrate nothing has changed.
+        // • Next, run preview with refresh and check that the refresh was performed.
         const previewRes = await stack.preview({ userAgent, refresh });
-        assert.strictEqual(previewRes.changeSummary.same, 1);
-        // • Now, we modify the state and refresh again.
-        // const state = await stack.exportStack();
-        // await stack.importStack(state);
-        toggle = false;
-        const secondPreview = await stack.preview({ userAgent, refresh });
-        assert.strictEqual(secondPreview.changeSummary.same, 0);
-        assert.strictEqual(secondPreview.changeSummary.refresh, 1);        
-        assert.strictEqual(true, false);        
+        assert.match(previewRes.stdout, /refreshing/);
+        assert.strictEqual(previewRes.changeSummary.same, 1, 'preview expected 1 same (the stack)');
     });
     it(`destroys an inline program with excludeProtected`, async () => {
         const program = async () => {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR adds support for `pulumi preview --refresh` in Automation API for NodeJS.

Fixes https://github.com/pulumi/pulumi/issues/12740

This is a blocker for [actions/#870](https://github.com/pulumi/actions/issues/870) and potential customer adoption.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
