### PR TITLE
Add pulumi package publish-sdk command structure and NPM publish functionality

### DIFF
--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -40,10 +40,10 @@ func newPackageCmd() *cobra.Command {
 Subcommands of this command are useful to package authors during development.`,
 		Args: cmdutil.NoArgs,
 	}
-
 	cmd.AddCommand(
 		newExtractSchemaCommand(),
 		newGenSdkCommand(),
+		newPackagePublishCmd(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -1,0 +1,179 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+func newPackagePublishCmd() *cobra.Command {
+	var publCmd publishCmd
+	cmd := &cobra.Command{
+		Use:    "publish-sdk <language>",
+		Args:   cobra.RangeArgs(0, 1),
+		Short:  "Publish a package SDK to supported package registries.",
+		Hidden: !env.Dev.Value(),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
+			return publCmd.Run(ctx, args)
+		}),
+	}
+	cmd.PersistentFlags().StringVar(&publCmd.Path, "path", "",
+		`The path to the root of your package.
+	Example: ./sdk/nodejs
+	`)
+	return cmd
+}
+
+type publishCmd struct {
+	Path string
+}
+
+func (cmd *publishCmd) Run(ctx context.Context, args []string) error {
+	lang := "all"
+	if len(args) > 0 {
+		lang = args[0]
+	}
+
+	switch lang {
+	case "nodejs":
+		err := publishToNPM(cmd.Path)
+		if err != nil {
+			return err
+		}
+	case "all", "python", "java", "dotnet":
+		return fmt.Errorf("support for %q coming soon", lang)
+
+	default:
+		return fmt.Errorf("unsupported language %q", lang)
+	}
+
+	return nil
+}
+
+func publishToNPM(path string) error {
+	// verify path
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("reading path %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a directory: %s", path)
+	}
+
+	// Verify npm exists and is set up: npm, user login
+	npm, err := executable.FindExecutable("npm")
+	if err != nil {
+		return fmt.Errorf("npm whoami: %w", err)
+	}
+
+	// verify auth for npm
+	whoamiCmd := exec.Command(npm, "whoami")
+	whoamiCmd.Stderr = os.Stderr
+	whoami, err := whoamiCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	logging.V(1).Infof("Logged in as %s", whoami)
+
+	// TODO: possibly check package dependencies
+
+	var pkgInfo struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+
+	file, err := os.ReadFile(filepath.Join(path, "package.json"))
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(file, &pkgInfo)
+	if err != nil {
+		return fmt.Errorf("unmarshal package.json: %w", err)
+	}
+
+	// Determine which tag to set
+	// npm adds `latest` as the default tag, and we want that to mean the newest released version.
+	var npmTag string
+
+	switch {
+	case strings.Contains(pkgInfo.Version, "-alpha"):
+		npmTag = "dev"
+	case strings.Contains(pkgInfo.Version, "dev"):
+		npmTag = "dev"
+	case strings.Contains(pkgInfo.Version, "-beta"):
+		npmTag = "beta"
+	case strings.Contains(pkgInfo.Version, "-rc"):
+		npmTag = "rc"
+	default:
+		npmTag = "latest"
+	}
+
+	pkgNameWithVersion := pkgInfo.Name + "@" + pkgInfo.Version
+
+	// Verify version doesn't already exist
+	infoCmd := exec.Command(npm, "info", pkgNameWithVersion)
+	infoCmd.Stderr = os.Stderr
+	logging.V(1).Infof("Running %s", infoCmd)
+	output, err := infoCmd.Output()
+	if err != nil {
+		return err
+	}
+
+	if len(output) > 0 {
+		return fmt.Errorf("publish %s failed, likely because the version already exists", pkgInfo.Name)
+	}
+
+	logging.V(1).Infof("The version does not exist yet, and it is safe to publish")
+	fmt.Printf("Publishing %s to npm package registry...\n", pkgInfo.Name)
+	npmPublishCmd := exec.Command(npm, "publish", path, "-tag", npmTag)
+	npmPublishCmd.Stdout = os.Stdout
+	npmPublishCmd.Stderr = os.Stderr
+	err = npmPublishCmd.Run()
+	if err != nil {
+		logging.V(1).Infof("error publishing package, verifying...")
+		// first, check if the package was published after all, by re-running npm info
+		// to verify we're not encountering a time-of-check to time-of-use (TOC/TOU) issue.
+		infoCheckCmd := exec.Command("npm", "info", pkgNameWithVersion)
+		infoCheckCmd.Stderr = os.Stderr
+		checkOutput, checkErr := infoCheckCmd.Output()
+		if checkErr != nil {
+			return fmt.Errorf("running npm info to verify failed %w", checkErr)
+		}
+		if len(checkOutput) > 0 {
+			// this means the package was published after all
+			fmt.Println("success! published to npm")
+			return nil
+		}
+		// if we get here, this means the package was not published. We bail.
+		return err
+	}
+	fmt.Println("success! published to npm")
+	return nil
+}


### PR DESCRIPTION
# Description

This pull request adds an _experimental_ subcommand to `pulumi package` called `publish-sdk`. 

- It scaffolds the structure of this new command.
- It implements the [npm publish logic from the scripts repo](https://github.com/pulumi/scripts/blob/master/ci/publish-tfgen-package) in Go and provides it via the Pulumi CLI.

Command help text output:
```sh
Usage:
  pulumi package publish-sdk <package> <language> [flags]

Flags:
  -h, --help          help for publish-sdk
      --path string   The path to the root of your package.
                        Example: ./sdk/nodejs
                        
      --tag string    The tag for your NPM package, such as "latest""
```

Fixes pulumi/home#2697

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
I am open to suggestions on how to test this.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
n/a; this feature is developer-only
