### PR TITLE
fix(host/go): Use official modfile package

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/opentracing/opentracing-go"
-	"github.com/rogpeppe/go-internal/modfile"
+	"golang.org/x/mod/modfile"
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"


### PR DESCRIPTION
Use the official golang.org/x/mod/modfile package to parse go.mod files
instead of the external copy of it.

Refs https://github.com/pulumi/pulumi/pull/12727#discussion_r1178333617
