### PR TITLE
[pcl/typescript] Only await promise-returning invokes in typescript program-gen

### DIFF
--- a/changelog/pending/20230602--programgen-nodejs--only-await-promise-returning-invokes-in-typescript-program-gen.yaml
+++ b/changelog/pending/20230602--programgen-nodejs--only-await-promise-returning-invokes-in-typescript-program-gen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Only await promise-returning invokes in typescript program-gen

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -235,10 +235,11 @@ func (g *generator) awaitInvokes(x model.Expression) model.Expression {
 			return x, nil
 		}
 
-		_, isPromise := call.Type().(*model.PromiseType)
-		contract.Assertf(isPromise, "invoke must return a promise")
+		if _, isPromise := call.Type().(*model.PromiseType); isPromise {
+			return newAwaitCall(call), nil
+		}
 
-		return newAwaitCall(call), nil
+		return call, nil
 	}
 	x, diags := model.VisitExpression(x, model.IdentityVisitor, rewriter)
 	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -285,8 +285,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "invoke-inside-conditional-range",
 		Description: "Using the result of an invoke inside a conditional range expression of a resource",
-		Skip:        allLanguages.Except("typescript"),
-		SkipCompile: allLanguages.Except("typescript"),
+		Skip:        allLanguages.Except("nodejs"),
+		SkipCompile: allLanguages.Except("nodejs"),
 	},
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -286,7 +286,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "invoke-inside-conditional-range",
 		Description: "Using the result of an invoke inside a conditional range expression of a resource",
 		Skip:        allLanguages.Except("nodejs"),
-		SkipCompile: allLanguages.Except("nodejs"),
+		SkipCompile: allLanguages,
 	},
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -285,8 +285,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "invoke-inside-conditional-range",
 		Description: "Using the result of an invoke inside a conditional range expression of a resource",
-		Skip:        allLanguages.Except("nodejs"),
-		SkipCompile: allLanguages,
+		Skip:        allProgLanguages.Except("nodejs"),
+		SkipCompile: allProgLanguages,
 	},
 }
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -282,6 +282,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs").Except("python"),
 		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
 	},
