### PR TITLE
[auto/python] Add support for the path option for config operations

### DIFF
--- a/changelog/pending/20230529--auto-python--add-support-for-the-path-option-for-config-operations.yaml
+++ b/changelog/pending/20230529--auto-python--add-support-for-the-path-option-for-config-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add support for the path option for config operations

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -216,10 +216,14 @@ class LocalWorkspace(Workspace):
         # Not used by LocalWorkspace
         return
 
-    def get_config(self, stack_name: str, key: str) -> ConfigValue:
-        result = self._run_pulumi_cmd_sync(
-            ["config", "get", key, "--json", "--stack", stack_name]
-        )
+    def get_config(
+        self, stack_name: str, key: str, *, path: bool = False
+    ) -> ConfigValue:
+        args = ["config", "get"]
+        if path:
+            args.append("--path")
+        args.extend([key, "--json", "--stack", stack_name])
+        result = self._run_pulumi_cmd_sync(args)
         val = json.loads(result.stdout)
         return ConfigValue(value=val["value"], secret=val["secret"])
 
@@ -236,12 +240,15 @@ class LocalWorkspace(Workspace):
             )
         return config_map
 
-    def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
+    def set_config(
+        self, stack_name: str, key: str, value: ConfigValue, *, path: bool = False
+    ) -> None:
+        args = ["config", "set"]
+        if path:
+            args.append("--path")
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(
+        args.extend(
             [
-                "config",
-                "set",
                 key,
                 secret_arg,
                 "--stack",
@@ -251,9 +258,14 @@ class LocalWorkspace(Workspace):
                 value.value,
             ]
         )
+        self._run_pulumi_cmd_sync(args)
 
-    def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
+    def set_all_config(
+        self, stack_name: str, config: ConfigMap, *, path: bool = False
+    ) -> None:
         args = ["config", "set-all", "--stack", stack_name]
+        if path:
+            args.append("--path")
 
         for key, value in config.items():
             secret_arg = "--secret" if value.secret else "--plaintext"
@@ -261,11 +273,18 @@ class LocalWorkspace(Workspace):
 
         self._run_pulumi_cmd_sync(args)
 
-    def remove_config(self, stack_name: str, key: str) -> None:
-        self._run_pulumi_cmd_sync(["config", "rm", key, "--stack", stack_name])
+    def remove_config(self, stack_name: str, key: str, *, path: bool = False) -> None:
+        args = ["config", "rm", key, "--stack", stack_name]
+        if path:
+            args.append("--path")
+        self._run_pulumi_cmd_sync(args)
 
-    def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
+    def remove_all_config(
+        self, stack_name: str, keys: List[str], *, path: bool = False
+    ) -> None:
         args = ["config", "rm-all", "--stack", stack_name]
+        if path:
+            args.append("--path")
         args.extend(keys)
         self._run_pulumi_cmd_sync(args)
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -580,14 +580,15 @@ class Stack:
             stdout=destroy_result.stdout, stderr=destroy_result.stderr, summary=summary
         )
 
-    def get_config(self, key: str) -> ConfigValue:
+    def get_config(self, key: str, *, path: bool = False) -> ConfigValue:
         """
         Returns the config value associated with the specified key.
 
         :param key: The key for the config item to get.
+        :param path: The key contains a path to a property in a map or list to get.
         :returns: ConfigValue
         """
-        return self.workspace.get_config(self.name, key)
+        return self.workspace.get_config(self.name, key, path=path)
 
     def get_all_config(self) -> ConfigMap:
         """
@@ -597,38 +598,42 @@ class Stack:
         """
         return self.workspace.get_all_config(self.name)
 
-    def set_config(self, key: str, value: ConfigValue) -> None:
+    def set_config(self, key: str, value: ConfigValue, *, path: bool = False) -> None:
         """
         Sets a config key-value pair on the Stack in the associated Workspace.
 
         :param key: The config key to add.
         :param value: The config value to add.
+        :param path: The key contains a path to a property in a map or list to set.
         """
