### PR TITLE
Improve publish output

### DIFF
--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -146,7 +146,7 @@ func publishToNPM(path string) error {
 
 	if len(output) > 0 {
 		// the package already exists, and we no-op.
-		fmt.Printf("did not publish %s, likely because the version %s already exists\n", pkgInfo.Name, pkgNameWithVersion)
+		fmt.Printf("did not publish %s because version %s already exists\n", pkgInfo.Name, pkgNameWithVersion)
 		return nil
 	}
 
@@ -170,7 +170,7 @@ func publishToNPM(path string) error {
 			return nil
 		}
 		// if we get here, this means the package was not published. We bail.
-		return fmt.Errorf("failed to publish package %w", err)
+		return fmt.Errorf("publish package: %w", err)
 	}
 	fmt.Println("success! published to npm")
 	return nil

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -143,11 +143,13 @@ func publishToNPM(path string) error {
 	logging.V(1).Infof("Running %s", infoCmd)
 	output, err := infoCmd.Output()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to run npm info to verify package %w", err)
 	}
 
 	if len(output) > 0 {
-		return fmt.Errorf("publish %s failed, likely because the version already exists", pkgInfo.Name)
+		// the package already exists, and we no-op.
+		fmt.Printf("did not publish %s, likely because the version %s already exists\n", pkgInfo.Name, pkgNameWithVersion)
+		return nil
 	}
 
 	logging.V(1).Infof("The version does not exist yet, and it is safe to publish")
@@ -164,7 +166,7 @@ func publishToNPM(path string) error {
 		infoCheckCmd.Stderr = os.Stderr
 		checkOutput, checkErr := infoCheckCmd.Output()
 		if checkErr != nil {
-			return fmt.Errorf("running npm info to verify failed %w", checkErr)
+			return fmt.Errorf("failed to publish; running npm info to verify failed %w", checkErr)
 		}
 		if len(checkOutput) > 0 {
 			// this means the package was published after all
@@ -172,7 +174,7 @@ func publishToNPM(path string) error {
 			return nil
 		}
 		// if we get here, this means the package was not published. We bail.
-		return err
+		return fmt.Errorf("failed to publish package %w", err)
 	}
 	fmt.Println("success! published to npm")
 	return nil

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -162,6 +162,7 @@ func publishToNPM(path string) error {
 		// to verify we're not encountering a time-of-check to time-of-use (TOC/TOU) issue.
 		infoCheckCmd := exec.Command("npm", "info", pkgNameWithVersion)
 		infoCheckCmd.Stderr = os.Stderr
+		// Ignore error. stdout will be empty if the package was not published.
 		checkOutput, _ := infoCheckCmd.Output()
 
 		if len(checkOutput) > 0 {

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -141,10 +141,8 @@ func publishToNPM(path string) error {
 	infoCmd := exec.Command(npm, "info", pkgNameWithVersion)
 	infoCmd.Stderr = os.Stderr
 	logging.V(1).Infof("Running %s", infoCmd)
-	output, err := infoCmd.Output()
-	if err != nil {
-		return fmt.Errorf("failed to run npm info to verify package %w", err)
-	}
+	// we actually do not care about the error here; we care whether the output is empty.
+	output, _ := infoCmd.Output()
 
 	if len(output) > 0 {
 		// the package already exists, and we no-op.
@@ -164,10 +162,8 @@ func publishToNPM(path string) error {
 		// to verify we're not encountering a time-of-check to time-of-use (TOC/TOU) issue.
 		infoCheckCmd := exec.Command("npm", "info", pkgNameWithVersion)
 		infoCheckCmd.Stderr = os.Stderr
-		checkOutput, checkErr := infoCheckCmd.Output()
-		if checkErr != nil {
-			return fmt.Errorf("failed to publish; running npm info to verify failed %w", checkErr)
-		}
+		checkOutput, _ := infoCheckCmd.Output()
+
 		if len(checkOutput) > 0 {
 			// this means the package was published after all
 			fmt.Println("success! published to npm")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds more detailed output to npm publish command. 
This command has been working well when run on its own but has been consistently [failing in CI](https://github.com/pulumi/pulumi-kafka/actions/runs/5092448086/jobs/9154177739#step:3:947).
Adding these extra steps will grant more insight.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
I have NOT run make tidy as it doesn't support Go 1.20
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
