### PR TITLE
[pcl/components] Fixes range scoping for PCL components

### DIFF
--- a/changelog/pending/20230608--programgen--fixes-range-scoping-for-pcl-components.yaml
+++ b/changelog/pending/20230608--programgen--fixes-range-scoping-for-pcl-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fixes range scoping for PCL components

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -389,9 +389,10 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 				source := item.Labels[1]
 
 				v := &Component{
-					name:   name,
-					syntax: item,
-					source: source,
+					name:         name,
+					syntax:       item,
+					source:       source,
+					VariableType: model.DynamicType,
 				}
 				diags := b.declareNode(name, v)
 				diagnostics = append(diagnostics, diags...)

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -57,7 +57,8 @@ func newComponentScopes(
 	root *model.Scope,
 	component *Component,
 	rangeKeyType model.Type,
-	rangeValueType model.Type) model.Scopes {
+	rangeValueType model.Type,
+) model.Scopes {
 	scopes := &componentScopes{
 		root:      root,
 		withRange: root,

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -335,7 +335,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 					contract.Assertf(len(diags) == 0, "failed to typecheck conditional expression: %v", diags)
 
 					node.VariableType = condExpr.Type()
-				case model.InputType(model.NumberType).ConversionFrom(typ) != model.NoConversion:
+				case model.InputType(model.NumberType).ConversionFrom(typ) == model.SafeConversion:
 					rangeArgs := []model.Expression{expr}
 					rangeSig, _ := pulumiBuiltins["range"].GetSignature(rangeArgs)
 

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -143,7 +143,8 @@ var pulumiBuiltins = map[string]*model.Function{
 			valueType := model.Type(model.DynamicType)
 			if len(args) > 0 {
 				valueType = args[0].Type()
-				switch valueType := model.ResolveOutputs(valueType).(type) {
+				elementType := UnwrapOption(model.ResolveOutputs(valueType))
+				switch valueType := elementType.(type) {
 				case *model.ListType, *model.MapType, *model.ObjectType, *model.TupleType:
 					// OK
 				default:


### PR DESCRIPTION
# Description

This PR implements proper `range` block scoping for `pcl.Component` so that when binding the component body, it understands references to the `range` expression. This fixes a couple of the PCL binder issues we have been seeing in TF converter such as  https://github.com/pulumi/pulumi-terraform-bridge/issues/1184, https://github.com/pulumi/pulumi-terraform-bridge/issues/1150, https://github.com/pulumi/pulumi-terraform-bridge/issues/1148 at least locally these errors are resolved for the linked TF example. 

Also small fix for the error we are seeing for `length(...)` because fields of object-typed config were implicitly optional and errored before. Now it flattens `option<T>` to just `T` and no longer errors. https://github.com/pulumi/pulumi-terraform-bridge/issues/1186

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
