### PR TITLE
Fix install failure messages

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -289,7 +289,7 @@ func runConvert(
 		}
 		version, err := pkgWorkspace.InstallPlugin(pluginSpec, log)
 		if err != nil {
-			pCtx.Diag.Warningf(diag.RawMessage("", "failed to install provider %q: %v"), provider, err)
+			pCtx.Diag.Warningf(diag.Message("", "failed to install provider %q: %v"), provider, err)
 			return nil
 		}
 		return version

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -508,7 +508,7 @@ func newImportCmd() *cobra.Command {
 					}
 					version, err := pkgWorkspace.InstallPlugin(pluginSpec, log)
 					if err != nil {
-						pCtx.Diag.Warningf(diag.RawMessage("", "failed to install provider %q: %v"), provider, err)
+						pCtx.Diag.Warningf(diag.Message("", "failed to install provider %q: %v"), provider, err)
 						return nil
 					}
 					return version


### PR DESCRIPTION
These use formatting so need to be `Message` not `RawMessage`.