### PR TITLE
[pcl/binder] Fix panic on component type traversal

### DIFF
--- a/changelog/pending/20230504--programgen--fix-panic-on-component-type-traversal.yaml
+++ b/changelog/pending/20230504--programgen--fix-panic-on-component-type-traversal.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix panic on component type traversal

--- a/pkg/codegen/pcl/component.go
+++ b/pkg/codegen/pcl/component.go
@@ -82,6 +82,10 @@ func (c *Component) Type() model.Type {
 }
 
 func (c *Component) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	if c == nil || c.VariableType == nil {
+		return model.DynamicType.Traverse(traverser)
+	}
+
 	return c.VariableType.Traverse(traverser)
 }
 


### PR DESCRIPTION
Fixes #12826 (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
