### PR TITLE
[sdk/python] Fix hang due to component children cycles

### DIFF
--- a/changelog/pending/20230510--sdk-python--fix-hang-due-to-component-children-cycles.yaml
+++ b/changelog/pending/20230510--sdk-python--fix-hang-due-to-component-children-cycles.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix hang due to component children cycles


### PR DESCRIPTION
A previous attempt to fix this in 5dd813ea47a06cfd9b6c06877bdca3dd90d1b209 didn't fully address the problem when there are more complex parent/child relationships with components.

This change fully addresses the problem by using the same cycle detection logic used elsewhere for local components. We now check for cycles up-front and exit early.

Fixes #12736
Fixes #12841