### PR TITLE
[typescript/program-gen] Allow iterating dynamic entries in TypeScript

### DIFF
--- a/changelog/pending/20230516--programgen-nodejs--allow-iterating-dynamic-entries-in-typescript.yaml
+++ b/changelog/pending/20230516--programgen-nodejs--allow-iterating-dynamic-entries-in-typescript.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Allow iterating dynamic entries in TypeScript

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -338,6 +338,10 @@ func (g *generator) genEntries(w io.Writer, expr *model.FunctionCallExpression) 
 		g.Fgenf(w, "%.20v.map((v, k)", expr.Args[0])
 	case *model.MapType, *model.ObjectType:
 		g.Fgenf(w, "Object.entries(%.v).map(([k, v])", expr.Args[0])
+	case *model.OpaqueType:
+		if entriesArgType.Equals(model.DynamicType) {
+			g.Fgenf(w, "Object.entries(%.v).map(([k, v])", expr.Args[0])
+		}
 	}
 	g.Fgenf(w, " => ({key: k, value: v}))")
 }

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -274,7 +274,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "dynamic-entries",
 		Description: "Testing iteration of dynamic entries in TypeScript",
 		Skip:        allProgLanguages.Except("nodejs"),
-		SkipCompile: allProgLanguages.Except("nodejs"),
+		SkipCompile: allProgLanguages,
 	},
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -270,6 +270,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Tests that we can return various literal values via stack outputs",
 		SkipCompile: codegen.NewStringSet("go"),
 	},
+	{
+		Directory:   "dynamic-entries",
+		Description: "Testing iteration of dynamic entries in TypeScript",
+		Skip:        allProgLanguages.Except("nodejs"),
+		SkipCompile: allProgLanguages.Except("nodejs"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/dynamic-entries-pp/dynamic-entries.pp
+++ b/pkg/codegen/testing/test/testdata/dynamic-entries-pp/dynamic-entries.pp
@@ -1,0 +1,20 @@
+config "domainName" "string" {
+  default     = ""
+  description = "A domain name for which the certificate should be issued"
+}
+config "validationMethod" "string" {
+  default     = "DNS"
+  description = "Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform."
+}
+config "validationOption" "any" {
+  default = {}
+}
+
+resource "certificate" "aws:acm/certificate:Certificate" {
+  validationOptions = [for entry in entries(validationOption) : {
+    domainName       = entry.value["domain_name"]
+    validationDomain = entry.value["validation_domain"]
+  }]
+  domainName              = domainName
+  validationMethod        = validationMethod
+}

--- a/pkg/codegen/testing/test/testdata/dynamic-entries-pp/nodejs/dynamic-entries.ts
+++ b/pkg/codegen/testing/test/testdata/dynamic-entries-pp/nodejs/dynamic-entries.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// A domain name for which the certificate should be issued
+const domainName = config.get("domainName") || "";
+// Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform.
+const validationMethod = config.get("validationMethod") || "DNS";
+const validationOption = config.getObject("validationOption") || {};
+const certificate = new aws.acm.Certificate("certificate", {
+    validationOptions: Object.entries(validationOption).map(([k, v]) => ({key: k, value: v})).map(entry => ({
+        domainName: entry.value.domain_name,
+        validationDomain: entry.value.validation_domain,
+    })),
+    domainName: domainName,
+    validationMethod: validationMethod,
+});


### PR DESCRIPTION
This PR fixes an issue in TypeScript program-gen to allow iterating over a dynamic variable. Treats them the same way maps and objects are handled. 

This piece of code:
```
  validationOptions = [for entry in entries(validationOption) : {
    domainName       = entry.value["domain_name"]
    validationDomain = entry.value["validation_domain"]
  }]
```
used to compile to 
```ts
// invalid TypeScript
validationOptions:  => ({key: k, value: v})).map(entry => ({
        domainName: entry.value.domain_name,
        validationDomain: entry.value.validation_domain,
    })),
```
but now fixed to compile to 
```ts
validationOptions: Object.entries(validationOption).map(([k, v]) => ({key: k, value: v})).map(entry => ({
        domainName: entry.value.domain_name,
        validationDomain: entry.value.validation_domain,
    })),
```
See added test example for full code.



## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
