### PR TITLE
Bump NodeJS CI version.

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -124,7 +124,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
     "go": "1.20.x",
-    "nodejs": "19.x",
+    "nodejs": "20.x",
     "python": "3.11.x",
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR switches CI testing of the "Node Lastest" line from Node 19 to Node 20. This will help us catch issues for users who are on the cutting edge.

Fixes https://github.com/pulumi/pulumi/issues/12790

## Checklist

N/A. This is a change to CI only.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
