### PR TITLE
lint(govet): Enable nilness linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,8 @@ linters-settings:
     # pre-emptively.
     # Don't complain about these.
     allow-unused: true
+  govet:
+    enable: [nilness]
 
 issues:
   exclude-rules:

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -279,7 +279,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	appendFileName := "Pulumi.yaml.append"
 	appendFile := filepath.Join(root, appendFileName)
-	os.Remove(appendFile)
+	err = os.Remove(appendFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
@@ -627,9 +627,6 @@ func promptAndCreateStack(ctx context.Context, b backend.Backend, prompt promptF
 			return nil, err
 		}
 		formattedStackName, err := buildStackName(stackName)
-		if err != nil {
-			return nil, err
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -187,10 +187,6 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("validating stack config: %w", configErr))
 			}
 
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
-			}
-
 			targetURNs := []string{}
 			targetURNs = append(targetURNs, targets...)
 

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -98,7 +98,7 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 		}
 
 		if len(files) == 0 {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
+			diagnostics = diagnostics.Append(errorf(nodeRange, "no files found"))
 			return nil, diagnostics, nil
 		}
 
@@ -128,11 +128,6 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 					return nil, diagnostics, err
 				}
 			}
-		}
-
-		if err != nil {
-			diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
-			return nil, diagnostics, err
 		}
 
 		componentProgram, programDiags, err := BindProgram(parser.Files,

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -370,9 +370,7 @@ func TestRuntimeErrorInlineGo(t *testing.T) {
 
 	// initialize
 	s, err := NewStackInlineSource(ctx, stackName, runtimeErrProj, func(ctx *pulumi.Context) error {
-		var x []string
-		ctx.Export("a", pulumi.String(x[0]))
-		return nil
+		panic("great sadness")
 	})
 	if err != nil {
 		t.Errorf("failed to initialize stack, err: %v", err)

--- a/tests/integration/construct_component_methods_resources/testcomponent-go/random.go
+++ b/tests/integration/construct_component_methods_resources/testcomponent-go/random.go
@@ -27,9 +27,6 @@ func NewRandom(ctx *pulumi.Context,
 	if args == nil || args.Length == nil {
 		return nil, errors.New("missing required argument 'Length'")
 	}
-	if args == nil {
-		args = &RandomArgs{}
-	}
 	var resource Random
 	err := ctx.RegisterResource("testprovider:index:Random", name, args, &resource, opts...)
 	if err != nil {


### PR DESCRIPTION
govet includes a nilness linter that detects a few nil issues.
This linter is not enabled by default in govet because the `go` tool
does not want a dependency on the libraries necessary to implement this
(golang/go#59714).

Enable the nilness linter and fix the following issues found by it
(commentary below each check mine):

    pkg/cmd/pulumi/new.go:283:9: nilness: impossible condition: nil != nil (govet)
        ^- the error was very likely supposed to be the `os.Remove`
    pkg/cmd/pulumi/new.go:633:10: nilness: impossible condition: nil != nil (govet)
        ^- same error checked on the previous line
    pkg/cmd/pulumi/preview.go:190:11: nilness: impossible condition: nil != nil (govet)
        ^- same error checked a few blocks above
    pkg/codegen/pcl/binder_component.go:101:64: nilness: nil dereference in dynamic method call (govet)
        ^- err is guaranteed nil
    pkg/codegen/pcl/binder_component.go:133:10: nilness: impossible condition: nil != nil (govet)
        ^- err is guaranteed nil
    sdk/go/auto/errors_test.go:374:34: nilness: nil dereference in index operation (govet)
        ^- this is intentional; I replaced it with a deliberate panic
    tests/integration/construct_component_methods_resources/testcomponent-go/random.go:30:10: nilness: impossible condition: non-nil == nil (govet)
        ^- args is rejected if it's nil
