### PR TITLE
Eliminate postfix-!!

### DIFF
--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -24,6 +24,13 @@
             },
             "performance": {
                 "noDelete": "error"
+            },
+            "suspicious": {
+                "noExtraNonNullAssertion": "error",
+                "noExplicitAny": "off",
+                "noEmptyInterface": "off",
+                "noShadowRestrictedNames": "off",
+                "noAsyncPromiseExecutor": "off"
             }
         }
     }

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1479,5 +1479,5 @@ function getNameOrSymbol(descriptor: ClosurePropertyDescriptor): symbol | string
         throw new Error("Descriptor didn't have symbol or name: " + JSON.stringify(descriptor));
     }
 
-    return descriptor.symbol || descriptor.name!!;
+    return descriptor.symbol || descriptor.name!;
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This simple lint eliminates postfix-`!!`, which has no effect over a single postfix `!`. This lint rule is enforced by Rome.

## Checklist

**N/A:** This change is a refactor only.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
