### PR TITLE
add aliases to front matter

### DIFF
--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -51,9 +51,13 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// Add some front matter to each file.
 				fileNameWithoutExtension := strings.TrimSuffix(filepath.Base(s), ".md")
 				title := strings.ReplaceAll(fileNameWithoutExtension, "_", " ")
+				ymlIndent := "  " // 2 spaces
 				buf := new(bytes.Buffer)
 				buf.WriteString("---\n")
 				fmt.Fprintf(buf, "title: %q\n", title)
+				// Add redirect aliases to the front matter.
+				fmt.Fprint(buf, "aliases:\n")
+				fmt.Fprintf(buf, "%s- /docs/reference/cli/%s/\n", ymlIndent, fileNameWithoutExtension)
 				buf.WriteString("---\n\n")
 				return buf.String()
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->
Fixes: https://github.com/pulumi/docs/issues/9087

Add redirect aliases to CLI docs gen. I was able to test this and gen the output to confirm. You can see the files this change outputs in this [test PR that I created in the docs repo](https://github.com/pulumi/docs/pull/9102). There is not much diff there content wise because susan manually fixed up the files that are committed there. This is probably a good sign the genned output is now correct. 





## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
