### PR TITLE
Move cancellation_scope to backend

### DIFF
--- a/pkg/backend/cancellation_scope.go
+++ b/pkg/backend/cancellation_scope.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+type cancellationScope struct {
+	context *cancel.Context
+	sigint  chan os.Signal
+	done    chan bool
+}
+
+func (s *cancellationScope) Context() *cancel.Context {
+	return s.context
+}
+
+func (s *cancellationScope) Close() {
+	signal.Stop(s.sigint)
+	close(s.sigint)
+	<-s.done
+}
+
+type cancellationScopeSource int
+
+var CancellationScopes = CancellationScopeSource(cancellationScopeSource(0))
+
+func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bool) CancellationScope {
+	cancelContext, cancelSource := cancel.NewContext(context.Background())
+
+	c := &cancellationScope{
+		context: cancelContext,
+		sigint:  make(chan os.Signal),
+		done:    make(chan bool),
+	}
+
+	go func() {
+		for range c.sigint {
+			// If we haven't yet received a SIGINT, call the cancellation func. Otherwise call the termination
+			// func.
+			if cancelContext.CancelErr() == nil {
+				message := "^C received; cancelling. If you would like to terminate immediately, press ^C again.\n"
+				if !isPreview {
+					message += colors.BrightRed + "Note that terminating immediately may lead to orphaned resources " +
+						"and other inconsistencies.\n" + colors.Reset
+				}
+				engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+					Message: message,
+					Color:   colors.Always,
+				})
+
+				cancelSource.Cancel()
+			} else {
+				message := colors.BrightRed + "^C received; terminating" + colors.Reset
+				engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+					Message: message,
+					Color:   colors.Always,
+				})
+
+				cancelSource.Terminate()
+			}
+		}
+		close(c.done)
+	}()
+	signal.Notify(c.sigint, os.Interrupt)
+
+	return c
+}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -266,7 +266,7 @@ func newDestroyCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
-				Scopes:             cancellationScopes,
+				Scopes:             backend.CancellationScopes,
 			})
 
 			if res == nil && protectedCount > 0 && !jsonDisplay {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -687,7 +687,7 @@ func newImportCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
-				Scopes:             cancellationScopes,
+				Scopes:             backend.CancellationScopes,
 			}, imports)
 
 			if generateCode {

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -44,7 +44,7 @@ func newPolicyDisableCmd() *cobra.Command {
 
 			// Attempt to disable the Policy Pack.
 			return policyPack.Disable(ctx, args.policyGroup, backend.PolicyPackOperation{
-				VersionTag: &args.version, Scopes: cancellationScopes,
+				VersionTag: &args.version, Scopes: backend.CancellationScopes,
 			})
 		}),
 	}

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -67,7 +67,7 @@ func newPolicyEnableCmd() *cobra.Command {
 			return policyPack.Enable(ctx, args.policyGroup,
 				backend.PolicyPackOperation{
 					VersionTag: version,
-					Scopes:     cancellationScopes,
+					Scopes:     backend.CancellationScopes,
 					Config:     config,
 				})
 		}),

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -93,7 +93,7 @@ func newPolicyPublishCmd() *cobra.Command {
 			//
 
 			res := policyPack.Publish(ctx, backend.PublishOperation{
-				Root: root, PlugCtx: plugctx, PolicyPack: proj, Scopes: cancellationScopes,
+				Root: root, PlugCtx: plugctx, PolicyPack: proj, Scopes: backend.CancellationScopes,
 			})
 			if res != nil && res.Error() != nil {
 				return res.Error()

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -60,7 +60,7 @@ func newPolicyRmCmd() *cobra.Command {
 
 			// Attempt to remove the Policy Pack.
 			err = policyPack.Remove(ctx, backend.PolicyPackOperation{
-				VersionTag: version, Scopes: cancellationScopes,
+				VersionTag: version, Scopes: backend.CancellationScopes,
 			})
 			if err != nil {
 				return result.FromError(err)

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -54,7 +54,7 @@ func newPolicyValidateCmd() *cobra.Command {
 			err = policyPack.Validate(ctx,
 				backend.PolicyPackOperation{
 					VersionTag: version,
-					Scopes:     cancellationScopes,
+					Scopes:     backend.CancellationScopes,
 					Config:     config,
 				})
 			if err != nil {

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -236,7 +236,7 @@ func newPreviewCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
-				Scopes:             cancellationScopes,
+				Scopes:             backend.CancellationScopes,
 			})
 
 			switch {

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -77,7 +77,7 @@ func newQueryCmd() *cobra.Command {
 				Proj:            project,
 				Root:            root,
 				Opts:            opts,
-				Scopes:          cancellationScopes,
+				Scopes:          backend.CancellationScopes,
 				SecretsProvider: stack.DefaultSecretsProvider,
 			})
 			switch {

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -262,7 +262,7 @@ func newRefreshCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
-				Scopes:             cancellationScopes,
+				Scopes:             backend.CancellationScopes,
 			})
 
 			switch {

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -176,7 +176,7 @@ func newUpCmd() *cobra.Command {
 			StackConfiguration: cfg,
 			SecretsManager:     sm,
 			SecretsProvider:    stack.DefaultSecretsProvider,
-			Scopes:             cancellationScopes,
+			Scopes:             backend.CancellationScopes,
 		})
 		switch {
 		case res != nil && res.Error() == context.Canceled:
@@ -371,7 +371,7 @@ func newUpCmd() *cobra.Command {
 			StackConfiguration: cfg,
 			SecretsManager:     sm,
 			SecretsProvider:    stack.DefaultSecretsProvider,
-			Scopes:             cancellationScopes,
+			Scopes:             backend.CancellationScopes,
 		})
 		switch {
 		case res != nil && res.Error() == context.Canceled:

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -145,7 +145,7 @@ func newWatchCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
-				Scopes:             cancellationScopes,
+				Scopes:             backend.CancellationScopes,
 			}, pathArray)
 
 			switch {


### PR DESCRIPTION
This is needed for matrix testing where we need a cancellation scope like a normal `up` but we don't want the matrix testing code to live in cmd.