### PR TITLE
Fix inconsistency in calling DiffConfig

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1481,7 +1481,7 @@ func (sg *stepGenerator) providerChanged(urn resource.URN, old, new *resource.St
 	newRes, ok := sg.providers[newRef.URN()]
 	contract.Assertf(ok, "new deployment didn't have provider, despite resource using it?")
 
-	diff, err := newProv.DiffConfig(newRef.URN(), oldRes.Inputs, newRes.Inputs, true, nil)
+	diff, err := newProv.DiffConfig(newRef.URN(), oldRes.Outputs, newRes.Inputs, true, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Diff/DiffConfig is currently always called with the old outputs and new inputs, except for this one case in step_generator where we called DiffConfig with the old inputs instead of old outputs.

For providers inputs and outputs are always the same (Configure doesn't allow providers to return any properties, so the engine enforces that outputs=inputs) so using inputs or outputs here doesn't have any effect, but less confusing to not have this inconsistency.