+	{
+		Directory:   "invoke-inside-conditional-range",
+		Description: "Using the result of an invoke inside a conditional range expression of a resource",
+		Skip:        allLanguages.Except("typescript"),
+		SkipCompile: allLanguages.Except("typescript"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/invoke-inside-conditional-range.pp
+++ b/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/invoke-inside-conditional-range.pp
@@ -1,0 +1,67 @@
+config "azs" "list(string)" {
+  default     = []
+  description = "A list of availability zones names or ids in the region"
+}
+
+config "publicSubnetIpv6Prefixes" "list(string)" {
+  default     = []
+  description = "Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+}
+config "oneNatGatewayPerAz" "bool" {
+  default     = false
+  description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`"
+}
+
+config "enableIpv6" "bool" {
+  default     = false
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block"
+}
+
+config "publicSubnetIpv6Native" "bool" {
+  default     = false
+  description = "Indicates whether to create an IPv6-only subnet. Default: `false`"
+}
+
+config "publicSubnetEnableDns64" "bool" {
+  default     = true
+  description = "Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `true`"
+}
+
+config "publicSubnetAssignIpv6AddressOnCreation" "bool" {
+  default     = false
+  description = "Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`"
+}
+
+config "publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch" "bool" {
+  default     = true
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records. Default: `true`"
+}
+
+config "publicSubnetEnableResourceNameDnsARecordOnLaunch" "bool" {
+  default     = false
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`"
+}
+
+lenPublicSubnets = invoke("std:index:max", {
+  input = [1, 2, 3]
+}).result
+
+resource "currentVpc" "aws:ec2/vpc:Vpc" {}
+
+createPublicSubnets = true
+resource "publicSubnet" "aws:ec2/subnet:Subnet" {
+  options {
+    range = createPublicSubnets && (!oneNatGatewayPerAz || lenPublicSubnets >= length(azs)) ? lenPublicSubnets : 0
+  }
+  assignIpv6AddressOnCreation             = enableIpv6 && publicSubnetIpv6Native ? true : publicSubnetAssignIpv6AddressOnCreation
+  enableDns64                             = enableIpv6 && publicSubnetEnableDns64
+  enableResourceNameDnsAaaaRecordOnLaunch = enableIpv6 && publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch
+  enableResourceNameDnsARecordOnLaunch    = !publicSubnetIpv6Native && publicSubnetEnableResourceNameDnsARecordOnLaunch
+  ipv6CidrBlock = enableIpv6 && length(publicSubnetIpv6Prefixes) > 0 ? invoke("std:index:cidrsubnet", {
+    input   = currentVpc.ipv6CidrBlock
+    newbits = 8
+    netnum  = publicSubnetIpv6Prefixes[range.value]
+  }).result : null
+  ipv6Native                     = enableIpv6 && publicSubnetIpv6Native
+  vpcId                          = currentVpc.id
+}

--- a/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
+++ b/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
@@ -1,0 +1,50 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as std from "@pulumi/std";
+
+export = async () => {
+    const config = new pulumi.Config();
+    // A list of availability zones names or ids in the region
+    const azs = config.getObject("azs") || [];
+    // Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list
+    const publicSubnetIpv6Prefixes = config.getObject("publicSubnetIpv6Prefixes") || [];
+    // Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`
+    const oneNatGatewayPerAz = config.getBoolean("oneNatGatewayPerAz") || false;
+    // Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block
+    const enableIpv6 = config.getBoolean("enableIpv6") || false;
+    // Indicates whether to create an IPv6-only subnet. Default: `false`
+    const publicSubnetIpv6Native = config.getBoolean("publicSubnetIpv6Native") || false;
+    // Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `true`
+    const publicSubnetEnableDns64 = config.getBoolean("publicSubnetEnableDns64") || true;
+    // Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`
+    const publicSubnetAssignIpv6AddressOnCreation = config.getBoolean("publicSubnetAssignIpv6AddressOnCreation") || false;
+    // Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records. Default: `true`
+    const publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch = config.getBoolean("publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch") || true;
+    // Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`
+    const publicSubnetEnableResourceNameDnsARecordOnLaunch = config.getBoolean("publicSubnetEnableResourceNameDnsARecordOnLaunch") || false;
+    const lenPublicSubnets = (await std.max({
+        input: [
+            1,
+            2,
+            3,
+        ],
+    })).result;
+    const currentVpc = new aws.ec2.Vpc("currentVpc", {});
+    const createPublicSubnets = true;
+    const publicSubnet: aws.ec2.Subnet[] = [];
+    for (const range = {value: 0}; range.value < (createPublicSubnets && (!oneNatGatewayPerAz || lenPublicSubnets >= azs.length) ? lenPublicSubnets : 0); range.value++) {
+        publicSubnet.push(new aws.ec2.Subnet(`publicSubnet-${range.value}`, {
+            assignIpv6AddressOnCreation: enableIpv6 && publicSubnetIpv6Native ? true : publicSubnetAssignIpv6AddressOnCreation,
+            enableDns64: enableIpv6 && publicSubnetEnableDns64,
+            enableResourceNameDnsAaaaRecordOnLaunch: enableIpv6 && publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch,
+            enableResourceNameDnsARecordOnLaunch: !publicSubnetIpv6Native && publicSubnetEnableResourceNameDnsARecordOnLaunch,
+            ipv6CidrBlock: enableIpv6 && publicSubnetIpv6Prefixes.length > 0 ? currentVpc.ipv6CidrBlock.apply(ipv6CidrBlock => std.cidrsubnetOutput({
+                input: ipv6CidrBlock,
+                newbits: 8,
+                netnum: publicSubnetIpv6Prefixes[range.value],
+            })).apply(invoke => invoke.result) : undefined,
+            ipv6Native: enableIpv6 && publicSubnetIpv6Native,
+            vpcId: currentVpc.id,
+        }));
+    }
+}

--- a/pkg/codegen/testing/test/testdata/std-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/std-1.0.0.json
@@ -121,6 +121,67 @@
           "type": "number"
         }
       },
+      "std:index:cidrsubnet": {
+        "description": "Takes an IP address range in CIDR notation (like 10.0.0.0/8) and extends its prefix \nto include an additional subnet number. For example, cidrsubnet(\"10.0.0.0/8\", 8, 2) returns 10.2.0.0/16; \ncidrsubnet(\"2607:f298:6051:516c::/64\", 8, 2) returns 2607:f298:6051:516c:200::/72.",
+        "inputs": {
+          "properties": {
+            "input": {
+              "type": "string"
+            },
+            "netnum": {
+              "type": "integer"
+            },
+            "newbits": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "required": [
+            "input",
+            "netnum",
+            "newbits"
+          ]
+        },
+        "outputs": {
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "result"
+          ]
+        }
+      },
+      "std:index:max": {
+        "description": "Returns the largest of the floats.",
+        "inputs": {
+          "properties": {
+            "input": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "type": "object",
+          "required": [
+            "input"
+          ]
+        },
+        "outputs": {
+          "properties": {
+            "result": {
+              "type": "number"
+            }
+          },
+          "type": "object",
+          "required": [
+            "result"
+          ]
+        }
+      },
       "std:index:AbsMultiArgsReducedOutputSwapped": {
         "description": "Returns the absolute value of a given float. \nExample: abs(1) returns 1, and abs(-1) would also return 1, whereas abs(-3.14) would return 3.14.",
         "multiArgumentInputs": ["b", "a"],


### PR DESCRIPTION
### Description

Replaces #13051 and addresses https://github.com/pulumi/pulumi-terraform-bridge/issues/1159

The problem with program-gen panicking is that for TypeScript, when program-gen decides that the main entry program should be async, it assumed all invokes are turned into promise-returning invokes and _panics_ when it encounters an invoke that isn't promise-returning when it tries to await the invoke. 

This PR fixes this issue by only applying `await(invoke(...))` when the invoke is actually promise-returning and **not expecting** all other invokes to be promise-returning. Some _can_ be output-returning invokes inside of a program with an async entry point. 

TL;DR of this PR
```diff
- _, isPromise := call.Type().(*model.PromiseType)
- contract.Assertf(isPromise, "invoke must return a promise")
- return newAwaitCall(call), nil

+ if _, isPromise := call.Type().(*model.PromiseType); isPromise {
+     return newAwaitCall(call), nil
+ }
+ 
+ return call, nil
```

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
