### PR TITLE
Add install command

### DIFF
--- a/changelog/pending/20231020--cli--adds-a-new-pulumi-install-command-which-will-install-packages-and-plugins-for-a-project.yaml
+++ b/changelog/pending/20231020--cli--adds-a-new-pulumi-install-command-which-will-install-packages-and-plugins-for-a-project.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds a new `pulumi install` command which will install packages and plugins for a project.

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -1,0 +1,156 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newInstallCmd() *cobra.Command {
+	var reinstall bool
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Args:  cmdutil.NoArgs,
+		Short: "Install packages and plugins for the current program",
+		Long: "Install packages and plugins for the current program.\n" +
+			"\n" +
+			"This command is used to manually install packages and plugins required by your program.",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
+			displayOpts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+
+			// Load the project
+			proj, root, err := readProject()
+			if err != nil {
+				return err
+			}
+
+			span := opentracing.SpanFromContext(ctx)
+			projinfo := &engine.Projinfo{Proj: proj, Root: root}
+			pwd, main, pctx, err := engine.ProjectInfoContext(
+				projinfo,
+				nil,
+				cmdutil.Diag(),
+				cmdutil.Diag(),
+				false,
+				span,
+				nil,
+			)
+			if err != nil {
+				return err
+			}
+
+			defer pctx.Close()
+
+			// First make sure the language plugin is present.  We need this to load the required resource plugins.
+			// TODO: we need to think about how best to version this.  For now, it always picks the latest.
+			runtime := proj.Runtime
+			lang, err := pctx.Host.LanguageRuntime(pctx.Root, pctx.Pwd, runtime.Name(), runtime.Options())
+			if err != nil {
+				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
+			}
+
+			if err = lang.InstallDependencies(root); err != nil {
+				return fmt.Errorf("installing dependencies: %w", err)
+			}
+
+			// Compute the set of plugins the current project needs.
+			installs, err := lang.GetRequiredPlugins(plugin.ProgInfo{
+				Proj:    proj,
+				Pwd:     pwd,
+				Program: main,
+			})
+			if err != nil {
+				return err
+			}
+
+			// Now for each kind, name, version pair, download it from the release website, and install it.
+			for _, install := range installs {
+				// PluginSpec.String() just returns the name and version, we want the kind too.
+				label := fmt.Sprintf("%s plugin %s", install.Kind, install)
+
+				// If the plugin already exists, don't download it unless --reinstall was passed.
+				if !reinstall {
+					if install.Version != nil {
+						if workspace.HasPlugin(install) {
+							logging.V(1).Infof("%s skipping install (existing == match)", label)
+							continue
+						}
+					} else {
+						if has, _ := workspace.HasPluginGTE(install); has {
+							logging.V(1).Infof("%s skipping install (existing >= match)", label)
+							continue
+						}
+					}
+				}
+
+				pctx.Diag.Infoerrf(diag.Message("", "%s installing"), label)
+
+				// If we got here, actually try to do the download.
+				withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
+					return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
+				}
+				retry := func(err error, attempt int, limit int, delay time.Duration) {
+					pctx.Diag.Warningf(
+						diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
+				}
+
+				r, err := workspace.DownloadToFile(install, withProgress, retry)
+				if err != nil {
+					return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
+				}
+				defer func() {
+					err := os.Remove(r.Name())
+					if err != nil {
+						pctx.Diag.Warningf(
+							diag.Message("", "Error removing temporary file %s: %s"), r.Name(), err)
+					}
+				}()
+
+				payload := workspace.TarPlugin(r)
+
+				logging.V(1).Infof("%s installing tarball ...", label)
+				if err = install.InstallWithContext(ctx, payload, reinstall); err != nil {
+					return fmt.Errorf("installing %s: %w", label, err)
+				}
+			}
+
+			return nil
+		}),
+	}
+
+	cmd.PersistentFlags().BoolVar(&reinstall,
+		"reinstall", false, "Reinstall a plugin even if it already exists")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -297,6 +297,7 @@ func NewPulumiCmd() *cobra.Command {
 				newImportCmd(),
 				newRefreshCmd(),
 				newStateCmd(),
+				newInstallCmd(),
 			},
 		},
 		{

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -533,7 +533,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 		if component, ok := node.(*pcl.Component); ok {
 			componentPath := strings.ReplaceAll(filepath.Base(component.DirPath()), "-", "_")
 			componentName := component.DeclarationName()
-			imports = append(imports, fmt.Sprintf("from .%s import %s", componentPath, componentName))
+			imports = append(imports, fmt.Sprintf("from %s import %s", componentPath, componentName))
 		}
 	}
 

