### PR TITLE
Fix race condition in go/generate function.

### DIFF
--- a/changelog/pending/20230504--build--fixes-race-condition-in-building-go-sdk.yaml
+++ b/changelog/pending/20230504--build--fixes-race-condition-in-building-go-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: build
+  description: Fixes race condition in building Go sdk.

--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -350,18 +349,10 @@ func main() {
 		f.Close()
 
 		gofmt := exec.Command("gofmt", "-s", "-w", fullname)
-		stderr, err := gofmt.StderrPipe()
-		if err != nil {
-			log.Fatalf("failed to pipe stderr from gofmt: %v", err)
-		}
-		go func() {
-			_, err := io.Copy(os.Stderr, stderr)
-			if err != nil {
-				panic(fmt.Sprintf("unexpected error running gofmt: %v", err))
-			}
-		}()
+		gofmt.Stdout = os.Stdout
+		gofmt.Stderr = os.Stderr
 		if err := gofmt.Run(); err != nil {
-			log.Fatalf("failed to gofmt %v: %v", fullname, err)
+			log.Fatalf("failed to run gofmt on %v: %v", fullname, err)
 		}
 	}
 }


### PR DESCRIPTION
We were building pulumi and hit an error in this function when running the makefile, but only in certain environments. I read the code, and it looks like there's a race condition here where the gofmt command finishes before the io.Copy starts, giving us this error:

```
⚠️  x86_64    | + make build
ℹ️  x86_64    | BUILD:
ℹ️  x86_64    | go generate ./pulumi/...
⚠️  x86_64    | panic: unexpected error running gofmt: read |0: file already closed
```

The go async function is unnecessary here, and the Go exec docs explain that StderrPipe should not be used with Run: https://pkg.go.dev/os/exec#Cmd.StderrPipe

CombinedOutput is a simpler way to accomplish the same thing, and fixes the race condition.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
