### PR TITLE
Fix TestNPMInstallCmd

### DIFF
--- a/sdk/nodejs/npm/npm_test.go
+++ b/sdk/nodejs/npm/npm_test.go
@@ -60,7 +60,7 @@ func TestNPMInstallCmd(t *testing.T) {
 			observedCommand := filepath.Base(command.Path)
 			// Trim the extension, which will appear on Windows systems.
 			if extension := filepath.Ext(observedCommand); extension != "" {
-				observedCommand = strings.TrimRight(observedCommand, extension)
+				observedCommand = strings.TrimSuffix(observedCommand, extension)
 			}
 			assert.Equal(t, "false", observedCommand)
 		})


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

I have _no_ idea how this ever got merged to master. But this fixes the TestNPMInstallCmd on windows.

What was happening was that `Path` was being set to "false.exe", the extension for that is ".exe", `TrimRight` takes a _set_ of characters to trim (as a string) so it would trim `Path` to "fals" because "e" is in the cutset.

Changing this to `TrimSuffix` trims off the exact suffix of ".exe".