### PR TITLE
Support Loading package.json from parent dir

### DIFF
--- a/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
+++ b/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdk/nodejs
-  description: Support loading package.json from parent directory. If `package.json` is not found in cwd, Pulumi recursively searches up the directory tree until it is found. If `package.json` provides a `main` field, that field is relative to cwd.
+  description: Support loading package.json from parent directory. If `package.json` is not found in the current directory, Pulumi recursively searches up the directory tree until it is found. If `package.json` provides a `main` field, that field is relative to the current directory.

--- a/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
+++ b/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdk/nodejs
-  description: Support loading package.json from parent directory. If `package.json` is not found in the current directory, Pulumi recursively searches up the directory tree until it is found. If `package.json` provides a `main` field, that field is relative to the current directory.
+  description: Support loading package.json from parent directory. If `package.json` is not found in the Pulumi main directory, Pulumi recursively searches up the directory tree until it is found. If `package.json` provides a `main` field, per the [NPM spec](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#main), that field is relative to the directory containing package.json.

--- a/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
+++ b/changelog/pending/20230426--sdk-nodejs--support-loading-package-json-from-parent-directory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Support loading package.json from parent directory. If `package.json` is not found in cwd, Pulumi recursively searches up the directory tree until it is found. If `package.json` provides a `main` field, that field is relative to cwd.

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -65,7 +65,6 @@ function projectRootFromProgramPath(program: string): string {
 }
 
 async function npmPackageRootFromProgramPath(programPath: string): Promise<string> {
-    console.log("Executing npmPackageRoot");
     // pkg-dir is an ESM module which we use to find the location of package.json
     // Because it's an ESM module, we cannot import it directly.
     const { packageDirectory } = await dynamicImport("pkg-dir");
@@ -76,18 +75,14 @@ async function npmPackageRootFromProgramPath(programPath: string): Promise<strin
         const fileStat = await fspromises.lstat(programPath);
         isDirectory = fileStat.isDirectory();
     }
-    console.log(`Is directory: ${isDirectory}`);
     const programDirectory = isDirectory ? programPath : path.dirname(programPath);
-    console.log(`Program directory: ${programDirectory}`);
     const pkgDir = await packageDirectory({
         cwd: programDirectory,
     });
     if (pkgDir === undefined) {
-        console.log(`Returning program dir: ${programDirectory}`);
         log.warn("Could not find a package.json file for the program. Using the pulumi program directory as the project root.");
         return programDirectory;
     }
-    console.log(`Pkg Dir: ${pkgDir}`);
     return pkgDir;
 }
 
@@ -97,7 +92,6 @@ function packageObjectFromProjectRoot(projectRoot: string): Record<string, any> 
     try {
         const packageJson = path.join(projectRoot, "package.json");
         packageObject = require(packageJson);
-        console.log(`Successfully loaded object from ${packageJson}`);
     } finally {
         // This is all best-effort so if we can't load the package.json file, that's
         // fine.
@@ -384,13 +378,14 @@ ${defaultMessage}`,
 
         try {
             const packageRoot = await npmPackageRootFromProgramPath(program);
-            console.log(`Breakpoint 1: Observed package root ${packageRoot}`);
             const packageObject = packageObjectFromProjectRoot(packageRoot);
-            console.log(`Observed package object: ${packageObject}`);
-            const keys = Object.keys(packageObject);
-            console.log(`Package object keys: ${keys}`);
-            
             let programExport: any;
+
+            // If the user provided an entrypoint, we use that file
+            // relative to the working dir.
+            if (packageObject["main"]) {
+                program = path.join(program, packageObject["main"]);
+            }
 
             // We use dynamic import instead of require for projects using native ES modules instead of commonjs
             if (packageObject["type"] === "module") {
@@ -413,22 +408,12 @@ ${defaultMessage}`,
                     programExport = programExport.default;
                 }
             } else {
-                // If the user provided an entrypoint, we use that file
-                // relative to the working dir.
-                // TODO(@Robbie): Confirm what happens if `main` is provided in a CommonJS module.
-                //                Maybe I need to return whether the `package.json` object is not
-                //                in pwd, because that indicates whether we will need to apply this `main`
-                //                function now or not.
-                if (packageObject["main"]) {
-                    program = path.join(program, packageObject["main"]);
-                }
                 // It's a CommonJS module, so require the module and capture any module outputs it exported.
                 // If this is a folder ensure it ends with a "/" so we require the folder, not any adjacent .json file
                 const programStats = await fs.promises.lstat(program);
                 if (programStats.isDirectory() && !program.endsWith("/")) {
                     program = program + "/";
                 }
-                console.log(`Observed program path: ${program}`);
                 programExport = require(program);
             }
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -25,6 +25,7 @@
         "js-yaml": "^3.14.0",
         "minimist": "^1.2.6",
         "normalize-package-data": "^2.4.0",
