### PR TITLE
[pcl] Fixes panic when trying to convert a null literal to a string value

### DIFF
--- a/changelog/pending/20230609--programgen--fixes-panic-when-trying-to-convert-a-null-literal-to-a-string-value.yaml
+++ b/changelog/pending/20230609--programgen--fixes-panic-when-trying-to-convert-a-null-literal-to-a-string-value.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fixes panic when trying to convert a null literal to a string value

--- a/pkg/codegen/pcl/rewrite_convert.go
+++ b/pkg/codegen/pcl/rewrite_convert.go
@@ -314,6 +314,9 @@ func convertLiteralToString(from model.Expression) (string, bool) {
 		}
 	case *model.LiteralValueExpression:
 		if stringValue, err := convert.Convert(expr.Value, cty.String); err == nil {
+			if stringValue.IsNull() {
+				return "", false
+			}
 			return stringValue.AsString(), true
 		}
 	}


### PR DESCRIPTION
# Description

Trying to convert https://github.com/philips-labs/terraform-aws-github-runner triggered a panic when trying to convert a null literal value to string. This PR fixes the issue and the makes the example convert successfully 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
