### PR TITLE
Support 'pulumi:tags' config to set stack tags

### DIFF
--- a/changelog/pending/20230523--engine--add-pulumi-tags-config-option-to-set-stack-tags.yaml
+++ b/changelog/pending/20230523--engine--add-pulumi-tags-config-option-to-set-stack-tags.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Add 'pulumi:tags' config option to set stack tags.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -651,9 +651,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 		return nil, &backend.StackAlreadyExistsError{StackName: string(stackName)}
 	}
 
-	tags := backend.GetEnvironmentTagsForCurrentStack(root, b.currentProject.Load())
-
-	if err = validation.ValidateStackProperties(stackName.Name().String(), tags); err != nil {
+	if err = validation.ValidateStackProperties(stackName.Name().String(), nil); err != nil {
 		return nil, fmt.Errorf("validating stack properties: %w", err)
 	}
 

--- a/tests/testdata/simple_tags/Pulumi.yaml
+++ b/tests/testdata/simple_tags/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: protect_resources
+description: A program that ensures we cannot delete protected resources.
+runtime: nodejs
+config:
+  pulumi:tags:
+    value:
+      projectTag: projectValue

--- a/tests/testdata/simple_tags/index.ts
+++ b/tests/testdata/simple_tags/index.ts
@@ -1,0 +1,9 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import { Resource } from "./resource";
+
+// Allocate a new resource. When this exists, we should not allow
+// the stack holding it to be `rm`'d without `--force`.
+let a = new Resource("res", { state: 1 });
+
+export let o = a.state;

--- a/tests/testdata/simple_tags/package.json
+++ b/tests/testdata/simple_tags/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "steps",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/testdata/simple_tags/resource.ts
+++ b/tests/testdata/simple_tags/resource.ts
@@ -1,0 +1,33 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public readonly create: (inputs: any) => Promise<pulumi.dynamic.CreateResult>;
+
+    constructor() {
+        this.create = async (inputs: any) => {
+            return {
+                id: (currentID++).toString(),
+                outs: undefined,
+            };
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public readonly state?: any;
+
+    constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+        this.state = props.state;
+    }
+}
+
+export interface ResourceProps {
+    state?: any; // arbitrary state bag that can be updated without replacing.
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Support a "pulumi:tags" config property to set the stacks tags on operations (e.g. up, refresh, etc).

Fixes https://github.com/pulumi/pulumi/issues/5004

Note that I've gone with a slightly different approach to #5004. The suggestion in that ticket was to add a new section "tags" to the yaml, but given that we probably want to allow setting tags per-project and per-stack with some way to merge them I figured it better to reuse normal config and benefit from https://github.com/pulumi/pulumi/issues/11547 when that's done.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
