### PR TITLE
[pcl/python] Fixes panic when emiting code for index expressions that aren't type-checked

### DIFF
--- a/changelog/pending/20230608--programgen-python--fixes-python-panic-when-emiting-code-for-index-expressions-that-arent-typechecked.yaml
+++ b/changelog/pending/20230608--programgen-python--fixes-python-panic-when-emiting-code-for-index-expressions-that-arent-typechecked.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Fixes python panic when emiting code for index expressions that aren't typechecked

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -535,7 +535,7 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 		var key cty.Value
 		switch traverser := traverser.(type) {
 		case hcl.TraverseAttr:
-			key = cty.StringVal(traverser.Name)
+			key = cty.StringVal(PyName(traverser.Name))
 		case hcl.TraverseIndex:
 			key = traverser.Key
 		default:
@@ -544,7 +544,7 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 
 		switch key.Type() {
 		case cty.String:
-			keyVal := key.AsString()
+			keyVal := PyName(key.AsString())
 			contract.Assertf(isLegalIdentifier(keyVal), "illegal identifier: %q", keyVal)
 			g.Fgenf(w, ".%s", keyVal)
 		case cty.Number:

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -55,7 +55,7 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 		_, isComponent := receiver.(*pcl.Component)
 
 		if hasSchema || isComponent {
-			objectKey, keyVal = true, PyName(keyVal)
+			objectKey = true
 			switch t := traverser.(type) {
 			case hcl.TraverseAttr:
 				t.Name = keyVal
@@ -95,6 +95,11 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 				Value: cty.StringVal(keyVal),
 			},
 		}
+
+		// typechecking the index expression will compute the type of the expression
+		// so that when we call Type() later on, we get the correct type.
+		typecheckDiags := currentExpression.Typecheck(true)
+		g.diagnostics = g.diagnostics.Extend(typecheckDiags)
 	}
 
 	if currentExpression == source {

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -299,6 +299,13 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Tests whether we are able to generate programs where output variables have same id as config var",
 		SkipCompile: codegen.NewStringSet("go"),
 	},
+	{
+		Directory:   "snowflake-python-12998",
+		Description: "Tests regression for issue https://github.com/pulumi/pulumi/issues/12998",
+		Skip:        allProgLanguages.Except("python"),
+		SkipCompile: allProgLanguages,
+		BindOptions: []pcl.BindOption{pcl.AllowMissingVariables, pcl.AllowMissingProperties},
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/snowflake-0.66.1.json
+++ b/pkg/codegen/testing/test/testdata/snowflake-0.66.1.json
@@ -1,0 +1,96 @@
+{
+  "name": "snowflake",
+  "description": "A Pulumi package for creating and managing snowflake cloud resources.",
+  "keywords": [
+    "pulumi",
+    "snowflake"
+  ],
+  "homepage": "https://pulumi.io",
+  "license": "Apache-2.0",
+  "attribution": "This Pulumi package is based on the [`snowflake` Terraform Provider](https://github.com/Snowflake-Labs/terraform-provider-snowflake).",
+  "repository": "https://github.com/pulumi/pulumi-snowflake",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "namespaces": null,
+      "packageReferences": {
+        "Pulumi": "3.*"
+      }
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-snowflake/sdk/go/snowflake"
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/mime": "^2.0.0",
+        "@types/node": "^10.0.0"
+      },
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package for creating and managing snowflake cloud resources.",
+      "packageName": "",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/Snowflake-Labs/terraform-provider-snowflake)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-snowflake` repo](https://github.com/pulumi/pulumi-snowflake/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-snowflake` repo](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues).",
+      "typescriptVersion": ""
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/Snowflake-Labs/terraform-provider-snowflake)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-snowflake` repo](https://github.com/pulumi/pulumi-snowflake/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-snowflake` repo](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues).",
+      "requires": {
+        "pulumi": "\u003e=3.0.0,\u003c4.0.0"
+      }
+    }
+  },
+  "types": {
+    "snowflake:index/TagAssociationObjectIdentifier:TagAssociationObjectIdentifier": {
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "resources": {
+    "snowflake:index/tagAssociation:TagAssociation": {
+      "properties": {
+        "objectIdentifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/snowflake:index/TagAssociationObjectIdentifier:TagAssociationObjectIdentifier"
+          }
+        }
+      },
+      "required": [
+        "objectIdentifiers"
+      ],
+      "inputProperties": {
+        "objectIdentifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/snowflake:index/TagAssociationObjectIdentifier:TagAssociationObjectIdentifier"
+          }
+        }
+      },
+      "requiredInputs": [
+        "objectIdentifiers"
+      ]
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/snowflake-python-12998-pp/python/snowflake-python-12998.py
+++ b/pkg/codegen/testing/test/testdata/snowflake-python-12998-pp/python/snowflake-python-12998.py
@@ -1,0 +1,8 @@
+import pulumi
+import pulumi_snowflake as snowflake
+
+table_association = snowflake.TagAssociation("tableAssociation", object_identifiers=[snowflake.TagAssociationObjectIdentifierArgs(
+    name=test["name"],
+    database=snowflake_database["value"]["name"],
+    schema=snowflake_schema["value"]["name"],
+)])

--- a/pkg/codegen/testing/test/testdata/snowflake-python-12998-pp/snowflake-python-12998.pp
+++ b/pkg/codegen/testing/test/testdata/snowflake-python-12998-pp/snowflake-python-12998.pp
@@ -1,0 +1,7 @@
+resource tableAssociation "snowflake:index/tagAssociation:TagAssociation" {
+  objectIdentifiers =[{
+    name     = test.name,
+    database = snowflake_database.value.name,
+    schema   = snowflake_schema.value.name
+  }]
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -83,5 +83,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"lambda", "0.1.0"},
 		SchemaProvider{"remoteref", "1.0.0"},
 		SchemaProvider{"splat", "1.0.0"},
+		SchemaProvider{"snowflake", "0.66.1"},
 	)
 }


### PR DESCRIPTION
# Description

When creating an expression `expr` of type `model.IndexExpression` and we don't call `expr.Typecheck(...)` on it, it doesn't compute/cache its type right away. This causes downstream code paths to panic when working `expr.Type()` since it is `nil` when it is not type-checked.  

This PR resolves this issue and fixes #12998. I uses a tiny snowflake schema and a small PCL to test my changes. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
