### PR TITLE
[pcl/go] Fix panic in go program-gen when encountering splat expressions

### DIFF
--- a/changelog/pending/20230607--programgen-go--fix-panic-in-go-program-gen-when-encountering-splat-expressions.yaml
+++ b/changelog/pending/20230607--programgen-go--fix-panic-in-go-program-gen-when-encountering-splat-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix panic in go program-gen when encountering splat expressions

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -991,11 +991,11 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type) (
 ) {
 	expr = pcl.RewritePropertyReferences(expr)
 	expr, diags := pcl.RewriteApplies(expr, nameInfo(0), false /*TODO*/)
+	expr, sTemps, splatDiags := g.rewriteSplat(expr, g.splatSpiller)
 	expr, convertDiags := pcl.RewriteConversions(expr, typ)
 	expr, tTemps, ternDiags := g.rewriteTernaries(expr, g.ternaryTempSpiller)
 	expr, jTemps, jsonDiags := g.rewriteToJSON(expr)
 	expr, rTemps, readDirDiags := g.rewriteReadDir(expr, g.readDirTempSpiller)
-	expr, sTemps, splatDiags := g.rewriteSplat(expr, g.splatSpiller)
 	expr, oTemps, optDiags := g.rewriteOptionals(expr, g.optionalSpiller)
 
 	bufferSize := len(tTemps) + len(jTemps) + len(rTemps) + len(sTemps) + len(oTemps)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -283,6 +283,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
 	},
 	{
+		Directory:   "simple-splat",
+		Description: "An example that shows we can compile splat expressions from array of objects",
+		// Skip compiling because we are using a test schema without a corresponding real package
+		SkipCompile: allProgLanguages,
+	},
+	{
 		Directory:   "invoke-inside-conditional-range",
 		Description: "Using the result of an invoke inside a conditional range expression of a resource",
 		Skip:        allProgLanguages.Except("nodejs").Except("dotnet"),

--- a/pkg/codegen/testing/test/testdata/simple-splat-pp/dotnet/simple-splat.cs
+++ b/pkg/codegen/testing/test/testdata/simple-splat-pp/dotnet/simple-splat.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Splat = Pulumi.Splat;
+
+return await Deployment.RunAsync(() => 
+{
+    var allKeys = Splat.GetSshKeys.Invoke();
+
+    var main = new Splat.Server("main", new()
+    {
+        SshKeys = allKeys.Apply(getSshKeysResult => getSshKeysResult.SshKeys).Select(__item => __item.Name).ToList(),
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/simple-splat-pp/go/simple-splat.go
+++ b/pkg/codegen/testing/test/testdata/simple-splat-pp/go/simple-splat.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-splat/sdk/go/splat"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		allKeys, err := splat.GetSshKeys(ctx, nil, nil)
+		if err != nil {
+			return err
+		}
+		var splat0 []string
+		for _, val0 := range allKeys.SshKeys {
+			splat0 = append(splat0, val0.Name)
+		}
+		_, err = splat.NewServer(ctx, "main", &splat.ServerArgs{
+			SshKeys: splat0,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/simple-splat-pp/nodejs/simple-splat.ts
+++ b/pkg/codegen/testing/test/testdata/simple-splat-pp/nodejs/simple-splat.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as splat from "@pulumi/splat";
+
+const allKeys = splat.getSshKeys({});
+const main = new splat.Server("main", {sshKeys: allKeys.then(allKeys => allKeys.sshKeys.map(__item => __item.name))});

--- a/pkg/codegen/testing/test/testdata/simple-splat-pp/python/simple-splat.py
+++ b/pkg/codegen/testing/test/testdata/simple-splat-pp/python/simple-splat.py
@@ -1,0 +1,5 @@
+import pulumi
+import pulumi_splat as splat
+
+all_keys = splat.get_ssh_keys()
+main = splat.Server("main", ssh_keys=[__item.name for __item in all_keys.ssh_keys])

--- a/pkg/codegen/testing/test/testdata/simple-splat-pp/simple-splat.pp
+++ b/pkg/codegen/testing/test/testdata/simple-splat-pp/simple-splat.pp
@@ -1,0 +1,5 @@
+allKeys = invoke("splat:index:getSshKeys", {})
+
+resource "main" "splat:index:Server" {
+  sshKeys = allKeys.sshKeys[*].name
+}

--- a/pkg/codegen/testing/test/testdata/splat-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/splat-1.0.0.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "splat",
+  "version": "1.0.0",
+  "types": {
+    "splat:index:SshKey": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": ["name"]
+    }
+  },
+  "functions": {
+    "splat:index:getSshKeys": {
+      "outputs": {
+        "properties": {
+          "sshKeys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/splat:index:SshKey"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "sshKeys"
+        ]
+      }
+    }
+  },
+  "resources": {
+    "splat:index:Server": {
+      "requiredInputs": ["sshKeys"],
+      "inputProperties": {
+        "sshKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -82,5 +82,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"range", "1.0.0"},
 		SchemaProvider{"lambda", "0.1.0"},
 		SchemaProvider{"remoteref", "1.0.0"},
+		SchemaProvider{"splat", "1.0.0"},
 	)
 }


### PR DESCRIPTION
# Description

This PR adds a test program to show compiling splat expressions in the different languages and fixing a panic in go program-gen. I created a simple schema for this specific test which is why compiling the example is skipped in all languages. 

The problem was that rewriting splat expressions happened after rewriting conversions so I switched the order of them.  

Fixes #13108 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
