### PR TITLE
filestate/upgrade: Add hook to fill missing project names

### DIFF
--- a/changelog/pending/20230601--backend-filestate--add-an-option-to-the-upgrade-operation-allowing-injection-of-an-external-source-of-project-names-for-stacks-where-the-project-name-could-not-be-automatically-determined.yaml
+++ b/changelog/pending/20230601--backend-filestate--add-an-option-to-the-upgrade-operation-allowing-injection-of-an-external-source-of-project-names-for-stacks-where-the-project-name-could-not-be-automatically-determined.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend/filestate
+  description: Add an option to the Upgrade operation allowing injection of an external source of project names for stacks where the project name could not be automatically determined.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -89,13 +89,16 @@ var (
 	PulumiFilestateLegacyLayoutEnvVar = env.SelfManagedStateLegacyLayout.Var().Name()
 )
 
+// UpgradeOptions customizes the behavior of the upgrade operation.
+type UpgradeOptions struct{}
+
 // Backend extends the base backend interface with specific information about local backends.
 type Backend interface {
 	backend.Backend
 	local() // at the moment, no local specific info, so just use a marker function.
 
 	// Upgrade to the latest state store version.
-	Upgrade(ctx context.Context) error
+	Upgrade(ctx context.Context, opts *UpgradeOptions) error
 }
 
 type localBackend struct {
@@ -348,7 +351,11 @@ func newLocalBackend(
 	return backend, nil
 }
 
-func (b *localBackend) Upgrade(ctx context.Context) error {
+func (b *localBackend) Upgrade(ctx context.Context, opts *UpgradeOptions) error {
+	if opts == nil {
+		opts = &UpgradeOptions{}
+	}
+
 	// We don't use the existing b.store because
 	// this may already be a projectReferenceStore
 	// with new legacy files introduced to it accidentally.

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -1031,6 +1033,125 @@ func TestLegacyUpgrade_partial(t *testing.T) {
 	ref, err := b.ParseStackReference("organization/project/foo")
 	require.NoError(t, err)
 	assert.Equal(t, tokens.QName("organization/project/foo"), ref.FullyQualifiedName())
+}
+
+// When a stack project could not be determined,
+// we should fill it in with ProjectsForDetachedStacks.
+func TestLegacyUpgrade_ProjectsForDetachedStacks(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	bucket, err := fileblob.OpenBucket(stateDir, nil)
+	require.NoError(t, err)
+
+	// Write a few empty stacks.
+	// These stacks have no resources, so we can't guess the project name.
+	ctx := context.Background()
+	for _, stack := range []string{"foo", "bar", "baz"} {
+		statePath := path.Join(".pulumi", "stacks", stack+".json")
+		require.NoError(t,
+			bucket.WriteAll(ctx, statePath,
+				[]byte(`{"latest": {"resources": []}}`), nil),
+			"write stack %s", stack)
+	}
+
+	var stderr bytes.Buffer
+	sink := diag.DefaultSink(io.Discard, &stderr, diag.FormatOptions{Color: colors.Never})
+	b, err := New(ctx, sink, "file://"+filepath.ToSlash(stateDir), nil)
+	require.NoError(t, err, "initialize backend")
+
+	// For the first two stacks, we'll return project names to upgrade them.
+	// For the third stack, we will not set a project name, and it should be skipped.
+	err = b.Upgrade(ctx, &UpgradeOptions{
+		ProjectsForDetachedStacks: func(stacks []tokens.Name) (projects []tokens.Name, err error) {
+			assert.ElementsMatch(t, []tokens.Name{"foo", "bar", "baz"}, stacks)
+
+			projects = make([]tokens.Name, len(stacks))
+			for idx, stack := range stacks {
+				switch stack {
+				case "foo":
+					projects[idx] = "proj1"
+				case "bar":
+					projects[idx] = "proj2"
+				case "baz":
+					// Leave baz detached.
+				}
+			}
+			return projects, nil
+		},
+	})
+	require.NoError(t, err)
+
+	for _, stack := range []string{"foo", "bar"} {
+		assert.NotContains(t, stderr.String(), fmt.Sprintf("Skipping stack %q", stack))
+	}
+	assert.Contains(t, stderr.String(), fmt.Sprintf("Skipping stack %q", "baz"))
+
+	wantFiles := []string{
+		".pulumi/stacks/proj1/foo.json",
+		".pulumi/stacks/proj2/bar.json",
+		".pulumi/stacks/baz.json",
+	}
+	for _, file := range wantFiles {
+		exists, err := bucket.Exists(ctx, file)
+		require.NoError(t, err, "exists(%q)", file)
+		assert.True(t, exists, "file %q must exist", file)
+	}
+}
+
+// When a stack project could not be determined
+// and ProjectsForDetachedStacks returns an error,
+// the upgrade should fail.
+func TestLegacyUpgrade_ProjectsForDetachedStacks_error(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	bucket, err := fileblob.OpenBucket(stateDir, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// We have one stack with a guessable project name, and one without.
+	// If ProjectsForDetachedStacks returns an error, the upgrade should
+	// fail for both because the user likely cancelled the upgrade.
+	require.NoError(t,
+		bucket.WriteAll(ctx, ".pulumi/stacks/foo.json", []byte(`{
+		"latest": {
+			"resources": [
+				{
+					"type": "package:module:resource",
+					"urn": "urn:pulumi:stack::project::package:module:resource::name"
+				}
+			]
+		}
+	}`), nil))
+	require.NoError(t,
+		bucket.WriteAll(ctx, ".pulumi/stacks/bar.json",
+			[]byte(`{"latest": {"resources": []}}`), nil))
+
+	sink := diag.DefaultSink(io.Discard, iotest.LogWriter(t), diag.FormatOptions{Color: colors.Never})
+	b, err := New(ctx, sink, "file://"+filepath.ToSlash(stateDir), nil)
+	require.NoError(t, err)
+
+	giveErr := errors.New("canceled operation")
+	err = b.Upgrade(ctx, &UpgradeOptions{
+		ProjectsForDetachedStacks: func(stacks []tokens.Name) (projects []tokens.Name, err error) {
+			assert.Equal(t, []tokens.Name{"bar"}, stacks)
+			return nil, giveErr
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, giveErr)
+
+	wantFiles := []string{
+		".pulumi/stacks/foo.json",
+		".pulumi/stacks/bar.json",
+	}
+	for _, file := range wantFiles {
+		exists, err := bucket.Exists(ctx, file)
+		require.NoError(t, err, "exists(%q)", file)
+		assert.True(t, exists, "file %q must exist", file)
+	}
 }
 
 // If an upgrade failed because we couldn't write the meta.yaml,

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -953,7 +953,7 @@ func TestLegacyUpgrade(t *testing.T) {
 	assert.NotNil(t, lb)
 	assert.IsType(t, &legacyReferenceStore{}, lb.store)
 
-	err = lb.Upgrade(ctx)
+	err = lb.Upgrade(ctx, nil /* opts */)
 	require.NoError(t, err)
 	assert.IsType(t, &projectReferenceStore{}, lb.store)
 
@@ -979,7 +979,7 @@ func TestLegacyUpgrade(t *testing.T) {
 	}`), os.ModePerm)
 	require.NoError(t, err)
 
-	err = lb.Upgrade(ctx)
+	err = lb.Upgrade(ctx, nil /* opts */)
 	require.NoError(t, err)
 
 	// Check that b has been moved
@@ -1021,7 +1021,7 @@ func TestLegacyUpgrade_partial(t *testing.T) {
 	b, err := New(ctx, sink, "file://"+filepath.ToSlash(stateDir), nil)
 	require.NoError(t, err)
 
-	require.NoError(t, b.Upgrade(ctx))
+	require.NoError(t, b.Upgrade(ctx, nil /* opts */))
 	assert.Contains(t, buff.String(), `Skipping stack "bar": no project found`)
 
 	exists, err := bucket.Exists(ctx, ".pulumi/stacks/project/foo.json")
@@ -1064,7 +1064,7 @@ func TestLegacyUpgrade_writeMetaError(t *testing.T) {
 	b, err := New(ctx, sink, "file://"+filepath.ToSlash(stateDir), nil)
 	require.NoError(t, err)
 
-	require.Error(t, b.Upgrade(ctx))
+	require.Error(t, b.Upgrade(ctx, nil /* opts */))
 
 	stderr := buff.String()
 	assert.Contains(t, stderr, "error: Could not write new state metadata file")
@@ -1137,7 +1137,7 @@ func TestUpgrade_manyFailures(t *testing.T) {
 	b, err := New(ctx, sink, "file://"+filepath.ToSlash(tmpDir), nil)
 	require.NoError(t, err)
 
-	require.NoError(t, b.Upgrade(ctx))
+	require.NoError(t, b.Upgrade(ctx, nil /* opts */))
 	out := output.String()
 	for i := 0; i < numStacks; i++ {
 		assert.Contains(t, out, fmt.Sprintf(`Skipping stack "stack-%d"`, i))

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -1022,7 +1022,7 @@ func TestLegacyUpgrade_partial(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, b.Upgrade(ctx, nil /* opts */))
-	assert.Contains(t, buff.String(), `Skipping stack "bar": no project found`)
+	assert.Contains(t, buff.String(), `Skipping stack "bar": no project name found`)
 
 	exists, err := bucket.Exists(ctx, ".pulumi/stacks/project/foo.json")
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -101,5 +101,5 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 		return nil
 	}
 
-	return lb.Upgrade(ctx)
+	return lb.Upgrade(ctx, nil /*opts*/)
 }

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -88,7 +88,7 @@ func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
 	cmd := stateUpgradeCmd{
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 			return &stubFileBackend{
-				UpgradeF: func(context.Context) error {
+				UpgradeF: func(context.Context, *filestate.UpgradeOptions) error {
 					called = true
 					return nil
 				},
@@ -110,7 +110,7 @@ func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
 	cmd := stateUpgradeCmd{
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 			return &stubFileBackend{
-				UpgradeF: func(context.Context) error {
+				UpgradeF: func(context.Context, *filestate.UpgradeOptions) error {
 					t.Fatal("Upgrade should not be called")
 					return nil
 				},
@@ -158,9 +158,11 @@ func TestStateUpgradeCmd_Run_backendError(t *testing.T) {
 type stubFileBackend struct {
 	filestate.Backend
 
-	UpgradeF func(context.Context) error
+	UpgradeF func(context.Context, *filestate.UpgradeOptions) error
 }
 
-func (f *stubFileBackend) Upgrade(ctx context.Context) error {
-	return f.UpgradeF(ctx)
+var _ filestate.Backend = (*stubFileBackend)(nil)
+
+func (f *stubFileBackend) Upgrade(ctx context.Context, opts *filestate.UpgradeOptions) error {
+	return f.UpgradeF(ctx, opts)
 }


### PR DESCRIPTION
Commits are individually reviewable.

---

The filestate upgrade operation is limited: it can only upgrade stacks
for which it's able to guess a project name by inspecting resources.
It cannot upgrade empty stacks, or stacks where someone recently called
`pulumi destroy` because they don't have any resources for it to inspect.

To resolve this, we need to support an external hook:
some means for the caller to fill in project names for stacks
where the names could not be guessed.
We'll use this hook in the CLI to prompt the user.

This change adds an UpgradeOptions argument to the Upgrade operation.
UpgradeOptions includes an option ProjectsForDetachedStacks.
This is a callback in the form:

    func(stacks []Name) (projects []Name, err error)

It takes a list of stack names and returns a list of project names for them
in the same order.

This also has the effect of splitting the upgrade operation.
Previously, it was roughly:

    for _, s := range stacks {
      go func(s) {
        proj := guessProject()
        if proj == "" { skip }
        upgrade(s, proj)
      }(s)
    }

A single parallelizable unit of work.

With this change, we have three separate steps. Roughly:

    for _, s := range stacks {
      go func(s) {
        guessProject(s)
        // ...
      }(s)
    }

    fillMissingProjects(...)

    for _, s := range stacks {
      go upgrade(s, projects[s])
    }

Only the first and third step are run concurrently.
The fillMissingProjects is blocking and runs after the first phase
has finished completely.

This change leverages the abstraction introduced in #13076
to make the above more manageable than it would be otherwise.

Refs #12600
