### PR TITLE
Consolidated Target parameters

### DIFF
--- a/changelog/pending/20230606--engine--fixes-a-bug-where-targeted-previews-would-error-on-deletes-of-targeted-resources.yaml
+++ b/changelog/pending/20230606--engine--fixes-a-bug-where-targeted-previews-would-error-on-deletes-of-targeted-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fixes a bug where targeted previews would error on deletes of targeted resources.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -249,7 +249,7 @@ func newDestroyCmd() *cobra.Command {
 				Parallel:                  parallel,
 				Debug:                     debug,
 				Refresh:                   refreshOption,
-				DestroyTargets:            deploy.NewUrnTargets(targetUrns),
+				Targets:                   deploy.NewUrnTargets(targetUrns),
 				TargetDependents:          targetDependents,
 				UseLegacyDiff:             useLegacyDiff(),
 				DisableProviderPreview:    disableProviderPreview(),

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -214,7 +214,7 @@ func newPreviewCmd() *cobra.Command {
 					DisableProviderPreview:    disableProviderPreview(),
 					DisableResourceReferences: disableResourceReferences(),
 					DisableOutputValues:       disableOutputValues(),
-					UpdateTargets:             deploy.NewUrnTargets(targetURNs),
+					Targets:                   deploy.NewUrnTargets(targetURNs),
 					TargetDependents:          targetDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -250,7 +250,7 @@ func newRefreshCmd() *cobra.Command {
 				DisableProviderPreview:    disableProviderPreview(),
 				DisableResourceReferences: disableResourceReferences(),
 				DisableOutputValues:       disableOutputValues(),
-				RefreshTargets:            deploy.NewUrnTargets(targetUrns),
+				Targets:                   deploy.NewUrnTargets(targetUrns),
 				Experimental:              hasExperimentalCommands(),
 			}
 

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -138,13 +138,12 @@ func newUpCmd() *cobra.Command {
 			Parallel:                  parallel,
 			Debug:                     debug,
 			Refresh:                   refreshOption,
-			RefreshTargets:            deploy.NewUrnTargets(targetURNs),
 			ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
 			UseLegacyDiff:             useLegacyDiff(),
 			DisableProviderPreview:    disableProviderPreview(),
 			DisableResourceReferences: disableResourceReferences(),
 			DisableOutputValues:       disableOutputValues(),
-			UpdateTargets:             deploy.NewUrnTargets(targetURNs),
+			Targets:                   deploy.NewUrnTargets(targetURNs),
 			TargetDependents:          targetDependents,
 			// Trigger a plan to be generated during the preview phase which can be constrained to during the
 			// update phase.

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -50,6 +50,10 @@ func Destroy(
 	logging.V(7).Infof("*** Starting Destroy(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Destroy(preview=%v) complete ***", dryRun)
 
+	if err := checkTargets(opts.Targets, u.GetTarget().Snapshot); err != nil {
+		return nil, nil, result.FromError(err)
+	}
+
 	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newDestroySource,

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -336,7 +336,7 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 		refreshTargets = append(refreshTargets, pickURN(t, urns, names, target))
 	}
 
-	p.Options.RefreshTargets = deploy.NewUrnTargetsFromUrns(refreshTargets)
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
 	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
@@ -496,10 +496,10 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 	refreshTargets := []resource.URN{}
 
 	for _, target := range targets {
-		refreshTargets = append(p.Options.RefreshTargets.Literals(), pickURN(t, urns, names, target))
+		refreshTargets = append(p.Options.Targets.Literals(), pickURN(t, urns, names, target))
 	}
 
-	p.Options.RefreshTargets = deploy.NewUrnTargetsFromUrns(refreshTargets)
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
 	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -122,7 +122,7 @@ func destroySpecificTargets(
 		destroyTargets = append(destroyTargets, pickURN(t, urns, complexTestDependencyGraphNames, target))
 	}
 
-	p.Options.DestroyTargets = deploy.NewUrnTargetsFromUrns(destroyTargets)
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns(destroyTargets)
 	t.Logf("Destroying targets: %v", destroyTargets)
 
 	// If we're not forcing the targets to be destroyed, then expect to get a failure here as
@@ -142,7 +142,7 @@ func destroySpecificTargets(
 				deleted[entry.Step.URN()] = true
 			}
 
-			for _, target := range p.Options.DestroyTargets.Literals() {
+			for _, target := range p.Options.Targets.Literals() {
 				assert.Contains(t, deleted, target)
 			}
 
@@ -232,7 +232,7 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 			string(pickURN(t, urns, complexTestDependencyGraphNames, target)))
 	}
 
-	p.Options.UpdateTargets = deploy.NewUrnTargets(updateTargets)
+	p.Options.Targets = deploy.NewUrnTargets(updateTargets)
 	t.Logf("Updating targets: %v", updateTargets)
 
 	p.Steps = []TestStep{{
@@ -256,13 +256,13 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 				}
 			}
 
-			for _, target := range p.Options.UpdateTargets.Literals() {
+			for _, target := range p.Options.Targets.Literals() {
 				assert.Contains(t, updated, target)
 			}
 
 			if !targetDependents {
 				// We should only perform updates on the entries we have targeted.
-				for _, target := range p.Options.UpdateTargets.Literals() {
+				for _, target := range p.Options.Targets.Literals() {
 					assert.Contains(t, targets, target.Name().String())
 				}
 			} else {
@@ -282,7 +282,7 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 				assert.True(t, found, "Updates: %v", updateList)
 			}
 
-			for _, target := range p.Options.UpdateTargets.Literals() {
+			for _, target := range p.Options.Targets.Literals() {
 				assert.NotContains(t, sames, target)
 			}
 			if expectedUpdates > -1 {
@@ -334,8 +334,8 @@ func updateInvalidTarget(t *testing.T) {
 
 	p.Options.Host = deploytest.NewPluginHost(nil, nil, program, loaders...)
 
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{"foo"})
-	t.Logf("Updating invalid targets: %v", p.Options.UpdateTargets)
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{"foo"})
+	t.Logf("Updating invalid targets: %v", p.Options.Targets)
 
 	p.Steps = []TestStep{{
 		Op:            Update,
@@ -383,7 +383,7 @@ func TestCreateDuringTargetedUpdate_CreateMentionedAsTarget(t *testing.T) {
 	resA := p.NewURN("pkgA:m:typA", "resA", "")
 	resB := p.NewURN("pkgA:m:typA", "resB", "")
 	p.Options.Host = host2
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA, resB})
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA, resB})
 	p.Steps = []TestStep{{
 		Op:            Update,
 		ExpectFailure: false,
@@ -445,7 +445,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateNotReferenced(t *testing.T) 
 	resA := p.NewURN("pkgA:m:typA", "resA", "")
 
 	p.Options.Host = host2
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
 	p.Steps = []TestStep{{
 		Op:            Update,
 		ExpectFailure: false,
@@ -509,7 +509,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTarget(t *testin
 	host2 := deploytest.NewPluginHost(nil, nil, program2, loaders...)
 
 	p.Options.Host = host2
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
 	p.Steps = []TestStep{{
 		Op:            Update,
 		ExpectFailure: true,
@@ -564,7 +564,7 @@ func TestCreateDuringTargetedUpdate_UntargetedProviderReferencedByTarget(t *test
 
 	resA := p.NewURN("pkgA:m:typA", "resA", "")
 
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
 	p.Steps = []TestStep{{
 		Op:            Update,
 		ExpectFailure: true,
@@ -618,7 +618,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUntargetedCreate
 	host2 := deploytest.NewPluginHost(nil, nil, program2, loaders...)
 
 	p.Options.Host = host2
-	p.Options.UpdateTargets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
 	p.Steps = []TestStep{{
 		Op:            Update,
 		ExpectFailure: false,
@@ -918,7 +918,7 @@ func destroySpecificTargetsWithChildren(
 		destroyTargets = append(destroyTargets, pickURN(t, urns, componentBasedTestDependencyGraphNames, target))
 	}
 
-	p.Options.DestroyTargets = deploy.NewUrnTargetsFromUrns(destroyTargets)
+	p.Options.Targets = deploy.NewUrnTargetsFromUrns(destroyTargets)
 	t.Logf("Destroying targets: %v", destroyTargets)
 
 	// If we're not forcing the targets to be destroyed, then expect to get a failure here as
@@ -938,7 +938,7 @@ func destroySpecificTargetsWithChildren(
 				deleted[entry.Step.URN()] = true
 			}
 
-			for _, target := range p.Options.DestroyTargets.Literals() {
+			for _, target := range p.Options.Targets.Literals() {
 				assert.Contains(t, deleted, target)
 			}
 
@@ -1003,7 +1003,7 @@ func TestTargetedCreateDefaultProvider(t *testing.T) {
 	// Check that update succeeds despite the default provider not being targeted.
 	snap, res := TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
 		Host: host,
-		UpdateTargets: deploy.NewUrnTargets([]string{
+		Targets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resA",
 		}),
 	}, false, p.BackendClient, nil)
@@ -1085,7 +1085,7 @@ func TestEnsureUntargetedSame(t *testing.T) {
 	// Target only `resA` and run a targeted update.
 	finalSnap, res := TestOp(Update).Run(project, p.GetTarget(t, origSnap), UpdateOptions{
 		Host: host,
-		UpdateTargets: deploy.NewUrnTargets([]string{
+		Targets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resA",
 		}),
 	}, false, p.BackendClient, nil)
@@ -1180,7 +1180,7 @@ func TestReplaceSpecificTargetsPlan(t *testing.T) {
 			GeneratePlan: true,
 
 			// `--target-replace a` means ReplaceTargets and UpdateTargets are both set for a.
-			UpdateTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{
+			Targets: deploy.NewUrnTargetsFromUrns([]resource.URN{
 				urnA,
 			}),
 			ReplaceTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{
@@ -1261,7 +1261,7 @@ func TestReplaceSpecificTargetsPlan(t *testing.T) {
 			Experimental: true,
 			GeneratePlan: true,
 
-			UpdateTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{
+			Targets: deploy.NewUrnTargetsFromUrns([]resource.URN{
 				urnB,
 			}),
 			ReplaceTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1685,7 +1685,7 @@ func TestResoucesTargeted(t *testing.T) {
 		Host:         host,
 		Experimental: true,
 		GeneratePlan: true,
-		UpdateTargets: deploy.NewUrnTargets([]string{
+		Targets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resB",
 		}),
 	}, p.BackendClient, nil)
@@ -1702,13 +1702,13 @@ func TestResoucesTargeted(t *testing.T) {
 	}, false, p.BackendClient, nil)
 	assert.NotNil(t, res)
 
-	// Check that running an update with the same UpdateTargets as the Plan succeeds.
+	// Check that running an update with the same Targets as the Plan succeeds.
 	_, res = TestOp(Update).Run(project, p.GetTarget(t, nil), UpdateOptions{
 		// Clone the plan as the plan will be mutated by the engine and useless in future runs.
 		Plan:         plan.Clone(),
 		Host:         host,
 		Experimental: true,
-		UpdateTargets: deploy.NewUrnTargets([]string{
+		Targets: deploy.NewUrnTargets([]string{
 			"urn:pulumi:test::test::pkgA:m:typA::resB",
 		}),
 	}, false, p.BackendClient, nil)
@@ -1754,7 +1754,7 @@ func TestStackOutputsWithTargetedPlan(t *testing.T) {
 		Host:         p.Options.Host,
 		Experimental: true,
 		GeneratePlan: true,
-		UpdateTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{
+		Targets: deploy.NewUrnTargetsFromUrns([]resource.URN{
 			resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"),
 		}),
 	}, p.BackendClient, nil)
@@ -1766,7 +1766,7 @@ func TestStackOutputsWithTargetedPlan(t *testing.T) {
 		Host:         p.Options.Host,
 		GeneratePlan: true,
 		Experimental: true,
-		UpdateTargets: deploy.NewUrnTargetsFromUrns([]resource.URN{
+		Targets: deploy.NewUrnTargetsFromUrns([]resource.URN{
 			resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"),
 		}),
 	}, false, p.BackendClient, nil)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -53,6 +53,10 @@ func Refresh(
 	logging.V(7).Infof("*** Starting Refresh(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Refresh(preview=%v) complete ***", dryRun)
 
+	if err := checkTargets(opts.Targets, u.GetTarget().Snapshot); err != nil {
+		return nil, nil, result.FromError(err)
+	}
+
 	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newRefreshSource,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -114,17 +114,11 @@ type UpdateOptions struct {
 	// true if the plan should refresh before executing.
 	Refresh bool
 
-	// Specific resources to refresh during a refresh operation.
-	RefreshTargets deploy.UrnTargets
-
 	// Specific resources to replace during an update operation.
 	ReplaceTargets deploy.UrnTargets
 
-	// Specific resources to destroy during a destroy operation.
-	DestroyTargets deploy.UrnTargets
-
-	// Specific resources to update during an update operation.
-	UpdateTargets deploy.UrnTargets
+	// Specific resources to update during a deployment.
+	Targets deploy.UrnTargets
 
 	// true if we're allowing dependent targets to change, even if not specified in one of the above
 	// XXXTargets lists.
@@ -194,6 +188,8 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 
 	logging.V(7).Infof("*** Starting Update(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Update(preview=%v) complete ***", dryRun)
+
+	// We skip the target check here because the targeted resource may not exist yet.
 
 	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -56,10 +56,8 @@ type Options struct {
 	Parallel                  int        // the degree of parallelism for resource operations (<=1 for serial).
 	Refresh                   bool       // whether or not to refresh before executing the deployment.
 	RefreshOnly               bool       // whether or not to exit after refreshing.
-	RefreshTargets            UrnTargets // The specific resources to refresh during a refresh op.
-	ReplaceTargets            UrnTargets // Specific resources to replace.
-	DestroyTargets            UrnTargets // Specific resources to destroy.
-	UpdateTargets             UrnTargets // Specific resources to update.
+	Targets                   UrnTargets // If specified, only operate on specified resources.
+	ReplaceTargets            UrnTargets // If specified, mark the specified resources for replacement.
 	TargetDependents          bool       // true if we're allowing things to proceed, even with unspecified targets
 	TrustDependencies         bool       // whether or not to trust the resource dependency graph.
 	UseLegacyDiff             bool       // whether or not to use legacy diffing behavior.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Consolidate `--target` handling internally to deduplicate `DestroyTargets` `RefreshTargets` `UpdateTargets` into a single `Targets` field.

Consequences:
-  this moves pre-update verification of `--target`s existing for destroyed resources into the Destroy command (similar to `--exclude-protected`)
- in the engine, `checkTargets()` now runs before `rebuildBaseState()` mutates the prev Snapshot it was checking
  - Fixes #6422 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13029

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works (tests broke on destroy after consolidation and are now fixed).
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
