### PR TITLE
[pcl/dotnet,go] Do not error out when generaing not yet implemented ForExpressions

### DIFF
--- a/changelog/pending/20230602--programgen-dotnet-go--do-not-error-out-when-generaing-not-yet-implemented-forexpressions.yaml
+++ b/changelog/pending/20230602--programgen-dotnet-go--do-not-error-out-when-generaing-not-yet-implemented-forexpressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet,go
+  description: Do not error out when generaing not yet implemented ForExpressions

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1366,7 +1366,7 @@ func (g *generator) genLocalVariable(w io.Writer, localVariable *pcl.LocalVariab
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
 	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
 	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
-		Severity: hcl.DiagError,
+		Severity: hcl.DiagWarning,
 		Summary:  message,
 		Detail:   message,
 	})

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1026,12 +1026,6 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type) (
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
-	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
-	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  message,
-		Detail:   message,
-	})
 	g.Fgenf(w, "\"TODO: %s\"", fmt.Sprintf(reason, vs...))
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1026,6 +1026,12 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type) (
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
+	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
+	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  message,
+		Detail:   message,
+	})
 	g.Fgenf(w, "\"TODO: %s\"", fmt.Sprintf(reason, vs...))
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -239,9 +239,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "entries-function",
 		Description: "Using the entries function",
-		// go and dotnet do not support GenForExpression yet
+		// go and dotnet do fully not support GenForExpression yet
 		// Todo: https://github.com/pulumi/pulumi/issues/12606
-		Skip:        allProgLanguages.Except("nodejs").Except("python"),
 		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
 	},
 	{

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/dotnet/entries-function.cs
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/dotnet/entries-function.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var data = new[]
+    {
+        1,
+        2,
+        3,
+    }.Select((v, k) => new { Key = k, Value = v }).Select(entry => 
+    {
+        return new Dictionary<string, object?>  
+        {
+            { "usingKey", entry.Key },
+            { "usingValue", entry.Value },
+        };
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/go/entries-function.go
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/go/entries-function.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_ := "TODO: For expression"
+		return nil
+	})
+}


### PR DESCRIPTION
# Description

Partially implements `ForExpressions` in dotnet/csharp and for go program-gen, simply not erroring out when encountering not yet implemented expressions like `ForExpression`



Partially addresses #12606

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
