### PR TITLE
Fix reusable workflow reference

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -171,7 +171,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           gradle-version: "7.6"
       - name: Uninstall pre-installed Pulumi (windows)

--- a/.github/workflows/pr-test-codegen-test-on-dispatch.yml
+++ b/.github/workflows/pr-test-codegen-test-on-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
   ci-downstream-test-dispatch:
     name: CI
     if: github.event_name == 'repository_dispatch'
-    uses: ./.github/workflows/ci-codegen.yml@master
+    uses: pulumi/pulumi/.github/workflows/ci-codegen.yml@master
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr-test-codegen-test-on-dispatch.yml
+++ b/.github/workflows/pr-test-codegen-test-on-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
   ci-downstream-test-dispatch:
     name: CI
     if: github.event_name == 'repository_dispatch'
-    uses: pulumi/pulumi./.github/workflows/ci-codegen.yml@master
+    uses: ./.github/workflows/ci-codegen.yml@master
     permissions:
       contents: read
     with:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This reference is broken and is currently breaking dependabot's ability to open PRs.

