### PR TITLE
Don't return empty hcl.Diagnostics

### DIFF
--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -205,7 +205,7 @@ func BindDirectory(directory string, loader schema.ReferenceLoader, strict bool)
 		return nil, nil, err
 	}
 
-	parseDiagnostics := make(hcl.Diagnostics, 0)
+	var parseDiagnostics hcl.Diagnostics
 	for _, file := range files {
 		if file.IsDir() {
 			continue

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -255,7 +255,7 @@ func (s *optionsScopes) GetScopeForAttribute(attr *hclsyntax.Attribute) (*model.
 
 func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostics) {
 	resourceOptions := &ResourceOptions{}
-	diagnostics := hcl.Diagnostics{}
+	var diagnostics hcl.Diagnostics
 	for _, item := range options.Body.Items {
 		switch item := item.(type) {
 		case *model.Attribute:

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -483,7 +483,7 @@ const (
 
 // Validate an individual name token.
 func (spec *PackageSpec) validateTypeToken(allowedPackageNames map[string]bool, section, token string) hcl.Diagnostics {
-	diags := hcl.Diagnostics{}
+	var diags hcl.Diagnostics
 
 	path := memberPath(section, token)
 	parts := strings.Split(token, ":")
@@ -506,7 +506,7 @@ func (spec *PackageSpec) validateTypeToken(allowedPackageNames map[string]bool, 
 
 // This is for validating non-reference type tokens.
 func (spec *PackageSpec) validateTypeTokens() hcl.Diagnostics {
-	diags := hcl.Diagnostics{}
+	var diags hcl.Diagnostics
 	allowedPackageNames := map[string]bool{spec.Name: true}
 	for _, prefix := range spec.AllowedPackageNames {
 		allowedPackageNames[prefix] = true

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -148,7 +148,7 @@ func (c *converter) ConvertProgram(ctx context.Context, req *ConvertProgramReque
 	}
 
 	// Translate the rpc diagnostics into hcl.Diagnostics.
-	diags := make(hcl.Diagnostics, 0, len(resp.Diagnostics))
+	var diags hcl.Diagnostics
 	for _, rpcDiag := range resp.Diagnostics {
 		diags = append(diags, RPCDiagnosticToHclDiagnostic(rpcDiag))
 	}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1201

hcl.Diagnostics implements the Error interface, but this means a list of zero diagnostics still looks like a non-nil error, which throws of normal "if err == nil" checks.

This changes a few use sites of hcl.Diagnostics to ensure we return nil when there aren't any diagnostics rather than an empty slice. This ensures if they get cast to `Error` they don't trip up standard `err == nil` checks.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
