### PR TITLE
[Node SDK] Enable Lints for Bizaare Behavior

### DIFF
--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -31,7 +31,8 @@
                 "noExplicitAny": "off",
                 "noEmptyInterface": "off",
                 "noShadowRestrictedNames": "off",
-                "noAsyncPromiseExecutor": "off"
+                "noAsyncPromiseExecutor": "off",
+                "noLabelVar": "error"
             }
         }
     }

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -20,6 +20,7 @@
             "recommended": false,
             "complexity": {
                 "noExtraBooleanCast": "error",
+                "useFlatMap": "error",
                 "useOptionalChain": "error"
             },
             "performance": {

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -29,9 +29,9 @@
             "suspicious": {
                 "noExtraNonNullAssertion": "error",
                 "noExplicitAny": "off",
+                "noAsyncPromiseExecutor": "error",
                 "noEmptyInterface": "off",
                 "noShadowRestrictedNames": "off",
-                "noAsyncPromiseExecutor": "off",
                 "noLabelVar": "error"
             }
         }

--- a/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
+++ b/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
@@ -51,12 +51,11 @@ describe("PushableAsyncIterable", () => {
     it("correctly terminates outstanding operations afte complete", async () => {
         const queue = new PushableAsyncIterable<number>();
         const queueIter = queue[Symbol.asyncIterator]();
-        const terminates = new Promise(async (resolve) => {
+        const terminates = async () => {
             assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
             assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
             assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
-            resolve();
-        });
+        };
         queue.complete();
         await terminates;
         assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR enables a number of other reasonable lints. They're all quite conservative, focused on identifying bizarre engineering choices that result in unintended behavior.

The only lint that appears in the codebase is `noAsyncPromiseExecutor`. The argument to `Promise` is supposed to be a synchronous function, not an async one. There's only one instances of this in the codebase, and it's in the test suite.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

**N/A.** Only one test was refactored.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have ~added tests~ edited a test that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
