### PR TITLE
[pcl/binder] Include the component source directory in diagnostics when reporting PCL errors

### DIFF
--- a/changelog/pending/20230524--programgen--include-the-component-source-directory-in-diagnostics-when-reporting-pcl-errors.yaml
+++ b/changelog/pending/20230524--programgen--include-the-component-source-directory-in-diagnostics-when-reporting-pcl-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Include the component source directory in diagnostics when reporting PCL errors

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -135,7 +135,28 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 			DirPath(componentSourceDir),
 			ComponentBinder(ComponentProgramBinderFromFileSystem()))
 
+		includeSourceDirectoryInDiagnostics(programDiags, componentSourceDir)
+
 		return componentProgram, programDiags, err
+	}
+}
+
+// Replaces the Subject of the input diagnostics from just a file name to the full path of the component directory.
+func includeSourceDirectoryInDiagnostics(diags hcl.Diagnostics, componentSourceDir string) {
+	for _, diag := range diags {
+		start := hcl.Pos{}
+		end := hcl.Pos{}
+
+		if diag.Subject != nil {
+			start = diag.Subject.Start
+			end = diag.Subject.End
+		}
+
+		diag.Subject = &hcl.Range{
+			Filename: componentSourceDir,
+			Start:    start,
+			End:      end,
+		}
 	}
 }
 

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -150,6 +150,7 @@ func includeSourceDirectoryInDiagnostics(diags hcl.Diagnostics, componentSourceD
 		if diag.Subject != nil {
 			start = diag.Subject.Start
 			end = diag.Subject.End
+			componentSourceDir = filepath.Join(componentSourceDir, diag.Subject.Filename)
 		}
 
 		diag.Subject = &hcl.Range{


### PR DESCRIPTION
# Description

Include the component source directory in diagnostics when reporting PCL errors. Usually when a PCL component reports an error, the `Subject` of the diagnostic is only a file name like `main.pp` but that is not enough information in programs with many components that have that same file name. This PR addresses the issue and replaces the `Subject` of diagnostic errors to the full path of the component directory. 

Fixes #13015

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
