### PR TITLE
[cli] Better memory profiling

### DIFF
--- a/changelog/pending/20230525--cli--replace-heap-profiles-with-allocation-profiles.yaml
+++ b/changelog/pending/20230525--cli--replace-heap-profiles-with-allocation-profiles.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: cli
+  description: >-
+    Replace heap profiles with allocation profiles and add a flag, --memprofilerate, to
+    control the sampling rate. --memprofilerate behaves like the -memprofilerate flag to
+    `go test`; set it to "1" to profile every allocation site.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -152,6 +152,7 @@ func NewPulumiCmd() *cobra.Command {
 	var profiling string
 	var verbose int
 	var color string
+	var memProfileRate int
 
 	updateCheckResult := make(chan *diag.Diag)
 
@@ -220,7 +221,7 @@ func NewPulumiCmd() *cobra.Command {
 			log.SetOutput(loggingWriter)
 
 			if profiling != "" {
-				if err := cmdutil.InitProfiling(profiling); err != nil {
+				if err := cmdutil.InitProfiling(profiling, memProfileRate); err != nil {
 					logging.Warningf("could not initialize profiling: %v", err)
 				}
 			}
@@ -277,6 +278,8 @@ func NewPulumiCmd() *cobra.Command {
 		"Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file")
 	cmd.PersistentFlags().StringVar(&profiling, "profiling", "",
 		"Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively")
+	cmd.PersistentFlags().IntVar(&memProfileRate, "memprofilerate", 0,
+		"Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate")
 	cmd.PersistentFlags().IntVarP(&verbose, "verbose", "v", 0,
 		"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
 	cmd.PersistentFlags().StringVar(


### PR DESCRIPTION
The current memory profile reports the live objects and their sources at the time at which it is captured. This is almost never what we want: instead, we want a profile of _all_ allocations over the lifetime of the process. These changes replace the heap profile with an allocation profile and add a parameter, --memprofilerate, to control the rate at which allocations are profiled.