### PR TITLE
[Node SDK] Replaces empty interfaces with type aliases.

### DIFF
--- a/changelog/pending/20230511--sdk-nodejs--replace-empty-interfaces-with-type-aliases.yaml
+++ b/changelog/pending/20230511--sdk-nodejs--replace-empty-interfaces-with-type-aliases.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Replaces empty interfaces with type aliases. Empty interfaces are equivalent to their supertype; this change expresses these type definitions using type aliases instead of interface extention to provide better clarity. This change will not affect type-checking.

--- a/sdk/nodejs/automation/events.ts
+++ b/sdk/nodejs/automation/events.ts
@@ -19,7 +19,7 @@
 // the update successfully completes.
 import { OpMap, OpType } from "./stack";
 
-export interface CancelEvent {}
+export type CancelEvent = {};
 
 // StdoutEngineEvent is emitted whenever a generic message is written, for example warnings
 // from the pulumi CLI itself. Less common than DiagnosticEvent

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -827,7 +827,7 @@ export type UnwrapSimple<T> =
         ? UnwrappedObject<T>
         : never;
 
-export interface UnwrappedArray<T> extends Array<Unwrap<T>> {}
+export type UnwrappedArray<T> = Array<Unwrap<T>>;
 
 export type UnwrappedObject<T> = {
     [P in keyof T]: Unwrap<T[P]>;

--- a/sdk/nodejs/queryable/index.ts
+++ b/sdk/nodejs/queryable/index.ts
@@ -40,7 +40,7 @@ type ResolvedSimple<T> = T extends primitive
     ? ResolvedObject<T>
     : never;
 
-interface ResolvedArray<T> extends Array<Resolved<T>> {}
+type ResolvedArray<T> = Array<Resolved<T>>;
 
 type ResolvedObject<T> = ModifyOptionalProperties<{ [P in keyof T]: Resolved<T[P]> }>;
 

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -32,7 +32,15 @@
                 "noAsyncPromiseExecutor": "error",
                 "noEmptyInterface": "error",
                 "noShadowRestrictedNames": "off",
-                "noLabelVar": "error"
+                "noLabelVar": "error",
+                "noCompareNegZero": "error",
+                "noConstEnum": "error",
+                "noSparseArray": "error",
+                "useDefaultSwitchClauseLast": "error",
+                "noArrayIndexKey": "error",
+                "noDebugger": "error",
+                "noImportAssign": "error",
+                "noFunctionAssign": "error"
             }
         }
     }

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -30,7 +30,7 @@
                 "noExtraNonNullAssertion": "error",
                 "noExplicitAny": "off",
                 "noAsyncPromiseExecutor": "error",
-                "noEmptyInterface": "off",
+                "noEmptyInterface": "error",
                 "noShadowRestrictedNames": "off",
                 "noLabelVar": "error"
             }

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -91,7 +91,7 @@ export interface PropertyInfoAndValue {
 // A mapping between the name of a property (symbolic or string) to information about the
 // value for that property.
 /** @internal */
-export interface PropertyMap extends Map<Entry, PropertyInfoAndValue> {}
+export type PropertyMap = Map<Entry, PropertyInfoAndValue>;
 
 /**
  * Entry is the environment slot for a named lexically captured variable.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

 This commit safely replaces empty interfaces with type aliases.

Empty interfaces have no effect, even when they are subtyping
other interfaces. An empty interface is always equivalent to its supertype.
They can be safely replaced with type aliases, better expressing
the semantic equivalence between the two types.

Rome is very conservative in determining what constitutes a "safe" fix. For example, import reordering is considered unsafe because imports can have side effects. However, **Rome states that this change is safe.**

See https://docs.rome.tools/lint/rules/noemptyinterface/ for more detail.

I'm going to call out this change in the CHANGELOG, even though it's nonmaterial, just to clue in community members.

## Checklist


<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ **N/A:** This is a cosmetic change to the type signature.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
