### PR TITLE
Handle installing plugins without versions in the defaultHost

### DIFF
--- a/changelog/pending/20230609--engine--fix-plugin-installation-when-looking-up-new-schemas.yaml
+++ b/changelog/pending/20230609--engine--fix-plugin-installation-when-looking-up-new-schemas.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix plugin installation when looking up new schemas.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1164,6 +1164,7 @@ func (d *pluginDownloader) tryDownloadToFile(pkgPlugin PluginSpec) (string, erro
 		return "", nil, err
 	}
 	readErr, writeErr := d.tryDownload(pkgPlugin, file)
+	logging.V(10).Infof("try downloaded plugin %s to %s: %v %v", pkgPlugin, file.Name(), readErr, writeErr)
 	if readErr != nil || writeErr != nil {
 		err2 := os.Remove(file.Name())
 		if err2 != nil {
@@ -1554,10 +1555,12 @@ func HasPluginGTE(spec PluginSpec) (bool, error) {
 	}
 
 	for _, p := range plugs {
-		if p.Name == spec.Name &&
-			p.Kind == spec.Kind &&
-			(p.Version != nil && spec.Version != nil && p.Version.GTE(*spec.Version)) {
-			return true, nil
+		if p.Name == spec.Name && p.Kind == spec.Kind {
+			if spec.Version == nil {
+				return true, nil
+			} else if p.Version != nil && p.Version.GTE(*spec.Version) {
+				return true, nil
+			}
 		}
 	}
 	return false, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Might fix https://github.com/pulumi/pulumi-terraform-bridge/issues/1209
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1200

When looking up schemas we would call into `defaultHost.InstallPlugin` to install any missing plugins, and we would generally _not_ have version information for that. Unfortunately `defaultHost.InstallPlugin` didn't handle the case of version not being set, double unfortunately it also didn't error.

This fixes that install path to call `GetLatestVersion` if version isn't set.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
