### PR TITLE
Change toggle for pyproject.toml

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2978,7 +2978,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 
 	// Finally, if pyproject.toml generation is enabled, generate
 	// this file and emit it as well.
-	if info.PyProject.Enabled {
+	if info.PyProject != nil {
 		project, err := genPyprojectTOML(
 			tool, pkg, pkgName,
 		)

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -56,9 +56,7 @@ type PackageInfo struct {
 	RespectSchemaVersion bool `json:"respectSchemaVersion,omitempty"`
 
 	// If enabled, a pyproject.toml file will be generated.
-	PyProject struct {
-		Enabled bool `json:"enabled,omitempty"`
-	} `json:"pyproject,omitempty"`
+	PyProject *struct{} `json:"pyproject,omitempty"`
 }
 
 // Importer implements schema.Language for Python.

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/schema.json
@@ -15,9 +15,7 @@
   "functions": {},
   "language": {
     "python": {
-      "pyproject": {
-        "enabled": true
-      }
+      "pyproject": {}
     }
   }
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR changes how the pyproject.toml feature is enabled when providers are codegenning Python.
Now, it uses the presence or absence of the "pyproject" field to indicate whether to generate a
pyproject.toml manifest.

This PR is optional. It's a follow-on to https://github.com/pulumi/pulumi/pull/12805
in which this original change was discussed.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