+        "pkg-dir": "^7.0.0",
         "read-package-tree": "^5.3.1",
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -1484,6 +1484,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
+  dependencies:
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -2076,6 +2084,13 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+locate-path@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
+  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
+  dependencies:
+    p-locate "^6.0.0"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -2419,6 +2434,13 @@ p-limit@^3.0.2:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
@@ -2432,6 +2454,13 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map@^3.0.0:
   version "3.0.0"
@@ -2466,6 +2495,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -2510,6 +2544,13 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-7.0.0.tgz#8f0c08d6df4476756c5ff29b3282d0bab7517d11"
+  integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
+  dependencies:
+    find-up "^6.3.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -3236,3 +3277,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==

--- a/tests/integration/aliases/nodejs/adopt_into_component/step1/package.json
+++ b/tests/integration/aliases/nodejs/adopt_into_component/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/aliases/nodejs/rename/step1/package.json
+++ b/tests/integration/aliases/nodejs/rename/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/aliases/nodejs/rename_component/step1/package.json
+++ b/tests/integration/aliases/nodejs/rename_component/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/aliases/nodejs/rename_component_and_child/step1/package.json
+++ b/tests/integration/aliases/nodejs/rename_component_and_child/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/aliases/nodejs/retype_component/step1/package.json
+++ b/tests/integration/aliases/nodejs/retype_component/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/aliases/nodejs/retype_parents/step1/package.json
+++ b/tests/integration/aliases/nodejs/retype_parents/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/config_capture_e2e/nodejs/package.json
+++ b/tests/integration/config_capture_e2e/nodejs/package.json
@@ -2,7 +2,7 @@
     "name": "config_basic_js",
     "version": "0.0.9",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
+    "main": "index.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/dependency_steps/step1/package.json
+++ b/tests/integration/dependency_steps/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "steps",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^3.0.0"
     },

--- a/tests/integration/duplicate_urns/step1/package.json
+++ b/tests/integration/duplicate_urns/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "duplicate_urns",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/explicit_provider/package.json
+++ b/tests/integration/explicit_provider/package.json
@@ -1,8 +1,6 @@
 {
     "name": "stack_project_name",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/get_created/package.json
+++ b/tests/integration/get_created/package.json
@@ -1,8 +1,6 @@
 {
     "name": "stack_project_name",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1132,6 +1132,15 @@ func TestESMTS(t *testing.T) {
 	})
 }
 
+func TestTSWithPackageJsonInParentDir(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "ts-with-package-json-in-parent-dir"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi"},
+		Quick:           true,
+	})
+}
+
 func TestESMTSDefaultExport(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("nodejs", "esm-ts-default-export"),

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1132,36 +1132,8 @@ func TestESMTS(t *testing.T) {
 	})
 }
 
-/*
-// Finding package.json when in the parent directory.
-// Two variables to test: whether the package is an ESM, and whether `main` is provided.
-//
-// Case 1 of 4:
-// main not provided, not an ESM.
-func TestPackageJsonInParentDirWithoutMain(t *testing.T) {
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:             filepath.Join("nodejs", "package-json-in-parent-dir-without-main"),
-		RelativeWorkDir: filepath.Join("myprogram"),
-		Dependencies:    []string{"@pulumi/pulumi", "@types/node"},
-		Quick:           true,
-	})
-}
-
-// Case 2 of 4:
-// main not provided, is an ESM.
-func TestESMPackageJsonInParentDirWithoutMain(t *testing.T) {
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:             filepath.Join("nodejs", "esm-package-json-in-parent-dir-without-main"),
-		RelativeWorkDir: filepath.Join("myprogram"),
-		Dependencies:    []string{"@pulumi/pulumi"},
-		Quick:           true,
-	})
-}
-*/
-
-// Case 3 of 4:
-// main provided, not an ESM.
 func TestTSWithPackageJsonInParentDir(t *testing.T) {
+	t.Parallel()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:             filepath.Join("nodejs", "ts-with-package-json-in-parent-dir"),
 		RelativeWorkDir: filepath.Join("myprogram"),
@@ -1170,9 +1142,8 @@ func TestTSWithPackageJsonInParentDir(t *testing.T) {
 	})
 }
 
