### PR TITLE
Eliminate spurious non-prototypal use of hasOwnProperty.

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -31,8 +31,8 @@ format:: ensure
 	yarn rome format --write .
 
 lint:: ensure
-	yarn run eslint -c .eslintrc.js --ext .ts .
 	yarn rome ci .
+	yarn run eslint -c .eslintrc.js --ext .ts .
 
 build_package:: ensure
 	yarn run tsc

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -356,7 +356,7 @@ export class LocalWorkspace implements Workspace {
 
             // Transform the serialized representation back to what we expect.
             for (const key of stackSettingsSerDeKeys) {
-                if (stackSettings.hasOwnProperty(key[0])) {
+                if (Object.hasOwn(stackSettings, key[0])) {
                     stackSettings[key[1]] = stackSettings[key[0]];
                     delete stackSettings[key[0]];
                 }
@@ -388,7 +388,7 @@ export class LocalWorkspace implements Workspace {
 
         // Transform the keys to the serialized representation that we expect.
         for (const key of stackSettingsSerDeKeys) {
-            if (serializeSettings.hasOwnProperty(key[1])) {
+            if (Object.hasOwn(serializeSettings, key[1])) {
                 serializeSettings[key[0]] = serializeSettings[key[1]];
                 delete serializeSettings[key[1]];
             }

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -224,7 +224,7 @@ This function may throw in a future version of @pulumi/pulumi.`;
                 // Recreate the prototype walk to ensure we find any actual members defined directly
                 // on `Output<T>`.
                 for (let o = obj; o; o = Object.getPrototypeOf(o)) {
-                    if (o.hasOwnProperty(prop)) {
+                    if (Object.hasOwn(a, prop)) {
                         return (<any>o)[prop];
                     }
                 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -527,11 +527,11 @@ function collapseAliasToUrn(
             return output(a);
         }
 
-        const name = a.hasOwnProperty("name") ? a.name : defaultName;
-        const type = a.hasOwnProperty("type") ? a.type : defaultType;
-        const parent = a.hasOwnProperty("parent") ? a.parent : defaultParent;
-        const project = a.hasOwnProperty("project") ? a.project : getProject();
-        const stack = a.hasOwnProperty("stack") ? a.stack : getStack();
+        const name = Object.hasOwn(a, "name") ? a.name : defaultName;
+        const type = Object.hasOwn(a, "type") ? a.type : defaultType;
+        const parent = Object.hasOwn(a, "parent") ? a.parent : defaultParent;
+        const project = Object.hasOwn(a, "project") ? a.project : getProject();
+        const stack = Object.hasOwn(a, "stack") ? a.stack : getStack();
 
         if (name === undefined) {
             throw new Error("No valid 'name' passed in for alias.");

--- a/sdk/nodejs/rome.json
+++ b/sdk/nodejs/rome.json
@@ -36,7 +36,6 @@
             },
             "suspicious": {
                 "noExtraNonNullAssertion": "error",
-                "noExplicitAny": "off",
                 "noAsyncPromiseExecutor": "error",
                 "noEmptyInterface": "error",
                 "noShadowRestrictedNames": "off",
@@ -50,8 +49,9 @@
                 "noImportAssign": "error",
                 "noFunctionAssign": "error",
                 "noAssignInExpressions": "error",
-                "noRedeclare": "off",
-                "noPrototypeBuiltins": "off"
+                "noPrototypeBuiltins": "error",
+                "noExplicitAny": "off",
+                "noRedeclare": "off"
             }
         }
     }

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -471,7 +471,7 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
         // Anything in the global dictionary is a built-in.  So is anything that's a global Node.js object;
         // note that these only exist in the scope of modules, and so are not truly global in the usual sense.
         // See https://nodejs.org/api/globals.html for more details.
-        return global.hasOwnProperty(ident) || nodeModuleGlobals[ident];
+        return Object.hasOwn(global, ident) || nodeModuleGlobals[ident];
     }
 
     function currentScope(): Set<string> {

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -274,7 +274,7 @@ function serializeJavaScriptText(
     }
 
     function simpleEnvEntryToString(envEntry: closure.Entry, varName: string): string {
-        if (envEntry.hasOwnProperty("json")) {
+        if (Object.hasOwn(envEntry, "json")) {
             return JSON.stringify(envEntry.json);
         } else if (envEntry.function !== undefined) {
             return emitFunctionAndGetName(envEntry.function);

--- a/sdk/nodejs/runtime/closure/v8.ts
+++ b/sdk/nodejs/runtime/closure/v8.ts
@@ -297,7 +297,7 @@ async function getValueForObjectId(objectId: inspector.Runtime.RemoteObjectId): 
         throw new Error(`Error calling "Runtime.callFunction(${objectId})": ` + retType.exceptionDetails.text);
     }
 
-    if (!context.calls.hasOwnProperty(tableId)) {
+    if (!Object.hasOwn(context.calls, tableId)) {
         throw new Error(`Value was not stored into table after calling "Runtime.callFunctionOn(${objectId})"`);
     }
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -341,7 +341,7 @@ function mapAliasesForRequest(aliases: (URN | Alias)[] | undefined, parentURN?: 
                 newAlias.setUrn(a);
             } else {
                 const newAliasSpec = new aliasproto.Alias.Spec();
-                const noParent = !a.hasOwnProperty("parent") && !parentURN;
+                const noParent = !Object.hasOwn(a, "parent") && !parentURN;
                 newAliasSpec.setName(a.name);
                 newAliasSpec.setType(a.type);
                 newAliasSpec.setStack(a.stack);
@@ -349,7 +349,7 @@ function mapAliasesForRequest(aliases: (URN | Alias)[] | undefined, parentURN?: 
                 if (noParent) {
                     newAliasSpec.setNoparent(noParent);
                 } else {
-                    const aliasParentUrn = a.hasOwnProperty("parent") ? getParentURN(a.parent) : output(parentURN);
+                    const aliasParentUrn = Object.hasOwn(a, "parent") ? getParentURN(a.parent) : output(parentURN);
                     const urn = await aliasParentUrn.promise();
                     newAliasSpec.setParenturn(urn);
                 }
@@ -920,7 +920,7 @@ async function resolveOutputs(
     const label = `resource:${name}[${t}]#...`;
     if (!isDryRun() || isLegacyApplyEnabled()) {
         for (const key of Object.keys(props)) {
-            if (!allProps.hasOwnProperty(key)) {
+            if (!Object.hasOwn(allProps, key)) {
                 // input prop the engine didn't give us a final value for.  Just use the value passed into the resource
                 // after round-tripping it through serialization. We do the round-tripping primarily s.t. we ensure that
                 // Output values are handled properly w.r.t. unknowns.

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -55,7 +55,7 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
         }
 
         // Create a property to wrap the value and store it on the resource.
-        if (onto.hasOwnProperty(k)) {
+        if (Object.hasOwn(onto, k)) {
             throw new Error(`Property '${k}' is already initialized on target '${label}`);
         }
 
@@ -271,7 +271,7 @@ export function resolveProperties(
     // We will resolve all of these values as `undefined`, and will mark the value as known if we are not running a
     // preview.
     for (const k of Object.keys(resolvers)) {
-        if (!allProps.hasOwnProperty(k)) {
+        if (!Object.hasOwn(allProps, k)) {
             const resolve = resolvers[k];
             resolve(undefined, !isDryRun(), false);
         }

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -90,7 +90,7 @@ export class StackReference extends CustomResource {
      */
     public requireOutput(name: Input<string>): Output<any> {
         const value = all([output(this.name), output(name), this.outputs]).apply(([stackname, n, os]) => {
-            if (!os.hasOwnProperty(n)) {
+            if (!Object.hasOwn(os, n)) {
                 throw new Error(`Required output '${n}' does not exist on stack '${stackname}'.`);
             }
             return os[n];


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
