### PR TITLE
[snapshot] Avoid string allocations

### DIFF
--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -32,7 +32,11 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-func asString(raw json.RawMessage) string {
+// unsafeAsString converts the contents of the given json.RawMessage into a string without allocating. The contents
+// of the returned string will change if the json.RawMessage is mutated before the referenced string goes out of scope.
+// It is imperative that callers ensure that the lifetime of the return value does not exceed the lifetime of the
+// input contents.
+func unsafeAsString(raw json.RawMessage) string {
 	// NOTE: this depends on the fact that the layout of a byte slice and a string share a common header. Both of these
 	// types are laid out as (ptr, len). Once the CLI targets Go 1.20, we should change this to
 	//
@@ -123,7 +127,7 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment)
 		checkpointHash = dds.computeHash(childCtx, after)
 	}()
 
-	delta, err := dds.computeEdits(childCtx, asString(before), asString(after))
+	delta, err := dds.computeEdits(childCtx, unsafeAsString(before), unsafeAsString(after))
 	if err != nil {
 		return deploymentDiff{}, fmt.Errorf("Cannot marshal the edits: %v", err)
 	}

--- a/pkg/backend/httpstate/diffs_pre_go120.go
+++ b/pkg/backend/httpstate/diffs_pre_go120.go
@@ -1,0 +1,18 @@
+//go:build !go1.20
+
+package httpstate
+
+import (
+	"encoding/json"
+	"unsafe"
+)
+
+// unsafeAsString converts the contents of the given json.RawMessage into a string without allocating. The contents
+// of the returned string will change if the json.RawMessage is mutated before the referenced string goes out of scope.
+// It is imperative that callers ensure that the lifetime of the return value does not exceed the lifetime of the
+// input contents.
+func unsafeAsString(raw json.RawMessage) string {
+	// NOTE: this depends on the fact that the layout of a byte slice and a string share a common header. Both of these
+	// types are laid out as (ptr, len).
+	return *(*string)(unsafe.Pointer(&raw))
+}


### PR DESCRIPTION
Use unsafe code to treat byte slices as strings when diffing.

These changes improve CPU time by 6% and allocation volume by 42%, respectively.

Benchmark results and analysis:

    httpstate ❯ go test -count=10 -run none -benchmem -bench . | tee unsafe-string.txt
    httpstate ❯ benchstat buffer-pool.txt unsafe-string.txt >stat.txt

