### PR TITLE
Skip trying to install the pulumi-resource-pulumi plugin

### DIFF
--- a/changelog/pending/20230511--engine--fix-the-engine-trying-to-install-the-pulumi-resource-pulumi-plugin-which-is-builtin.yaml
+++ b/changelog/pending/20230511--engine--fix-the-engine-trying-to-install-the-pulumi-resource-pulumi-plugin-which-is-builtin.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix the engine trying to install the pulumi-resource-pulumi plugin which is builtin.

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -181,6 +181,11 @@ func ensurePluginsAreInstalled(ctx context.Context, plugins pluginSet, projectPl
 	logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): beginning")
 	var installTasks errgroup.Group
 	for _, plug := range plugins.Values() {
+		if plug.Name == "pulumi" && plug.Kind == workspace.ResourcePlugin {
+			logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): pulumi is a builtin plugin")
+			continue
+		}
+
 		path, err := workspace.GetPluginPath(plug.Kind, plug.Name, plug.Version, projectPlugins)
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Noticed looking at a customer log which must have been using stack references. The snapshot reports back a resource in the "pulumi" package and so ensurePluginsareInstalled tries to install "pulumi-resource-pulumi" but that's a plugin built into the CLI.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
