### PR TITLE
Fix converter diagnostics

### DIFF
--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -148,7 +148,7 @@ func (c *converter) ConvertProgram(ctx context.Context, req *ConvertProgramReque
 	}
 
 	// Translate the rpc diagnostics into hcl.Diagnostics.
-	diags := make(hcl.Diagnostics, len(resp.Diagnostics))
+	diags := make(hcl.Diagnostics, 0, len(resp.Diagnostics))
 	for _, rpcDiag := range resp.Diagnostics {
 		diags = append(diags, RPCDiagnosticToHclDiagnostic(rpcDiag))
 	}

--- a/sdk/go/common/resource/plugin/converter_plugin_test.go
+++ b/sdk/go/common/resource/plugin/converter_plugin_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type testConverterClient struct{}
+
+func (c *testConverterClient) ConvertState(
+	ctx context.Context, req *pulumirpc.ConvertStateRequest, opts ...grpc.CallOption,
+) (*pulumirpc.ConvertStateResponse, error) {
+	if req.MapperTarget != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperTarget: %s", req.MapperTarget)
+	}
+
+	return &pulumirpc.ConvertStateResponse{
+		Resources: []*pulumirpc.ResourceImport{
+			{
+				Type:              "test:type",
+				Name:              "test:name",
+				Id:                "test:id",
+				Version:           "test:version",
+				PluginDownloadURL: "test:pluginDownloadURL",
+			},
+		},
+	}, nil
+}
+
+func (c *testConverterClient) ConvertProgram(
+	ctx context.Context, req *pulumirpc.ConvertProgramRequest, opts ...grpc.CallOption,
+) (*pulumirpc.ConvertProgramResponse, error) {
+	if req.MapperTarget != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperTarget: %s", req.MapperTarget)
+	}
+	if req.SourceDirectory != "src" {
+		return nil, fmt.Errorf("unexpected SourceDirectory: %s", req.SourceDirectory)
+	}
+	if req.TargetDirectory != "dst" {
+		return nil, fmt.Errorf("unexpected TargetDirectory: %s", req.TargetDirectory)
+	}
+
+	return &pulumirpc.ConvertProgramResponse{
+		Diagnostics: []*codegenrpc.Diagnostic{
+			{
+				Severity: codegenrpc.DiagnosticSeverity_DIAG_ERROR,
+				Summary:  "test:summary",
+				Detail:   "test:detail",
+			},
+		},
+	}, nil
+}
+
+func TestConverterPlugin_State(t *testing.T) {
+	t.Parallel()
+
+	plugin := &converter{
+		clientRaw: &testConverterClient{},
+	}
+
+	resp, err := plugin.ConvertState(context.Background(), &ConvertStateRequest{
+		MapperAddress: "localhost:1234",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Resources))
+
+	res := resp.Resources[0]
+	assert.Equal(t, "test:type", res.Type)
+	assert.Equal(t, "test:name", res.Name)
+	assert.Equal(t, "test:id", res.ID)
+	assert.Equal(t, "test:version", res.Version)
+	assert.Equal(t, "test:pluginDownloadURL", res.PluginDownloadURL)
+}
+
+func TestConverterPlugin_Program(t *testing.T) {
+	t.Parallel()
+
+	plugin := &converter{
+		clientRaw: &testConverterClient{},
+	}
+
+	resp, err := plugin.ConvertProgram(context.Background(), &ConvertProgramRequest{
+		MapperAddress:   "localhost:1234",
+		SourceDirectory: "src",
+		TargetDirectory: "dst",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Diagnostics))
+
+	diag := resp.Diagnostics[0]
+	assert.Equal(t, hcl.DiagError, diag.Severity)
+	assert.Equal(t, "test:summary", diag.Summary)
+	assert.Equal(t, "test:detail", diag.Detail)
+}

--- a/sdk/go/common/resource/plugin/converter_server.go
+++ b/sdk/go/common/resource/plugin/converter_server.go
@@ -71,7 +71,7 @@ func (c *converterServer) ConvertProgram(ctx context.Context,
 	}
 
 	// Translate the hcl.Diagnostics into rpc diagnostics.
-	diags := make([]*codegenrpc.Diagnostic, len(resp.Diagnostics))
+	diags := make([]*codegenrpc.Diagnostic, 0, len(resp.Diagnostics))
 	for _, diag := range resp.Diagnostics {
 		diags = append(diags, HclDiagnosticToRPCDiagnostic(diag))
 	}

--- a/sdk/go/common/resource/plugin/converter_server_test.go
+++ b/sdk/go/common/resource/plugin/converter_server_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testConverter struct{}
+
+func (c *testConverter) Close() error {
+	return nil
+}
+
+func (c *testConverter) ConvertState(
+	ctx context.Context, req *ConvertStateRequest,
+) (*ConvertStateResponse, error) {
+	if req.MapperAddress != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperAddress: %s", req.MapperAddress)
+	}
+
+	return &ConvertStateResponse{
+		Resources: []ResourceImport{
+			{
+				Type:              "test:type",
+				Name:              "test:name",
+				ID:                "test:id",
+				Version:           "test:version",
+				PluginDownloadURL: "test:pluginDownloadURL",
+			},
+		},
+	}, nil
+}
+
+func (c *testConverter) ConvertProgram(
+	ctx context.Context, req *ConvertProgramRequest,
+) (*ConvertProgramResponse, error) {
+	if req.MapperAddress != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperAddress: %s", req.MapperAddress)
+	}
+	if req.SourceDirectory != "src" {
+		return nil, fmt.Errorf("unexpected SourceDirectory: %s", req.SourceDirectory)
+	}
+	if req.TargetDirectory != "dst" {
+		return nil, fmt.Errorf("unexpected TargetDirectory: %s", req.TargetDirectory)
+	}
+
+	diags := hcl.Diagnostics{
+		{
+			Severity: hcl.DiagError,
+			Summary:  "test:summary",
+			Detail:   "test:detail",
+		},
+	}
+
+	return &ConvertProgramResponse{
+		Diagnostics: diags,
+	}, nil
+}
+
+func TestConverterServer_State(t *testing.T) {
+	t.Parallel()
+
+	server := NewConverterServer(&testConverter{})
+
+	resp, err := server.ConvertState(context.Background(), &pulumirpc.ConvertStateRequest{
+		MapperTarget: "localhost:1234",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Resources))
+
+	res := resp.Resources[0]
+	assert.Equal(t, "test:type", res.Type)
+	assert.Equal(t, "test:name", res.Name)
+	assert.Equal(t, "test:id", res.Id)
+	assert.Equal(t, "test:version", res.Version)
+	assert.Equal(t, "test:pluginDownloadURL", res.PluginDownloadURL)
+}
+
+func TestConverterServer_Program(t *testing.T) {
+	t.Parallel()
+
+	server := NewConverterServer(&testConverter{})
+
+	resp, err := server.ConvertProgram(context.Background(), &pulumirpc.ConvertProgramRequest{
+		MapperTarget:    "localhost:1234",
+		SourceDirectory: "src",
+		TargetDirectory: "dst",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Diagnostics))
+
+	diag := resp.Diagnostics[0]
+	assert.Equal(t, codegenrpc.DiagnosticSeverity_DIAG_ERROR, diag.Severity)
+	assert.Equal(t, "test:summary", diag.Summary)
+	assert.Equal(t, "test:detail", diag.Detail)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The converter diagnostics were appending to a pre-allocated but also pre-sized slice and so returning a load of `nil`s over RPC. This fixes that and adds some sanity tests for both sides of the interface.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
