### PR TITLE
Revert "Fix destroy without project file"

### DIFF
--- a/changelog/pending/20230427--backend-filestate--revert-change-causing-provided-project-name-doesnt-match-pulumi-yaml-error.yaml
+++ b/changelog/pending/20230427--backend-filestate--revert-change-causing-provided-project-name-doesnt-match-pulumi-yaml-error.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/filestate
+  description: Revert change causing `provided project name "" doesn't match Pulumi.yaml` error

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -74,9 +74,6 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
-	// Project is the project name that this stack belongs to. For old filestate backends this will be empty.
-	Project() tokens.Name
-
 	// Fully qualified name of the stack, including any organization, project, or other information.
 	FullyQualifiedName() tokens.QName
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -653,7 +653,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 
 	return cloudBackendReference{
 		owner:   qualifiedName.Owner,
-		project: tokens.Name(qualifiedName.Project),
+		project: qualifiedName.Project,
 		name:    tokens.Name(qualifiedName.Name),
 		b:       b,
 	}, nil
@@ -1452,7 +1452,7 @@ func (b *cloudBackend) getCloudStackIdentifier(stackRef backend.StackReference) 
 
 	return client.StackIdentifier{
 		Owner:   cloudBackendStackRef.owner,
-		Project: cleanProjectName(string(cloudBackendStackRef.project)),
+		Project: cleanProjectName(cloudBackendStackRef.project),
 		Stack:   string(cloudBackendStackRef.name),
 	}, nil
 }

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -43,7 +43,7 @@ type Stack interface {
 
 type cloudBackendReference struct {
 	name    tokens.Name
-	project tokens.Name
+	project string
 	owner   string
 	b       *cloudBackend
 }
@@ -53,7 +53,7 @@ func (c cloudBackendReference) String() string {
 	currentProject := c.b.currentProject
 
 	// If the project names match, we can elide them.
-	if currentProject != nil && c.project == tokens.Name(currentProject.Name) {
+	if currentProject != nil && c.project == string(currentProject.Name) {
 
 		// Elide owner too, if it is the default owner.
 		defaultOrg, err := workspace.GetBackendConfigDefaultOrg(currentProject)
@@ -76,10 +76,6 @@ func (c cloudBackendReference) String() string {
 
 func (c cloudBackendReference) Name() tokens.Name {
 	return c.name
-}
-
-func (c cloudBackendReference) Project() tokens.Name {
-	return c.project
 }
 
 func (c cloudBackendReference) FullyQualifiedName() tokens.QName {
@@ -107,7 +103,7 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 	return &cloudStack{
 		ref: cloudBackendReference{
 			owner:   apistack.OrgName,
-			project: tokens.Name(apistack.ProjectName),
+			project: apistack.ProjectName,
 			name:    tokens.Name(apistack.StackName.String()),
 			b:       b,
 		},
@@ -218,7 +214,7 @@ func (css cloudStackSummary) Name() backend.StackReference {
 
 	return cloudBackendReference{
 		owner:   css.summary.OrgName,
-		project: tokens.Name(css.summary.ProjectName),
+		project: css.summary.ProjectName,
 		name:    tokens.Name(css.summary.StackName),
 		b:       css.b,
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -521,7 +521,6 @@ func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets
 type MockStackReference struct {
 	StringV             string
 	NameV               tokens.Name
-	ProjectV            tokens.Name
 	FullyQualifiedNameV tokens.QName
 }
 
@@ -537,13 +536,6 @@ func (r *MockStackReference) String() string {
 func (r *MockStackReference) Name() tokens.Name {
 	if r.NameV != "" {
 		return r.NameV
-	}
-	panic("not implemented")
-}
-
-func (r *MockStackReference) Project() tokens.Name {
-	if r.ProjectV != "" {
-		return r.ProjectV
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -171,9 +170,7 @@ func newDestroyCmd() *cobra.Command {
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
 				logging.Warningf("failed to find current Pulumi project, continuing with an empty project"+
 					"using stack %v from backend %v", s.Ref().Name(), s.Backend().Name())
-				proj = &workspace.Project{
-					Name: tokens.PackageName(s.Ref().Project()),
-				}
+				proj = &workspace.Project{}
 				root = ""
 			} else if err != nil {
 				return result.FromError(err)


### PR DESCRIPTION
Reverting the change that is causing `error: could not create stack: provided project name "" doesn't match Pulumi.yaml` errors when using the filestate backend.

Before this revert, with v3.65.0, I get the error:

```
$ pulumi login --local
$ pulumi new go -g
$ pulumi stack init dev
error: could not create stack: provided project name "" doesn't match Pulumi.yaml
```

After revert, no longer getting the error.


Fixes https://github.com/pulumi/pulumi/issues/12760