### PR TITLE
Hardcode some known provider plugin locations

### DIFF
--- a/changelog/pending/20230524--cli-plugin--plugin-install-auto-fills-the-download-url-for-some-known-third-party-plugins.yaml
+++ b/changelog/pending/20230524--cli-plugin--plugin-install-auto-fills-the-download-url-for-some-known-third-party-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Plugin install auto-fills the download URL for some known third-party plugins.

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -103,6 +104,12 @@ func newPluginInstallCmd() *cobra.Command {
 					Version:           version,
 					PluginDownloadURL: serverURL, // If empty, will use default plugin source.
 					Checksums:         checksums,
+				}
+
+				// Try and set known plugin download URLs
+				if urlSet := util.SetKnownPluginDownloadURL(&pluginSpec); urlSet {
+					cmdutil.Diag().Infof(
+						diag.Message("", "Plugin download URL set to %s"), pluginSpec.PluginDownloadURL)
 				}
 
 				// If we don't have a version try to look one up

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -28,6 +28,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/segmentio/encoding/json"
 
+	"github.com/pulumi/pulumi/pkg/v3/util"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -210,11 +212,14 @@ func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (P
 }
 
 func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]byte, *semver.Version, error) {
-	err := l.host.InstallPlugin(workspace.PluginSpec{
+	spec := workspace.PluginSpec{
 		Kind:    workspace.ResourcePlugin,
 		Name:    pkg,
 		Version: version,
-	})
+	}
+	util.SetKnownPluginDownloadURL(&spec)
+
+	err := l.host.InstallPlugin(spec)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -1,0 +1,67 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// SetKnownPluginDownloadURL sets the PluginDownloadURL for the given PluginSpec if it's a known plugin.
+// Returns true if it filled in the URL.
+func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
+	// If the download url is already set don't touch it
+	if spec.PluginDownloadURL != "" {
+		return false
+	}
+
+	pulumiversePlugins := []string{
+		"acme",
+		"aquasec",
+		"astra",
+		"aws-eksa",
+		"buildkite",
+		"concourse",
+		"configcat",
+		"doppler",
+		"exoscale",
+		"gandi",
+		"github-credentials",
+		"googleworkspace",
+		"harbor",
+		"hcp",
+		"heroku",
+		"ibm",
+		"matchbox",
+		"mssql",
+		"ngrok",
+		"purrl",
+		"sentry",
+		"statuscake",
+		"time",
+		"unifi",
+		"vra",
+		"zitadel",
+	}
+	if spec.Kind == workspace.ResourcePlugin {
+		for _, plugin := range pulumiversePlugins {
+			if spec.Name == plugin {
+				spec.PluginDownloadURL = "github://api.github.com/pulumiverse"
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func TestUrlAlreadySet(t *testing.T) {
+	t.Parallel()
+
+	spec := workspace.PluginSpec{
+		Name:              "acme",
+		Kind:              workspace.ResourcePlugin,
+		PluginDownloadURL: "github://api.github.com/pulumiverse",
+	}
+	res := SetKnownPluginDownloadURL(&spec)
+	assert.False(t, res)
+}
+
+func TestKnownProvider(t *testing.T) {
+	t.Parallel()
+
+	spec := workspace.PluginSpec{
+		Name: "acme",
+		Kind: workspace.ResourcePlugin,
+	}
+	res := SetKnownPluginDownloadURL(&spec)
+	assert.True(t, res)
+	assert.Equal(t, "github://api.github.com/pulumiverse", spec.PluginDownloadURL)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Hardcode a list of some known third-party providers so "plugin install" works even without "--server" being set. Currently this is just the pulumiverse plugins, but we could add any other popular ones (Like lbrlabs) here as well.

Long term this would all be replaced with registry lookups.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1058

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
