### PR TITLE
Fix project renames for filestate

### DIFF
--- a/changelog/pending/20230529--backend-filestate--fix-stack-rename-renaming-projects-for-the-self-managed-backend.yaml
+++ b/changelog/pending/20230529--backend-filestate--fix-stack-rename-renaming-projects-for-the-self-managed-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/filestate
+  description: Fix stack rename renaming projects for the self-managed backend.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -794,7 +794,10 @@ func (b *localBackend) renameStack(ctx context.Context, oldRef *localBackendRefe
 
 	// If we have a snapshot, we need to rename the URNs inside it to use the new stack name.
 	if snap != nil {
-		if err = edit.RenameStack(snap, newRef.name, ""); err != nil {
+		project, has := newRef.Project()
+		contract.Assertf(has || project == "", "project should be blank for legacy stacks")
+
+		if err = edit.RenameStack(snap, newRef.name, tokens.PackageName(project)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix renaming the project using "stack rename" for filestate.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
