### PR TITLE
PNPM Support

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -181,9 +181,9 @@ jobs:
             echo "Deleting pulumi"
             rm -rf "$(command -v pulumi.exe)/../pulumi*"
           fi
-      - name: Install yarn
+      - name: Install yarn and pnpm
         run: |
-          npm install -g yarn
+          npm install -g yarn pnpm
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet

--- a/changelog/pending/20230605--sdk-nodejs--add-support-for-pnpm.yaml
+++ b/changelog/pending/20230605--sdk-nodejs--add-support-for-pnpm.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add Support for PNPM

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -73,7 +73,9 @@ func Install(ctx context.Context, dir string, production bool, stdout, stderr io
 }
 
 // This error occurs when the user has selected two package managers; only one can be selected at a time.
-var mutuallyExclusiveEnvVars = fmt.Errorf("both PULUMI_PREFER_YARN and PULUMI_PREFER_PNPM are set; these env vars are mutually exclusive")
+var errMutuallyExclusiveEnvVars = fmt.Errorf(
+	"both PULUMI_PREFER_YARN and PULUMI_PREFER_PNPM are set; these env vars are mutually exclusive",
+)
 
 // ResolvePackageManager determines which package manager to use.
 // First, we check if a package manager is explicitly selected via env var.
@@ -90,7 +92,7 @@ func ResolvePackageManager(pwd string) (PackageManager, error) {
 
 	// • Error if both PULUMI_PREFER_PNPM and PULUMI_PREFER_YARN are set.
 	if yarnEnvSet && pnpmEnvSet {
-		return nil, mutuallyExclusiveEnvVars
+		return nil, errMutuallyExclusiveEnvVars
 	}
 
 	// • Now, check if either of these variables are set, since they take
@@ -157,7 +159,10 @@ func ResolvePackageManager(pwd string) (PackageManager, error) {
 	if err == nil {
 		return yarn, nil
 	}
-	logging.Warningf("found lockfiles for PNPM and Yarn, but could not find yarn on the $PATH, trying pnpm instead: %v", err)
+	logging.Warningf(
+		"found lockfiles for PNPM and Yarn, but could not find yarn on the $PATH, trying pnpm instead: %v",
+		err,
+	)
 	var manager PackageManager
 	manager, err = newPNPM()
 	if err != nil {

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -23,6 +23,11 @@ func newNPM() (*npmManager, error) {
 	instance := &npmManager{
 		executable: npmPath,
 	}
+	if err != nil {
+		err = fmt.Errorf("could not find npm on the $PATH; npm is installed with Node.js "+
+			"available at https://nodejs.org/: %w", err)
+	}
+
 	return instance, err
 }
 

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -77,7 +77,7 @@ func (node *npmManager) Pack(ctx context.Context, dir string, stderr io.Writer) 
 
 	packTarball, err := os.ReadFile(packfile)
 	if err != nil {
-		newErr := fmt.Errorf("'npm pack' completed successfully but the package .tgz file was not generated: %v", err)
+		newErr := fmt.Errorf("'npm pack' completed successfully but the packaged .tgz file was not generated: %v", err)
 		return nil, newErr
 	}
 

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -17,7 +17,7 @@ type pnpm struct {
 	executable string
 }
 
-// Assert that YarnClassic is an instance of PackageManager.
+// Assert that it is an instance of PackageManager.
 var _ PackageManager = &pnpm{}
 
 func newPNPM() (*pnpm, error) {

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -1,0 +1,66 @@
+package npm
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// pnpm is an implementation of PackageManager that uses PNPM,
+// to install dependencies.
+type pnpm struct {
+	executable string
+}
+
+// Assert that YarnClassic is an instance of PackageManager.
+var _ PackageManager = &pnpm{}
+
+func newPNPM() (*pnpm, error) {
+	path, err := exec.LookPath("pnpm")
+	manager := &pnpm{
+		executable: path,
+	}
+	return manager, err
+}
+
+func (manager *pnpm) Name() string {
+	return "pnpm"
+}
+
+func (manager *pnpm) Install(ctx context.Context, dir string, production bool, stdout, stderr io.Writer) error {
+	command := manager.installCmd(ctx, production)
+	command.Dir = dir
+	command.Stdout = stdout
+	command.Stderr = stderr
+	return command.Run()
+}
+
+// Generates the command to install packages with PNPM.
+func (manager *pnpm) installCmd(ctx context.Context, production bool) *exec.Cmd {
+	args := []string{"install"}
+
+	if production {
+		args = append(args, "--prod")
+	}
+
+	//nolint:gosec // False positive on tained command execution. We aren't accepting input from the user here.
+	return exec.CommandContext(ctx, manager.executable, args...)
+}
+
+// Pack runs `pnpm pack` in the given directory, packaging the Node.js app located
+// there into a tarball an returning it as `[]byte`. `stdout` is ignored for this command,
+// as it does not produce useful data.
+func (manager *pnpm) Pack(ctx context.Context, dir string, stderr io.Writer) ([]byte, error) {
+	panic("TODO")
+}
+
+// checkPNPMLock checks if there's a file named pnpm-lock.yaml in pwd.
+// This function is used to indicate whether to prefer PNPM over
+// other package managers.
+func checkPNPMLock(pwd string) bool {
+	yarnFile := filepath.Join(pwd, "pnpm-lock.yaml")
+	_, err := os.Stat(yarnFile)
+	return err == nil
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR introduces official PNPM support for the Node SDK. PNPM is largely compatible with NPM; in particular, `pnpm pack` and `npm pack` produce compatible tarballs, and `pnpm install` produces a `node_modules` directory which is compatible with `npm install` _in general_, but not vice versa.

Users can run `PULUMI_PREFER_PNPM=true pulumi new ...` to use PNPM with `pulumi new`. 

Additionally, this PR uses `pnpm pack` instead of `npm pack` to support PNPM's content addressable store, allowing users to use PNPM with policy packs. This PR also makes us forward-compatible in case PNPM or NPM change how they pack tarballs or install dependencies. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
