### PR TITLE
[programgen/dotnet,go] Implement singleOrNone intrinsic

### DIFF
--- a/changelog/pending/20230611--programgen-dotnet-go--add-support-for-the-singleornone-intrinsic.yaml
+++ b/changelog/pending/20230611--programgen-dotnet-go--add-support-for-the-singleornone-intrinsic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go
+  description: Add support for the singleOrNone intrinsic

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -299,6 +299,7 @@ var functionNamespaces = map[string][]string{
 	"toBase64":         {"System"},
 	"fromBase64":       {"System"},
 	"sha1":             {"System.Security.Cryptography", "System.Text"},
+	"singleOrNone":     {"System.Linq"},
 }
 
 func (g *generator) genFunctionUsings(x *model.FunctionCallExpression) []string {
@@ -510,6 +511,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "ComputeFileBase64Sha256(%v)", expr.Args[0])
 	case "notImplemented":
 		g.Fgenf(w, "NotImplemented(%v)", expr.Args[0])
+	case "singleOrNone":
+		g.Fgenf(w, "Enumerable.Single(%v)", expr.Args[0])
 	case pcl.Invoke:
 		_, fullFunctionName := g.functionName(expr.Args[0])
 		functionParts := strings.Split(fullFunctionName, ".")

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -264,6 +264,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "filebase64sha256OrPanic(%v)", expr.Args[0])
 	case "notImplemented":
 		g.Fgenf(w, "notImplemented(%v)", expr.Args[0])
+	case "singleOrNone":
+		g.Fgenf(w, "singleOrNone(%v)", expr.Args[0])
 	case pcl.Invoke:
 		if expr.Signature.MultiArgumentInputs {
 			panic(fmt.Errorf("go program-gen does not implement MultiArgumentInputs for function '%v'",
@@ -1205,6 +1207,7 @@ var functionPackages = map[string][]string{
 	"sha1":             {"fmt", "crypto/sha1"},
 	"filebase64sha256": {"fmt", "crypto/sha256", "os"},
 	"cwd":              {"os"},
+	"singleOrNone":     {"fmt"},
 }
 
 func (g *generator) genFunctionPackages(x *model.FunctionCallExpression) []string {

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -96,6 +96,13 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 %sfunc notImplemented(message string) pulumi.AnyOutput {
 %s  panic(message)
 %s}`, indent, indent, indent), true
+	case "singleOrNone":
+		return fmt.Sprintf(`%sfunc singleOrNone[T any](elements []T) T {
+%s	if len(elements) != 1 {
+%s		panic(fmt.Errorf("singleOrNone expected input slice to have a single element"))
+%s	}
+%s	return elements[0]
+%s}`, indent, indent, indent, indent, indent, indent), true
 	default:
 		return "", false
 	}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -278,9 +278,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "single-or-none",
 		Description: "Tests using the singleOrNone function",
-		// TODO: dotnet and go support
-		Skip:        allProgLanguages.Except("nodejs").Except("python"),
-		SkipCompile: allProgLanguages.Except("nodejs").Except("python"),
+		// TODO[pulumi/pulumi#4899]: Skip compiling for Go because it is trying to pass a value of type float64
+		// as an argument to ctx.Export but float64 does not implement pulumi.Input. The value needs to be
+		// wrapped as a pulumi.Float64.
+		SkipCompile: codegen.NewStringSet("go"),
 	},
 	{
 		Directory:   "simple-splat",

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/dotnet/single-or-none.cs
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/dotnet/single-or-none.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    return new Dictionary<string, object?>
+    {
+        ["result"] = Enumerable.Single(new[]
+        {
+            1,
+        }),
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/single-or-none-pp/go/single-or-none.go
+++ b/pkg/codegen/testing/test/testdata/single-or-none-pp/go/single-or-none.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func singleOrNone[T any](elements []T) T {
+	if len(elements) != 1 {
+		panic(fmt.Errorf("singleOrNone expected input slice to have a single element"))
+	}
+	return elements[0]
+}
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		ctx.Export("result", singleOrNone([]float64{
+			1,
+		}))
+		return nil
+	})
+}


### PR DESCRIPTION
This change adds support for the `singleOrNone` intrinsic to Go and C# programgen.

Fixes #13148