### PR TITLE
[snapshot] Pool checkpoint buffers

### DIFF
--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -178,8 +178,10 @@ func TestPatchUpdateCheckpointVerbatimIndents(t *testing.T) {
 
 	sequenceNumber := 1
 
-	indented, err := MarshalUntypedDeployment(&deployment)
+	var b bytes.Buffer
+	err = MarshalUntypedDeployment(&b, &deployment)
 	assert.NoError(t, err)
+	indented := b.Bytes()
 
 	err = client.PatchUpdateCheckpointVerbatim(context.Background(),
 		UpdateIdentifier{}, sequenceNumber, indented, updateTokenStaticSource("token"))

--- a/pkg/backend/httpstate/client/marshal.go
+++ b/pkg/backend/httpstate/client/marshal.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
@@ -36,13 +36,9 @@ var jsonIterConfig = jsoniter.Config{SortMapKeys: true}.Froze()
 // Injects newlines to allow efficient textual diffs over the JSON. Textual diffs currently use O(N^2) memory in the
 // number of newlines, so the injection needs to be conservative. Currently it limits to up to maxNewLines newlines
 // which would result in max 8MB memory use by the algorithm.
-func MarshalUntypedDeployment(deployment *apitype.DeploymentV3) (json.RawMessage, error) {
-	var buf bytes.Buffer
+func MarshalUntypedDeployment(b *bytes.Buffer, deployment *apitype.DeploymentV3) error {
 	md := &marshalUntypedDeployment{deployment}
-	if err := md.Write(&buf); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return md.Write(b)
 }
 
 func marshalVerbatimCheckpointRequest(req apitype.PatchUpdateVerbatimCheckpointRequest) (json.RawMessage, error) {

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -15,6 +15,7 @@
 package httpstate
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -24,14 +25,22 @@ import (
 
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+type deployment struct {
+	raw json.RawMessage
+	buf *bytes.Buffer
+}
+
 type deploymentDiffState struct {
-	lastSavedDeployment json.RawMessage
+	lastSavedDeployment deployment
 	sequenceNumber      int
 	minimalDiffSize     int
+	buffer              *bytes.Buffer
 }
 
 type deploymentDiff struct {
@@ -52,25 +61,39 @@ func (dds *deploymentDiffState) SequenceNumber() int {
 }
 
 func (dds *deploymentDiffState) CanDiff() bool {
-	return dds.lastSavedDeployment != nil
+	return dds.lastSavedDeployment.raw != nil
+}
+
+func (dds *deploymentDiffState) MarshalDeployment(d *apitype.DeploymentV3) (deployment, error) {
+	var b *bytes.Buffer
+	if dds.buffer != nil {
+		b, dds.buffer = dds.buffer, nil
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	if err := client.MarshalUntypedDeployment(b, d); err != nil {
+		return deployment{}, err
+	}
+	return deployment{raw: json.RawMessage(b.Bytes()), buf: b}, nil
 }
 
 // Size-based heuristics trying to estimate if the diff method will be
 // worth it and take less time than sending the entire deployment.
-func (dds *deploymentDiffState) ShouldDiff(new json.RawMessage) bool {
+func (dds *deploymentDiffState) ShouldDiff(new deployment) bool {
 	if !dds.CanDiff() {
 		return false
 	}
-	if len(dds.lastSavedDeployment) < dds.minimalDiffSize {
+	if len(dds.lastSavedDeployment.raw) < dds.minimalDiffSize {
 		return false
 	}
-	if len(new) < dds.minimalDiffSize {
+	if len(new.raw) < dds.minimalDiffSize {
 		return false
 	}
 	return true
 }
 
-func (dds *deploymentDiffState) Diff(ctx context.Context, deployment json.RawMessage) (deploymentDiff, error) {
+func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment) (deploymentDiff, error) {
 	if !dds.CanDiff() {
 		return deploymentDiff{}, fmt.Errorf("Diff() cannot be called before Saved()")
 	}
@@ -78,8 +101,8 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment json.RawMes
 	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "Diff")
 	defer tracingSpan.Finish()
 
-	before := dds.lastSavedDeployment
-	after := deployment
+	before := dds.lastSavedDeployment.raw
+	after := deployment.raw
 
 	var checkpointHash string
 	checkpointHashReady := &sync.WaitGroup{}
@@ -113,7 +136,11 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment json.RawMes
 }
 
 // Indicates that a deployment was just saved to the service.
-func (dds *deploymentDiffState) Saved(ctx context.Context, deployment json.RawMessage) error {
+func (dds *deploymentDiffState) Saved(ctx context.Context, deployment deployment) error {
+	if dds.lastSavedDeployment.buf != nil {
+		dds.buffer = dds.lastSavedDeployment.buf
+		dds.buffer.Reset()
+	}
 	dds.lastSavedDeployment = deployment
 	dds.sequenceNumber++
 

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -340,14 +340,14 @@ func testDiffStack(t *testing.T, snaps []*apitype.DeploymentV3) {
 
 	dds := newDeploymentDiffState(0)
 	for _, s := range snaps {
-		json, err := client.MarshalUntypedDeployment(s)
+		json, err := dds.MarshalDeployment(s)
 		require.NoError(t, err)
 		if dds.ShouldDiff(json) {
 			d, err := dds.Diff(ctx, json)
 			require.NoError(t, err)
-			actual, err := applyEdits(dds.lastSavedDeployment, d.deploymentDelta)
+			actual, err := applyEdits(dds.lastSavedDeployment.raw, d.deploymentDelta)
 			require.NoError(t, err)
-			assert.Equal(t, json, actual)
+			assert.Equal(t, json.raw, actual)
 		}
 		err = dds.Saved(ctx, json)
 		require.NoError(t, err)
@@ -361,9 +361,9 @@ func benchmarkDiffStack(b *testing.B, snaps []*apitype.DeploymentV3) {
 		dds := newDeploymentDiffState(0)
 
 		for _, s := range snaps {
-			json, err := client.MarshalUntypedDeployment(s)
+			json, err := dds.MarshalDeployment(s)
 			require.NoError(b, err)
-			verbatimSize += len(json)
+			verbatimSize += len(json.raw)
 			if dds.ShouldDiff(json) {
 				diffs++
 				d, err := dds.Diff(ctx, json)
@@ -371,7 +371,7 @@ func benchmarkDiffStack(b *testing.B, snaps []*apitype.DeploymentV3) {
 				wireSize += len(d.deploymentDelta)
 			} else {
 				verbatims++
-				wireSize += len(json)
+				wireSize += len(json.raw)
 			}
 			err = dds.Saved(ctx, json)
 			require.NoError(b, err)


### PR DESCRIPTION
Pool the buffers used for marshaling checkpoints. The pooling works by returning the last saved checkpoint's buffer to the diff state when a new checkpoint is saved. If a pooled buffer is available, it is reused when a checkpoint is marshaled. With our current usage patterns, this will cycle through two buffers. Starting from a fresh diff state:

- The first call to `MarshalDeployment` will create a new buffer `B1`
- The first call to `Saved` will put `B1` into `lastSavedDeployment`
- The second call to `MarshalDeployment` will create a new buffer `B2`
- The second call to `Saved` will put `B1` into the pool and `B2` into `lastSavedDeployment`
- The third call to `MarshalDeployment` will get `B1` from the pool
- The third call to `Saved` will put `B2` into the pool and `B1` into `lastSavedDeployment`

These changes reduce CPU time and allocation volume by a geomean of 6% and 27%, respectively.

Benchmark results and analysis:

    httpstate ❯ go test -count=10 -run none -benchmem -bench . | tee buffer-pool.txt
    httpstate ❯ benchstat base.txt buffer-pool.txt >stat.txt

```
                                                │   base.txt   │           buffer-pool.txt           │
                                                │    sec/op    │   sec/op     vs base                │
DiffStack/1_x_2_B-10                               46.30µ ± 1%   43.17µ ± 0%   -6.74% (p=0.000 n=10)
DiffStack/2_x_2_B-10                               82.68µ ± 1%   80.07µ ± 0%   -3.16% (p=0.000 n=10)
DiffStack/4_x_2_B-10                               191.0µ ± 1%   175.3µ ± 1%   -8.22% (p=0.000 n=10)
DiffStack/8_x_2_B-10                               499.7µ ± 0%   470.6µ ± 1%   -5.83% (p=0.000 n=10)
DiffStack/16_x_2_B-10                              1.489m ± 0%   1.400m ± 1%   -5.92% (p=0.000 n=10)
DiffStack/32_x_2_B-10                              4.895m ± 1%   4.540m ± 0%   -7.25% (p=0.000 n=10)
DiffStack/48_x_2_B-10                              9.651m ± 1%   8.538m ± 1%  -11.53% (p=0.000 n=10)
DiffStack/64_x_2_B-10                              15.11m ± 0%   13.82m ± 0%   -8.56% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                            103.3µ ± 1%   123.9µ ± 1%  +19.93% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                            308.8µ ± 0%   317.1µ ± 1%   +2.70% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                            899.2µ ± 0%   835.6µ ± 0%   -7.07% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                            2.989m ± 1%   2.757m ± 1%   -7.76% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                          10.528m ± 0%   9.305m ± 1%  -11.61% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                           36.27m ± 1%   30.55m ± 1%  -15.77% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                           72.53m ± 0%   69.05m ± 0%   -4.80% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                           125.5m ± 0%   113.5m ± 0%   -9.58% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                             317.4µ ± 1%   314.2µ ± 0%   -1.01% (p=0.001 n=10)
DiffStack/2_x_33_kB-10                             756.8µ ± 1%   797.3µ ± 1%   +5.35% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                             2.605m ± 0%   2.371m ± 0%   -8.99% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                             9.241m ± 2%   8.342m ± 0%   -9.73% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                            32.86m ± 1%   27.11m ± 1%  -17.50% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                            110.2m ± 2%   101.3m ± 1%   -8.01% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                            231.3m ± 0%   202.1m ± 1%  -12.64% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                            383.8m ± 1%   333.4m ± 1%  -13.14% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                            2.748m ± 1%   2.678m ± 0%   -2.52% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                            8.609m ± 0%   8.278m ± 0%   -3.85% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                            28.44m ± 0%   25.46m ± 0%  -10.49% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                           96.98m ± 1%   88.22m ± 0%   -9.03% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                           349.4m ± 1%   315.3m ± 0%   -9.74% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                           761.7m ± 0%   677.9m ± 1%  -11.00% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                            1.312 ± 1%    1.195 ± 0%   -8.90% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                            3.238m ± 1%   3.213m ± 0%   -0.78% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                            9.867m ± 0%   9.613m ± 0%   -2.58% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                            29.65m ± 0%   29.11m ± 0%   -1.83% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                            98.91m ± 1%   92.23m ± 0%   -6.76% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                           348.1m ± 1%   322.5m ± 1%   -7.34% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10    46.62m ± 0%   46.42m ± 1%   -0.42% (p=0.004 n=10)
geomean                                            11.15m        10.44m        -6.39%

                                                │  base.txt   │            buffer-pool.txt             │
                                                │    ratio    │    ratio      vs base                  │
DiffStack/1_x_2_B-10                              789.5m ± 0%    700.9m ± 0%  -11.22% (p=0.000 n=10)
DiffStack/2_x_2_B-10                               1.034 ± 0%     1.030 ± 0%   -0.39% (p=0.000 n=10)
DiffStack/4_x_2_B-10                               1.676 ± 0%     1.608 ± 0%   -4.06% (p=0.000 n=10)
DiffStack/8_x_2_B-10                               2.883 ± 0%     2.879 ± 0%   -0.14% (p=0.000 n=10)
DiffStack/16_x_2_B-10                              5.270 ± 0%     5.268 ± 0%   -0.04% (p=0.000 n=10)
DiffStack/32_x_2_B-10                              10.20 ± 0%     10.03 ± 0%   -1.67% (p=0.000 n=10)
DiffStack/48_x_2_B-10                              14.24 ± 0%     13.39 ± 0%   -5.97% (p=0.000 n=10)
DiffStack/64_x_2_B-10                              17.51 ± 0%     17.34 ± 0%   -0.97% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                           950.9m ± 0%   1383.0m ± 0%  +45.44% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                            1.716 ± 0%     1.900 ± 0%  +10.72% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                            2.792 ± 0%     2.792 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/8_x_8.2_kB-10                            5.350 ± 0%     5.516 ± 0%   +3.10% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                           10.62 ± 0%     10.60 ± 0%   -0.19% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                           20.01 ± 0%     19.10 ± 0%   -4.55% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                           27.48 ± 0%     30.24 ± 0%  +10.04% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                           36.97 ± 0%     38.22 ± 0%   +3.38% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                             1.467 ± 0%     1.467 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/2_x_33_kB-10                             1.581 ± 0%     1.777 ± 0%  +12.40% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                             2.967 ± 0%     2.967 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/8_x_33_kB-10                             5.766 ± 0%     5.809 ± 0%   +0.75% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                            10.87 ± 0%     10.05 ± 0%   -7.54% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                            19.00 ± 0%     20.13 ± 0%   +5.95% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                            27.14 ± 0%     27.18 ± 0%   +0.15% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                            34.39 ± 0%     33.97 ± 0%   -1.22% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                            1.993 ± 0%     1.993 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/4_x_131_kB-10                            3.173 ± 0%     3.263 ± 0%   +2.84% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                            5.334 ± 0%     5.291 ± 0%   -0.81% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                           9.296 ± 0%     9.423 ± 0%   +1.37% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                           17.10 ± 0%     17.21 ± 0%   +0.64% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                           25.25 ± 0%     25.06 ± 0%   -0.75% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                           33.13 ± 0%     33.46 ± 0%   +1.00% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                            1.498 ± 0%     1.498 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/2_x_524_kB-10                            1.998 ± 0%     1.998 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/4_x_524_kB-10                            2.998 ± 0%     3.089 ± 0%   +3.04% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                            5.084 ± 0%     5.084 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/16_x_524_kB-10                           9.079 ± 0%     9.058 ± 0%   -0.23% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10    1.997 ± 0%     1.997 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                            5.961          6.039        +1.31%
¹ all samples are equal

                                                │   base.txt    │           buffer-pool.txt            │
                                                │     B/op      │     B/op      vs base                │
DiffStack/1_x_2_B-10                               35.17Ki ± 0%   29.56Ki ± 0%  -15.97% (p=0.000 n=10)
DiffStack/2_x_2_B-10                               70.05Ki ± 0%   61.61Ki ± 0%  -12.04% (p=0.000 n=10)
DiffStack/4_x_2_B-10                               186.8Ki ± 0%   149.9Ki ± 0%  -19.75% (p=0.000 n=10)
DiffStack/8_x_2_B-10                               529.0Ki ± 0%   432.0Ki ± 0%  -18.33% (p=0.000 n=10)
DiffStack/16_x_2_B-10                              1.768Mi ± 0%   1.392Mi ± 0%  -21.28% (p=0.000 n=10)
DiffStack/32_x_2_B-10                              6.513Mi ± 0%   4.986Mi ± 0%  -23.45% (p=0.000 n=10)
DiffStack/48_x_2_B-10                             14.054Mi ± 0%   9.885Mi ± 0%  -29.66% (p=0.000 n=10)
DiffStack/64_x_2_B-10                              22.39Mi ± 0%   16.84Mi ± 0%  -24.79% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                            154.7Ki ± 0%   202.4Ki ± 0%  +30.89% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                            571.9Ki ± 0%   540.8Ki ± 0%   -5.43% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                            1.846Mi ± 0%   1.430Mi ± 0%  -22.52% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                            6.920Mi ± 0%   4.809Mi ± 0%  -30.51% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                           26.50Mi ± 0%   16.34Mi ± 0%  -38.35% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                           98.33Mi ± 0%   55.24Mi ± 0%  -43.82% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                           209.4Mi ± 0%   127.2Mi ± 0%  -39.23% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                           365.6Mi ± 0%   211.2Mi ± 0%  -42.23% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                             808.7Ki ± 0%   764.2Ki ± 0%   -5.50% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                             2.013Mi ± 0%   1.992Mi ± 0%   -1.03% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                             7.551Mi ± 0%   5.764Mi ± 0%  -23.67% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                             28.58Mi ± 0%   18.90Mi ± 0%  -33.87% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                           104.40Mi ± 0%   59.42Mi ± 0%  -43.08% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                            365.5Mi ± 0%   219.9Mi ± 0%  -39.82% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                            801.1Mi ± 0%   438.7Mi ± 0%  -45.24% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                           1314.3Mi ± 0%   718.3Mi ± 0%  -45.35% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                            9.179Mi ± 0%   8.063Mi ± 0%  -12.16% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                            29.14Mi ± 0%   22.68Mi ± 0%  -22.18% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                            98.77Mi ± 0%   65.16Mi ± 0%  -34.03% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                           337.1Mi ± 0%   207.8Mi ± 0%  -38.36% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                          1234.6Mi ± 0%   705.3Mi ± 0%  -42.87% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                           2.771Gi ± 0%   1.468Gi ± 0%  -47.03% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                           4.606Gi ± 0%   2.553Gi ± 0%  -44.56% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                            12.41Mi ± 1%   11.85Mi ± 1%   -4.50% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                            37.01Mi ± 1%   32.79Mi ± 1%  -11.41% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                           110.56Mi ± 0%   89.08Mi ± 1%  -19.43% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                            367.3Mi ± 1%   254.3Mi ± 1%  -30.76% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                          1291.7Mi ± 0%   801.6Mi ± 0%  -37.95% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10    69.25Mi ± 0%   69.25Mi ± 0%        ~ (p=0.165 n=10)
geomean                                            26.14Mi        19.06Mi       -27.07%

                                                │   base.txt   │          buffer-pool.txt           │
                                                │  allocs/op   │  allocs/op   vs base               │
DiffStack/1_x_2_B-10                                361.0 ± 0%    326.0 ± 0%  -9.70% (p=0.000 n=10)
DiffStack/2_x_2_B-10                                649.0 ± 0%    621.0 ± 0%  -4.31% (p=0.000 n=10)
DiffStack/4_x_2_B-10                               1.512k ± 0%   1.399k ± 0%  -7.47% (p=0.000 n=10)
DiffStack/8_x_2_B-10                               4.141k ± 0%   4.006k ± 0%  -3.25% (p=0.000 n=10)
DiffStack/16_x_2_B-10                              13.09k ± 0%   12.73k ± 0%  -2.72% (p=0.000 n=10)
DiffStack/32_x_2_B-10                              46.38k ± 0%   44.88k ± 0%  -3.25% (p=0.000 n=10)
DiffStack/48_x_2_B-10                              94.38k ± 0%   87.94k ± 0%  -6.82% (p=0.000 n=10)
DiffStack/64_x_2_B-10                              152.7k ± 0%   149.3k ± 0%  -2.18% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                             323.0 ± 0%    335.0 ± 0%  +3.72% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                             630.0 ± 0%    613.0 ± 0%  -2.70% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                            1.354k ± 0%   1.279k ± 0%  -5.54% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                            3.606k ± 0%   3.490k ± 0%  -3.22% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                           11.16k ± 0%   10.71k ± 0%  -4.11% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                           36.45k ± 0%   34.06k ± 0%  -6.54% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                           71.55k ± 0%   76.00k ± 0%  +6.22% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                           123.9k ± 0%   125.2k ± 0%  +1.07% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                              346.0 ± 0%    329.0 ± 0%  -4.91% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                              607.0 ± 0%    594.0 ± 0%  -2.14% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                             1.396k ± 0%   1.310k ± 0%  -6.16% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                             3.764k ± 0%   3.564k ± 0%  -5.30% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                            11.26k ± 0%   10.15k ± 0%  -9.88% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                            34.55k ± 0%   34.91k ± 0%  +1.03% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                            69.72k ± 0%   67.76k ± 0%  -2.82% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                            114.1k ± 0%   110.1k ± 0%  -3.46% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                             678.0 ± 0%    643.0 ± 0%  -5.16% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                            1.494k ± 0%   1.419k ± 0%  -4.99% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                            3.737k ± 0%   3.489k ± 0%  -6.64% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                          10.400k ± 0%   9.917k ± 0%  -4.64% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                           32.24k ± 0%   31.08k ± 0%  -3.59% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                           66.12k ± 0%   63.62k ± 0%  -3.79% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                           110.9k ± 0%   109.1k ± 0%  -1.67% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                             374.0 ± 1%    356.0 ± 0%  -4.81% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                             707.0 ± 0%    668.0 ± 0%  -5.52% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                            1.528k ± 0%   1.460k ± 1%  -4.48% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                            3.797k ± 1%   3.571k ± 0%  -5.95% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                          10.562k ± 1%   9.966k ± 0%  -5.65% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10    512.1k ± 0%   512.1k ± 0%       ~ (p=0.222 n=10)
DiffStackRecorded/checkpoints.json-10              7.240M ± 0%   7.237M ± 0%  -0.03% (p=0.000 n=10)
geomean                                            8.309k        7.996k       -3.77%
```