### PR TITLE
[pcl/binder] Allow traversing unknown properties from resources when skipping type checking

### DIFF
--- a/changelog/pending/20230616--programgen--allow-traversing-unknown-properties-from-resources-when-skipping-resouce-type-checking.yaml
+++ b/changelog/pending/20230616--programgen--allow-traversing-unknown-properties-from-resources-when-skipping-resouce-type-checking.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Allow traversing unknown properties from resources when skipping resource type checking 

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -342,12 +342,9 @@ func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostic
 func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
-	if b.options.skipResourceTypecheck {
-		node.VariableType = model.DynamicType
-	} else {
-		node.VariableType = node.OutputType
-	}
-
+	// Allow for lenient traversal when we choose to skip resource type-checking.
+	node.LenientTraversal = b.options.skipResourceTypecheck
+	node.VariableType = node.OutputType
 	// If the resource has a range option, we need to know the type of the collection being ranged over. Pre-bind the
 	// range expression now, but ignore the diagnostics.
 	var rangeKey, rangeValue model.Type

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -342,9 +342,14 @@ func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostic
 func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
+	if b.options.skipResourceTypecheck {
+		node.VariableType = model.DynamicType
+	} else {
+		node.VariableType = node.OutputType
+	}
+
 	// If the resource has a range option, we need to know the type of the collection being ranged over. Pre-bind the
 	// range expression now, but ignore the diagnostics.
-	node.VariableType = node.OutputType
 	var rangeKey, rangeValue model.Type
 	for _, block := range node.syntax.Body.Blocks {
 		if block.Type == "options" {


### PR DESCRIPTION
# Description

When using the `pcl.SkipResourceTypechecking` we want to make it such that it allows traversal of unknown properties in a resource. For example, this program:
```
resource randomPet "random:index/randomPet:RandomPet" {
  prefix = "doggo"
}

output "mainId" {
    value = randomPet.unknownProperty
}
```
Should binds without errors when using `pcl.SkipResourceTypechecking` but fails to bind otherwise (in strict mode). This PR addresses this case and adds a couple more unit tests to document the behaviour of `pcl.SkipResourceTypechecking`

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
