### PR TITLE
[pcl/binder] Extend SkipResourceTypechecking to allow binding and generating unknown resources

### DIFF
--- a/changelog/pending/20230614--programgen-dotnet-go-nodejs-python--extend-skipresourcetypechecking-to-allow-generating-unknown-resources.yaml
+++ b/changelog/pending/20230614--programgen-dotnet-go-nodejs-python--extend-skipresourcetypechecking-to-allow-generating-unknown-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Extend SkipResourceTypechecking to allow generating unknown resources

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1143,12 +1143,14 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 	csharpInputPropertyNameMap := g.extractInputPropertyNameMap(r)
 
 	// Add conversions to input properties
-	for _, input := range r.Inputs {
-		destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: input.Name})
-		g.diagnostics = append(g.diagnostics, diagnostics...)
-		input.Value = g.lowerExpression(input.Value, destType.(model.Type))
-		if csharpName, ok := csharpInputPropertyNameMap[input.Name]; ok {
-			input.Name = csharpName
+	if r.Schema != nil {
+		for _, input := range r.Inputs {
+			destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: input.Name})
+			g.diagnostics = append(g.diagnostics, diagnostics...)
+			input.Value = g.lowerExpression(input.Value, destType.(model.Type))
+			if csharpName, ok := csharpInputPropertyNameMap[input.Name]; ok {
+				input.Name = csharpName
+			}
 		}
 	}
 

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -850,10 +850,14 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 					propertyName = fmt.Sprintf("%q", propertyName)
 				}
 
