### PR TITLE
Test for literals in output places

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -266,6 +266,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		// We are using a synthetic schema defined in range-1.0.0.json so we can't compile all the way
 		SkipCompile: allProgLanguages,
 	},
+	{
+		Directory:   "output-literals",
+		Description: "Tests that we can return various literal values via stack outputs",
+		SkipCompile: codegen.NewStringSet("go"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/output-literals-pp/dotnet/output-literals.cs
+++ b/pkg/codegen/testing/test/testdata/output-literals-pp/dotnet/output-literals.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    return new Dictionary<string, object?>
+    {
+        ["output_true"] = true,
+        ["output_false"] = false,
+        ["output_number"] = 4,
+        ["output_string"] = "hello",
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/output-literals-pp/go/output-literals.go
+++ b/pkg/codegen/testing/test/testdata/output-literals-pp/go/output-literals.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("output_true", true)
+		ctx.Export("output_false", false)
+		ctx.Export("output_number", 4)
+		ctx.Export("output_string", "hello")
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/output-literals-pp/nodejs/output-literals.ts
+++ b/pkg/codegen/testing/test/testdata/output-literals-pp/nodejs/output-literals.ts
@@ -1,0 +1,6 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const output_true = true;
+export const output_false = false;
+export const output_number = 4;
+export const output_string = "hello";

--- a/pkg/codegen/testing/test/testdata/output-literals-pp/output-literals.pp
+++ b/pkg/codegen/testing/test/testdata/output-literals-pp/output-literals.pp
@@ -1,0 +1,15 @@
+output "output_true" "bool" {
+    value = true
+}
+
+output "output_false" "bool" {
+    value = false
+}
+
+output "output_number" "number" {
+    value = 4
+}
+
+output "output_string" "string" {
+    value = "hello"
+}

--- a/pkg/codegen/testing/test/testdata/output-literals-pp/python/output-literals.py
+++ b/pkg/codegen/testing/test/testdata/output-literals-pp/python/output-literals.py
@@ -1,0 +1,6 @@
+import pulumi
+
+pulumi.export("output_true", True)
+pulumi.export("output_false", False)
+pulumi.export("output_number", 4)
+pulumi.export("output_string", "hello")


### PR DESCRIPTION
This currently isn't generating valid Go code, so we skip the compile for that.