-// Case 4 of 4:
-// main provided, is an ESM.
 func TestESMWithPackageJsonInParentDir(t *testing.T) {
+	t.Parallel()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:             filepath.Join("nodejs", "esm-with-package-json-in-parent-dir"),
 		RelativeWorkDir: filepath.Join("myprogram"),

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1133,7 +1133,6 @@ func TestESMTS(t *testing.T) {
 }
 
 func TestTSWithPackageJsonInParentDir(t *testing.T) {
-	t.Parallel()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:             filepath.Join("nodejs", "ts-with-package-json-in-parent-dir"),
 		RelativeWorkDir: filepath.Join("myprogram"),
@@ -1143,9 +1142,26 @@ func TestTSWithPackageJsonInParentDir(t *testing.T) {
 }
 
 func TestESMWithPackageJsonInParentDir(t *testing.T) {
-	t.Parallel()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:             filepath.Join("nodejs", "esm-with-package-json-in-parent-dir"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi"},
+		Quick:           true,
+	})
+}
+
+func TestESMWithoutPackageJsonInParentDir(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "esm-package-json-in-parent-dir-without-main"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi"},
+		Quick:           true,
+	})
+}
+
+func TestPackageJsonInParentDirWithoutMain(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "package-json-in-parent-dir-without-main"),
 		RelativeWorkDir: filepath.Join("myprogram"),
 		Dependencies:    []string{"@pulumi/pulumi"},
 		Quick:           true,

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1132,9 +1132,49 @@ func TestESMTS(t *testing.T) {
 	})
 }
 
