### PR TITLE
ci(lint): Helpful message on tidy failure

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error go.mod not tidy"
+            echo "::error Please run ./scripts/tidy.sh"
             exit 1
           fi
 


### PR DESCRIPTION
When the 'go mod tidy' lint check fails,
it prints a simple error message reporting the failure.

Most will resort to running `go mod tidy` manually
to attempt to fix this, but this will not always work.
We need to run `./scripts/tidy.sh` which updates all go.mod files
and includes specific compatibility flags.
