### PR TITLE
Fix PULUMI_DEBUG_GPRC to intercept client errors

### DIFF
--- a/changelog/pending/20230519--cli-plugin--fixes-pulumi_debug_grpc-to-surface-provider-errors.yaml
+++ b/changelog/pending/20230519--cli-plugin--fixes-pulumi_debug_grpc-to-surface-provider-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fixes PULUMI_DEBUG_GRPC to surface provider errors

--- a/pkg/util/rpcdebug/interceptors.go
+++ b/pkg/util/rpcdebug/interceptors.go
@@ -127,7 +127,11 @@ func (i *DebugInterceptor) DebugClientInterceptor(opts LogOptions) grpc.UnaryCli
 		}
 		i.trackRequest(&log, req)
 		err := invoker(ctx, method, req, reply, cc, gopts...)
-		i.trackResponse(&log, reply)
+		if err != nil {
+			i.track(&log, err)
+		} else {
+			i.trackResponse(&log, reply)
+		}
 		if e := i.record(log); e != nil {
 			return e
 		}

--- a/pkg/util/rpcdebug/interceptors_test.go
+++ b/pkg/util/rpcdebug/interceptors_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcdebug
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func TestClientInterceptorCatchesErrors(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	logFile := filepath.Join(tmp, "test.log")
+
+	i, err := NewDebugInterceptor(DebugInterceptorOptions{
+		LogFile: logFile,
+	})
+	require.NoError(t, err)
+
+	uci := i.DebugClientInterceptor(LogOptions{})
+
+	ctx := context.Background()
+
+	giveErr := fmt.Errorf("oops")
+
+	var inner grpc.UnaryInvoker = func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		opts ...grpc.CallOption,
+	) error {
+		return giveErr
+	}
+
+	err = uci(ctx, "/pulumirpc.ResourceProvider/Configure",
+		&pulumirpc.ConfigureRequest{
+			Variables: map[string]string{"x": "y"},
+		},
+		&pulumirpc.ConfigureResponse{}, nil, inner)
+
+	assert.ErrorIs(t, err, giveErr)
+
+	log, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"method": "/pulumirpc.ResourceProvider/Configure",
+		"request": {"variables": {"x": "y"}},
+		"errors": ["oops"]
+	}`, string(log))
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is useful for a lot of provider debugging when a resource provider returns an error. Previously this error would
not surface in the PULUMI_DEBUG_GRPC log, and with this change it does.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
