### PR TITLE
Make GetMapping contextful

### DIFF
--- a/pkg/codegen/convert/mapper.go
+++ b/pkg/codegen/convert/mapper.go
@@ -14,11 +14,13 @@
 
 package convert
 
+import "context"
+
 // An interface to map provider names (N.B. These aren't Pulumi provider names, but the names of "providers"
 // in the source language being converted from) to plugin specific mapping data.
 type Mapper interface {
 	// Returns plugin specific mapping data for the given provider name. The "pulumiProvider" is used as a
 	// hint for which pulumi plugin will provider this mapping. Returns an empty result if no mapping
 	// information was available.
-	GetMapping(provider string, pulumiProvider string) ([]byte, error)
+	GetMapping(ctx context.Context, provider string, pulumiProvider string) ([]byte, error)
 }

--- a/pkg/codegen/convert/mapper_client.go
+++ b/pkg/codegen/convert/mapper_client.go
@@ -63,11 +63,11 @@ func (m *mapperClient) Close() error {
 	return nil
 }
 
-func (m *mapperClient) GetMapping(provider string, pulumiProvider string) ([]byte, error) {
+func (m *mapperClient) GetMapping(ctx context.Context, provider string, pulumiProvider string) ([]byte, error) {
 	label := "GetMapping"
 	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s", label, provider, pulumiProvider)
 
-	resp, err := m.clientRaw.GetMapping(context.TODO(), &codegenrpc.GetMappingRequest{
+	resp, err := m.clientRaw.GetMapping(ctx, &codegenrpc.GetMappingRequest{
 		Provider:       provider,
 		PulumiProvider: pulumiProvider,
 	})

--- a/pkg/codegen/convert/mapper_server.go
+++ b/pkg/codegen/convert/mapper_server.go
@@ -39,9 +39,7 @@ func (m *mapperServer) GetMapping(ctx context.Context,
 	label := "GetMapping"
 	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s", label, req.Provider, req.PulumiProvider)
 
-	// TODO: GetMapping should take a context because it's async, but we need to break the tfbridge build loop
-	// first.
-	data, err := m.mapper.GetMapping(req.Provider, req.PulumiProvider)
+	data, err := m.mapper.GetMapping(ctx, req.Provider, req.PulumiProvider)
 	if err != nil {
 		logging.V(7).Infof("%s failed: %v", label, err)
 		return nil, err

--- a/pkg/codegen/convert/plugin_mapper.go
+++ b/pkg/codegen/convert/plugin_mapper.go
@@ -15,6 +15,7 @@
 package convert
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -224,7 +225,7 @@ func (l *pluginMapper) getMappingForPlugin(pluginSpec mapperPluginSpec) ([]byte,
 	return nil, "", err
 }
 
-func (l *pluginMapper) GetMapping(provider string, pulumiProvider string) ([]byte, error) {
+func (l *pluginMapper) GetMapping(ctx context.Context, provider string, pulumiProvider string) ([]byte, error) {
 	// If we already have an entry for this provider, use it
 	if entry, has := l.entries[provider]; has {
 		return entry, nil

--- a/pkg/codegen/convert/plugin_mapper_test.go
+++ b/pkg/codegen/convert/plugin_mapper_test.go
@@ -15,6 +15,7 @@
 package convert
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -182,7 +183,9 @@ func TestPluginMapper_InstalledPluginMatches(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mapper)
 
-	data, err := mapper.GetMapping("provider", "")
+	ctx := context.Background()
+
+	data, err := mapper.GetMapping(ctx, "provider", "")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
 }
@@ -224,7 +227,9 @@ func TestPluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mapper)
 
-	data, err := mapper.GetMapping("otherProvider", "")
+	ctx := context.Background()
+
+	data, err := mapper.GetMapping(ctx, "otherProvider", "")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
 }
@@ -267,7 +272,9 @@ func TestPluginMapper_NoPluginMatches(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, mapper)
 
-		data, err := mapper.GetMapping("yetAnotherProvider", "")
+		ctx := context.Background()
+
+		data, err := mapper.GetMapping(ctx, "yetAnotherProvider", "")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("data"), data)
 	})
@@ -299,7 +306,9 @@ func TestPluginMapper_NoPluginMatches(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, mapper)
 
-		data, err := mapper.GetMapping("yetAnotherProvider", "")
+		ctx := context.Background()
+
+		data, err := mapper.GetMapping(ctx, "yetAnotherProvider", "")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{}, data)
 	})
@@ -344,7 +353,9 @@ func TestPluginMapper_UseMatchingNameFirst(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mapper)
 
-	data, err := mapper.GetMapping("provider", "")
+	ctx := context.Background()
+
+	data, err := mapper.GetMapping(ctx, "provider", "")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
 }
@@ -401,13 +412,15 @@ func TestPluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mapper)
 
+	ctx := context.Background()
+
 	// Get the mapping for the GCP provider.
-	data, err := mapper.GetMapping("gcp", "")
+	data, err := mapper.GetMapping(ctx, "gcp", "")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("datagcp"), data)
 
 	// Now get the mapping for the AWS provider, it should be cached.
-	data, err = mapper.GetMapping("aws", "")
+	data, err = mapper.GetMapping(ctx, "aws", "")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("dataaws"), data)
 }
@@ -451,8 +464,10 @@ func TestPluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mapper)
 
+	ctx := context.Background()
+
 	// Get the mapping for the GCP provider, telling the mapper that it's pulumi name is "pulumiProviderGcp".
-	data, err := mapper.GetMapping("gcp", "pulumiProviderGcp")
+	data, err := mapper.GetMapping(ctx, "gcp", "pulumiProviderGcp")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("datagcp"), data)
 }


### PR DESCRIPTION
Now that we've removed the build link to terraform-bridge we can fix this TODO. Pass a `context.Context` to `GetMapping` because it's normally an async method.

This will require a small fix up in terraform-bridge when it updates to this version of pulumi/pkg.