### PR TITLE
Upgrade Rome to v12.1.0

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -52,7 +52,7 @@
         "mocha": "^9.0.0",
         "mockpackage": "file:tests/mockpackage",
         "nyc": "^15.1.0",
-        "rome": "^12.0.0",
+        "rome": "^12.1.0",
         "sinon": "^14.0.0"
     },
     "pulumi": {

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -5,8 +5,15 @@
     },
     "files": {
         "ignore": [
-            "bin/", "proto/", "dist/", "node_modules", ".nyc_output/", ".direnv/", "tests/runtime/jsClosureCases_*.js",
-            "tests/runtime/tsClosureCases.ts", "tests/mockpackage/lib/"
+            "bin/",
+            "proto/",
+            "dist/",
+            "node_modules",
+            ".nyc_output/",
+            ".direnv/",
+            "tests/runtime/jsClosureCases_*.js",
+            "tests/runtime/tsClosureCases.ts",
+            "tests/mockpackage/lib/"
         ]
     },
     "formatter": {
@@ -20,7 +27,9 @@
             "recommended": false,
             "complexity": {
                 "noExtraBooleanCast": "error",
-                "useOptionalChain": "error"
+                "useFlatMap": "error",
+                "useOptionalChain": "error",
+                "noUselessConstructor": "off"
             },
             "performance": {
                 "noDelete": "error"
@@ -39,7 +48,10 @@
                 "noArrayIndexKey": "error",
                 "noDebugger": "error",
                 "noImportAssign": "error",
-                "noFunctionAssign": "error"
+                "noFunctionAssign": "error",
+                "noRedeclare": "off",
+                "noPrototypeBuiltins": "off",
+                "noAssignInExpressions": "off"
             }
         }
     }

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -489,35 +489,35 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
-"@rometools/cli-darwin-arm64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-12.0.0.tgz#a21db92a9d24c1173489e4f2527415abfe0796c4"
-  integrity sha512-kEFCzU6cgy6vfY0mkMzq57ea3srqV5X2wyCAxjVfA2JF7fioq695uWhy7yOCBW+nUUFIz62N9v1nf/aYqX8XkA==
+"@rometools/cli-darwin-arm64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-12.1.0.tgz#3a52e43ab2379b79b8565afced391b009b3b7531"
+  integrity sha512-U9trIXqE+WVsPUQRE8vooh97jNcyC1cvhNO91Q31FfWgccfbiJbfiQzPewpQ1+UseyJIdpWFAYLs8VFykhAl3g==
 
-"@rometools/cli-darwin-x64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-x64/-/cli-darwin-x64-12.0.0.tgz#66f2d647825f17190a24d2c06119f8e5d39bcbb6"
-  integrity sha512-YDevVPKrkRFdjjM/3zOpOWI5mEY2ivjKM2eR8Yqv9xH3SZhyD/t67f/xo7Azp6NkGUVXSnHLGdkmIg+qrYgz5A==
+"@rometools/cli-darwin-x64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-x64/-/cli-darwin-x64-12.1.0.tgz#424f0bf209fb45d0417f4e7547dbb1bd9dcd157a"
+  integrity sha512-ePyRJwprT+POsGue1gdqPYOHojXfDz/OJI18renU0NI2CHeeeMhnquu+MZJaiBGyBd1ezIgWZWiQ4DhLFOaCUg==
 
-"@rometools/cli-linux-arm64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-arm64/-/cli-linux-arm64-12.0.0.tgz#f577cae2a283f69fa019848d886e8874169a4810"
-  integrity sha512-n2LJg6eAZENUcJF99wjDeqQCr/40IqGUJDbX7NwiU1RvCy+RBZNmhcmSAaKOc6rCoLUcM9W5q+H4jfn4bWfJBA==
+"@rometools/cli-linux-arm64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-arm64/-/cli-linux-arm64-12.1.0.tgz#13cf086641b42297ed48ca8978c9c8e10fa703b6"
+  integrity sha512-j/pF6pF+lKihw7CIvwQZqQG9gpaUy2FyO9+nu5dvCChblXNEaA2zMnpLnDlCue0B7xY0jZkk1EZdF49ztEZZFA==
 
