### PR TITLE
ci: Lint Go language host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TESTS_PKGS      := $(shell cd ./tests && go list -tags all ./... | grep -v tests
 VERSION         := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ./scripts/pulumi-version.sh))
 
 # Relative paths to directories with go.mod files that should be linted.
-LINT_GOLANG_PKGS := sdk pkg tests
+LINT_GOLANG_PKGS := sdk pkg tests sdk/go/pulumi-language-go
 
 # Additional arguments to pass to golangci-lint.
 GOLANGCI_LINT_ARGS ?=

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -817,8 +817,8 @@ func (host *goLanguageHost) RunPlugin(
 }
 
 func (host *goLanguageHost) GenerateProject(
-	ctx context.Context, req *pulumirpc.GenerateProjectRequest) (*pulumirpc.GenerateProjectResponse, error) {
-
+	ctx context.Context, req *pulumirpc.GenerateProjectRequest,
+) (*pulumirpc.GenerateProjectResponse, error) {
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
 	})
@@ -863,8 +863,8 @@ func (host *goLanguageHost) GenerateProject(
 }
 
 func (host *goLanguageHost) GenerateProgram(
-	ctx context.Context, req *pulumirpc.GenerateProgramRequest) (*pulumirpc.GenerateProgramResponse, error) {
-
+	ctx context.Context, req *pulumirpc.GenerateProgramRequest,
+) (*pulumirpc.GenerateProgramResponse, error) {
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
 	})
@@ -912,8 +912,8 @@ func (host *goLanguageHost) GenerateProgram(
 }
 
 func (host *goLanguageHost) GeneratePackage(
-	ctx context.Context, req *pulumirpc.GeneratePackageRequest) (*pulumirpc.GeneratePackageResponse, error) {
-
+	ctx context.Context, req *pulumirpc.GeneratePackageRequest,
+) (*pulumirpc.GeneratePackageResponse, error) {
 	if len(req.ExtraFiles) > 0 {
 		return nil, errors.New("overlays are not supported for Go")
 	}

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -489,7 +488,7 @@ func TestGeneratePackage(t *testing.T) {
 
 	// This is just a simple test that we wrote the doc file. This will be better covered by matrix tests
 	// soon.
-	contents, err := ioutil.ReadFile(filepath.Join(root, "test/doc.go"))
+	contents, err := os.ReadFile(filepath.Join(root, "test/doc.go"))
 	require.NoError(t, err)
 
 	assert.Contains(t, string(contents), "// A test package")
@@ -541,7 +540,7 @@ output "dummyOutput" {
 
 	// This is just a simple test that we wrote a program. This will be better covered by matrix tests
 	// soon.
-	contents, err := ioutil.ReadFile(filepath.Join(root, "main.go"))
+	contents, err := os.ReadFile(filepath.Join(root, "main.go"))
 	require.NoError(t, err)
 
 	assert.Contains(t, string(contents), "dummyOutput")


### PR DESCRIPTION
The Go language host is a separate Go module
and did not have linting enabled.

This adds it to the list of packages that should be linted in CI
and fixes issues that were found:

- not gofumpted
- using ioutil