### PR TITLE
Add debug logs to Mapping calls

### DIFF
--- a/pkg/codegen/convert/mapper_client.go
+++ b/pkg/codegen/convert/mapper_client.go
@@ -65,7 +65,7 @@ func (m *mapperClient) Close() error {
 
 func (m *mapperClient) GetMapping(provider string, pulumiProvider string) ([]byte, error) {
 	label := "GetMapping"
-	logging.V(7).Infof("%s executing", label)
+	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s", label, provider, pulumiProvider)
 
 	resp, err := m.clientRaw.GetMapping(context.TODO(), &codegenrpc.GetMappingRequest{
 		Provider:       provider,
@@ -73,10 +73,10 @@ func (m *mapperClient) GetMapping(provider string, pulumiProvider string) ([]byt
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
-		logging.V(8).Infof("%s mapper received rpc error `%s`: `%s`", label, rpcError.Code(), rpcError.Message())
+		logging.V(7).Infof("%s failed: %v", label, rpcError)
 		return nil, err
 	}
 
-	logging.V(7).Infof("%s success", label)
+	logging.V(7).Infof("%s success: data=#%d", label, len(resp.Data))
 	return resp.Data, nil
 }

--- a/pkg/codegen/convert/mapper_server.go
+++ b/pkg/codegen/convert/mapper_server.go
@@ -19,6 +19,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
@@ -35,13 +36,18 @@ func NewMapperServer(mapper Mapper) codegenrpc.MapperServer {
 func (m *mapperServer) GetMapping(ctx context.Context,
 	req *codegenrpc.GetMappingRequest,
 ) (*codegenrpc.GetMappingResponse, error) {
+	label := "GetMapping"
+	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s", label, req.Provider, req.PulumiProvider)
+
 	// TODO: GetMapping should take a context because it's async, but we need to break the tfbridge build loop
 	// first.
 	data, err := m.mapper.GetMapping(req.Provider, req.PulumiProvider)
 	if err != nil {
+		logging.V(7).Infof("%s failed: %v", label, err)
 		return nil, err
 	}
 
+	logging.V(7).Infof("%s success: data=#%d", label, len(data))
 	return &codegenrpc.GetMappingResponse{
 		Data: data,
 	}, nil

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -672,7 +672,7 @@ func (p *provider) Check(urn resource.URN,
 	allowUnknowns bool, randomSeed []byte,
 ) (resource.PropertyMap, []CheckFailure, error) {
 	label := fmt.Sprintf("%s.Check(%s)", p.label(), urn)
-	logging.V(7).Infof("%s executing (#olds=%d,#news=%d", label, len(olds), len(news))
+	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(olds), len(news))
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
@@ -1805,6 +1805,9 @@ func decorateProviderSpans(span opentracing.Span, method string, req, resp inter
 
 // GetMapping fetches the conversion mapping (if any) for this resource provider.
 func (p *provider) GetMapping(key string) ([]byte, string, error) {
+	label := fmt.Sprintf("%s.GetMapping", p.label())
+	logging.V(7).Infof("%s executing: key=%s", label, key)
+
 	resp, err := p.clientRaw.GetMapping(p.requestContext(), &pulumirpc.GetMappingRequest{
 		Key: key,
 	})
@@ -1814,9 +1817,13 @@ func (p *provider) GetMapping(key string) ([]byte, string, error) {
 		if code == codes.Unimplemented {
 			// For backwards compatibility, just return nothing as if the provider didn't have a mapping for
 			// the given key
+			logging.V(7).Infof("%s unimplemented", label)
 			return nil, "", nil
 		}
+		logging.V(7).Infof("%s failed: %v", label, rpcError)
 		return nil, "", err
 	}
+
+	logging.V(7).Infof("%s success: data=#%d provider=%s", label, len(resp.Data), resp.Provider)
 	return resp.Data, resp.Provider, nil
 }


### PR DESCRIPTION
Makes it easier to trace conversion mappings via debug logs.