### PR TITLE
test(sdk/npm): Don't download from NPM or Yarn regstries

### DIFF
--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,7 +120,8 @@ func testInstall(t *testing.T, expectedBin string, production bool) {
 	// them to the file descriptor for the null device (os.DevNull).
 	pulumi_testing.YarnInstallMutex.Lock()
 	defer pulumi_testing.YarnInstallMutex.Unlock()
-	bin, err := Install(context.Background(), pkgdir, production, nil, nil)
+	out := iotest.LogWriter(t)
+	bin, err := Install(context.Background(), pkgdir, production, out, out)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBin, bin)
 }

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -32,17 +32,21 @@ import (
 
 	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// chdir temporarily changes the current directory of the program.
+// It restores it to the original directory when the test is done.
 func chdir(t *testing.T, dir string) {
 	cwd, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(dir)) // Set directory
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir)) // Set directory
 	t.Cleanup(func() {
-		assert.NoError(t, os.Chdir(cwd)) // Restore directory
+		require.NoError(t, os.Chdir(cwd)) // Restore directory
 		restoredDir, err := os.Getwd()
-		assert.NoError(t, err)
-		assert.Equal(t, cwd, restoredDir)
+		if assert.NoError(t, err) {
+			assert.Equal(t, cwd, restoredDir)
+		}
 	})
 }
 

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -52,15 +52,26 @@ func chdir(t *testing.T, dir string) {
 
 //nolint:paralleltest // mutates environment variables, changes working directory
 func TestNPMInstall(t *testing.T) {
-	testInstall(t, "npm", false /*production*/)
-	testInstall(t, "npm", true /*production*/)
+	t.Run("development", func(t *testing.T) {
+		testInstall(t, "npm", false /*production*/)
+	})
+
+	t.Run("production", func(t *testing.T) {
+		testInstall(t, "npm", true /*production*/)
+	})
 }
 
 //nolint:paralleltest // mutates environment variables, changes working directory
 func TestYarnInstall(t *testing.T) {
 	t.Setenv("PULUMI_PREFER_YARN", "true")
-	testInstall(t, "yarn", false /*production*/)
-	testInstall(t, "yarn", true /*production*/)
+
+	t.Run("development", func(t *testing.T) {
+		testInstall(t, "yarn", false /*production*/)
+	})
+
+	t.Run("production", func(t *testing.T) {
+		testInstall(t, "yarn", true /*production*/)
+	})
 }
 
 func testInstall(t *testing.T, expectedBin string, production bool) {


### PR DESCRIPTION
Follow up to #12983

Tests that download from NPM or Yarn will be brittle, unsafe, and slow.
We don't need to hit these servers directly.

This change alters the package installation tests to
set up a local HTTP server that implements a subset of the
[NPM Package Registry API][1] -- just enough to satisfy these tests.

  [1]: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md

In the tests, we'll set `$HOME` to a new temporary directory and write
an `~/.npmrc` or `~/.yarnrc` requesting use of the local server as the
registry.

With this, the tests are entirely local. No external requests.

Also contains minor fix-ups to the test that were pointed out in #12983:

- Use 'require' in chdir
- Use subtests for `Test*Install`
- Don't send command output to /dev/null

These fix-ups are in separate commits to keep the meat of this change
independently reviewable.
