### PR TITLE
Regularlize lint workflow.

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -132,9 +132,6 @@ jobs:
       - name: Ensure
         run: |
           make ensure
-      # Ensure that the Node SDK adheres to the Autoformatter's guidelines.
-      - name: Format Node
-        run: cd sdk/nodejs && make format_ci
       - name: Lint Node
         run: |
           cd sdk/nodejs && make lint

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -30,11 +30,9 @@ ensure:: yarn.ensure node.ensure .ensure.phony
 format:: ensure
 	yarn rome format --write .
 
-format_ci:: ensure
-	yarn rome ci .
-
 lint:: ensure
 	yarn run eslint -c .eslintrc.js --ext .ts .
+	yarn rome ci .
 
 build_package:: ensure
 	yarn run tsc


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When we introduced Rome into the Node SDK, we added a Make rule
for formatting separate from our linting rule. This commit moves
format-checking into the lint rule so that the Node SDK's Make rules
will more closely match the Python SDK's Make rules.
Now, in both SDKs, `make lint` also checks formatting.

## Checklist

**N/A:** This is strictly a workflow refactor.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
