### PR TITLE
Fix version number in typerefs when marshalling schemas

### DIFF
--- a/changelog/pending/20230523--sdkgen-go--fix-versioned-typerefs-being-marshalled-across-code-generator-rpcs.yaml
+++ b/changelog/pending/20230523--sdkgen-go--fix-versioned-typerefs-being-marshalled-across-code-generator-rpcs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix versioned typerefs being marshalled across code generator RPCs.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1342,7 +1342,7 @@ func (pkg *Package) marshalTypeRef(container PackageReference, section, token st
 	}
 
 	// TODO(schema): this isn't quite right--it doesn't handle schemas sourced from URLs--but it's good enough for now.
-	return fmt.Sprintf("/%s/%v/schema.json#/%s/%s", container.Name(), container.Version(), section, token)
+	return fmt.Sprintf("/%s/v%v/schema.json#/%s/%s", container.Name(), container.Version(), section, token)
 }
 
 func marshalLanguage(lang map[string]interface{}) (map[string]RawMessage, error) {

--- a/pkg/codegen/testing/test/testdata/remoteref-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/remoteref-1.0.0.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "remoteref",
+  "version": "1.0.0",
+  "//": [
+    "Simple schema with a remote reference to another schemas type"
+  ],
+  "resources": {
+    "remoteref:index:Root": {
+      "properties": {
+        "ec2": {
+          "$ref": "/aws/v5.16.2/schema.json#/resources/aws:ec2/instance:Instance"
+        }
+      },
+      "required": ["ec2"],
+      "type": "object"
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -81,5 +81,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"synthetic", "1.0.0"},
 		SchemaProvider{"range", "1.0.0"},
 		SchemaProvider{"lambda", "0.1.0"},
+		SchemaProvider{"remoteref", "1.0.0"},
 	)
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13000

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