-"@rometools/cli-linux-x64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-x64/-/cli-linux-x64-12.0.0.tgz#0ae22b92177db99c0a3994c075292b13020f2d72"
-  integrity sha512-VuQO4eOrKmfrLrc8KzMaZypz3i1rD9FXRxwOFk6ha16DNHV+17dRQYm7jRZ1p+HrXdjAJYTScxR/E03yGLThlQ==
+"@rometools/cli-linux-x64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-x64/-/cli-linux-x64-12.1.0.tgz#9271c9e955b84ac51608c0ad14b374ad2cc629eb"
+  integrity sha512-zh6tW0JumP/rQkFDdsg6FEDBv0ZPvPLFirfHqzJA8VDNRBHkOTq27oVCbTJIGyUCGm9VvIzG8sJFVKkYpxkl2g==
 
-"@rometools/cli-win32-arm64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-arm64/-/cli-win32-arm64-12.0.0.tgz#d9958d9fe8e3c03b35a4230f04f60658188fb22e"
-  integrity sha512-lvOh5/B8YuQdI2ieGJnJ6CUMZxvVwA8+1VDkEZJyl5IEF8AXzbXYx4k6SFA5a79cfXEL9tJuJy0rn+Zs/+1yJQ==
+"@rometools/cli-win32-arm64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-arm64/-/cli-win32-arm64-12.1.0.tgz#43c6c575d4b8614338f006f1c04116be77651672"
+  integrity sha512-ggug6gUWFnO2QK0KC5XsYRhuZ22jeLksebdHMnkaHzZBtxXnKMC7yXnYwU/Lg2fGAwmMsluIbaqFYgen4+c8RA==
 
-"@rometools/cli-win32-x64@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-x64/-/cli-win32-x64-12.0.0.tgz#63ab2dd525f501864251d8115570471c728aba22"
-  integrity sha512-yTfz71k8+9QIDzglKnMbEMMv1JUk30qfeSomgEUG2v0qDSbSq0Gs1ff0H0dysYOHLvZZmWA3IheOY/SC8fj1nA==
+"@rometools/cli-win32-x64@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-x64/-/cli-win32-x64-12.1.0.tgz#703783a238a867713555c74bfb8f4b2cfcd47185"
+  integrity sha512-TnurdnlzBwcvRSsgmNz9Gorffnjr5cS8TdHo9w+3pT4GdSsrLZqvd1IV2tj4uRKkNn6OJtSqW3tZ5SiTrf0LuA==
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
@@ -2675,17 +2675,17 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rome@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/rome/-/rome-12.0.0.tgz#629f17d1db2c3bfdd8fd2b55f443d44adde4ad7d"
-  integrity sha512-w/tLvLj5PGUCx3R+Kna08BMq4zL83Xzh9spvrqoWa3Nkzk16SkD8JSpyWWP9WhI2r3qv3Xvc7FnYZ4QDnjAiYg==
+rome@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/rome/-/rome-12.1.0.tgz#be218acf21d86b5368205ce6917c1c2b62f9698c"
+  integrity sha512-inIBYc2/Das6LDXcw8IQp7yeXth6Rhmj9y8sS/Y/0g5/29Lyzr785SjCmKyiN2No4MNsaP3YJNm2QZAs2UpR2w==
   optionalDependencies:
-    "@rometools/cli-darwin-arm64" "12.0.0"
-    "@rometools/cli-darwin-x64" "12.0.0"
-    "@rometools/cli-linux-arm64" "12.0.0"
-    "@rometools/cli-linux-x64" "12.0.0"
-    "@rometools/cli-win32-arm64" "12.0.0"
-    "@rometools/cli-win32-x64" "12.0.0"
+    "@rometools/cli-darwin-arm64" "12.1.0"
+    "@rometools/cli-darwin-x64" "12.1.0"
+    "@rometools/cli-linux-arm64" "12.1.0"
+    "@rometools/cli-linux-x64" "12.1.0"
+    "@rometools/cli-win32-arm64" "12.1.0"
+    "@rometools/cli-win32-x64" "12.1.0"
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Upgrade Rome to v12.1.0

This commit upgrades the Rome CLI to 12.1.0,
which advances many new lints from the nursery to stable.
This PR disables lints we violate that are enabled by default.
We can enable those lints again individually, as needed.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

**N/A:** This PR is strictly a nonfunctional change.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
