### PR TITLE
ci(lint): make tidy > ./scripts/tidy.sh

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error go.mod not tidy"
-            echo "::error Please run ./scripts/tidy.sh"
+            echo "::error Please run 'make tidy'"
             exit 1
           fi
 


### PR DESCRIPTION
`make tidy` is a more future-proof advice than `./scripts/tidy.sh`.

Refs https://github.com/pulumi/pulumi/pull/13054#discussion_r1210794437
