### PR TITLE
Add support for asynchronous typescript mocks

### DIFF
--- a/changelog/pending/20230601--sdk-nodejs--add-support-for-asynchronous-mock-implementations.yaml
+++ b/changelog/pending/20230601--sdk-nodejs--add-support-for-asynchronous-mock-implementations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add support for asynchronous mock implementations

--- a/sdk/nodejs/runtime/index.ts
+++ b/sdk/nodejs/runtime/index.ts
@@ -20,7 +20,7 @@ export {
 } from "./closure/serializeClosure";
 
 export { CodePathOptions, computeCodePaths } from "./closure/codePaths";
-export { Mocks, setMocks, MockResourceArgs, MockCallArgs } from "./mocks";
+export { Mocks, setMocks, MockResourceArgs, MockResourceResult, MockCallArgs, MockCallResult } from "./mocks";
 
 export * from "./config";
 export * from "./invoke";

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -55,7 +55,7 @@ export interface MockResourceArgs {
 }
 
 /**
- * MockResourceResult is the expect result of a newResource Mock, returning a physical identifier and the output properties
+ * MockResourceResult is the result of a newResource Mock, returning a physical identifier and the output properties
  * for the resource being constructed.
  */
 export type MockResourceResult = {
@@ -84,7 +84,7 @@ export interface MockCallArgs {
 }
 
 /**
- * MockCallResult is the expect result of a call Mock.
+ * MockCallResult is the result of a call Mock.
  */
 export type MockCallResult = Record<string, any>;
 

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -20,7 +20,7 @@ const resproto = require("../proto/resource_pb.js");
 const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 
 /**
- * MockResourceArgs is used to construct a newResource Mock
+ * MockResourceArgs is used to construct a newResource Mock.
  */
 export interface MockResourceArgs {
     /**
@@ -64,7 +64,7 @@ export type MockResourceResult = {
 };
 
 /**
- * MockResourceArgs is used to construct call Mock
+ * MockResourceArgs is used to construct call Mock.
  */
 export interface MockCallArgs {
     /**
@@ -94,7 +94,18 @@ export type MockCallResult = Record<string, any>;
  * return predictable values.
  */
 export interface Mocks {
+    /**
+     * Mocks provider-implemented function calls (e.g. aws.get_availability_zones).
+     *
+     * @param args: MockCallArgs
+     */
     call(args: MockCallArgs): MockCallResult | Promise<MockCallResult>;
+    /**
+     * Mocks resource construction calls. This function should return the physical identifier and the output properties
+     * for the resource being constructed.
+     *
+     * @param args: MockResourceArgs
+     */
     newResource(args: MockResourceArgs): MockResourceResult | Promise<MockResourceResult>;
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR implements the feature request #13049.

Pulumi's mocking feature for TypeScript is configured by calling `pulumi.runtime.setMocks(...)`. It only supports synchronous mock implementations. I.e., the functions call and `newResource`, which are provided as an object of type Mocks, must be synchronous. This prevents using any asynchronous function or APIs to generate or retrieve values to return because they cannot be awaited in a synchronous TS function.

This PR extends the `Mocks` interface with support for asynchronous mock implementations. The changes are backward compatible. In contrast to the implementation sketched in [#13049](https://github.com/pulumi/pulumi/issues/13049), this version is more elegant, requires less code, and is still type-safe.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
