### PR TITLE
Support SSH-style Git URLs

### DIFF
--- a/changelog/pending/20230504--cli-new--support-ssh-style-git-urls-including-for-pulumi-new-private-templates.yaml
+++ b/changelog/pending/20230504--cli-new--support-ssh-style-git-urls-including-for-pulumi-new-private-templates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Support SSH-style Git URLs, including for `pulumi new` private templates

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -107,13 +107,31 @@ func TestParseGitRepoURL(t *testing.T) {
 	test(exp, "", pre)
 	test(exp, "foobar", pre+"/foobar")
 
+	// SSH URLs.
+	pre = "git@github.com:acmecorp/templates"
+	exp = "git@github.com:acmecorp/templates"
+	test(exp, "", pre)
+	test(exp, "", pre+"/")
+	pre = "git@github.com:acmecorp/templates/website"
+	exp = "git@github.com:acmecorp/templates"
+	test(exp, "website", pre)
+	test(exp, "website", pre+"/")
+	pre = "git@github.com:acmecorp/templates/somewhere/in/there/is/a/website"
+	exp = "git@github.com:acmecorp/templates"
+	test(exp, "somewhere/in/there/is/a/website", pre)
+	test(exp, "somewhere/in/there/is/a/website", pre+"/")
+
 	// No owner.
 	testError("https://github.com")
 	testError("https://github.com/")
+	testError("git@github.com")
+	testError("git@github.com/")
 
 	// No repo.
 	testError("https://github.com/pulumi")
 	testError("https://github.com/pulumi/")
+	testError("git@github.com:pulumi")
+	testError("git@github.com:pulumi/")
 
 	// Not HTTPS.
 	testError("http://github.com/pulumi/templates.git")

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -268,9 +268,9 @@ func cleanupLegacyTemplateDir(templateKind TemplateKind) error {
 	return nil
 }
 
-// IsTemplateURL returns true if templateNamePathOrURL starts with "https://".
+// IsTemplateURL returns true if templateNamePathOrURL starts with "https://" (SSL) or "git@" (SSH).
 func IsTemplateURL(templateNamePathOrURL string) bool {
-	return strings.HasPrefix(templateNamePathOrURL, "https://")
+	return strings.HasPrefix(templateNamePathOrURL, "https://") || strings.HasPrefix(templateNamePathOrURL, "git@")
 }
 
 // isTemplateFileOrDirectory returns true if templateNamePathOrURL is the name of a valid file or directory.


### PR DESCRIPTION
This adds support for SSH-style Git URLs, enabling folks to use private repos for their templates.

For instance,

    $ pulumi new git@github.com:acmecorp/templates/website

will now work as intended.

The logic to find the SSH key depends on the well-known ~/.ssh/config file when available (as that is typically how the ssh-agent is configured for auth with the Git client), but falls back on other common key names in the event that isn't configured.

If the SSH key is protected by a password, the user will be prompted to supply the password on-demand. (It is memoized to avoid asking multiple times, as the template workflow requires using it more than once.) To avoid prompting, the PULUMI_GITSSH_PASSPHRASE envvar can be set -- which is coincidentally the only option in non-interactive modes.

Fixes #4872 and #5007.

**Note:** still draft status until I figure out a good way to test the actual template flow, since it requires having a valid Git repo and SSH key, which is tricky obviously from a security perspective.