```
                                                │ buffer-pool.txt │          unsafe-string.txt          │
                                                │     sec/op      │   sec/op     vs base                │
DiffStack/1_x_2_B-10                                  43.17µ ± 0%   42.17µ ± 2%   -2.32% (p=0.015 n=10)
DiffStack/2_x_2_B-10                                  80.07µ ± 0%   77.33µ ± 1%   -3.41% (p=0.000 n=10)
DiffStack/4_x_2_B-10                                  175.3µ ± 1%   165.6µ ± 0%   -5.53% (p=0.000 n=10)
DiffStack/8_x_2_B-10                                  470.6µ ± 1%   436.6µ ± 1%   -7.21% (p=0.000 n=10)
DiffStack/16_x_2_B-10                                 1.400m ± 1%   1.308m ± 1%   -6.63% (p=0.000 n=10)
DiffStack/32_x_2_B-10                                 4.540m ± 0%   4.176m ± 1%   -8.01% (p=0.000 n=10)
DiffStack/48_x_2_B-10                                 8.538m ± 1%   8.043m ± 0%   -5.80% (p=0.000 n=10)
DiffStack/64_x_2_B-10                                 13.82m ± 0%   13.30m ± 0%   -3.73% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                              123.88µ ± 1%   96.66µ ± 0%  -21.97% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                               317.1µ ± 1%   287.5µ ± 0%   -9.33% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                               835.6µ ± 0%   794.6µ ± 0%   -4.91% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                               2.757m ± 1%   2.392m ± 0%  -13.26% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                              9.305m ± 1%   8.571m ± 2%   -7.89% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                              30.55m ± 1%   31.01m ± 2%        ~ (p=0.089 n=10)
DiffStack/48_x_8.2_kB-10                              69.05m ± 0%   61.06m ± 2%  -11.57% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                             113.49m ± 0%   98.35m ± 3%  -13.34% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                                314.2µ ± 0%   233.3µ ± 2%  -25.73% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                                797.3µ ± 1%   791.4µ ± 0%   -0.75% (p=0.002 n=10)
DiffStack/4_x_33_kB-10                                2.371m ± 0%   2.159m ± 2%   -8.94% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                                8.342m ± 0%   7.752m ± 1%   -7.06% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                               27.11m ± 1%   26.56m ± 0%   -2.05% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                              101.33m ± 1%   90.66m ± 1%  -10.53% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                               202.1m ± 1%   187.9m ± 0%   -7.04% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                               333.4m ± 1%   326.0m ± 0%   -2.21% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                               2.678m ± 0%   2.536m ± 0%   -5.31% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                               8.278m ± 0%   7.808m ± 0%   -5.68% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                               25.46m ± 0%   24.61m ± 0%   -3.32% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                              88.22m ± 0%   83.45m ± 0%   -5.41% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                              315.3m ± 0%   298.7m ± 0%   -5.29% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                              677.9m ± 1%   648.8m ± 0%   -4.30% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                               1.195 ± 0%    1.129 ± 0%   -5.53% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                               3.213m ± 0%   3.115m ± 0%   -3.03% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                               9.613m ± 0%   9.244m ± 0%   -3.83% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                               29.11m ± 0%   27.76m ± 0%   -4.62% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                               92.23m ± 0%   88.63m ± 0%   -3.90% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                              322.5m ± 1%   305.0m ± 0%   -5.43% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10       46.42m ± 1%   46.08m ± 1%   -0.73% (p=0.005 n=10)
DiffStackRecorded/checkpoints.json-10                 809.5m ± 0%   788.9m ± 5%   -2.54% (p=0.023 n=10)
geomean                                               10.44m        9.742m        -6.65%

                                                │ buffer-pool.txt │           unsafe-string.txt           │
                                                │      ratio      │    ratio     vs base                  │
DiffStack/1_x_2_B-10                                  700.9m ± 0%   700.5m ± 0%   -0.06% (p=0.000 n=10)
DiffStack/2_x_2_B-10                                   1.030 ± 0%    1.034 ± 0%   +0.39% (p=0.000 n=10)
DiffStack/4_x_2_B-10                                   1.608 ± 0%    1.576 ± 0%   -1.99% (p=0.000 n=10)
DiffStack/8_x_2_B-10                                   2.879 ± 0%    2.883 ± 0%   +0.14% (p=0.000 n=10)
DiffStack/16_x_2_B-10                                  5.268 ± 0%    5.362 ± 0%   +1.78% (p=0.000 n=10)
DiffStack/32_x_2_B-10                                 10.030 ± 0%    9.859 ± 0%   -1.70% (p=0.000 n=10)
DiffStack/48_x_2_B-10                                  13.39 ± 0%    13.60 ± 0%   +1.57% (p=0.000 n=10)
DiffStack/64_x_2_B-10                                  17.34 ± 0%    17.56 ± 0%   +1.27% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                              1383.0m ± 0%   950.9m ± 0%  -31.24% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                                1.900 ± 0%    1.902 ± 0%   +0.11% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                                2.792 ± 0%    3.050 ± 0%   +9.24% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                                5.516 ± 0%    5.350 ± 0%   -3.01% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                               10.60 ± 0%    10.56 ± 0%   -0.38% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                               19.10 ± 0%    20.60 ± 0%   +7.85% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                               30.24 ± 0%    28.39 ± 0%   -6.12% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                               38.22 ± 0%    34.87 ± 0%   -8.77% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                               1467.0m ± 0%   986.0m ± 0%  -32.79% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                                 1.777 ± 0%    1.973 ± 0%  +11.03% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                                 2.967 ± 0%    2.878 ± 0%   -3.00% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                                 5.809 ± 0%    5.809 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/16_x_33_kB-10                                10.05 ± 0%    10.66 ± 0%   +6.07% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                                20.13 ± 0%    18.88 ± 0%   -6.21% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                                27.18 ± 0%    26.53 ± 0%   -2.39% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                                33.97 ± 0%    35.09 ± 0%   +3.30% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                                1.993 ± 0%    1.993 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/4_x_131_kB-10                                3.263 ± 0%    3.263 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/8_x_131_kB-10                                5.291 ± 0%    5.421 ± 0%   +2.46% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                               9.423 ± 0%    9.466 ± 0%   +0.46% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                               17.21 ± 0%    17.28 ± 0%   +0.41% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                               25.06 ± 0%    25.21 ± 0%   +0.60% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                               33.46 ± 0%    33.10 ± 0%   -1.08% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                                1.498 ± 0%    1.498 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/2_x_524_kB-10                                1.998 ± 0%    1.998 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/4_x_524_kB-10                                3.089 ± 0%    3.089 ± 0%        ~ (p=1.000 n=10) ¹
DiffStack/8_x_524_kB-10                                5.084 ± 0%    5.127 ± 0%   +0.85% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                               9.058 ± 0%    9.016 ± 0%   -0.46% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10        1.997 ± 0%    1.997 ± 0%        ~ (p=1.000 n=10) ¹
DiffStackRecorded/checkpoints.json-10                  36.60 ± 0%    36.60 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                6.039         5.933        -1.76%
¹ all samples are equal

                                                │ buffer-pool.txt │          unsafe-string.txt           │
                                                │      B/op       │     B/op      vs base                │
DiffStack/1_x_2_B-10                                 29.56Ki ± 0%   25.64Ki ± 0%  -13.24% (p=0.000 n=10)
DiffStack/2_x_2_B-10                                 61.61Ki ± 0%   52.00Ki ± 0%  -15.60% (p=0.000 n=10)
DiffStack/4_x_2_B-10                                 149.9Ki ± 0%   120.7Ki ± 0%  -19.45% (p=0.000 n=10)
DiffStack/8_x_2_B-10                                 432.0Ki ± 0%   340.9Ki ± 0%  -21.09% (p=0.000 n=10)
DiffStack/16_x_2_B-10                                1.392Mi ± 0%   1.092Mi ± 0%  -21.53% (p=0.000 n=10)
DiffStack/32_x_2_B-10                                4.986Mi ± 0%   3.744Mi ± 0%  -24.90% (p=0.000 n=10)
DiffStack/48_x_2_B-10                                9.885Mi ± 0%   7.608Mi ± 0%  -23.04% (p=0.000 n=10)
DiffStack/64_x_2_B-10                                16.84Mi ± 0%   12.88Mi ± 0%  -23.50% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                              202.4Ki ± 0%   122.6Ki ± 0%  -39.44% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                              540.8Ki ± 0%   372.9Ki ± 0%  -31.04% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                             1464.5Ki ± 0%   930.9Ki ± 0%  -36.43% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                              4.809Mi ± 0%   2.413Mi ± 0%  -49.82% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                            16.336Mi ± 0%   7.576Mi ± 0%  -53.63% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                             55.24Mi ± 0%   25.44Mi ± 0%  -53.93% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                            127.21Mi ± 0%   50.79Mi ± 0%  -60.07% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                            211.19Mi ± 0%   80.11Mi ± 0%  -62.07% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                               764.2Ki ± 0%   436.1Ki ± 0%  -42.94% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                               1.992Mi ± 0%   1.436Mi ± 0%  -27.94% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                               5.764Mi ± 0%   3.473Mi ± 0%  -39.75% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                               18.90Mi ± 0%   10.18Mi ± 0%  -46.15% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                              59.42Mi ± 0%   30.15Mi ± 0%  -49.26% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                             219.94Mi ± 0%   92.74Mi ± 0%  -57.84% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                              438.7Mi ± 0%   186.5Mi ± 0%  -57.49% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                              718.3Mi ± 0%   312.6Mi ± 0%  -56.48% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                              8.063Mi ± 0%   5.614Mi ± 0%  -30.38% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                              22.68Mi ± 0%   13.69Mi ± 0%  -39.61% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                              65.16Mi ± 0%   35.03Mi ± 0%  -46.24% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                            207.79Mi ± 0%   96.82Mi ± 0%  -53.40% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                             705.3Mi ± 0%   295.2Mi ± 0%  -58.14% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                            1502.8Mi ± 0%   604.4Mi ± 0%  -59.78% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                            2614.6Mi ± 0%   999.3Mi ± 0%  -61.78% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                             11.855Mi ± 1%   9.254Mi ± 0%  -21.94% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                              32.79Mi ± 1%   23.72Mi ± 1%  -27.65% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                              89.08Mi ± 1%   56.75Mi ± 1%  -36.29% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                              254.3Mi ± 1%   141.1Mi ± 0%  -44.53% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                             801.6Mi ± 0%   381.2Mi ± 1%  -52.45% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10      69.25Mi ± 0%   59.95Mi ± 0%  -13.43% (p=0.000 n=10)
DiffStackRecorded/checkpoints.json-10                914.2Mi ± 0%   618.6Mi ± 0%  -32.34% (p=0.000 n=10)
geomean                                              19.06Mi        11.14Mi       -41.54%

                                                │ buffer-pool.txt │          unsafe-string.txt          │
                                                │    allocs/op    │  allocs/op   vs base                │
DiffStack/1_x_2_B-10                                   326.0 ± 0%    316.0 ± 0%   -3.07% (p=0.000 n=10)
DiffStack/2_x_2_B-10                                   621.0 ± 0%    600.0 ± 0%   -3.38% (p=0.000 n=10)
DiffStack/4_x_2_B-10                                  1.399k ± 0%   1.353k ± 0%   -3.29% (p=0.000 n=10)
DiffStack/8_x_2_B-10                                  4.006k ± 0%   3.929k ± 0%   -1.93% (p=0.000 n=10)
DiffStack/16_x_2_B-10                                 12.73k ± 0%   12.83k ± 0%   +0.75% (p=0.000 n=10)
DiffStack/32_x_2_B-10                                 44.88k ± 0%   43.95k ± 0%   -2.06% (p=0.000 n=10)
DiffStack/48_x_2_B-10                                 87.94k ± 0%   88.82k ± 0%   +0.99% (p=0.000 n=10)
DiffStack/64_x_2_B-10                                 149.3k ± 0%   150.8k ± 0%   +0.96% (p=0.000 n=10)
DiffStack/1_x_8.2_kB-10                                335.0 ± 0%    298.0 ± 0%  -11.04% (p=0.000 n=10)
DiffStack/2_x_8.2_kB-10                                613.0 ± 0%    595.0 ± 0%   -2.94% (p=0.000 n=10)
DiffStack/4_x_8.2_kB-10                               1.279k ± 0%   1.300k ± 0%   +1.64% (p=0.000 n=10)
DiffStack/8_x_8.2_kB-10                               3.490k ± 0%   3.342k ± 0%   -4.24% (p=0.000 n=10)
DiffStack/16_x_8.2_kB-10                              10.71k ± 0%   10.50k ± 0%   -1.89% (p=0.000 n=10)
DiffStack/32_x_8.2_kB-10                              34.06k ± 0%   35.93k ± 0%   +5.49% (p=0.000 n=10)
DiffStack/48_x_8.2_kB-10                              76.00k ± 0%   71.36k ± 0%   -6.10% (p=0.000 n=10)
DiffStack/64_x_8.2_kB-10                              125.2k ± 0%   114.5k ± 0%   -8.56% (p=0.000 n=10)
DiffStack/1_x_33_kB-10                                 329.0 ± 0%    297.5 ± 0%   -9.57% (p=0.000 n=10)
DiffStack/2_x_33_kB-10                                 594.0 ± 0%    588.0 ± 0%   -1.01% (p=0.000 n=10)
DiffStack/4_x_33_kB-10                                1.310k ± 0%   1.246k ± 0%   -4.89% (p=0.000 n=10)
DiffStack/8_x_33_kB-10                                3.564k ± 0%   3.466k ± 0%   -2.75% (p=0.000 n=10)
DiffStack/16_x_33_kB-10                               10.15k ± 0%   10.38k ± 0%   +2.31% (p=0.000 n=10)
DiffStack/32_x_33_kB-10                               34.91k ± 0%   32.65k ± 0%   -6.46% (p=0.000 n=10)
DiffStack/48_x_33_kB-10                               67.76k ± 0%   65.63k ± 0%   -3.14% (p=0.000 n=10)
DiffStack/64_x_33_kB-10                               110.1k ± 0%   112.4k ± 0%   +2.06% (p=0.000 n=10)
DiffStack/2_x_131_kB-10                                643.0 ± 0%    619.5 ± 0%   -3.65% (p=0.000 n=10)
DiffStack/4_x_131_kB-10                               1.419k ± 0%   1.369k ± 0%   -3.49% (p=0.000 n=10)
DiffStack/8_x_131_kB-10                               3.489k ± 0%   3.433k ± 0%   -1.62% (p=0.000 n=10)
DiffStack/16_x_131_kB-10                              9.917k ± 0%   9.704k ± 0%   -2.15% (p=0.000 n=10)
DiffStack/32_x_131_kB-10                              31.08k ± 0%   30.63k ± 0%   -1.47% (p=0.000 n=10)
DiffStack/48_x_131_kB-10                              63.62k ± 0%   63.03k ± 0%   -0.93% (p=0.000 n=10)
DiffStack/64_x_131_kB-10                              109.1k ± 0%   106.8k ± 0%   -2.05% (p=0.000 n=10)
DiffStack/1_x_524_kB-10                                356.0 ± 0%    343.0 ± 0%   -3.65% (p=0.000 n=10)
DiffStack/2_x_524_kB-10                                668.0 ± 0%    648.0 ± 0%   -2.99% (p=0.000 n=10)
DiffStack/4_x_524_kB-10                               1.460k ± 1%   1.413k ± 0%   -3.18% (p=0.000 n=10)
DiffStack/8_x_524_kB-10                               3.571k ± 0%   3.478k ± 0%   -2.60% (p=0.000 n=10)
DiffStack/16_x_524_kB-10                              9.966k ± 0%   9.697k ± 0%   -2.70% (p=0.000 n=10)
DiffStackRecorded/two-large-checkpoints.json-10       512.1k ± 0%   512.1k ± 0%   -0.00% (p=0.000 n=10)
DiffStackRecorded/checkpoints.json-10                 7.237M ± 0%   7.236M ± 0%   -0.02% (p=0.000 n=10)
geomean                                               7.996k        7.797k        -2.49%
```