### PR TITLE
[pcl/nodejs] Support range expressions that are of type output

### DIFF
--- a/changelog/pending/20230426--programgen-nodejs--support-range-expressions-that-are-of-type-output.yaml
+++ b/changelog/pending/20230426--programgen-nodejs--support-range-expressions-that-are-of-type-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/nodejs
+  description: Support range expressions that are of type output

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -71,9 +71,13 @@ type observeContext struct {
 	nameCounts    map[string]int
 }
 
-func (r *applyRewriter) hasEventualTypes(t model.Type) bool {
+func HasEventualTypes(t model.Type) bool {
 	resolved := model.ResolveOutputs(t)
 	return resolved != t
+}
+
+func (r *applyRewriter) hasEventualTypes(t model.Type) bool {
+	return HasEventualTypes(t)
 }
 
 func (r *applyRewriter) hasEventualValues(x model.Expression) bool {

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -246,3 +246,19 @@ func SortedStringKeys[V any](m map[string]V) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+// UnwrapOption returns type T if the input is an Option(T)
+func UnwrapOption(exprType model.Type) model.Type {
+	switch exprType := exprType.(type) {
+	case *model.UnionType:
+		if len(exprType.ElementTypes) == 2 && exprType.ElementTypes[0] == model.NoneType {
+			return exprType.ElementTypes[1]
+		} else if len(exprType.ElementTypes) == 2 && exprType.ElementTypes[1] == model.NoneType {
+			return exprType.ElementTypes[0]
+		} else {
+			return exprType
+		}
+	default:
+		return exprType
+	}
+}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -261,8 +261,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "iterating-optional-range-expressions",
 		Description: "Test that we can iterate over range expression that are option(iterator)",
-		// TODO: the example doesn't generate correct code because we iterate over a range which is an output
-		Skip: allProgLanguages,
+		// TODO: python, dotnet and go
+		Skip: allProgLanguages.Except("nodejs"),
+		// We are using a synthetic schema defined in range-1.0.0.json so we can't compile all the way
+		SkipCompile: allProgLanguages,
 	},
 }
 

