### PR TITLE
[pcl] Allow output variables to have the same identifier as other program nodes

### DIFF
--- a/changelog/pending/20230607--programgen-nodejs--allow-output-variables-to-have-the-same-identifier-as-other-program-nodes.yaml
+++ b/changelog/pending/20230607--programgen-nodejs--allow-output-variables-to-have-the-same-identifier-as-other-program-nodes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/nodejs
+  description: Allow output variables to have the same identifier as other program nodes

--- a/pkg/codegen/hcl2/model/scope.go
+++ b/pkg/codegen/hcl2/model/scope.go
@@ -116,12 +116,19 @@ func (c *Constant) Value(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 
 // A Scope is used to map names to definitions during expression binding.
 //
-// A scope has two namespaces: one that is exclusive to functions and one that contains both variables and functions.
-// When binding a reference, only the latter is checked; when binding a function, only the former is checked.
+// A scope has three namespaces:
+//   - one that is exclusive to functions
+//   - one that is exclusive to output variables
+//   - and one that contains config variables, local variables and resource definitions.
+//
+// When binding a reference, we check defs and outputs. When binding a function, we check inside functions
+// Definitions within a namespace such as defs, outputs or functions are expected to have a unique identifier
+// and cannot be redeclared.
 type Scope struct {
 	parent    *Scope
 	syntax    hclsyntax.Node
 	defs      map[string]Definition
+	outputs   map[string]Definition
 	functions map[string]*Function
 }
 
@@ -130,6 +137,7 @@ func NewRootScope(syntax hclsyntax.Node) *Scope {
 	return &Scope{
 		syntax:    syntax,
 		defs:      map[string]Definition{},
+		outputs:   map[string]Definition{},
 		functions: map[string]*Function{},
 	}
 }
@@ -163,9 +171,18 @@ func (s *Scope) SyntaxNode() hclsyntax.Node {
 // a definition is found or no parent scope remains.
 func (s *Scope) BindReference(name string) (Definition, bool) {
 	if s != nil {
+		// first we check inside defs which include config variables, local variables and resource definitions
 		if def, ok := s.defs[name]; ok {
 			return def, true
 		}
+
+		// then we check the namespace of the outputs.
+		// it is unlikely that an output is being referenced by something but still possible
+		// that is why we check outputs after checking defs
+		if output, ok := s.outputs[name]; ok {
+			return output, true
+		}
+
 		if s.parent != nil {
 			return s.parent.BindReference(name)
 		}
@@ -187,13 +204,35 @@ func (s *Scope) BindFunctionReference(name string) (*Function, bool) {
 	return nil, false
 }
 
+// isOutputDefinition returns whether the input definition is an output variable
+func isOutputDefinition(def Definition) bool {
+	syntax := def.SyntaxNode()
+	if syntax != nil {
+		switch syntax := syntax.(type) {
+		case *hclsyntax.Block:
+			return syntax.Type == "output"
+		}
+	}
+
+	return false
+}
+
 // Define maps the given name to the given definition. If the name is already defined in this scope, the existing
 // definition is not overwritten and Define returns false.
 func (s *Scope) Define(name string, def Definition) bool {
 	if s != nil {
-		if _, hasDef := s.defs[name]; !hasDef {
-			s.defs[name] = def
-			return true
+		if isOutputDefinition(def) {
+			// if the definition we have is an output
+			// then we only check inside the outputs namespace
+			if _, hasDef := s.outputs[name]; !hasDef {
+				s.outputs[name] = def
+				return true
+			}
+		} else {
+			if _, hasDef := s.defs[name]; !hasDef {
+				s.defs[name] = def
+				return true
+			}
 		}
 	}
 	return false
@@ -220,6 +259,7 @@ func (s *Scope) DefineScope(name string, syntax hclsyntax.Node) (*Scope, bool) {
 				parent:    s,
 				syntax:    syntax,
 				defs:      map[string]Definition{},
+				outputs:   map[string]Definition{},
 				functions: map[string]*Function{},
 			}
 			s.defs[name] = child
@@ -235,6 +275,7 @@ func (s *Scope) Push(syntax hclsyntax.Node) *Scope {
 		parent:    s,
 		syntax:    syntax,
 		defs:      map[string]Definition{},
+		outputs:   map[string]Definition{},
 		functions: map[string]*Function{},
 	}
 }

--- a/pkg/codegen/hcl2/model/scope.go
+++ b/pkg/codegen/hcl2/model/scope.go
@@ -121,8 +121,8 @@ func (c *Constant) Value(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 //   - one that is exclusive to output variables
 //   - and one that contains config variables, local variables and resource definitions.
 //
-// When binding a reference, we check defs and outputs. When binding a function, we check inside functions
-// Definitions within a namespace such as defs, outputs or functions are expected to have a unique identifier
+// When binding a reference, we check `defs` and `outputs`. When binding a function, we check `functions`.
+// Definitions within a namespace such as `defs`, `outputs` or `functions` are expected to have a unique identifier
 // and cannot be redeclared.
 type Scope struct {
 	parent    *Scope

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -288,3 +288,19 @@ func TestConfigNodeTypedAnyMap(t *testing.T) {
 	assert.True(t, ok, "the type of config is a map type")
 	assert.Equal(t, mapType.ElementType, model.DynamicType, "the element type is a dynamic")
 }
+
+func TestOutputsCanHaveSameNameAsOtherNodes(t *testing.T) {
+	t.Parallel()
+	// here we have an output with the same name as a config variable
+	// this should bind and type-check just fine
+	source := `
+config cidrBlock string { }
+output cidrBlock {
+  value = cidrBlock
+}
+`
+	program, diags, err := ParseAndBindProgram(t, source, "config.pp")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(diags), "There are no diagnostics")
+	assert.NotNil(t, program)
+}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -288,6 +288,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs").Except("dotnet"),
 		SkipCompile: allProgLanguages,
 	},
+	{
+		Directory:   "output-name-conflict",
+		Description: "Tests whether we are able to generate programs where output variables have same id as config var",
+		SkipCompile: codegen.NewStringSet("go"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
@@ -144,41 +144,39 @@ export = async () => {
             minSize: 1,
         },
     });
-    const clusterName = eksCluster.name;
-    const kubeconfig = pulumi.all([eksCluster.endpoint, eksCluster.certificateAuthority, eksCluster.name]).apply(([endpoint, certificateAuthority, name]) => JSON.stringify({
-        apiVersion: "v1",
-        clusters: [{
-            cluster: {
-                server: endpoint,
-                "certificate-authority-data": certificateAuthority.data,
-            },
-            name: "kubernetes",
-        }],
-        contexts: [{
-            contest: {
-                cluster: "kubernetes",
-                user: "aws",
-            },
-        }],
-        "current-context": "aws",
-        kind: "Config",
-        users: [{
-            name: "aws",
-            user: {
-                exec: {
-                    apiVersion: "client.authentication.k8s.io/v1alpha1",
-                    command: "aws-iam-authenticator",
-                },
-                args: [
-                    "token",
-                    "-i",
-                    name,
-                ],
-            },
-        }],
-    }));
     return {
-        clusterName: clusterName,
-        kubeconfig: kubeconfig,
+        clusterName: eksCluster.name,
+        kubeconfig: pulumi.all([eksCluster.endpoint, eksCluster.certificateAuthority, eksCluster.name]).apply(([endpoint, certificateAuthority, name]) => JSON.stringify({
+            apiVersion: "v1",
+            clusters: [{
+                cluster: {
+                    server: endpoint,
+                    "certificate-authority-data": certificateAuthority.data,
+                },
+                name: "kubernetes",
+            }],
+            contexts: [{
+                contest: {
+                    cluster: "kubernetes",
+                    user: "aws",
+                },
+            }],
+            "current-context": "aws",
+            kind: "Config",
+            users: [{
+                name: "aws",
+                user: {
+                    exec: {
+                        apiVersion: "client.authentication.k8s.io/v1alpha1",
+                        command: "aws-iam-authenticator",
+                    },
+                    args: [
+                        "token",
+                        "-i",
+                        name,
+                    ],
+                },
+            }],
+        })),
     };
 }

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
@@ -5,8 +5,7 @@ export = async () => {
     const config = new pulumi.Config();
     const configLexicalName = config.require("cC-Charlie_charlie.😃⁉️");
     const resourceLexicalName = new random.RandomPet("aA-Alpha_alpha.🤯⁉️", {prefix: configLexicalName});
-    const outputLexicalName = resourceLexicalName.id;
     return {
-        "bB-Beta_beta.💜⁉": outputLexicalName,
+        "bB-Beta_beta.💜⁉": resourceLexicalName.id,
     };
 }

--- a/pkg/codegen/testing/test/testdata/output-name-conflict-pp/dotnet/output-name-conflict.cs
+++ b/pkg/codegen/testing/test/testdata/output-name-conflict-pp/dotnet/output-name-conflict.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var config = new Config();
+    var cidrBlock = config.Get("cidrBlock") ?? "Test config variable";
+    return new Dictionary<string, object?>
+    {
+        ["cidrBlock"] = cidrBlock,
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/output-name-conflict-pp/go/output-name-conflict.go
+++ b/pkg/codegen/testing/test/testdata/output-name-conflict-pp/go/output-name-conflict.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		cidrBlock := "Test config variable"
+		if param := cfg.Get("cidrBlock"); param != "" {
+			cidrBlock = param
+		}
+		ctx.Export("cidrBlock", cidrBlock)
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/output-name-conflict-pp/nodejs/output-name-conflict.ts
+++ b/pkg/codegen/testing/test/testdata/output-name-conflict-pp/nodejs/output-name-conflict.ts
@@ -1,0 +1,9 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export = async () => {
+    const config = new pulumi.Config();
+    const cidrBlock = config.get("cidrBlock") || "Test config variable";
+    return {
+        cidrBlock: cidrBlock,
+    };
+}

--- a/pkg/codegen/testing/test/testdata/output-name-conflict-pp/output-name-conflict.pp
+++ b/pkg/codegen/testing/test/testdata/output-name-conflict-pp/output-name-conflict.pp
@@ -1,0 +1,7 @@
+config cidrBlock string {
+    default = "Test config variable"
+}
+
+output cidrBlock {
+  value = cidrBlock
+}

--- a/pkg/codegen/testing/test/testdata/output-name-conflict-pp/python/output-name-conflict.py
+++ b/pkg/codegen/testing/test/testdata/output-name-conflict-pp/python/output-name-conflict.py
@@ -1,0 +1,7 @@
+import pulumi
+
+config = pulumi.Config()
+cidr_block = config.get("cidrBlock")
+if cidr_block is None:
+    cidr_block = "Test config variable"
+pulumi.export("cidrBlock", cidr_block)


### PR DESCRIPTION
# Description

This PR extends the PCL binder to allow declaring _output_ variables that have the same identifier as other program node types. The outputs now have their own namespace within a scope. This means that the binder now checks that outputs have unique identifier with respect to only other outputs. 

```diff
type Scope struct {
	parent    *Scope
	syntax    hclsyntax.Node
	defs      map[string]Definition
+	outputs   map[string]Definition
	functions map[string]*Function
}
```

It used to be the case that the binder would fail if it encounters an output variable with ID equal to that of another node. However, as we have seen in many terraform examples, module variables and module outputs can have the same identifier. 

All program-gens except for TypeScript can already handle this case so in this PR I've updated TypeScript program-gen to support it as well by switching the main program entry point into an async one which accumulates all the exported variables into a single object. This might seem a bit weird but this case almost never happens in top-level programs. Instead, this name conflict is usually implemented in components which don't have to directly export their output variables.

After this is merged, we would need to update pulumi-terraform-bridge include these changes in the PCL binding and change the tf converter such that it doesn't _mangle_ output variables but instead ensure uniqueness within the set of output variables only. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
