### PR TITLE
Add per-language smoke tests to the integration tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -165,6 +165,15 @@ jobs:
           node-version: ${{ fromJson(inputs.version-set).nodejs }}
           cache: yarn
           cache-dependency-path: sdk/nodejs/yarn.lock
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: "7.6"
       - name: Uninstall pre-installed Pulumi (windows)
         if: inputs.platform == 'windows-latest'
         run: |

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -657,7 +657,7 @@ func (host *goLanguageHost) InstallDependencies(
 		return err
 	}
 
-	cmd := exec.Command(gobin, "mod", "tidy")
+	cmd := exec.Command(gobin, "mod", "tidy", "-compat=1.18")
 	cmd.Dir = req.Directory
 	cmd.Env = os.Environ()
 	cmd.Stdout, cmd.Stderr = stdout, stderr

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/stretchr/testify/require"
+)
+
+var Runtimes = []string{"python", "java", "go", "yaml", "nodejs", "dotnet"}
+
+// Mapping from the language runtime names to the common language name used by templates and the like.
+var Languages = map[string]string{
+	"python": "python",
+	"java":   "java",
+	"go":     "go",
+	"yaml":   "yaml",
+	"nodejs": "typescript",
+	"dotnet": "csharp",
+}
+
+// Quick sanity tests for each downstream language to check that a minimal example can be created and run.
+//
+//nolint:paralleltest // pulumi new is not parallel safe
+func TestLanguageNewSmoke(t *testing.T) {
+	for _, test := range Runtimes {
+		tt := test
+		t.Run(tt, func(t *testing.T) {
+			//nolint:paralleltest
+
+			e := ptesting.NewEnvironment(t)
+			defer deleteIfNotFailed(e)
+
+			// `new` wants to work in an empty directory but our use of local filestate means we have a
+			// ".pulumi" directory at root.
+			projectDir := filepath.Join(e.RootPath, "project")
+			err := os.Mkdir(projectDir, 0o700)
+			require.NoError(t, err)
+
+			e.CWD = projectDir
+
+			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+			e.RunCommand("pulumi", "new", "random-"+Languages[tt], "--yes")
+			e.RunCommand("pulumi", "up", "--yes")
+			e.RunCommand("pulumi", "destroy", "--yes")
+		})
+	}
+}
+
+// Quick sanity tests for each downstream language to check that convert works.
+func TestLanguageConvertSmoke(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range Runtimes {
+		tt := test
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+
+			e := ptesting.NewEnvironment(t)
+			defer deleteIfNotFailed(e)
+
+			// We need PULUMI_DEV set to use `--from pcl` in convert.
+			e.SetEnvVars("PULUMI_DEV=true")
+
+			e.ImportDirectory("testdata/random_pp")
+
+			// Make sure random is installed
+			out, _ := e.RunCommand("pulumi", "plugin", "ls")
+			if !strings.Contains(out, "random  resource  4.13.0") {
+				e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
+			}
+
+			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+			e.RunCommand("pulumi", "convert", "--language", Languages[tt], "--from", "pcl", "--out", "out")
+			e.CWD = filepath.Join(e.RootPath, "out")
+			e.RunCommand("pulumi", "stack", "init", "test")
+
+			// TODO: Skipping `up` until we have a way to tell the language host to install dependencies.
+			// e.RunCommand("pulumi", "up", "--yes")
+			// e.RunCommand("pulumi", "destroy", "--yes")
+		})
+	}
+}
+
+// Quick sanity tests for each downstream language to check that sdk-gen works.
+func TestLanguageGenerateSmoke(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range Runtimes {
+		if test == "yaml" {
+			// yaml doesn't support sdks
+			continue
+		}
+
+		tt := test
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+
+			e := ptesting.NewEnvironment(t)
+			defer deleteIfNotFailed(e)
+
+			e.ImportDirectory("testdata/simple_schema")
+			e.RunCommand("pulumi", "package", "gen-sdk", "--language", tt, "schema.json")
+		})
+	}
+}
+
+// Quick sanity tests for each downstream language to check that import works.
+//
+//nolint:paralleltest // pulumi new is not parallel safe
+func TestLanguageImportSmoke(t *testing.T) {
+	for _, test := range Runtimes {
+		tt := test
+		t.Run(tt, func(t *testing.T) {
+			//nolint:paralleltest
+
+			e := ptesting.NewEnvironment(t)
+			defer deleteIfNotFailed(e)
+
+			// `new` wants to work in an empty directory but our use of local filestate means we have a
+			// ".pulumi" directory at root.
+			projectDir := filepath.Join(e.RootPath, "project")
+			err := os.Mkdir(projectDir, 0o700)
+			require.NoError(t, err)
+
+			e.CWD = projectDir
+
+			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+			e.RunCommand("pulumi", "new", Languages[tt], "--yes")
+			e.RunCommand("pulumi", "import", "--yes", "random:index/randomId:RandomId", "identifier", "p-9hUg")
+		})
+	}
+}

--- a/tests/testdata/random_pp/main.pp
+++ b/tests/testdata/random_pp/main.pp
@@ -1,0 +1,9 @@
+resource "pet" "random:index:RandomPet" {
+    options {
+        version = "4.13.0"
+    }
+}
+
+output "name" {
+    value = pet.id
+}

--- a/tests/testdata/simple_schema/schema.json
+++ b/tests/testdata/simple_schema/schema.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.0.1",
+    "name": "simple",
+    "resources": {
+        "simple:index:SomeResource": {
+            "properties": {
+                "a": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "a"
+            ],
+            "inputProperties": {
+                "a": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As discussed in ideation, some simple smoke tests to just validate that the downstream languages run against the current engine.
