### PR TITLE
Updates the error handling logic around RPC deserialization in Python

### DIFF
--- a/changelog/pending/20230613--sdk-python--no-longer-raises-error-on-unexpected-output-type-for-lists.yaml
+++ b/changelog/pending/20230613--sdk-python--no-longer-raises-error-on-unexpected-output-type-for-lists.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: No longer raises error on unexpected output type for lists

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -158,7 +158,8 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
         if len(args) == 1:
             return args[0]
 
-    raise AssertionError(f"Unexpected type. Expected 'list' got '{typ}'")
+    log.error(f"Unexpected type. Expected 'list' got '{typ}'")
+    return None
 
 
 async def serialize_properties(


### PR DESCRIPTION
Today, if the resolved output value for a resource does not match exactly the expected type for that output, deserialization will fail on an unhandled exception. For sum types where an output can be either a map or a list, we do not fall back, so the program will not complete. This PR changes the exception raising logic to simply log an error when parsing. This will allow the program to fall back, and continue running.

I'm very open to discussion around what level we log at (if at all!) as well.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes pulumi/pulumi-azure-native#2525 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
