### PR TITLE
[pcl/program-gen] Implement singleOrNone intrinsic for python and typescript

### DIFF
--- a/changelog/pending/20230525--programgen-nodejs-python--implement-singleornone-intrinsic.yaml
+++ b/changelog/pending/20230525--programgen-nodejs-python--implement-singleornone-intrinsic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/nodejs,python
+  description: Implement singleOrNone intrinsic

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -415,6 +415,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "computeFilebase64sha256(%v)", expr.Args[0])
 	case "notImplemented":
 		g.Fgenf(w, "notImplemented(%v)", expr.Args[0])
+	case "singleOrNone":
+		g.Fgenf(w, "singleOrNone(%v)", expr.Args[0])
 	case pcl.Invoke:
 		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)

--- a/pkg/codegen/nodejs/gen_program_utils.go
+++ b/pkg/codegen/nodejs/gen_program_utils.go
@@ -20,11 +20,11 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 %s}`, indent, indent, indent), true
 	case "singleOrNone":
 		return fmt.Sprintf(
-			`%sfunction singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> | undefined {
-%s    if (elements.length == 1) {
-%s        return elements[0];
+			`%sfunction singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> {
+%s    if (elements.length != 1) {
+%s        throw new Error("singleOrNone expected input list to have a single element");
 %s    }
-%s    return undefined;
+%s    return elements[0];
 %s}`, indent, indent, indent, indent, indent, indent), true
 	default:
 		return "", false

--- a/pkg/codegen/nodejs/gen_program_utils.go
+++ b/pkg/codegen/nodejs/gen_program_utils.go
@@ -18,6 +18,14 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 			`%sfunction notImplemented(message: string) {
 %s    throw new Error(message);
 %s}`, indent, indent, indent), true
+	case "singleOrNone":
+		return fmt.Sprintf(
+			`%sfunction singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> | undefined {
+%s    if (elements.length == 1) {
+%s        return elements[0];
+%s    }
+%s    return undefined;
+%s}`, indent, indent, indent, indent, indent, indent), true
 	default:
 		return "", false
 	}

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
@@ -163,29 +162,13 @@ func TestWritingProgramSource(t *testing.T) {
 	assert.True(t, exampleMainExists, "main program file of example component should exist")
 }
 
