### PR TITLE
cli/new: Escape special characters in project description

### DIFF
--- a/changelog/pending/20230607--cli-new--escape-special-characters-in-project-description.yaml
+++ b/changelog/pending/20230607--cli-new--escape-special-characters-in-project-description.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Escape special characters in project description

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -52,6 +52,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 		yes:               true,
 		prompt:            promptForValue,
 		secretsProvider:   "default",
+		description:       "foo: bar", // Needs special escaping for YAML
 		stack:             stackName,
 		templateNameOrURL: "typescript",
 	}


### PR DESCRIPTION
# Description

The `transform` method does a simple find-and-replace for all occurrences of `${PROJECT}` and `${DESCRIPTION}` we encounter when templating a new project.

The templates repo only uses `${DESCRIPTION}` in `Pulumi.yaml` files, and all use cases are identical:
```
description: ${DESCRIPTION}
```

`${PROJECT}` is validated, but `${DESCRIPTION}` is freeform text. This means the user can accidentally provide a description that generates a malformed `Pulumi.yaml`.

This PR escapes any special characters by marshaling the description to YAML before performing the find-and-replace. A test was modified to reproduce the issue and confirm the fix.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
