### PR TITLE
Fix hcl.Diagnostic roundtripping

### DIFF
--- a/changelog/pending/20230602--programgen-go-nodejs--fix-a-panic-in-diagnostics-from-go-nodejs-project-generation.yaml
+++ b/changelog/pending/20230602--programgen-go-nodejs--fix-a-panic-in-diagnostics-from-go-nodejs-project-generation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go,nodejs
+  description: Fix a panic in diagnostics from go/nodejs project generation.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -495,20 +495,30 @@ func HclDiagnosticToRPCDiagnostic(diag *hcl.Diagnostic) *codegenrpc.Diagnostic {
 		}
 	}
 
+	var subject *codegenrpc.Range
+	if diag.Subject != nil {
+		subject = &codegenrpc.Range{
+			Filename: diag.Subject.Filename,
+			Start:    hclPosToPos(diag.Subject.Start),
+			End:      hclPosToPos(diag.Subject.End),
+		}
+	}
+
+	var context *codegenrpc.Range
+	if diag.Context != nil {
+		context = &codegenrpc.Range{
+			Filename: diag.Context.Filename,
+			Start:    hclPosToPos(diag.Context.Start),
+			End:      hclPosToPos(diag.Context.End),
+		}
+	}
+
 	return &codegenrpc.Diagnostic{
 		Severity: codegenrpc.DiagnosticSeverity(diag.Severity),
 		Summary:  diag.Summary,
 		Detail:   diag.Detail,
-		Subject: &codegenrpc.Range{
-			Filename: diag.Subject.Filename,
-			Start:    hclPosToPos(diag.Subject.Start),
-			End:      hclPosToPos(diag.Subject.End),
-		},
-		Context: &codegenrpc.Range{
-			Filename: diag.Context.Filename,
-			Start:    hclPosToPos(diag.Context.Start),
-			End:      hclPosToPos(diag.Context.End),
-		},
+		Subject:  subject,
+		Context:  context,
 	}
 }
 
@@ -521,19 +531,29 @@ func RPCDiagnosticToHclDiagnostic(diag *codegenrpc.Diagnostic) *hcl.Diagnostic {
 		}
 	}
 
+	var subject *hcl.Range
+	if diag.Subject != nil {
+		subject = &hcl.Range{
+			Filename: diag.Subject.Filename,
+			Start:    rpcPosToPos(diag.Subject.Start),
+			End:      rpcPosToPos(diag.Subject.End),
+		}
+	}
+
+	var context *hcl.Range
+	if diag.Context != nil {
+		context = &hcl.Range{
+			Filename: diag.Context.Filename,
+			Start:    rpcPosToPos(diag.Context.Start),
+			End:      rpcPosToPos(diag.Context.End),
+		}
+	}
+
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagnosticSeverity(diag.Severity),
 		Summary:  diag.Summary,
 		Detail:   diag.Detail,
-		Subject: &hcl.Range{
-			Filename: diag.Subject.Filename,
-			Start:    rpcPosToPos(diag.Subject.Start),
-			End:      rpcPosToPos(diag.Subject.End),
-		},
-		Context: &hcl.Range{
-			Filename: diag.Context.Filename,
-			Start:    rpcPosToPos(diag.Context.Start),
-			End:      rpcPosToPos(diag.Context.End),
-		},
+		Subject:  subject,
+		Context:  context,
 	}
 }

--- a/sdk/go/common/resource/plugin/langruntime_plugin_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundtripDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		diag hcl.Diagnostic
+	}{
+		{
+			name: "simple",
+			diag: hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Some issue",
+				Detail:   "More info",
+			},
+		},
+		{
+			name: "with subject",
+			diag: hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Some issue",
+				Detail:   "More info",
+				Subject: &hcl.Range{
+					Filename: "foo",
+					Start:    hcl.Pos{Line: 1, Column: 2, Byte: 3},
+					End:      hcl.Pos{Line: 4, Column: 5, Byte: 6},
+				},
+			},
+		},
+		{
+			name: "with context",
+			diag: hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Some issue",
+				Detail:   "More info",
+				Context: &hcl.Range{
+					Filename: "foo",
+					Start:    hcl.Pos{Line: 1, Column: 2, Byte: 3},
+					End:      hcl.Pos{Line: 4, Column: 5, Byte: 6},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rpcDiag := HclDiagnosticToRPCDiagnostic(&tt.diag)
+			roundtripDiag := RPCDiagnosticToHclDiagnostic(rpcDiag)
+			assert.Equal(t, tt.diag, *roundtripDiag)
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes some nil pointer dereferences in the diagnostic marshaling code.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1177

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
