### PR TITLE
[pcl/pretty-printing] Fix stack overflow panic when pretty printing recursive types

### DIFF
--- a/changelog/pending/20230511--programgen--fix-stack-overflow-panic-when-pretty-printing-recursive-types.yaml
+++ b/changelog/pending/20230511--programgen--fix-stack-overflow-panic-when-pretty-printing-recursive-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix stack overflow panic when pretty printing recursive types

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -45,6 +45,7 @@ type Type interface {
 	Equals(other Type) bool
 	AssignableFrom(src Type) bool
 	ConversionFrom(src Type) ConversionKind
+	pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter
 	Pretty() pretty.Formatter
 
 	equals(other Type, seen map[Type]struct{}) bool

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -39,7 +39,7 @@ func NewConstType(typ Type, value cty.Value) *ConstType {
 	return &ConstType{Type: typ, Value: value}
 }
 
-func (t *ConstType) Pretty() pretty.Formatter {
+func (t *ConstType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
 	if t.Value.IsNull() {
 		return pretty.FromString("null")
 	}
@@ -55,6 +55,11 @@ func (t *ConstType) Pretty() pretty.Formatter {
 		return pretty.FromStringer(t.Value.AsBigFloat())
 	}
 	return pretty.FromStringer(t)
+}
+
+func (t *ConstType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.

--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -78,14 +78,14 @@ func (*EnumType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
-func (t *EnumType) Pretty() pretty.Formatter {
+func (t *EnumType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
 	types := make([]pretty.Formatter, len(t.Elements))
 	for i, c := range t.Elements {
 		types[i] = pretty.FromStringer(
 			NewConstType(ctyTypeToType(c.Type(), false), c).Pretty(),
 		)
 	}
-	return &pretty.Wrap{
+	seenFormatters[t] = &pretty.Wrap{
 		Prefix:  "enum(",
 		Postfix: ")",
 		Value: &pretty.List{
@@ -93,6 +93,13 @@ func (t *EnumType) Pretty() pretty.Formatter {
 			Elements:  types,
 		},
 	}
+
+	return seenFormatters[t]
+}
+
+func (t *EnumType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // Traverse attempts to traverse the enum type with the given traverser. This always fails.

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -35,12 +35,24 @@ func NewMapType(elementType Type) *MapType {
 	return &MapType{ElementType: elementType}
 }
 
-func (t *MapType) Pretty() pretty.Formatter {
+func (t *MapType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
+	var formatter pretty.Formatter
+	if seenFormatter, ok := seenFormatters[t.ElementType]; ok {
+		formatter = seenFormatter
+	} else {
+		formatter = t.ElementType.pretty(seenFormatters)
+	}
+
 	return &pretty.Wrap{
 		Prefix:  "map(",
-		Value:   t.ElementType.Pretty(),
 		Postfix: ")",
+		Value:   formatter,
 	}
+}
+
+func (t *MapType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // Traverse attempts to traverse the optional type with the given traverser. The result type of traverse(map(T))

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -28,6 +28,10 @@ func (noneType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
+func (noneType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
+	return pretty.FromStringer(NoneType)
+}
+
 func (noneType) Pretty() pretty.Formatter {
 	return pretty.FromStringer(NoneType)
 }

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -162,8 +162,13 @@ func NewOpaqueType(name string) *OpaqueType {
 	return &t
 }
 
-func (t *OpaqueType) Pretty() pretty.Formatter {
+func (t *OpaqueType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
 	return pretty.FromStringer(t)
+}
+
+func (t *OpaqueType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 func (t *OpaqueType) string(_ map[Type]struct{}) string {

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -40,12 +40,24 @@ func (*OutputType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
-func (t *OutputType) Pretty() pretty.Formatter {
+func (t *OutputType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
+	var formatter pretty.Formatter
+	if seenFormatter, ok := seenFormatters[t.ElementType]; ok {
+		formatter = seenFormatter
+	} else {
+		formatter = t.ElementType.pretty(seenFormatters)
+	}
+
 	return &pretty.Wrap{
 		Prefix:  "output(",
-		Value:   t.ElementType.Pretty(),
 		Postfix: ")",
+		Value:   formatter,
 	}
+}
+
+func (t *OutputType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // Traverse attempts to traverse the output type with the given traverser. The result type of traverse(output(T))

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -41,12 +41,24 @@ func (*PromiseType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
-func (t *PromiseType) Pretty() pretty.Formatter {
+func (t *PromiseType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
+	var formatter pretty.Formatter
+	if seenFormatter, ok := seenFormatters[t.ElementType]; ok {
+		formatter = seenFormatter
+	} else {
+		formatter = t.ElementType.pretty(seenFormatters)
+	}
+
 	return &pretty.Wrap{
 		Prefix:  "promise(",
-		Value:   t.ElementType.Pretty(),
 		Postfix: ")",
+		Value:   formatter,
 	}
+}
+
+func (t *PromiseType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // Traverse attempts to traverse the promise type with the given traverser. The result type of traverse(promise(T))

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -99,12 +99,24 @@ func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}
 	})
 }
 
-func (t *SetType) Pretty() pretty.Formatter {
+func (t *SetType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
+	var formatter pretty.Formatter
+	if seenFormatter, ok := seenFormatters[t.ElementType]; ok {
+		formatter = seenFormatter
+	} else {
+		formatter = t.ElementType.pretty(seenFormatters)
+	}
+
 	return &pretty.Wrap{
 		Prefix:  "set(",
-		Value:   t.ElementType.Pretty(),
 		Postfix: ")",
+		Value:   formatter,
 	}
+}
+
+func (t *SetType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 func (t *SetType) String() string {

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -107,28 +107,44 @@ func (*UnionType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
-func (t *UnionType) Pretty() pretty.Formatter {
+func (t *UnionType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
 	elements := make([]pretty.Formatter, 0, len(t.ElementTypes))
 	isOptional := false
+	unionFormatter := &pretty.List{
+		Separator: " | ",
+		Elements:  elements,
+	}
+
+	seenFormatters[t] = unionFormatter
+
 	for _, el := range t.ElementTypes {
 		if el == NoneType {
 			isOptional = true
 			continue
 		}
-		elements = append(elements, el.Pretty())
+		if seenFormatter, ok := seenFormatters[el]; ok {
+			unionFormatter.Elements = append(unionFormatter.Elements, seenFormatter)
+		} else {
+			formatter := el.pretty(seenFormatters)
+			seenFormatters[el] = formatter
+			unionFormatter.Elements = append(unionFormatter.Elements, formatter)
+		}
 	}
-	var v pretty.Formatter = &pretty.List{
-		Separator: " | ",
-		Elements:  elements,
-	}
+
 	if isOptional {
-		v = &pretty.Wrap{
-			Value:           v,
+		return &pretty.Wrap{
+			Value:           seenFormatters[t],
 			Postfix:         "?",
 			PostfixSameline: true,
 		}
 	}
-	return v
+
+	return seenFormatters[t]
+}
+
+func (t *UnionType) Pretty() pretty.Formatter {
+	seenFormatters := map[Type]pretty.Formatter{}
+	return t.pretty(seenFormatters)
 }
 
 // Traverse attempts to traverse the union type with the given traverser. This always fails.
@@ -228,6 +244,9 @@ func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct
 		}
 
 		for _, t := range t.ElementTypes {
+			if t == NoneType {
+				continue
+			}
 			ck, why := t.conversionFrom(src, unifying, seen)
 			if ck > conversionKind {
 				conversionKind = ck

--- a/pkg/codegen/hcl2/model/type_union_test.go
+++ b/pkg/codegen/hcl2/model/type_union_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrettyPrintingUnionType(t *testing.T) {
+	t.Parallel()
+	union := NewUnionType(StringType, IntType)
+	pretty := union.Pretty().String()
+	assert.Equal(t, "int | string", pretty)
+}
+
+func TestPrettyPrintingNestedUnionType(t *testing.T) {
+	t.Parallel()
+	union := NewUnionType(StringType, NewUnionType(IntType, BoolType))
+	pretty := union.Pretty().String()
+	assert.Equal(t, "bool | int | string", pretty)
+}
+
+func TestPrettyPrintingSelfReferencingUnionType(t *testing.T) {
+	t.Parallel()
+	union := &UnionType{ElementTypes: []Type{
+		StringType,
+		IntType,
+	}}
+
+	union = &UnionType{ElementTypes: []Type{
+		StringType,
+		&ListType{
+			ElementType: &ObjectType{
+				Properties: map[string]Type{
+					"selfReferences": union,
+				},
+			},
+		},
+	}}
+
+	pretty := union.Pretty().String()
+	assert.Equal(t, "string | list({ selfReferences: string | int })", pretty)
+}

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -424,7 +424,8 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 			attrNames.Add(attr.Name)
 
 			if typ, ok := objectType.Properties[attr.Name]; ok {
-				if !typ.ConversionFrom(attr.Value.Type()).Exists() {
+				conversion := typ.ConversionFrom(attr.Value.Type())
+				if !conversion.Exists() {
 					diag(model.ExprNotConvertible(typ, attr.Value))
 				}
 			} else {


### PR DESCRIPTION
Partially addresses #12832 so that it no longer panics with a stack overflow due to recursive `Pretty(...)` call that doesn't find the base case. Resolved by threading a `map[Type]pretty.Formatter` which short-circuits the recursion when it finds an existing formatter for the current type that we are pretty printing. 

The program mentioned in the issue still doesn't bind and fails type-checking. That is to be addressed in a later issue


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
