### PR TITLE
[pcl/binder] Allow null literal as a default value for config variables

### DIFF
--- a/changelog/pending/20230503--programgen--allow-null-literal-as-a-default-value-for-config-variables.yaml
+++ b/changelog/pending/20230503--programgen--allow-null-literal-as-a-default-value-for-config-variables.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Allow null literal as a default value for config variables

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -195,6 +195,22 @@ func TestConfigNodeTypedString(t *testing.T) {
 	assert.Equal(t, config.Type(), model.StringType, "the type is a string")
 }
 
+func TestConfigNodeTypedOptionalString(t *testing.T) {
+	t.Parallel()
+	source := "config cidrBlock string { default = null }"
+	program, diags := parseAndBindProgram(t, source, "config.pp")
+	contract.Ignore(diags)
+	assert.NotNil(t, program, "failed to parse and bind program")
+	assert.Equal(t, len(program.Nodes), 1, "there is one node")
+	config, ok := program.Nodes[0].(*pcl.ConfigVariable)
+	assert.True(t, ok, "first node is a config variable")
+	assert.Equal(t, config.Name(), "cidrBlock")
+	assert.True(t, model.IsOptionalType(config.Type()), "the type is optional")
+	elementType := pcl.UnwrapOption(config.Type())
+	assert.Equal(t, elementType, model.StringType, "element type is a string")
+	assert.True(t, config.Nullable, "The config variable is nullable")
+}
+
 func TestConfigNodeTypedInt(t *testing.T) {
 	t.Parallel()
 	source := "config count int { }"


### PR DESCRIPTION
Fixes #12810 (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
