### PR TITLE
Fix ignoreChanges[idx] reseting values to zero

### DIFF
--- a/changelog/pending/20230526--engine--fix-ignorechanges-setting-ignore-array-indexs-to-zero.yaml
+++ b/changelog/pending/20230526--engine--fix-ignorechanges-setting-ignore-array-indexs-to-zero.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix ignoreChanges setting ignore array indexes to zero.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1310,6 +1310,23 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 
 	_, res = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
 	assert.NotNil(t, res)
+
+	program = func(monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"qux": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewStringProperty("zed"),
+					resource.NewStringProperty("zob"),
+				}),
+			},
+			IgnoreChanges: []string{"qux[1]"},
+		})
+		assert.Error(t, err)
+		return nil
+	}
+
+	_, res = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
 }
 
 type DiffFunc = func(urn resource.URN, id resource.ID,

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -248,11 +248,7 @@ func (p PropertyPath) Delete(dest PropertyValue) bool {
 	key := p[len(p)-1]
 	switch {
 	case dest.IsArray():
-		index, ok := key.(int)
-		if !ok || index < 0 || index >= len(dest.ArrayValue()) {
-			return false
-		}
-		dest.ArrayValue()[index] = PropertyValue{}
+		return false
 	case dest.IsObject():
 		k, ok := key.(string)
 		if !ok {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Before this change PropertiesPath.Delete would "delete" locations from an array by just writing null to them but not changing the size of the array.

This could result in a deployment that looked like it should have been a same ending up as an update. For example given a resource `X` with a property `foo` set to `[1]` if you changed the program to set `foo` to `[1, 2]` and set `ignoreChanges` to `foo[1]` the deployment would do an update with `foo` set to `[1, 0]`.

This now errors that the path is invalid, this is similar to how we error on invalid paths if intermediate objects are missing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
