### PR TITLE
[program-gen/dotnet] Only await task-returning invokes

### DIFF
--- a/changelog/pending/20230603--programgen-dotnet--only-await-task-returning-invokes-in-dotnet-program-gen.yaml
+++ b/changelog/pending/20230603--programgen-dotnet--only-await-task-returning-invokes-in-dotnet-program-gen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Only await task-returning invokes in dotnet program-gen

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -82,10 +82,11 @@ func (g *generator) awaitInvokes(x model.Expression) model.Expression {
 			return x, nil
 		}
 
-		_, isPromise := call.Type().(*model.PromiseType)
-		contract.Assertf(isPromise, "invoke should return a promise, got %v", call.Type())
+		if _, isPromise := call.Type().(*model.PromiseType); isPromise {
+			return newAwaitCall(call), nil
+		}
 
-		return newAwaitCall(call), nil
+		return call, nil
 	}
 	x, diags := model.VisitExpression(x, model.IdentityVisitor, rewriter)
 	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -285,7 +285,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "invoke-inside-conditional-range",
 		Description: "Using the result of an invoke inside a conditional range expression of a resource",
-		Skip:        allProgLanguages.Except("nodejs"),
+		Skip:        allProgLanguages.Except("nodejs").Except("dotnet"),
 		SkipCompile: allProgLanguages,
 	},
 }

--- a/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/dotnet/invoke-inside-conditional-range.cs
+++ b/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/dotnet/invoke-inside-conditional-range.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pulumi;
+using Aws = Pulumi.Aws;
+using Std = Pulumi.Std;
+
+return await Deployment.RunAsync(async() => 
+{
+    var config = new Config();
+    // A list of availability zones names or ids in the region
+    var azs = config.GetObject<dynamic>("azs") ?? new[] {};
+    // Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list
+    var publicSubnetIpv6Prefixes = config.GetObject<dynamic>("publicSubnetIpv6Prefixes") ?? new[] {};
+    // Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`
+    var oneNatGatewayPerAz = config.GetBoolean("oneNatGatewayPerAz") ?? false;
+    // Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block
+    var enableIpv6 = config.GetBoolean("enableIpv6") ?? false;
+    // Indicates whether to create an IPv6-only subnet. Default: `false`
+    var publicSubnetIpv6Native = config.GetBoolean("publicSubnetIpv6Native") ?? false;
+    // Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `true`
+    var publicSubnetEnableDns64 = config.GetBoolean("publicSubnetEnableDns64") ?? true;
+    // Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`
+    var publicSubnetAssignIpv6AddressOnCreation = config.GetBoolean("publicSubnetAssignIpv6AddressOnCreation") ?? false;
+    // Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records. Default: `true`
+    var publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch = config.GetBoolean("publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch") ?? true;
+    // Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`
+    var publicSubnetEnableResourceNameDnsARecordOnLaunch = config.GetBoolean("publicSubnetEnableResourceNameDnsARecordOnLaunch") ?? false;
+    var lenPublicSubnets = (await Std.Max.InvokeAsync(new()
+    {
+        Input = new[]
+        {
+            1,
+            2,
+            3,
+        },
+    })).Result;
+
+    var currentVpc = new Aws.Ec2.Vpc("currentVpc");
+
+    var createPublicSubnets = true;
+
+    var publicSubnet = new List<Aws.Ec2.Subnet>();
+    for (var rangeIndex = 0; rangeIndex < createPublicSubnets && (!oneNatGatewayPerAz || lenPublicSubnets >= azs.Length) ? lenPublicSubnets : 0; rangeIndex++)
+    {
+        var range = new { Value = rangeIndex };
+        publicSubnet.Add(new Aws.Ec2.Subnet($"publicSubnet-{range.Value}", new()
+        {
+            AssignIpv6AddressOnCreation = enableIpv6 && publicSubnetIpv6Native ? true : publicSubnetAssignIpv6AddressOnCreation,
+            EnableDns64 = enableIpv6 && publicSubnetEnableDns64,
+            EnableResourceNameDnsAaaaRecordOnLaunch = enableIpv6 && publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch,
+            EnableResourceNameDnsARecordOnLaunch = !publicSubnetIpv6Native && publicSubnetEnableResourceNameDnsARecordOnLaunch,
+            Ipv6CidrBlock = enableIpv6 && publicSubnetIpv6Prefixes.Length > 0 ? currentVpc.Ipv6CidrBlock.Apply(ipv6CidrBlock => Std.Cidrsubnet.Invoke(new()
+            {
+                Input = ipv6CidrBlock,
+                Newbits = 8,
+                Netnum = publicSubnetIpv6Prefixes[range.Value],
+            })).Apply(invoke => invoke.Result) : null,
+            Ipv6Native = enableIpv6 && publicSubnetIpv6Native,
+            VpcId = currentVpc.Id,
+        }));
+    }
+});
+


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Similar to #13085 but for dotnet. No longer panics when encountering different types of invokes in the same program. Addresses https://github.com/pulumi/pulumi-terraform-bridge/issues/1161

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
