### PR TITLE
Change secret.Manager State to json.RawMessage

### DIFF
--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -142,14 +142,8 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets 
 	var secretsProvider *apitype.SecretsProvidersV1
 	if sm != nil {
 		secretsProvider = &apitype.SecretsProvidersV1{
-			Type: sm.Type(),
-		}
-		if state := sm.State(); state != nil {
-			rm, err := json.Marshal(state)
-			if err != nil {
-				return nil, err
-			}
-			secretsProvider.State = rm
+			Type:  sm.Type(),
+			State: sm.State(),
 		}
 	}
 

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -84,7 +84,7 @@ func (csm *cachingSecretsManager) Type() string {
 	return csm.manager.Type()
 }
 
-func (csm *cachingSecretsManager) State() interface{} {
+func (csm *cachingSecretsManager) State() json.RawMessage {
 	return csm.manager.State()
 }
 

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -24,7 +24,7 @@ type testSecretsManager struct {
 
 func (t *testSecretsManager) Type() string { return "test" }
 
-func (t *testSecretsManager) State() interface{} { return nil }
+func (t *testSecretsManager) State() json.RawMessage { return nil }
 
 func (t *testSecretsManager) Encrypter() (config.Encrypter, error) {
 	return t, nil
@@ -211,7 +211,7 @@ type mapTestSecretsManager struct {
 
 func (t *mapTestSecretsManager) Type() string { return t.sm.Type() }
 
-func (t *mapTestSecretsManager) State() interface{} { return t.sm.State() }
+func (t *mapTestSecretsManager) State() json.RawMessage { return t.sm.State() }
 
 func (t *mapTestSecretsManager) Encrypter() (config.Encrypter, error) {
 	return t.sm.Encrypter()

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package b64
 
 import (
+	"encoding/json"
+
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 )
@@ -30,6 +32,6 @@ func NewBase64SecretsManager() secrets.Manager {
 type manager struct{}
 
 func (m *manager) Type() string                         { return Type }
-func (m *manager) State() interface{}                   { return map[string]string{} }
+func (m *manager) State() json.RawMessage               { return nil }
 func (m *manager) Encrypter() (config.Encrypter, error) { return config.Base64Crypter, nil }
 func (m *manager) Decrypter() (config.Decrypter, error) { return config.Base64Crypter, nil }

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package secrets
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -23,13 +24,13 @@ import (
 
 // Manager provides the interface for providing stack encryption.
 type Manager interface {
-	// Type retruns a string that reflects the type of this provider. This is serialized along with the state of
+	// Type returns a string that reflects the type of this provider. This is serialized along with the state of
 	// the manager into the deployment such that we can re-construct the correct manager when deserializing a
 	// deployment into a snapshot.
 	Type() string
-	// An opaque state, which can be JSON serialized and used later to reconstruct the provider when deserializing
-	// the deployment into a snapshot.
-	State() interface{}
+	// An opaque JSON blob, which can be used later to reconstruct the provider when deserializing the
+	// deployment into a snapshot.
+	State() json.RawMessage
 	// Encrypter returns a `config.Encrypter` that can be used to encrypt values when serializing a snapshot into a
 	// deployment, or an error if one can not be constructed.
 	Encrypter() (config.Encrypter, error)
@@ -48,13 +49,7 @@ func AreCompatible(a, b Manager) bool {
 		return false
 	}
 
-	as, err := json.Marshal(a.State())
-	if err != nil {
-		return false
-	}
-	bs, err := json.Marshal(b.State())
-	if err != nil {
-		return false
-	}
-	return string(as) == string(bs)
+	as := a.State()
+	bs := b.State()
+	return bytes.Equal(as, bs)
 }


### PR DESCRIPTION
The state from a secret manager _always_ has to be something json serialisable because we store it into the json state files. Rather than allowing any `interface{}` to be returned here and then error'ing if it happens to not be something that can be marshalled to JSON this changes the interface to return a `json.RawMessage` moving the marshalling/unmarshalling concerns into the individual implementations that can pretty much guarantee valid structures.