### PR TITLE
Don't pass a second SecretsProvider to backend.Watch

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -892,7 +892,7 @@ func (b *localBackend) Query(ctx context.Context, op backend.QueryOperation) res
 func (b *localBackend) Watch(ctx context.Context, stk backend.Stack,
 	op backend.UpdateOperation, paths []string,
 ) result.Result {
-	return backend.Watch(ctx, stack.DefaultSecretsProvider, b, stk, op, b.apply, paths)
+	return backend.Watch(ctx, b, stk, op, b.apply, paths)
 }
 
 // apply actually performs the provided type of update on a locally hosted stack.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -43,7 +43,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -998,7 +997,7 @@ func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
 func (b *cloudBackend) Watch(ctx context.Context, stk backend.Stack,
 	op backend.UpdateOperation, paths []string,
 ) result.Result {
-	return backend.Watch(ctx, stack.DefaultSecretsProvider, b, stk, op, b.apply, paths)
+	return backend.Watch(ctx, b, stk, op, b.apply, paths)
 }
 
 func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -39,7 +38,7 @@ import (
 
 // Watch watches the project's working directory for changes and automatically updates the active
 // stack.
-func Watch(ctx context.Context, secretsProvider secrets.Provider, b Backend, stack Stack, op UpdateOperation,
+func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 	apply Applier, paths []string,
 ) result.Result {
 	opts := ApplierOptions{
@@ -52,7 +51,7 @@ func Watch(ctx context.Context, secretsProvider secrets.Provider, b Backend, sta
 	go func() {
 		shown := map[operations.LogEntry]bool{}
 		for {
-			logs, err := b.GetLogs(ctx, secretsProvider, stack, op.StackConfiguration, operations.LogQuery{
+			logs, err := b.GetLogs(ctx, op.SecretsProvider, stack, op.StackConfiguration, operations.LogQuery{
 				StartTime: &startTime,
 			})
 			if err != nil {


### PR DESCRIPTION
`backend.Watch` was taking a `SecretsProvider` parameter, but it already took an `UpdateOperation` parameter which already has a `SecretProvider` on it. So now we just use that.
