### PR TITLE
Log the version from GetPluginInfo

### DIFF
--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1630,6 +1630,7 @@ func (p *provider) GetPluginInfo() (workspace.PluginInfo, error) {
 		path = p.plug.Bin
 	}
 
+	logging.V(7).Infof("%s success (#version=%v) success", label, version)
 	return workspace.PluginInfo{
 		Name:    string(p.pkg),
 		Path:    path,


### PR DESCRIPTION
Most of the grpc methods log their success information. GetPluginInfo didn't and it would be really nice if it did to make it easy to see in debug logs that the provider loaded reported the version we expect.