### PR TITLE
testing/Environment: Tolerate faillures in deleting the test directory

### DIFF
--- a/changelog/pending/20230511--sdk-go--testing-environment-now-tolerates-errors-in-deleting-the-test-environment.yaml
+++ b/changelog/pending/20230511--sdk-go--testing-environment-now-tolerates-errors-in-deleting-the-test-environment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: testing.Environment now tolerates errors in deleting the test environment.

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -129,7 +129,12 @@ func (e *Environment) ImportDirectory(path string) {
 func (e *Environment) DeleteEnvironment() {
 	e.Helper()
 	err := os.RemoveAll(e.RootPath)
-	assert.NoErrorf(e, err, "cleaning up test directory %q", e.RootPath)
+	if err != nil {
+		// In CI, Windows sometimes lags behind in marking a resource
+		// as unused. This causes otherwise passing tests to fail.
+		// So ignore errors during cleanup.
+		e.Logf("error cleaning up test directory %q: %v", e.RootPath, err)
+	}
 }
 
 // DeleteEnvironment deletes the environment's RootPath, and everything


### PR DESCRIPTION
CI land attempts have started failing occasionally on Windows
with the following error:

```
=== FAIL: . TestLanguageImportSmoke/go (4.00s)
    environment.go:96: Created new test environment:  C:\Users\RUNNER~1\AppData\Local\Temp\test-env711178549
    smoke_test.go:129: Running command pulumi login --cloud-url file://C:/Users/RUNNER~1/AppData/Local/Temp/test-env711178549
    smoke_test.go:130: Running command pulumi new go --yes
    smoke_test.go:131: Running command pulumi import --yes random:index/randomId:RandomId identifier p-9hUg
    history_test.go:28:
        	Error Trace:	C:/a/pulumi/pulumi/sdk/go/common/testing/environment.go:132
        	            				C:/a/pulumi/pulumi/tests/history_test.go:28
        	            				C:/a/pulumi/pulumi/tests/smoke_test.go:132
        	Error:      	Received unexpected error:
        	            	remove C:\Users\RUNNER~1\AppData\Local\Temp\test-env711178549\project: The process cannot access the file because it is being used by another process.
        	Test:       	TestLanguageImportSmoke/go
        	Messages:   	cleaning up test directory "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\test-env711178549"
```

The code path that is encountering this issue
is hit after the integration test has already passed.
So we're failing tests that are otherwise green
because it's taking a little too long for the system
to mark the resource as free.

This makes make DeleteEnvironment more tolerant of these failures,
logging them without marking the test as failed.
