### PR TITLE
Untargeted resources now have update plans.

### DIFF
--- a/changelog/pending/20230512--engine--nontargeted-resources-are-now-added-to-internal-update-plans.yaml
+++ b/changelog/pending/20230512--engine--nontargeted-resources-are-now-added-to-internal-update-plans.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Non-targeted resources are now added to internal update plans fixing a bug where the step_executor would error due to missing resources in the plan.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -656,7 +656,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	}
 
 	// If the resource is valid and we're generating plans then generate a plan
-	if !invalid && sg.opts.GeneratePlan && isTargeted {
+	if !invalid && sg.opts.GeneratePlan {
 		if recreating || wasExternal || sg.isTargetedReplace(urn) || !hasOld {
 			oldInputs = nil
 		}


### PR DESCRIPTION
Fixes #12926

# What
This change modifies the step_generator to include untargeted resources in plans.

# Why
This prevents the step_executor from erroring from an untargeted resource being registered.

The `step_executor` would error due to an untargeted resource being registered while not being included in the update plan.

This appeared to be applicable only to users using update plans, but update plans are enabled by default internally.

There are some rare cases where they are not such as if `--skip-preview` is set, or if using `pulumi up` with URLs or Templates without PULUMI_EXPERIMENTAL being truthy.

# Previous Context
This error previously appeared in #12824 and was believed to be due to the root stack resource not being targeted in liue of informative error messages.

A fix was merged in:

https://github.com/pulumi/pulumi/pull/12834

This also contained an enhanced error message containing the offending URN of the resource.

The fix was shipped in 3.67.0, but #12926 was opened with the new error message indicating that the problem was still outstanding and it was applicable to resources that weren't the root stack resource.