+/*
+// Finding package.json when in the parent directory.
+// Two variables to test: whether the package is an ESM, and whether `main` is provided.
+//
+// Case 1 of 4:
+// main not provided, not an ESM.
+func TestPackageJsonInParentDirWithoutMain(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "package-json-in-parent-dir-without-main"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi", "@types/node"},
+		Quick:           true,
+	})
+}
+
+// Case 2 of 4:
+// main not provided, is an ESM.
+func TestESMPackageJsonInParentDirWithoutMain(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "esm-package-json-in-parent-dir-without-main"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi"},
+		Quick:           true,
+	})
+}
+*/
+
+// Case 3 of 4:
+// main provided, not an ESM.
 func TestTSWithPackageJsonInParentDir(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:             filepath.Join("nodejs", "ts-with-package-json-in-parent-dir"),
+		RelativeWorkDir: filepath.Join("myprogram"),
+		Dependencies:    []string{"@pulumi/pulumi"},
+		Quick:           true,
+	})
+}
+
+// Case 4 of 4:
+// main provided, is an ESM.
+func TestESMWithPackageJsonInParentDir(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:             filepath.Join("nodejs", "esm-with-package-json-in-parent-dir"),
 		RelativeWorkDir: filepath.Join("myprogram"),
 		Dependencies:    []string{"@pulumi/pulumi"},
 		Quick:           true,

--- a/tests/integration/invalid_package_json/package.json
+++ b/tests/integration/invalid_package_json/package.json
@@ -3,7 +3,6 @@
     "comment": "The version flag below is invalid.  But we don't want to throw on it.",
     "version": "0.1",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: package-json-in-parent-dir-without-main
+runtime: nodejs
+description: Run a TypeScript program where package.json is in a parent directory, and no main field is provided in package.json.

--- a/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/index.js
+++ b/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/index.js
@@ -1,0 +1,11 @@
+// This test asserts that node_modules can be found when package.json
+// is located in a parent directory. We extract a dummy value from an
+// installed package. 
+import { version } from "@pulumi/pulumi";
+import assert from "node:assert";
+
+const myVersion = version;
+// As long as these values are truthy, we've successfully loaded
+// the dep from node_modules
+assert.ok(myVersion);
+assert.strictEquals(myVersion, version);

--- a/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/index.js
+++ b/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/myprogram/index.js
@@ -1,11 +1,12 @@
-// This test asserts that node_modules can be found when package.json
-// is located in a parent directory. We extract a dummy value from an
-// installed package. 
-import { version } from "@pulumi/pulumi";
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+// If this program runs successfully, then the test passes.
+// Locating and executing this file is enough to demonstrate that the package.json
+// has been read correctly, because the assert statement proves that the 
+// module field has been read from the package.json located 
+// in the parent directory.
+import * as fs from "fs";
 import assert from "node:assert";
 
-const myVersion = version;
-// As long as these values are truthy, we've successfully loaded
-// the dep from node_modules
-assert.ok(myVersion);
-assert.strictEquals(myVersion, version);
+// ensure that import.meta.url exists which is only available in ESM modules.
+// This just serves as a verification that this module is actually treated as an ESM module.
+assert(import.meta.url !== undefined);

--- a/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/package.json
+++ b/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/package.json
@@ -1,6 +1,5 @@
 {
-    "name": "ts-with-package-json-in-parent-dir",
-    "main": "main.ts",
+    "name": "esm-package-json-in-parent-dir-without-main",
     "license": "Apache-2.0",
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/package.json
+++ b/tests/integration/nodejs/esm-package-json-in-parent-dir-without-main/package.json
@@ -1,6 +1,7 @@
 {
     "name": "esm-package-json-in-parent-dir-without-main",
     "license": "Apache-2.0",
+    "type": "module",
     "peerDependencies": {
         "@pulumi/pulumi": "latest"
     }

--- a/tests/integration/nodejs/esm-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: esm-with-package-json-in-parent-dir
+runtime: nodejs
+description: Run an ESM module where package.json is in a parent directory.

--- a/tests/integration/nodejs/esm-with-package-json-in-parent-dir/myprogram/main.js
+++ b/tests/integration/nodejs/esm-with-package-json-in-parent-dir/myprogram/main.js
@@ -1,0 +1,13 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+// If this program runs successfully, then the test passes.
+// Locating and executing this file is enough to demonstrate that the `main` field
+// has been read correctly, because the package.json file
+// in the parent directory will inform Pulumi to look for main.ts
+// as the entrypoint instead of main.js.
+
+import * as fs from "fs";
+import assert from "node:assert";
+
+// ensure that import.meta.url exists which is only available in ESM modules.
+// This just serves as a verification that this module is actually treated as an ESM module.
+assert(import.meta.url !== undefined);

--- a/tests/integration/nodejs/esm-with-package-json-in-parent-dir/package.json
+++ b/tests/integration/nodejs/esm-with-package-json-in-parent-dir/package.json
@@ -1,6 +1,7 @@
 {
-    "name": "ts-with-package-json-in-parent-dir",
-    "main": "main.ts",
+    "name": "esm-with-package-json-in-parent-dir",
+    "main": "main.js",
+    "type": "module",
     "license": "Apache-2.0",
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/nodejs/esm-with-package-json-in-parent-dir/package.json
+++ b/tests/integration/nodejs/esm-with-package-json-in-parent-dir/package.json
@@ -1,6 +1,6 @@
 {
     "name": "esm-with-package-json-in-parent-dir",
-    "main": "main.js",
+    "main": "myprogram/main.js",
     "type": "module",
     "license": "Apache-2.0",
     "peerDependencies": {

--- a/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/Pulumi.yaml
+++ b/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: package-json-in-parent-dir-without-main
+runtime: nodejs
+description: Run a TypeScript program where package.json is in a parent directory, and no main field is provided in package.json.

--- a/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/index.ts
+++ b/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/index.ts
@@ -1,0 +1,12 @@
+// This test asserts that node_modules can be found when package.json
+// is located in a parent directory. We extract a dummy value from an
+// installed package. 
+import { version as pulumiVersion } from "@pulumi/pulumi/version";
+import { strict as assert } from 'assert';
+// const assert = require("assert");
+
+const version = pulumiVersion;
+// As long as these values are truthy, we've successfully loaded
+// the dep from node_modules
+assert(version);
+assert(version === pulumiVersion);

--- a/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/index.ts
+++ b/tests/integration/nodejs/package-json-in-parent-dir-without-main/myprogram/index.ts
@@ -3,7 +3,6 @@
 // installed package. 
 import { version as pulumiVersion } from "@pulumi/pulumi/version";
 import { strict as assert } from 'assert';
-// const assert = require("assert");
 
 const version = pulumiVersion;
 // As long as these values are truthy, we've successfully loaded

--- a/tests/integration/nodejs/package-json-in-parent-dir-without-main/package.json
+++ b/tests/integration/nodejs/package-json-in-parent-dir-without-main/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "package-json-in-parent-dir-without-main",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@types/node": "latest"
+    }
+}

--- a/tests/integration/nodejs/regression-12301/package.json
+++ b/tests/integration/nodejs/regression-12301/package.json
@@ -1,8 +1,6 @@
 {
     "name": "regression-12301",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/nodejs/ts-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
+++ b/tests/integration/nodejs/ts-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ts-with-package-json-in-parent-dir
+runtime: nodejs
+description: Run a TypeScript program where package.json is in a parent directory.

--- a/tests/integration/nodejs/ts-with-package-json-in-parent-dir/myprogram/main.ts
+++ b/tests/integration/nodejs/ts-with-package-json-in-parent-dir/myprogram/main.ts
@@ -1,0 +1,5 @@
+// If this program runs successfully, then the test passes.
+// We don't have to create any resources; we just need this file
+// to be found as the entrypoint, because the package.json file
+// in the parent directory will inform Pulumi to look for main.ts
+// as the entrypoint instead of main.js.

--- a/tests/integration/nodejs/ts-with-package-json-in-parent-dir/package.json
+++ b/tests/integration/nodejs/ts-with-package-json-in-parent-dir/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "esm-js-with-package-json-in-parent-dir",
+    "main": "main.ts",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/nodejs/ts-with-package-json-in-parent-dir/package.json
+++ b/tests/integration/nodejs/ts-with-package-json-in-parent-dir/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-with-package-json-in-parent-dir",
-    "main": "main.ts",
+    "main": "myprogram/main.ts",
     "license": "Apache-2.0",
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/query/step1/package.json
+++ b/tests/integration/query/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "steps",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^3.0.0"
     },

--- a/tests/integration/read/import_acquire/step1/package.json
+++ b/tests/integration/read/import_acquire/step1/package.json
@@ -1,7 +1,5 @@
 {
     "name": "read_relinquish",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/read/read_dbr/step1/package.json
+++ b/tests/integration/read/read_dbr/step1/package.json
@@ -1,7 +1,5 @@
 {
     "name": "read_dbr",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/read/read_relinquish/step1/package.json
+++ b/tests/integration/read/read_relinquish/step1/package.json
@@ -1,7 +1,5 @@
 {
     "name": "read_relinquish",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/read/read_replace/step1/package.json
+++ b/tests/integration/read/read_replace/step1/package.json
@@ -1,7 +1,5 @@
 {
     "name": "read_dbr",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/stack_reference/nodejs/package.json
+++ b/tests/integration/stack_reference/nodejs/package.json
@@ -1,8 +1,6 @@
 {
     "name": "stack_project_name",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/targets/delete_targets_many_deps/package.json
+++ b/tests/integration/targets/delete_targets_many_deps/package.json
@@ -1,8 +1,6 @@
 {
     "name": "delete_targets_many_deps",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/targets/untargeted_create/package.json
+++ b/tests/integration/targets/untargeted_create/package.json
@@ -1,8 +1,6 @@
 {
     "name": "stack_project_name",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "scripts": {
         "build": "tsc"
     },

--- a/tests/integration/transformations/nodejs/simple/package.json
+++ b/tests/integration/transformations/nodejs/simple/package.json
@@ -1,8 +1,6 @@
 {
     "name": "aliases",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^2.5.3"
     },


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR changes how the Node SDK resolves `package.json` to recursively look up the directory tree for the file when it's
not present in the cwd. The previous behavior was to only look in the current directory, and fallback to an empty object
when the file could not be found.

Fixes https://github.com/pulumi/pulumi/issues/10459, https://github.com/pulumi/pulumi/pull/11045,
and https://github.com/pulumi/pulumi/issues/2619

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
