### PR TITLE
[engine] engine now always targets stack resource during updates

### DIFF
--- a/changelog/pending/20230508--engine--fix-bug-with-targeting-and-plans-where-root-stack-resource-and-target-replaces-were-not-being-marked-targeted.yaml
+++ b/changelog/pending/20230508--engine--fix-bug-with-targeting-and-plans-where-root-stack-resource-and-target-replaces-were-not-being-marked-targeted.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix bug with targeting and plans where root stack resource and target-replaces were not being marked targeted.

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -185,7 +185,8 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 			resourcePlan.Goal.OutputDiff = NewPlanDiff(oldOuts.Diff(outs))
 			resourcePlan.Outputs = outs
 		} else {
-			return result.FromError(fmt.Errorf("this should already have a plan from when we called register resources"))
+			return result.FromError(
+				fmt.Errorf("resource should already have a plan from when we called register resources [urn=%v]", urn))
 		}
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes 2 bugs
* --target not being specified, marked all resources as targeted even though --target-replace was specified
* update plans erroring due to the root stack not being in the update plan.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12824 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
