### PR TITLE
fix(host/go): Allow Pulumi program in a subdir of the module

### DIFF
--- a/changelog/pending/20230517--sdk-go--fix-regression-disallowing-placing-a-pulumi-program-in-a-subdirectory-of-a-module.yaml
+++ b/changelog/pending/20230517--sdk-go--fix-regression-disallowing-placing-a-pulumi-program-in-a-subdirectory-of-a-module.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix regression disallowing placing a Pulumi program in a subdirectory of a Go module.

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/README
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/README
@@ -1,0 +1,1 @@
+This is a root of a project that places its Pulumi program in a subdirectory.

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.mod
@@ -1,0 +1,16 @@
+module example.com/prog-subdir
+
+go 1.18
+
+replace (
+	example.com/dep => ../dep
+	example.com/indirect-dep/v2 => ../indirect-dep
+	example.com/plugin => ../plugin
+)
+
+require (
+	example.com/dep v1.5.0
+	example.com/plugin v1.2.3
+)
+
+require example.com/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: prog
+description: A program with a few dependencies.
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"example.com/dep"
+	"example.com/plugin"
+)
+
+func main() {
+	plugin.Foo()
+	dep.Bar()
+}


### PR DESCRIPTION
Fixes a regression in the Go language host where we started misbehaving
if the Pulumi.yaml was in a subdirectory of the Go module.

    myproject/
      |- go.mod
      |- foo.go
      '- infra/
          |- Pulumi.yaml
          '- main.go

This regression was introduced in #12727,
where we started parsing go.mod files to extract version information
and incorrectly assumed that the go.mod file was in the request
directory.

To fix this, we'll use the following command to get the absolute path
to the go.mod file.

    go list -m -f '{{.GoMod}}'

This command works in the root or subdirectory of a module
in both vendor and module mode.

Testing:
Includes a regression test in both module and vendor mode.

Resolves #12963
