### PR TITLE
[logging] Guard verbose logs on glog.Verbose

### DIFF
--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -60,19 +60,25 @@ type VerboseLogger glog.Verbose
 // Info is equivalent to the global Info function, guarded by the value of v.
 // See the documentation of V for usage.
 func (v VerboseLogger) Info(args ...interface{}) {
-	glog.Verbose(v).Info(FilterString(fmt.Sprint(args...)))
+	if v {
+		glog.Verbose(v).Info(FilterString(fmt.Sprint(args...)))
+	}
 }
 
 // Infoln is equivalent to the global Infoln function, guarded by the value of v.
 // See the documentation of V for usage.
 func (v VerboseLogger) Infoln(args ...interface{}) {
-	glog.Verbose(v).Infoln(FilterString(fmt.Sprint(args...)))
+	if v {
+		glog.Verbose(v).Infoln(FilterString(fmt.Sprint(args...)))
+	}
 }
 
 // Infof is equivalent to the global Infof function, guarded by the value of v.
 // See the documentation of V for usage.
 func (v VerboseLogger) Infof(format string, args ...interface{}) {
-	glog.Verbose(v).Infof("%s", FilterString(fmt.Sprintf(format, args...)))
+	if v {
+		glog.Verbose(v).Infof("%s", FilterString(fmt.Sprintf(format, args...)))
+	}
 }
 
 // V builds a logger that logs messages only if verbosity is at least at the provided level.


### PR DESCRIPTION
`glog.Verbose(int)` returns a bool that indicates whether or not logging is enabled at the given level. Check that result prior to actually calling the logger in order to avoid extra work when verbose logging is disabled.