### PR TITLE
Eliminate assignment statements used as expressions.

### DIFF
--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -104,9 +104,10 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
+        programRunning = true;
         const promise: Promise<void> = require("./run").run({
             argv,
-            programStarted: () => (programRunning = true),
+            programStarted: () => programRunning,
             reportLoggedError: (err: Error) => loggedErrors.add(err),
             runInStack: false,
             typeScript: true, // Should have no deleterious impact on JS codebases.

--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -104,10 +104,11 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
-        programRunning = true;
         const promise: Promise<void> = require("./run").run({
             argv,
-            programStarted: () => programRunning,
+            programStarted: () => {
+                programRunning = true;
+            },
             reportLoggedError: (err: Error) => loggedErrors.add(err),
             runInStack: false,
             typeScript: true, // Should have no deleterious impact on JS codebases.

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -255,6 +255,8 @@ ${errMsg}`,
     process.on("unhandledRejection", uncaughtHandler);
     process.on("exit", settings.disconnectSync);
 
+    // Trigger callback to update a sentinel variable tracking
+    // whether the program is running.
     opts.programStarted();
 
     // Construct a `Stack` resource to represent the outputs of the program.

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -160,9 +160,10 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
+        programRunning = true;
         const promise: Promise<void> = require("./run").run(
             argv,
-            /*programStarted:   */ () => (programRunning = true),
+            /*programStarted:   */ () => programRunning,
             /*reportLoggedError:*/ (err: Error) => loggedErrors.add(err),
             /*isErrorReported:  */ (err: Error) => loggedErrors.has(err),
         );

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -160,10 +160,11 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
-        programRunning = true;
         const promise: Promise<void> = require("./run").run(
             argv,
-            /*programStarted:   */ () => programRunning,
+            /*programStarted:   */ () => {
+                programRunning = true;
+            },
             /*reportLoggedError:*/ (err: Error) => loggedErrors.add(err),
             /*isErrorReported:  */ (err: Error) => loggedErrors.has(err),
         );

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -307,6 +307,8 @@ ${defaultMessage}`,
     process.on("unhandledRejection", uncaughtHandler);
     process.on("exit", settings.disconnectSync);
 
+    // Trigger callback to update a sentinel variable tracking
+    // whether the program is running.
     programStarted();
 
     // This needs to occur after `programStarted` to ensure execution of the parent process stops.

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -49,9 +49,9 @@
                 "noDebugger": "error",
                 "noImportAssign": "error",
                 "noFunctionAssign": "error",
+                "noAssignInExpressions": "error",
                 "noRedeclare": "off",
-                "noPrototypeBuiltins": "off",
-                "noAssignInExpressions": "off"
+                "noPrototypeBuiltins": "off"
             }
         }
     }

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -401,7 +401,13 @@ export function disconnectSync(): void {
 export function rpcKeepAlive(): () => void {
     const localStore = getStore();
     let done: (() => void) | undefined = undefined;
-    const donePromise = debuggablePromise(new Promise<void>((resolve) => (done = resolve)), "rpcKeepAlive");
+    const donePromise = debuggablePromise(
+        new Promise<void>((resolve) => {
+            done = resolve;
+            return done;
+        }),
+        "rpcKeepAlive",
+    );
     localStore.settings.rpcDone = localStore.settings.rpcDone.then(() => donePromise);
     return done!;
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Eliminate assignment statements used as expressions.

This change refactors assignment statements used as expressions
to prefer assignment statements instead. Assignments are often
assumed to now evaluate to a value, but instead to represent a
change to a lexical binding. By using them as expressions, we can
write confusing and buggy code. This commit eliminates those instances
and enables a lint to prevent future occurrences.

## Checklist

**N/A:** This PR is strictly a non-functional change.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
