### PR TITLE
Fix plugin mapper to not retry installs

### DIFF
--- a/pkg/codegen/convert/plugin_mapper.go
+++ b/pkg/codegen/convert/plugin_mapper.go
@@ -274,7 +274,9 @@ func (l *pluginMapper) GetMapping(ctx context.Context, provider string, pulumiPr
 	// installed so the user can manually edit their plugin cache to be the set of plugins they want to use.
 	for {
 		if len(l.plugins) == 0 {
-			// No plugins left to look in, return that we don't have a mapping
+			// No plugins left to look in, return that we don't have a mapping but first save that we'll never
+			// find a mapping for this provider key.
+			l.entries[provider] = []byte{}
 			return []byte{}, nil
 		}
 


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13105

When we failed to find a mapping for a provider we wouldn't save that result, so on calling GetMapping again we'd try installing and querying that provider again.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