-        self.workspace.set_config(self.name, key, value)
+        self.workspace.set_config(self.name, key, value, path=path)
 
-    def set_all_config(self, config: ConfigMap) -> None:
+    def set_all_config(self, config: ConfigMap, *, path: bool = False) -> None:
         """
         Sets all specified config values on the stack in the associated Workspace.
 
         :param config: A mapping of key to ConfigValue to set to config.
+        :param path: The keys contain a path to a property in a map or list to set.
         """
-        self.workspace.set_all_config(self.name, config)
+        self.workspace.set_all_config(self.name, config, path=path)
 
-    def remove_config(self, key: str) -> None:
+    def remove_config(self, key: str, *, path: bool = False) -> None:
         """
         Removes the specified config key from the Stack in the associated Workspace.
 
         :param key: The key to remove from config.
+        :param path: The key contains a path to a property in a map or list to remove.
         """
-        self.workspace.remove_config(self.name, key)
+        self.workspace.remove_config(self.name, key, path=path)
 
-    def remove_all_config(self, keys: List[str]) -> None:
+    def remove_all_config(self, keys: List[str], *, path: bool = False) -> None:
         """
         Removes the specified config keys from the Stack in the associated Workspace.
 
         :param keys: The keys to remove from config.
+        :param path: The keys contain a path to a property in a map or list to remove.
         """
-        self.workspace.remove_all_config(self.name, keys)
+        self.workspace.remove_all_config(self.name, keys, path=path)
 
     def refresh_config(self) -> None:
         """Gets and sets the config map used with the last update."""

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -207,13 +207,16 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def get_config(self, stack_name: str, key: str) -> ConfigValue:
+    def get_config(
+        self, stack_name: str, key: str, *, path: bool = False
+    ) -> ConfigValue:
         """
         Returns the value associated with the specified stack name and key,
         scoped to the Workspace.
 
         :param stack_name: The name of the stack.
         :param key: The key for the config item to get.
+        :param path: The key contains a path to a property in a map or list to get.
         :returns: ConfigValue
         """
 
@@ -227,40 +230,50 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
+    def set_config(
+        self, stack_name: str, key: str, value: ConfigValue, *, path: bool = False
+    ) -> None:
         """
         Sets the specified key-value pair on the provided stack name.
 
         :param stack_name: The name of the stack.
         :param key: The config key to add.
         :param value: The config value to add.
+        :param path: The key contains a path to a property in a map or list to set.
         """
 
     @abstractmethod
-    def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
+    def set_all_config(
+        self, stack_name: str, config: ConfigMap, *, path: bool = False
+    ) -> None:
         """
         Sets all values in the provided config map for the specified stack name.
 
         :param stack_name: The name of the stack.
         :param config: A mapping of key to ConfigValue to set to config.
+        :param path: The keys contain a path to a property in a map or list to set.
         """
 
     @abstractmethod
-    def remove_config(self, stack_name: str, key: str) -> None:
+    def remove_config(self, stack_name: str, key: str, *, path: bool = False) -> None:
         """
         Removes the specified key-value pair on the provided stack name.
 
         :param stack_name: The name of the stack.
         :param key: The key to remove from config.
+        :param path: The key contains a path to a property in a map or list to remove.
         """
 
     @abstractmethod
-    def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
+    def remove_all_config(
+        self, stack_name: str, keys: List[str], *, path: bool = False
+    ) -> None:
         """
         Removes all values in the provided key list for the specified stack name.
 
         :param stack_name: The name of the stack.
         :param keys: The keys to remove from config.
+        :param path: The keys contain a path to a property in a map or list to remove.
         """
 
     @abstractmethod


### PR DESCRIPTION
Add support for the `--path` flag for config operations in Python automation API.

Part of #5506
Related: #12265