### PR TITLE
Context'ify LanguageRuntime

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -144,7 +144,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 			if err != nil {
 				addError(err, fmt.Sprintf("Failed to load language plugin %s", proj.Runtime.Name()))
 			} else {
-				aboutResponse, err := lang.About()
+				aboutResponse, err := lang.About(pluginContext.Request())
 				if err != nil {
 					addError(err, "Failed to get information about the project runtime")
 				} else {
@@ -157,7 +157,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 				}
 
 				progInfo := plugin.ProgInfo{Proj: proj, Pwd: pwd, Program: program}
-				deps, err := lang.GetProgramDependencies(progInfo, transitiveDependencies)
+				deps, err := lang.GetProgramDependencies(pluginContext.Request(), progInfo, transitiveDependencies)
 				if err != nil {
 					addError(err, "Failed to get information about the Pulumi program's dependencies")
 				} else {

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -686,7 +686,7 @@ func installDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 		return fmt.Errorf("failed to load language plugin %s: %w", runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(directory); err != nil {
+	if err = lang.InstallDependencies(ctx.Request(), directory); err != nil {
 		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
 			"then run `pulumi up` to perform an initial deployment: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -238,7 +238,7 @@ func installPolicyPackDependencies(ctx *plugin.Context,
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(directory); err != nil {
+	if err = lang.InstallDependencies(ctx.Request(), directory); err != nil {
 		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
 			"then run `pulumi up` to perform an initial deployment: %w", err)
 	}

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -41,7 +41,7 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 	client := pulumirpc.NewLanguageRuntimeClient(conn)
 	return &clientLanguageRuntimeHost{
 		Host:            ctx.Host,
-		languageRuntime: plugin.NewLanguageRuntimeClient(ctx, clientRuntimeName, client),
+		languageRuntime: plugin.NewLanguageRuntimeClient(clientRuntimeName, client),
 	}, nil
 }
 

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -42,12 +42,14 @@ func (p *languageRuntime) Close() error {
 	return nil
 }
 
-func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
+func (p *languageRuntime) GetRequiredPlugins(ctx context.Context,
+	info plugin.ProgInfo,
+) ([]workspace.PluginSpec, error) {
 	return p.requiredPlugins, nil
 }
 
-func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
-	monitor, err := dialMonitor(context.Background(), info.MonitorAddress)
+func (p *languageRuntime) Run(ctx context.Context, info plugin.RunInfo) (string, bool, error) {
+	monitor, err := dialMonitor(ctx, info.MonitorAddress)
 	if err != nil {
 		return "", false, err
 	}
@@ -64,24 +66,27 @@ func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
 	return "", false, nil
 }
 
-func (p *languageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
+func (p *languageRuntime) GetPluginInfo(ctx context.Context) (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{Name: "TestLanguage"}, nil
 }
 
-func (p *languageRuntime) InstallDependencies(directory string) error {
+func (p *languageRuntime) InstallDependencies(ctx context.Context, directory string) error {
 	return nil
 }
 
-func (p *languageRuntime) About() (plugin.AboutInfo, error) {
+func (p *languageRuntime) About(ctx context.Context) (plugin.AboutInfo, error) {
 	return plugin.AboutInfo{}, nil
 }
 
 func (p *languageRuntime) GetProgramDependencies(
+	ctx context.Context,
 	info plugin.ProgInfo, transitiveDependencies bool,
 ) ([]plugin.DependencyInfo, error) {
 	return nil, nil
 }
 
-func (p *languageRuntime) RunPlugin(info plugin.RunPluginInfo) (io.Reader, io.Reader, context.CancelFunc, error) {
-	return nil, nil, nil, fmt.Errorf("inline plugins are not currently supported")
+func (p *languageRuntime) RunPlugin(ctx context.Context,
+	info plugin.RunPluginInfo,
+) (io.Reader, io.Reader, error) {
+	return nil, nil, fmt.Errorf("inline plugins are not currently supported")
 }

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -468,7 +468,7 @@ func (host *pluginHost) ResolvePlugin(
 func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 	kinds plugin.Flags,
 ) ([]workspace.PluginSpec, error) {
-	return host.languageRuntime.GetRequiredPlugins(info)
+	return host.languageRuntime.GetRequiredPlugins(context.TODO(), info)
 }
 
 func (host *pluginHost) GetProjectPlugins() []workspace.ProjectPlugin {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -213,7 +213,7 @@ func (iter *evalSourceIterator) forkRun(opts Options, config map[config.Key]stri
 			defer contract.IgnoreClose(langhost)
 
 			// Now run the actual program.
-			progerr, bail, err := langhost.Run(plugin.RunInfo{
+			progerr, bail, err := langhost.Run(iter.src.plugctx.Request(), plugin.RunInfo{
 				MonitorAddress:   iter.mon.Address(),
 				Stack:            string(iter.src.runinfo.Target.Name),
 				Project:          string(iter.src.runinfo.Proj.Name),

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -168,7 +168,7 @@ func runLangPlugin(src *querySource) result.Result {
 	}
 
 	// Now run the actual program.
-	progerr, bail, err := langhost.Run(plugin.RunInfo{
+	progerr, bail, err := langhost.Run(src.plugctx.Request(), plugin.RunInfo{
 		MonitorAddress: src.mon.Address(),
 		Stack:          name,
 		Project:        string(src.runinfo.Proj.Name),

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -425,7 +426,7 @@ func (host *defaultHost) LanguageRuntime(root, pwd, runtime string,
 		// If not, allocate a new one.
 		plug, err := NewLanguageRuntime(host, host.ctx, root, pwd, runtime, options)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo()
+			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
@@ -612,7 +613,7 @@ func GetRequiredPlugins(host Host, root string, info ProgInfo, kinds Flags) ([]w
 			// TODO: we want to support loading precisely what the project needs, rather than doing a static scan of resolved
 			//     packages.  Doing this requires that we change our RPC interface and figure out how to configure plugins
 			//     later than we do (right now, we do it up front, but at that point we don't know the version).
-			deps, err := lang.GetRequiredPlugins(info)
+			deps, err := lang.GetRequiredPlugins(context.TODO(), info)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to discover plugin requirements")
 			}

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -29,7 +29,7 @@ type LanguageRuntime interface {
 	// Closer closes any underlying OS resources associated with this plugin (like processes, RPC channels, etc).
 	io.Closer
 	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error)
+	GetRequiredPlugins(ctx context.Context, info ProgInfo) ([]workspace.PluginSpec, error)
 	// Run executes a program in the language runtime for planning or deployment purposes.  If
 	// info.DryRun is true, the code must not assume that side-effects or final values resulting
 	// from resource deployments are actually available.  If it is false, on the other hand, a real
@@ -37,21 +37,21 @@ type LanguageRuntime interface {
 	//
 	// Returns a triple of "error message", "bail", or real "error".  If "bail", the caller should
 	// return result.Bail immediately and not print any further messages to the user.
-	Run(info RunInfo) (string, bool, error)
+	Run(ctx context.Context, info RunInfo) (string, bool, error)
 	// GetPluginInfo returns this plugin's information.
-	GetPluginInfo() (workspace.PluginInfo, error)
+	GetPluginInfo(ctx context.Context) (workspace.PluginInfo, error)
 
 	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-	InstallDependencies(directory string) error
+	InstallDependencies(ctx context.Context, directory string) error
 
 	// About returns information about the language runtime.
-	About() (AboutInfo, error)
+	About(ctx context.Context) (AboutInfo, error)
 
 	// GetProgramDependencies returns information about the dependencies for the given program.
-	GetProgramDependencies(info ProgInfo, transitiveDependencies bool) ([]DependencyInfo, error)
+	GetProgramDependencies(ctx context.Context, info ProgInfo, transitiveDependencies bool) ([]DependencyInfo, error)
 
 	// RunPlugin executes a plugin program and returns its result asynchronously.
-	RunPlugin(info RunPluginInfo) (io.Reader, io.Reader, context.CancelFunc, error)
+	RunPlugin(ctx context.Context, info RunPluginInfo) (io.Reader, io.Reader, error)
 }
 
 type DependencyInfo struct {

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -337,7 +337,9 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 			return nil, errors.Wrap(err, "loading runtime")
 		}
 
-		stdout, stderr, kill, err := runtime.RunPlugin(RunPluginInfo{
+		ctx, kill := context.WithCancel(ctx.Request())
+
+		stdout, stderr, err := runtime.RunPlugin(ctx, RunPluginInfo{
 			Pwd:     pwd,
 			Program: pluginDir,
 			Args:    pluginArgs,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This adds a context parameter to all the LanguageRuntime methods as these are (generally) implemented via async grpc calls. This used to _always_ set the grpc context via `plugin.Context.Request()`, we now use that method when calling the LanguageRuntime methods where appropriate, but that's not appropriate at every callsite, and some callsites don't have access to that (we've used `context.TODO()` for those for now).