### PR TITLE
Revert change in targeted update behavior.

### DIFF
--- a/changelog/pending/20230518--engine--revert-change-in-behavior-where-providers-would-skip-running-check-on-untargeted-resources-leading-to-unexpected-diffs.yaml
+++ b/changelog/pending/20230518--engine--revert-change-in-behavior-where-providers-would-skip-running-check-on-untargeted-resources-leading-to-unexpected-diffs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Step generation now uses old inputs for untargeted resources and does not send current inputs to `Check()` on providers.


### PR DESCRIPTION
Fixes #12964

This commit uses an untargeted resource's old inputs directly and does
not send the untargeted resource's inputs to the provider for
alterations in `provider.Check()`.

This commit fixes a bug in behavior where `provider.Check()` was
no longer be called on untargeted resources. `provider.Check()` would
alter the engine's inputs for use in resource.Goals and skipping this
would cause `__defaults` to not be configured properly in same steps by
`provider.Check()` and cause replaces in some cases.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