-func parseAndBindProgram(t *testing.T, text, name string, options ...pcl.BindOption) (*pcl.Program, hcl.Diagnostics) {
-	parser := syntax.NewParser()
-	err := parser.ParseFile(strings.NewReader(text), name)
-	if err != nil {
-		t.Fatalf("could not read %v: %v", name, err)
-	}
-	if parser.Diagnostics.HasErrors() {
-		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
-	}
-
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
-
-	program, diags, err := pcl.BindProgram(parser.Files, options...)
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
-	return program, diags
-}
-
 func TestConfigNodeTypedString(t *testing.T) {
 	t.Parallel()
 	source := "config cidrBlock string { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -198,7 +181,10 @@ func TestConfigNodeTypedString(t *testing.T) {
 func TestConfigNodeTypedOptionalString(t *testing.T) {
 	t.Parallel()
 	source := "config cidrBlock string { default = null }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -214,7 +200,10 @@ func TestConfigNodeTypedOptionalString(t *testing.T) {
 func TestConfigNodeTypedInt(t *testing.T) {
 	t.Parallel()
 	source := "config count int { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -227,7 +216,10 @@ func TestConfigNodeTypedInt(t *testing.T) {
 func TestConfigNodeTypedStringList(t *testing.T) {
 	t.Parallel()
 	source := "config names \"list(string)\" { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -242,7 +234,10 @@ func TestConfigNodeTypedStringList(t *testing.T) {
 func TestConfigNodeTypedIntList(t *testing.T) {
 	t.Parallel()
 	source := "config names \"list(int)\" { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -257,7 +252,10 @@ func TestConfigNodeTypedIntList(t *testing.T) {
 func TestConfigNodeTypedStringMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(string)\" { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -272,7 +270,10 @@ func TestConfigNodeTypedStringMap(t *testing.T) {
 func TestConfigNodeTypedIntMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(int)\" { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -287,7 +288,10 @@ func TestConfigNodeTypedIntMap(t *testing.T) {
 func TestConfigNodeTypedAnyMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(any)\" { }"
-	program, diags := parseAndBindProgram(t, source, "config.pp")
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	if err != nil {
+		t.Fatalf("could not bind program: %v", err)
+	}
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -182,9 +182,7 @@ func TestConfigNodeTypedOptionalString(t *testing.T) {
 	t.Parallel()
 	source := "config cidrBlock string { default = null }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -201,9 +199,7 @@ func TestConfigNodeTypedInt(t *testing.T) {
 	t.Parallel()
 	source := "config count int { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -217,9 +213,7 @@ func TestConfigNodeTypedStringList(t *testing.T) {
 	t.Parallel()
 	source := "config names \"list(string)\" { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -235,9 +229,7 @@ func TestConfigNodeTypedIntList(t *testing.T) {
 	t.Parallel()
 	source := "config names \"list(int)\" { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -253,9 +245,7 @@ func TestConfigNodeTypedStringMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(string)\" { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -271,9 +261,7 @@ func TestConfigNodeTypedIntMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(int)\" { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")
@@ -289,9 +277,7 @@ func TestConfigNodeTypedAnyMap(t *testing.T) {
 	t.Parallel()
 	source := "config names \"map(any)\" { }"
 	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
-	if err != nil {
-		t.Fatalf("could not bind program: %v", err)
-	}
+	require.NoError(t, err)
 	contract.Ignore(diags)
 	assert.NotNil(t, program, "failed to parse and bind program")
 	assert.Equal(t, len(program.Nodes), 1, "there is one node")

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -360,9 +360,15 @@ var pulumiBuiltins = map[string]*model.Function{
 				}}
 			}
 
+			elementType := model.Type(model.DynamicType)
+
 			switch valueType := model.ResolveOutputs(valueType).(type) {
-			case *model.ListType, *model.TupleType:
-				// OK
+			case *model.ListType:
+				elementType = valueType.ElementType
+			case *model.TupleType:
+				if len(valueType.ElementTypes) > 0 {
+					elementType = valueType.ElementTypes[0]
+				}
 			default:
 				if valueType != model.DynamicType {
 					rng := args[0].SyntaxNode().Range()
@@ -379,7 +385,7 @@ var pulumiBuiltins = map[string]*model.Function{
 					Name: "value",
 					Type: valueType,
 				}},
-				ReturnType: model.NewOptionalType(valueType),
+				ReturnType: model.NewOptionalType(elementType),
 			}, diagnostics
 		})),
 }

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -1,0 +1,55 @@
+package pcl_test
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSingleOrNoneErrorsWithoutArguments(t *testing.T) {
+	t.Parallel()
+	source := "value = singleOrNone()"
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	contract.Ignore(diags)
+	assert.Nil(t, program, "The program doesn't bind")
+	assert.Contains(t, err.Error(), "'singleOrNone' only expects one argument")
+}
+
+func TestSingleOrNoneErrorsWithManyArguments(t *testing.T) {
+	t.Parallel()
+	source := "value = singleOrNone(1, 2, 3)"
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	contract.Ignore(diags)
+	assert.Nil(t, program, "The program doesn't bind")
+	assert.Contains(t, err.Error(), "'singleOrNone' only expects one argument")
+}
+
+func TestSingleOrNoneErrorsWhenFirstArgumentIsNotListOrTuple(t *testing.T) {
+	t.Parallel()
+	source := "value = singleOrNone(\"hello\")"
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	contract.Ignore(diags)
+	assert.Nil(t, program, "The program doesn't bind")
+	assert.Contains(t, err.Error(), "the first argument to 'singleOrNone' must be a list or tuple")
+}
+
+func TestSingleOrNoneBindsCorrectlyWhenFirstArgumentIsList(t *testing.T) {
+	t.Parallel()
+	// Test that the expression binds and type checks correctly
+	// and assert that value: Option<'T> when singleOrNone accepts `T[]
+	source := "value = singleOrNone([1, 2, 3])"
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	contract.Ignore(diags)
+	assert.NotNil(t, program, "The program doesn't bind")
+	assert.Nil(t, err, "There is no bind error")
+	assert.Equal(t, len(program.Nodes), 1, "there is one node")
+	localVariable, ok := program.Nodes[0].(*pcl.LocalVariable)
+	assert.True(t, ok, "first node is a local variable variable")
+	assert.Equal(t, localVariable.Name(), "value")
+	variableType := localVariable.Type()
+	assert.True(t, model.IsOptionalType(variableType), "the type is an optional")
+	elementType := pcl.UnwrapOption(variableType)
+	assert.True(t, model.IsConstType(elementType), "element type must the type of one element in the list")
+}

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -1,11 +1,12 @@
 package pcl_test
 
 import (
+	"testing"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSingleOrNoneErrorsWithoutArguments(t *testing.T) {

--- a/pkg/codegen/pcl/utilities_test.go
+++ b/pkg/codegen/pcl/utilities_test.go
@@ -1,18 +1,20 @@
 package pcl_test
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
-	"strings"
-	"testing"
 )
 
 func ParseAndBindProgram(t *testing.T,
 	text string,
 	name string,
-	options ...pcl.BindOption) (*pcl.Program, hcl.Diagnostics, error) {
+	options ...pcl.BindOption,
+) (*pcl.Program, hcl.Diagnostics, error) {
 	parser := syntax.NewParser()
 	err := parser.ParseFile(strings.NewReader(text), name)
 	if err != nil {

--- a/pkg/codegen/pcl/utilities_test.go
+++ b/pkg/codegen/pcl/utilities_test.go
@@ -1,0 +1,28 @@
+package pcl_test
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"strings"
+	"testing"
+)
+
+func ParseAndBindProgram(t *testing.T,
+	text string,
+	name string,
+	options ...pcl.BindOption) (*pcl.Program, hcl.Diagnostics, error) {
+	parser := syntax.NewParser()
+	err := parser.ParseFile(strings.NewReader(text), name)
+	if err != nil {
+		t.Fatalf("could not read %v: %v", name, err)
+	}
+	if parser.Diagnostics.HasErrors() {
+		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
+	}
+
+	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+
+	return pcl.BindProgram(parser.Files, options...)
+}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -298,6 +298,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "computeFilebase64sha256(%v)", expr.Args[0])
 	case "notImplemented":
 		g.Fgenf(w, "not_implemented(%v)", expr.Args[0])
+	case "singleOrNone":
+		g.Fgenf(w, "single_or_none(%v)", expr.Args[0])
 	case pcl.Invoke:
 		if expr.Signature.MultiArgumentInputs {
 			err := fmt.Errorf("python program-gen does not implement MultiArgumentInputs for function '%v'",

--- a/pkg/codegen/python/gen_program_utils.go
+++ b/pkg/codegen/python/gen_program_utils.go
@@ -17,6 +17,13 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 		return fmt.Sprintf(`
 %sdef not_implemented(msg):
 %s    raise NotImplementedError(msg)`, indent, indent), true
+	case "singleOrNone":
+		return fmt.Sprintf(
+			`%sdef single_or_none(elements):
+%s    if len(elements) == 1:
+%s        return elements[0]
+%s    return None
+`, indent, indent, indent, indent), true
 	default:
 		return "", false
 	}

--- a/pkg/codegen/python/gen_program_utils.go
+++ b/pkg/codegen/python/gen_program_utils.go
@@ -20,9 +20,9 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 	case "singleOrNone":
 		return fmt.Sprintf(
 			`%sdef single_or_none(elements):
-%s    if len(elements) == 1:
-%s        return elements[0]
-%s    return None
+%s    if len(elements) != 1:
+%s        raise Exception("single_or_none expected input list to have a single element")
+%s    return elements[0]
 `, indent, indent, indent, indent), true
 	default:
 		return "", false

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -276,6 +276,13 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs"),
 		SkipCompile: allProgLanguages,
 	},
+	{
+		Directory:   "single-or-none",
+		Description: "Tests using the singleOrNone function",
+		// TODO: dotnet and go support
+		Skip:        allProgLanguages.Except("nodejs").Except("python"),
+		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/nodejs/single-or-none.ts
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/nodejs/single-or-none.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+
+function singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> | undefined {
+    if (elements.length == 1) {
+        return elements[0];
+    }
+    return undefined;
+}
+
+export const result = singleOrNone([1]);

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/nodejs/single-or-none.ts
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/nodejs/single-or-none.ts
@@ -1,10 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
 
-function singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> | undefined {
-    if (elements.length == 1) {
-        return elements[0];
+function singleOrNone<T>(elements: pulumi.Input<T>[]): pulumi.Input<T> {
+    if (elements.length != 1) {
+        throw new Error("singleOrNone expected input list to have a single element");
     }
-    return undefined;
+    return elements[0];
 }
 
 export const result = singleOrNone([1]);

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/python/single-or-none.py
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/python/single-or-none.py
@@ -1,9 +1,9 @@
 import pulumi
 
 def single_or_none(elements):
-    if len(elements) == 1:
-        return elements[0]
-    return None
+    if len(elements) != 1:
+        raise Exception("single_or_none expected input list to have a single element")
+    return elements[0]
 
 
 pulumi.export("result", single_or_none([1]))

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/python/single-or-none.py
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/python/single-or-none.py
@@ -1,0 +1,9 @@
+import pulumi
+
+def single_or_none(elements):
+    if len(elements) == 1:
+        return elements[0]
+    return None
+
+
+pulumi.export("result", single_or_none([1]))

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/single-or-none.pp
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/single-or-none.pp
@@ -1,0 +1,3 @@
+output result {
+ value = singleOrNone([ 1 ])
+}


### PR DESCRIPTION
### Description

Implements the `singleOrNone` PCL intrinsic function and its implementation for python and typescript. This function is used when converting terraform's dynamic block that are used with resource attributes where `maxItems == 1` which means the dynamic block (compiled to a for-expression) should evaluate to a single value or none at all. 

The PR adds unit tests to assert the possible error messages produced by the binder when it doesn't type-check correctly

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
