### PR TITLE
lint(vet): Enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,14 @@ linters-settings:
     # Don't complain about these.
     allow-unused: true
   govet:
-    enable: [nilness]
+    enable:
+      - nilness
+      # Reject comparisons of reflect.Value with DeepEqual or '=='.
+      - reflectvaluecompare
+      # Reject sort.Slice calls with a non-slice argument.
+      - sortslice
+      # Detect write to struct/arrays by-value that aren't read again.
+      - unusedwrite
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Enables a few more linters that aren't part of 'go vet' by default
because of the same reason as nilness: the Go toolchain doesn't want
a dependency on the SSA analysis library.

The following checks are enabled:

- reflectvaluecompare: Checks for incorrect comparison of
  `reflect.Value`s with `==` or `reflect.DeepEqual`.
  Given our use of reflection APIs,
  this is probably a good idea to catch.
- sortslice: `sort.Slice(interface{}, ..)` with a non-slice argument
  will panic at runtime. This catches that.
- unusedwrite: Looks for writes to struct fields and the like
  when they're not read again. e.g.,

    ```go
    for _, f := range []foo{...} {
        f.x = 42
        // f is a struct copied by value.
        // The write will be ignored.
    }
    ```

Although we don't have any current instances of these issues,
these are possible in our code base, so guarding against them makes
sense.
