### PR TITLE
Eliminate unnecessary double negations.

### DIFF
--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -60,7 +60,7 @@ export async function runPulumiCmd(
 
         if (onOutput && proc.stdout) {
             proc.stdout!.on("data", (data: any) => {
-                if (data && data.toString) {
+                if (data?.toString) {
                     data = data.toString();
                 }
                 onOutput(data);

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -228,7 +228,7 @@ export class LocalWorkspace implements Workspace {
         }
 
         if (!wsOpts.projectSettings) {
-            if (!!wsOpts.workDir) {
+            if (wsOpts.workDir) {
                 try {
                     // Try to load the project settings.
                     loadProjectSettings(wsOpts.workDir);
@@ -289,10 +289,10 @@ export class LocalWorkspace implements Workspace {
 
         const readinessPromises: Promise<any>[] = [this.getPulumiVersion(minimumVersion)];
 
-        if (opts && opts.projectSettings) {
+        if (opts?.projectSettings) {
             readinessPromises.push(this.saveProjectSettings(opts.projectSettings));
         }
-        if (opts && opts.stackSettings) {
+        if (opts?.stackSettings) {
             for (const [name, value] of Object.entries(opts.stackSettings)) {
                 readinessPromises.push(this.saveStackSettings(name, value));
             }

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -148,7 +148,7 @@ function newUncaughtHandler(errorSet: Set<Error>): (err: Error) => void {
         // If both the stack and message are empty, then just stringify the err object itself. This
         // is also necessary as users can throw arbitrary things in JS (including non-Errors).
         let defaultMessage = "";
-        if (!!err) {
+        if (err) {
             defaultMessage = err.stack || err.message || "" + err;
         }
 

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -6,7 +6,7 @@
     "files": {
         "ignore": [
             "bin/", "proto/", "dist/", "node_modules", ".nyc_output/", ".direnv/", "tests/runtime/jsClosureCases_*.js",
-            "tests/runtime/tsClosureCases.ts"
+            "tests/runtime/tsClosureCases.ts", "tests/mockpackage/lib/"
         ]
     },
     "formatter": {
@@ -18,6 +18,10 @@
         "enabled": true,
         "rules": {
             "recommended": false,
+            "complexity": {
+                "noExtraBooleanCast": "error",
+                "useOptionalChain": "error"
+            },
             "performance": {
                 "noDelete": "error"
             }

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -202,7 +202,7 @@ function allFoldersForPackages(
                 // .devDependencies or or .peerDependencies.  These are not what are considered part
                 // of the final runtime configuration of the app and should not be uploaded.
                 const referencedPackages = new Set<string>(includedPackages);
-                if (root.package && root.package.dependencies) {
+                if (root?.package.dependencies) {
                     for (const depName of Object.keys(root.package.dependencies)) {
                         referencedPackages.add(depName);
                     }

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -202,7 +202,7 @@ function allFoldersForPackages(
                 // .devDependencies or or .peerDependencies.  These are not what are considered part
                 // of the final runtime configuration of the app and should not be uploaded.
                 const referencedPackages = new Set<string>(includedPackages);
-                if (root?.package.dependencies) {
+                if (root.package.dependencies) {
                     for (const depName of Object.keys(root.package.dependencies)) {
                         referencedPackages.add(depName);
                     }

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1193,7 +1193,7 @@ async function getOrCreateEntryAsync(
     }
 
     function usesNonLexicalThis(localEntry: Entry | undefined) {
-        return localEntry && localEntry.function && localEntry.function.usesNonLexicalThis;
+        return localEntry?.function?.usesNonLexicalThis;
     }
 
     async function captureModuleAsync(normalizedModuleName: string): Promise<void> {

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -189,9 +189,7 @@ function parseFunctionCode(funcString: string): [string, ParsedFunctionCode] {
         const constructor = <ts.ConstructorDeclaration>classDecl.members.find((m) => ts.isConstructorDeclaration(m));
         if (!constructor) {
             // class without explicit constructor.
-            const isSubClass =
-                classDecl.heritageClauses &&
-                classDecl.heritageClauses.some((c) => c.token === ts.SyntaxKind.ExtendsKeyword);
+            const isSubClass = classDecl.heritageClauses?.some((c) => c.token === ts.SyntaxKind.ExtendsKeyword);
             return isSubClass
                 ? makeFunctionDeclaration(
                       "constructor() { super(); }",
@@ -590,12 +588,7 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
 
         // Walk up a sequence of property-access'es, recording the names we hit, until we hit
         // something that isn't a property-access.
-        while (
-            node &&
-            node.parent &&
-            isPropertyOrElementAccessExpression(node.parent) &&
-            node.parent.expression === node
-        ) {
+        while (node?.parent && isPropertyOrElementAccessExpression(node.parent) && node.parent.expression === node) {
             if (!infos) {
                 infos = [];
             }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -222,7 +222,7 @@ function getProvider(tok: string, opts: InvokeOptions) {
 
 function deserializeResponse(tok: string, resp: any): any {
     const failures: any = resp.getFailuresList();
-    if (failures && failures.length) {
+    if (failures?.length) {
         let reasons = "";
         for (let i = 0; i < failures.length; i++) {
             if (reasons !== "") {
@@ -365,7 +365,7 @@ function createOutput<T>(
     let rejectDeps: (err: Error) => void;
 
     const resolver = (v: T, isKnown: boolean, isSecret: boolean, deps: Resource[] = [], err?: Error) => {
-        if (!!err) {
+        if (err) {
             rejectValue(err);
             rejectIsKnown(err);
             rejectIsSecret(err);

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -168,7 +168,7 @@ export function getResource(
 
                         // If the invoke failed, raise an error
                         const failures: any = resp.getFailuresList();
-                        if (failures && failures.length) {
+                        if (failures?.length) {
                             let reasons = "";
                             for (let i = 0; i < failures.length; i++) {
                                 if (reasons !== "") {
@@ -592,7 +592,7 @@ async function prepareResource(
             );
 
             resolveURN = (v, err) => {
-                if (!!err) {
+                if (err) {
                     rejectValue(err);
                     rejectIsKnown(err);
                 } else {
@@ -631,7 +631,7 @@ async function prepareResource(
             );
 
             resolveID = (v, isKnown, err) => {
-                if (!!err) {
+                if (err) {
                     rejectValue(err);
                     rejectIsKnown(err);
                 } else {

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -69,7 +69,7 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
         let rejectDeps: (err: Error) => void;
 
         resolvers[k] = (v: any, isKnown: boolean, isSecret: boolean, deps: Resource[] = [], err?: Error) => {
-            if (!!err) {
+            if (err) {
                 rejectValue(err);
                 rejectIsKnown(err);
                 rejectIsSecret(err);


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR removes instances of prefix-!! where the value
would already be coerced into a boolean. It also removes
instances where the "optional chaining" operator (?.)
would suffice.

This PR enables two lints using Rome to detect and eliminate these instances.

**Documentation:** 
1. https://docs.rome.tools/lint/rules/noextrabooleancast/
2. https://docs.rome.tools/lint/rules/useoptionalchain/


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


## Checklist

**N/A:** This change is purely a refactor.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