-				destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: attr.Name})
-				g.diagnostics = append(g.diagnostics, diagnostics...)
-				g.Fgenf(w, fmtString, propertyName,
-					g.lowerExpression(attr.Value, destType.(model.Type)))
+				if r.Schema != nil {
+					destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: attr.Name})
+					g.diagnostics = append(g.diagnostics, diagnostics...)
+					g.Fgenf(w, fmtString, propertyName,
+						g.lowerExpression(attr.Value, destType.(model.Type)))
+				} else {
+					g.Fgenf(w, fmtString, propertyName, attr.Value)
+				}
 			}
 		})
 		if len(r.Inputs) > 1 {

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -273,6 +273,9 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 
 		pkg, err := b.options.packageCache.loadPackageSchema(b.options.loader, name, pkgOpts.version)
 		if err != nil {
+			if b.options.skipResourceTypecheck {
+				continue
+			}
 			return err
 		}
 		b.referencedPackages[name] = pkg.schema

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -348,6 +348,37 @@ func TestLengthFunctionCanBeUsedWithDynamic(t *testing.T) {
 	assert.NotNil(t, program)
 }
 
+func TestBindingUnknownResourceWhenSkippingResourceTypeChecking(t *testing.T) {
+	t.Parallel()
+	source := `
+resource provider "pulumi:providers:unknown" { }
+
+resource main "unknown:index:main" {
+    first = "hello"
+    second = {
+        foo = "bar"
+    }
+}
+
+resource fromModule "unknown:eks:example" {
+   options { range = 10 }
+   associatedMain = main.id
+}
+
+output "mainId" {
+    value = main.id
+}
+
+output "values" {
+    value = fromModule.values.first
+}`
+
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp", pcl.SkipResourceTypechecking)
+	require.NoError(t, err)
+	assert.False(t, diags.HasErrors(), "There are no errors")
+	assert.NotNil(t, program)
+}
+
 func TestTraversalOfOptionalObject(t *testing.T) {
 	t.Parallel()
 	// foo : Option<{ bar: string }>

--- a/pkg/codegen/pcl/diagnostics.go
+++ b/pkg/codegen/pcl/diagnostics.go
@@ -45,6 +45,15 @@ func resourceLoadError(token string, err error, tokenRange hcl.Range) *hcl.Diagn
 	return errorf(tokenRange, "error loading resource type '%s': %v", token, err)
 }
 
+func asWarningDiagnostic(diag *hcl.Diagnostic) *hcl.Diagnostic {
+	if diag == nil {
+		return diag
+	}
+
+	diag.Severity = hcl.DiagWarning
+	return diag
+}
+
 func unknownResourceType(token string, tokenRange hcl.Range) *hcl.Diagnostic {
 	return errorf(tokenRange, "unknown resource type '%s'", token)
 }

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -146,7 +146,7 @@ func Linearize(p *Program) []Node {
 // The resultant program should be a shallow copy of the source with only the modified resource nodes copied.
 func MapProvidersAsResources(p *Program) {
 	for _, n := range p.Nodes {
-		if r, ok := n.(*Resource); ok {
+		if r, ok := n.(*Resource); ok && r.Schema != nil {
 			pkg, mod, name, _ := r.DecomposeToken()
 			if r.Schema.IsProvider && pkg == "pulumi" && mod == "providers" {
 				// the binder emits tokens like this when the module is "index"

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -741,13 +741,16 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 		g.genTrivia(w, r.Definition.Tokens.GetOpenBrace())
 	}
 
-	for _, input := range r.Inputs {
-		destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: input.Name})
-		g.diagnostics = append(g.diagnostics, diagnostics...)
-		value, valueTemps := g.lowerExpression(input.Value, destType.(model.Type))
-		temps = append(temps, valueTemps...)
-		input.Value = value
+	if r.Schema != nil {
+		for _, input := range r.Inputs {
+			destType, diagnostics := r.InputType.Traverse(hcl.TraverseAttr{Name: input.Name})
+			g.diagnostics = append(g.diagnostics, diagnostics...)
+			value, valueTemps := g.lowerExpression(input.Value, destType.(model.Type))
+			temps = append(temps, valueTemps...)
+			input.Value = value
+		}
 	}
+
 	g.genTemps(w, temps)
 
 	instantiate := func(resName string) {

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -307,6 +307,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages,
 		BindOptions: []pcl.BindOption{pcl.AllowMissingVariables, pcl.AllowMissingProperties},
 	},
+	{
+		Directory:   "unknown-resource",
+		Description: "Tests generating code for unknown resources when skipping resource type-checking",
+		SkipCompile: allProgLanguages,
+		BindOptions: []pcl.BindOption{pcl.SkipResourceTypechecking},
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/dotnet/unknown-resource.cs
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/dotnet/unknown-resource.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Unknown = Pulumi.Unknown;
+
+return await Deployment.RunAsync(() => 
+{
+    var provider = new Pulumi.Providers.Unknown("provider");
+
+    var main = new Unknown.Index.Main("main", new()
+    {
+        First = "hello",
+        Second = 
+        {
+            { "foo", "bar" },
+        },
+    });
+
+    var fromModule = new List<Unknown.Eks.Example>();
+    for (var rangeIndex = 0; rangeIndex < 10; rangeIndex++)
+    {
+        var range = new { Value = rangeIndex };
+        fromModule.Add(new Unknown.Eks.Example($"fromModule-{range.Value}", new()
+        {
+            AssociatedMain = main.Id,
+        }));
+    }
+    return new Dictionary<string, object?>
+    {
+        ["mainId"] = main.Id,
+        ["values"] = fromModule.Values.First,
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/go/unknown-resource.go
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/go/unknown-resource.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown"
+	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown/eks"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := unknown.NewProvider(ctx, "provider", nil)
+		if err != nil {
+			return err
+		}
+		main, err := index.NewMain(ctx, "main", &index.MainArgs{
+			First: "hello",
+			Second: map[string]interface{}{
+				"foo": "bar",
+			},
+		})
+		if err != nil {
+			return err
+		}
+		var fromModule []*eks.Example
+		for index := 0; index < 10; index++ {
+			key0 := index
+			_ := index
+			__res, err := eks.NewExample(ctx, fmt.Sprintf("fromModule-%v", key0), &eks.ExampleArgs{
+				AssociatedMain: main.Id,
+			})
+			if err != nil {
+				return err
+			}
+			fromModule = append(fromModule, __res)
+		}
+		ctx.Export("mainId", main.Id)
+		ctx.Export("values", fromModule.Values.First)
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/nodejs/unknown-resource.ts
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/nodejs/unknown-resource.ts
@@ -1,0 +1,16 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as unknown from "@pulumi/unknown";
+
+const provider = new pulumi.providers.Unknown("provider", {});
+const main = new unknown.index.Main("main", {
+    first: "hello",
+    second: {
+        foo: "bar",
+    },
+});
+const fromModule: unknown.eks.Example[] = [];
+for (const range = {value: 0}; range.value < 10; range.value++) {
+    fromModule.push(new unknown.eks.Example(`fromModule-${range.value}`, {associatedMain: main.id}));
+}
+export const mainId = main.id;
+export const values = fromModule.values.first;

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/python/unknown-resource.py
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/python/unknown-resource.py
@@ -1,0 +1,14 @@
+import pulumi
+import pulumi_unknown as unknown
+
+provider = pulumi.providers.Unknown("provider")
+main = unknown.index.Main("main",
+    first=hello,
+    second={
+        foo: bar,
+    })
+from_module = []
+for range in [{"value": i} for i in range(0, 10)]:
+    from_module.append(unknown.eks.Example(f"fromModule-{range['value']}", associated_main=main.id))
+pulumi.export("mainId", main["id"])
+pulumi.export("values", from_module["values"]["first"])

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/unknown-resource.pp
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/unknown-resource.pp
@@ -1,0 +1,21 @@
+resource provider "pulumi:providers:unknown" { }
+
+resource main "unknown:index:main" {
+    first = "hello"
+    second = {
+        foo = "bar"
+    }
+}
+
+resource fromModule "unknown:eks:example" {
+   options { range = 10 }
+   associatedMain = main.id
+}
+
+output "mainId" {
+    value = main.id
+}
+
+output "values" {
+    value = fromModule.values.first
+}


### PR DESCRIPTION
# Description

Currently when generating code from PCL and we have unknown resources (those without a schema), the binder fails and the conversion stops. This is not ideal when we try to convert terraform codebases that include resources which we haven't bridged yet. 

This PR addresses this issue by extending `pcl.SkipResourceTypechecking` to _allow_ binding unknown resources and making a best guess in program-gen of how those will look even when we their schema is `nil`. 

The option `pcl.SkipResourceTypechecking` is already enabled for `pulumi convert` and it can be disabled when running in _strict_ mode `pulumi convert --strict` 

A similar feature is still be needed for unknown _invokes_ but that can be tackled in a separate PR

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
