### PR TITLE
Update DoesProjectExist to not list all projects

### DIFF
--- a/changelog/pending/20230502--backend-filestate--improve-performance-of-project-existence-check.yaml
+++ b/changelog/pending/20230502--backend-filestate--improve-performance-of-project-existence-check.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend/filestate
+  description: Improve performance of project-existence check.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -590,20 +590,7 @@ func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string)
 		return false, nil
 	}
 
-	// TODO[pulumi/pulumi#12547]:
-	// This could be faster if we list "$project/" instead of all projects.
-	projects, err := projStore.ListProjects(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for _, project := range projects {
-		if string(project) == projectName {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return projStore.ProjectExists(ctx, projectName)
 }
 
 // Confirm the specified stack's project doesn't contradict the meta.yaml of the current project.

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	pathPkg "path"
 	"path/filepath"
 	"strings"
 
@@ -233,15 +234,13 @@ func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name
 }
 
 func (p *projectReferenceStore) ProjectExists(ctx context.Context, projectName string) (bool, error) {
-	if projectName == "" {
-		return false, fmt.Errorf("empty project name")
-	}
+	contract.Requiref(projectName != "", "projectName", "must not be empty")
 
-	path := filepath.Join(StacksDir, projectName)
+	path := pathPkg.Join(StacksDir, projectName)
 
 	files, err := listBucket(ctx, p.bucket, path)
 	if err != nil {
-		return false, fmt.Errorf("error listing stacks: %w", err)
+		return false, fmt.Errorf("list stacks at %q: %w", path, err)
 	}
 
 	// If files is empty, it means that project is not found in bucket

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	pathPkg "path"
+	pkgPath "path"
 	"path/filepath"
 	"strings"
 
@@ -236,7 +236,7 @@ func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name
 func (p *projectReferenceStore) ProjectExists(ctx context.Context, projectName string) (bool, error) {
 	contract.Requiref(projectName != "", "projectName", "must not be empty")
 
-	path := pathPkg.Join(StacksDir, projectName)
+	path := pkgPath.Join(StacksDir, projectName)
 
 	files, err := listBucket(ctx, p.bucket, path)
 	if err != nil {

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	pkgPath "path"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -236,7 +236,7 @@ func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name
 func (p *projectReferenceStore) ProjectExists(ctx context.Context, projectName string) (bool, error) {
 	contract.Requiref(projectName != "", "projectName", "must not be empty")
 
-	path := pkgPath.Join(StacksDir, projectName)
+	path := path.Join(StacksDir, projectName)
 
 	files, err := listBucket(ctx, p.bucket, path)
 	if err != nil {

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -232,6 +232,22 @@ func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name
 	return projects, nil
 }
 
+func (p *projectReferenceStore) ProjectExists(ctx context.Context, projectName string) (bool, error) {
+	if projectName == "" {
+		return false, fmt.Errorf("empty project name")
+	}
+
+	path := filepath.Join(StacksDir, projectName)
+
+	files, err := listBucket(ctx, p.bucket, path)
+	if err != nil {
+		return false, fmt.Errorf("error listing stacks: %w", err)
+	}
+
+	// If files is empty, it means that project is not found in bucket
+	return len(files) > 0, nil
+}
+
 func (p *projectReferenceStore) ListReferences(ctx context.Context) ([]*localBackendReference, error) {
 	// The first level of the bucket is the project name.
 	// The second level of the bucket is the stack name.

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -16,7 +16,6 @@ package filestate
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -412,17 +411,7 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 
 		// Result that should be returned by ProjectExists.
 		exist bool
-
-		// Err that should be returned by ProjectExists.
-		err error
 	}{
-		{
-			desc:        "empty string project name",
-			files:       []string{},
-			projectName: "",
-			exist:       false,
-			err:         fmt.Errorf("empty project name"),
-		},
 		{
 			desc: "project exists",
 			files: []string{
@@ -430,7 +419,6 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 			},
 			projectName: "a",
 			exist:       true,
-			err:         nil,
 		},
 		{
 			desc: "project exists as empty directory",
@@ -439,7 +427,6 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 			},
 			projectName: "a",
 			exist:       false,
-			err:         nil,
 		},
 		{
 			desc: "project does not exist",
@@ -448,7 +435,6 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 			},
 			projectName: "b",
 			exist:       false,
-			err:         nil,
 		},
 		{
 			desc: "subproject exist",
@@ -457,7 +443,6 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 			},
 			projectName: "a",
 			exist:       false,
-			err:         nil,
 		},
 	}
 
@@ -477,8 +462,7 @@ func TestProjectReferenceStore_ProjectExists(t *testing.T) {
 			}
 
 			exist, err := store.ProjectExists(ctx, tt.projectName)
-			assert.Equal(t, tt.err, err)
-
+			assert.NoError(t, err)
 			assert.Equal(t, tt.exist, exist)
 		})
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Add `projectReferenceStore.ProjectExists`.

`projectReferenceStore.ProjectExists` enables us to search for a specific project in `localBackend.DoesProjectExist`.

**Tasks**

- [X] Add `projectReferenceStore.ProjectExists`
- [X] Replace `projectReferenceStore.ListProjects` with `projectReferenceStore.ProjectExists` in `localBackend.DoesProjectExist`

Fixes https://github.com/pulumi/pulumi/issues/12547

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