--- a/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/iterating-optional-range-expressions.pp
+++ b/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/iterating-optional-range-expressions.pp
@@ -1,18 +1,40 @@
-resource "vpc" "aws:ec2/vpc:Vpc" {
-  cidrBlock          = "10.0.0.0/16"
-  enableDnsHostnames = true
-  enableDnsSupport   = true
-  tags = {
-    Name = "Example VPC"
+resource "root" "range:index:Root" {}
+
+// creating resources by iterating a property of type array(string) of another resource
+resource "fromListOfStrings" "range:index:Example" {
+  options {
+    range = root.arrayOfString
   }
+
+  someString = range.value
 }
 
-resource "gateway" "aws:ec2/internetGateway:InternetGateway" {
+// creating resources by iterating a property of type map(string) of another resource
+resource "fromMapOfStrings" "range:index:Example" {
   options {
-    range = vpc.tags
+    range = root.mapOfString
   }
-  vpcId = "${vpc.id}"
-  tags = {
-    Name = "${range.key} ${range.value}"
+
+  someString = "${range.key} ${range.value}"
+}
+
+// computed range list expression to create instances of range:index:Example resource
+resource "fromComputedListOfStrings" "range:index:Example" {
+  options {
+    range = [
+        root.mapOfString["hello"],
+        root.mapOfString["world"]
+    ]
   }
+
+  someString = "${range.key} ${range.value}"
+}
+
+// computed range for expression to create instances of range:index:Example resource
+resource "fromComputedForExpression" "range:index:Example" {
+  options {
+    range = [for value in root.arrayOfString : root.mapOfString[value]]
+  }
+
+  someString = "${range.key} ${range.value}"
 }

--- a/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/nodejs/iterating-optional-range-expressions.ts
+++ b/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/nodejs/iterating-optional-range-expressions.ts
@@ -1,0 +1,35 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as range from "@pulumi/range";
+
+const root = new range.Root("root", {});
+// creating resources by iterating a property of type array(string) of another resource
+const fromListOfStrings: range.Example[] = [];
+root.arrayOfString.apply(rangeBody => {
+    for (const range of rangeBody.map((v, k) => ({key: k, value: v}))) {
+        fromListOfStrings.push(new range.Example(`fromListOfStrings-${range.key}`, {someString: range.value}));
+    }
+});
+// creating resources by iterating a property of type map(string) of another resource
+const fromMapOfStrings: range.Example[] = [];
+root.mapOfString.apply(rangeBody => {
+    for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
+        fromMapOfStrings.push(new range.Example(`fromMapOfStrings-${range.key}`, {someString: `${range.key} ${range.value}`}));
+    }
+});
+// computed range list expression to create instances of range:index:Example resource
+const fromComputedListOfStrings: range.Example[] = [];
+pulumi.all([
+    root.mapOfString.apply(mapOfString => mapOfString?.hello),
+    root.mapOfString.apply(mapOfString => mapOfString?.world),
+]).apply(rangeBody => {
+    for (const range of rangeBody.map((v, k) => ({key: k, value: v}))) {
+        fromComputedListOfStrings.push(new range.Example(`fromComputedListOfStrings-${range.key}`, {someString: `${range.key} ${range.value}`}));
+    }
+});
+// computed range for expression to create instances of range:index:Example resource
+const fromComputedForExpression: range.Example[] = [];
+pulumi.all([root.arrayOfString, root.mapOfString]).apply(([arrayOfString, mapOfString]) => {
+    for (const range of arrayOfString.map(value => (mapOfString[value])).map((v, k) => ({key: k, value: v}))) {
+        fromComputedForExpression.push(new range.Example(`fromComputedForExpression-${range.key}`, {someString: `${range.key} ${range.value}`}));
+    }
+});

--- a/pkg/codegen/testing/test/testdata/range-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/range-1.0.0.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "range",
+  "version": "0.1.0",
+  "//": [
+    "The range:index:Root resource is a simple resource that has two properties:",
+    " - arrayOfString: list(string)",
+    " - mapOfString: map(string)",
+    "Will use those in a PCL file to create instances of range:index:Example by iterating the properties above"
+  ],
+  "resources": {
+    "range:index:Root": {
+      "properties": {
+        "arrayOfString": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "mapOfString": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["arrayOfString"],
+      "type": "object"
+    },
+    "range:index:Example": {
+      "type": "object",
+      "inputProperties": {
+        "someString": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "language": {
+    "nodejs": {
+      "packageName": "@pulumi/range"
+    },
+    "csharp": {
+      "rootNamespace": "Pulumi.Range"
+    },
+    "python": {
+      "packageName": "pulumi_range"
+    },
+    "go": {
+      "importBasePath": "git.example.org/range",
+      "packageImportAliases": {
+        "git.example.org/pulumi-range/index": "index"
+      }
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -79,6 +79,7 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 
 		SchemaProvider{"other", "0.1.0"},
 		SchemaProvider{"synthetic", "1.0.0"},
+		SchemaProvider{"range", "1.0.0"},
 		SchemaProvider{"lambda", "0.1.0"},
 	)
 }


### PR DESCRIPTION
# Description

This PR implements nodejs program-gen support for `range` expressions that are of type `Output<T>` where `T` is a collection that should be iterated inside an `apply` call. 

<details>
    <summary>Example PCL</summary>

```terraform
resource "root" "range:index:Root" {}

// creating resources by iterating a property of type array(string) of another resource
resource "fromListOfStrings" "range:index:Example" {
  options {
    range = root.arrayOfString
  }

  someString = range.value
}

// creating resources by iterating a property of type map(string) of another resource
resource "fromMapOfStrings" "range:index:Example" {
  options {
    range = root.mapOfString
  }

  someString = "${range.key} ${range.value}"
}

// computed range list expression to create instances of range:index:Example resource
resource "fromComputedListOfStrings" "range:index:Example" {
  options {
    range = [
        root.mapOfString["hello"],
        root.mapOfString["world"]
    ]
  }

  someString = "${range.key} ${range.value}"
}

// computed range for expression to create instances of range:index:Example resource
resource "fromComputedForExpression" "range:index:Example" {
  options {
    range = [for value in root.arrayOfString : root.mapOfString[value]]
  }

  someString = "${range.key} ${range.value}"
}

```

</details>

<details>
<summary>Generated TypeScript</summary>

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as range from "@pulumi/range";

const root = new range.Root("root", {});
// creating resources by iterating a property of type array(string) of another resource
const fromListOfStrings: range.Example[] = [];
root.arrayOfString.apply(rangeBody => {
    for (const range of rangeBody.map((v, k) => ({key: k, value: v}))) {
        fromListOfStrings.push(new range.Example(`fromListOfStrings-${range.key}`, {someString: range.value}));
    }
});
// creating resources by iterating a property of type map(string) of another resource
const fromMapOfStrings: range.Example[] = [];
root.mapOfString.apply(rangeBody => {
    for (const range of Object.entries(rangeBody).map(([k, v]) => ({key: k, value: v}))) {
        fromMapOfStrings.push(new range.Example(`fromMapOfStrings-${range.key}`, {someString: `${range.key} ${range.value}`}));
    }
});
// computed range list expression to create instances of range:index:Example resource
const fromComputedListOfStrings: range.Example[] = [];
pulumi.all([
    root.mapOfString.apply(mapOfString => mapOfString?.hello),
    root.mapOfString.apply(mapOfString => mapOfString?.world),
]).apply(rangeBody => {
    for (const range of rangeBody.map((v, k) => ({key: k, value: v}))) {
        fromComputedListOfStrings.push(new range.Example(`fromComputedListOfStrings-${range.key}`, {someString: `${range.key} ${range.value}`}));
    }
});
// computed range for expression to create instances of range:index:Example resource
const fromComputedForExpression: range.Example[] = [];
pulumi.all([root.arrayOfString, root.mapOfString]).apply(([arrayOfString, mapOfString]) => {
    for (const range of arrayOfString.map(value => (mapOfString[value])).map((v, k) => ({key: k, value: v}))) {
        fromComputedForExpression.push(new range.Example(`fromComputedForExpression-${range.key}`, {someString: `${range.key} ${range.value}`}));
    }
});
```

</details>

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
