### PR TITLE
[go/program-gen] Do not error when generated Go code cannot be formatted

### DIFF
--- a/changelog/pending/20230530--programgen-go--do-not-error-when-generated-go-code-cannot-be-formatted.yaml
+++ b/changelog/pending/20230530--programgen-go--do-not-error-when-generated-go-code-cannot-be-formatted.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Do not error when generated Go code cannot be formatted

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -405,6 +405,14 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 	if err == nil {
 		// if we were able to format the code, use prefer the formatted version
 		mainProgramContent = formattedSource
+	} else {
+		// add a warning diagnostic when there is a formatting error
+		g.diagnostics = g.diagnostics.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Subject:  &hcl.Range{Filename: "main.go"},
+			Summary:  "could not format go code",
+			Detail:   err.Error(),
+		})
 	}
 
 	files := map[string][]byte{
@@ -433,6 +441,14 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 		if err == nil {
 			// if we were able to format the code, use prefer the formatted version
 			componentContent = formattedComponentSource
+		} else {
+			// add a warning diagnostic when there is a formatting error
+			componentGenerator.diagnostics = componentGenerator.diagnostics.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Subject:  &hcl.Range{Filename: componentName + ".go"},
+				Summary:  "could not format go code",
+				Detail:   err.Error(),
+			})
 		}
 		files[componentName+".go"] = componentContent
 	}


### PR DESCRIPTION
### Description

When generating go code in program-gen, we format the code before saving it to disk. However, if formatting fails, we don't generated anything at all and we simply error. This PR changes this behaviour such that we fall back to and generate the original, non-formatted code when formatting fails. 

Fixes part of https://github.com/pulumi/pulumi-terraform-bridge/issues/1158

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
