### PR TITLE
[pcl/python] Support range expressions that are of type output

### DIFF
--- a/changelog/pending/20230502--programgen-python--support-range-expressions-that-are-of-type-output.yaml
+++ b/changelog/pending/20230502--programgen-python--support-range-expressions-that-are-of-type-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/python
+  description: Support range expressions that are of type output

--- a/pkg/codegen/pcl/rewrite_convert.go
+++ b/pkg/codegen/pcl/rewrite_convert.go
@@ -45,8 +45,8 @@ func sameSchemaTypes(xt, yt model.Type) bool {
 // rewriteConversions implements the core of RewriteConversions. It returns the rewritten expression and true if the
 // type of the expression may have changed.
 func rewriteConversions(x model.Expression, to model.Type, diags *hcl.Diagnostics) (model.Expression, bool) {
-	if x == nil {
-		return nil, false
+	if x == nil || to == nil {
+		return x, false
 	}
 	// If rewriting an operand changed its type and the type of the expression depends on the type of that operand, the
 	// expression must be typechecked in order to update its type.
@@ -251,6 +251,8 @@ func RewriteConversions(x model.Expression, to model.Type) (model.Expression, hc
 func convertPrimitiveValues(from model.Expression, to model.Type) (model.Expression, bool) {
 	var expression model.Expression
 	switch {
+	case from == nil || to == nil:
+		return from, false
 	case to.AssignableFrom(from.Type()) || to.AssignableFrom(model.DynamicType):
 		return nil, false
 	case to.AssignableFrom(model.BoolType):

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -16,13 +16,14 @@ package python
 import (
 	"bytes"
 	"fmt"
-	"github.com/zclconf/go-cty/cty"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -261,8 +261,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "iterating-optional-range-expressions",
 		Description: "Test that we can iterate over range expression that are option(iterator)",
-		// TODO: python, dotnet and go
-		Skip: allProgLanguages.Except("nodejs"),
+		// TODO: dotnet and go
+		Skip: allProgLanguages.Except("nodejs").Except("python"),
 		// We are using a synthetic schema defined in range-1.0.0.json so we can't compile all the way
 		SkipCompile: allProgLanguages,
 	},

--- a/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/python/iterating-optional-range-expressions.py
+++ b/pkg/codegen/testing/test/testdata/iterating-optional-range-expressions-pp/python/iterating-optional-range-expressions.py
@@ -1,0 +1,38 @@
+import pulumi
+import pulumi_range as range
+
+root = range.Root("root")
+# creating resources by iterating a property of type array(string) of another resource
+from_list_of_strings = []
+def create_from_list_of_strings(range_body):
+    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
+        from_list_of_strings.append(range.Example(f"fromListOfStrings-{range['key']}", some_string=range["value"]))
+
+root.array_of_string.apply(create_from_list_of_strings)
+# creating resources by iterating a property of type map(string) of another resource
+from_map_of_strings = []
+def create_from_map_of_strings(range_body):
+    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
+        from_map_of_strings.append(range.Example(f"fromMapOfStrings-{range['key']}", some_string=f"{range['key']} {range['value']}"))
+
+root.map_of_string.apply(create_from_map_of_strings)
+# computed range list expression to create instances of range:index:Example resource
+from_computed_list_of_strings = []
+def create_from_computed_list_of_strings(range_body):
+    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
+        from_computed_list_of_strings.append(range.Example(f"fromComputedListOfStrings-{range['key']}", some_string=f"{range['key']} {range['value']}"))
+
+pulumi.Output.all(
+    root.map_of_string["hello"],
+    root.map_of_string["world"]
+).apply(create_from_computed_list_of_strings)
+# computed range for expression to create instances of range:index:Example resource
+from_computed_for_expression = []
+def create_from_computed_for_expression(range_body):
+    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
+        from_computed_for_expression.append(range.Example(f"fromComputedForExpression-{range['key']}", some_string=f"{range['key']} {range['value']}"))
+
+pulumi.Output.all(
+    array_of_string=root.array_of_string,
+    map_of_string=root.map_of_string
+).apply(lambda resolved_outputs: create_from_computed_for_expression([resolved_outputs["map_of_string"][value] for value in resolved_outputs["array_of_string"]]))


### PR DESCRIPTION
# Description

This PR implements python program-gen support for range expressions that are of type Output<T> where T is a collection that should be iterated inside an apply call. 

It generates intermediate helper functions that contain the loop to create the resources, then references those functions in the apply call. (see code below)

I had to change/fix `rewriteTraversal` where it type-checked a traversal expression (i.e. `value.something`) after the casing of a member has changed to snake case (i.e. `someValue` -> `some_value`) and failed the program generation. Now it no longer type checks the resulting expression, since we rely on the bind phase to do the type checking.

<details>
    <summary>Example PCL</summary>

```terraform
resource "root" "range:index:Root" {}

// creating resources by iterating a property of type array(string) of another resource
resource "fromListOfStrings" "range:index:Example" {
  options {
    range = root.arrayOfString
  }

  someString = range.value
}

// creating resources by iterating a property of type map(string) of another resource
resource "fromMapOfStrings" "range:index:Example" {
  options {
    range = root.mapOfString
  }

  someString = "${range.key} ${range.value}"
}

// computed range list expression to create instances of range:index:Example resource
resource "fromComputedListOfStrings" "range:index:Example" {
  options {
    range = [
        root.mapOfString["hello"],
        root.mapOfString["world"]
    ]
  }

  someString = "${range.key} ${range.value}"
}

// computed range for expression to create instances of range:index:Example resource
resource "fromComputedForExpression" "range:index:Example" {
  options {
    range = [for value in root.arrayOfString : root.mapOfString[value]]
  }

  someString = "${range.key} ${range.value}"
}

```

</details>

<details>
<summary>Generated python code</summary>

```python
import pulumi
import pulumi_range as range

root = range.Root("root")
# creating resources by iterating a property of type array(string) of another resource
from_list_of_strings = []
def create_from_list_of_strings(range_body):
    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
        from_list_of_strings.append(range.Example(f"fromListOfStrings-{range['key']}", some_string=range["value"]))

root.array_of_string.apply(create_from_list_of_strings)
# creating resources by iterating a property of type map(string) of another resource
from_map_of_strings = []
def create_from_map_of_strings(range_body):
    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
        from_map_of_strings.append(range.Example(f"fromMapOfStrings-{range['key']}", some_string=f"{range['key']} {range['value']}"))

root.map_of_string.apply(create_from_map_of_strings)
# computed range list expression to create instances of range:index:Example resource
from_computed_list_of_strings = []
def create_from_computed_list_of_strings(range_body):
    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
        from_computed_list_of_strings.append(range.Example(f"fromComputedListOfStrings-{range['key']}", some_string=f"{range['key']} {range['value']}"))

pulumi.Output.all(
    root.map_of_string["hello"],
    root.map_of_string["world"]
).apply(create_from_computed_list_of_strings)
# computed range for expression to create instances of range:index:Example resource
from_computed_for_expression = []
def create_from_computed_for_expression(range_body):
    for range in [{"key": k, "value": v} for [k, v] in enumerate(range_body)]:
        from_computed_for_expression.append(range.Example(f"fromComputedForExpression-{range['key']}", some_string=f"{range['key']} {range['value']}"))

pulumi.Output.all(
    array_of_string=root.array_of_string,
    map_of_string=root.map_of_string
).apply(lambda resolved_outputs: create_from_computed_for_expression([resolved_outputs["map_of_string"][value] for value in resolved_outputs["array_of_string"]]))

```

</details>

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