--- a/pkg/codegen/testing/test/testdata/components-pp/python/components.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/components.py
@@ -1,7 +1,7 @@
 import pulumi
-from .another_component import AnotherComponent
-from .exampleComponent import ExampleComponent
-from .simpleComponent import SimpleComponent
+from another_component import AnotherComponent
+from exampleComponent import ExampleComponent
+from simpleComponent import SimpleComponent
 
 simple_component = SimpleComponent("simpleComponent")
 another_component = AnotherComponent("anotherComponent")

--- a/pkg/codegen/testing/test/testdata/components-pp/python/exampleComponent.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/exampleComponent.py
@@ -1,6 +1,6 @@
 import pulumi
-from .simpleComponent import SimpleComponent
 from pulumi import Input
+from simpleComponent import SimpleComponent
 from typing import Optional, Dict, TypedDict, Any
 import pulumi_random as random
 

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -117,10 +117,9 @@ func TestLanguageConvertSmoke(t *testing.T) {
 			e.CWD = filepath.Join(e.RootPath, "out")
 			e.RunCommand("pulumi", "stack", "init", "test")
 
-			// TODO[pulumi/pulumi#13075]: Skipping `up` until we have a way to tell the language host to
-			// install dependencies.
-			// e.RunCommand("pulumi", "up", "--yes")
-			// e.RunCommand("pulumi", "destroy", "--yes")
+			e.RunCommand("pulumi", "install")
+			e.RunCommand("pulumi", "up", "--yes")
+			e.RunCommand("pulumi", "destroy", "--yes")
 		})
 	}
 }
@@ -167,7 +166,7 @@ func TestLanguageConvertComponentSmoke(t *testing.T) {
 				t.Skip("yaml doesn't support components")
 			}
 			if runtime == "java" {
-				t.Skip("yaml doesn't support components")
+				t.Skip("java doesn't support components")
 			}
 
 			e := ptesting.NewEnvironment(t)
@@ -186,10 +185,13 @@ func TestLanguageConvertComponentSmoke(t *testing.T) {
 			e.CWD = filepath.Join(e.RootPath, "out")
 			e.RunCommand("pulumi", "stack", "init", "test")
 
-			// TODO[pulumi/pulumi#13075]: Skipping `up` until we have a way to tell the language host to
-			// install dependencies.
-			// e.RunCommand("pulumi", "up", "--yes")
-			// e.RunCommand("pulumi", "destroy", "--yes")
+			// TODO(https://github.com/pulumi/pulumi/issues/14339): This doesn't work for Go yet because the
+			// source code convert emits is not valid
+			if runtime != "go" {
+				e.RunCommand("pulumi", "install")
+				e.RunCommand("pulumi", "up", "--yes")
+				e.RunCommand("pulumi", "destroy", "--yes")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/10990.

This also includes a couple of fixes for python to get the `TestLanguageConvertComponentSmoke` test working for it.
Firstly it fixes InstallDependencies to not create a venv if no venv path is set. The language host was trying to install a venv to the same directory as the program itself (that is not nested under "venv" or the like). But then because the runtime option wasn't set the execution wasn't using that created venv anyway.

Secondly the imports for components are not relative. We're not in a proper module when running a python program so relative imports to side-by-side component folders don't work.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
