### PR TITLE
[sdk/nodejs] Write port as string to avoid colorized output

### DIFF
--- a/changelog/pending/20230619--sdk-nodejs--write-port-to-stdout-as-a-string-so-node-doesnt-colorize-the-output.yaml
+++ b/changelog/pending/20230619--sdk-nodejs--write-port-to-stdout-as-a-string-so-node-doesnt-colorize-the-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Write port to stdout as a string so Node doesn't colorize the output

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -408,7 +408,8 @@ export async function main(args: string[]) {
     server.start();
 
     // Emit the address so the monitor can read it to connect.  The gRPC server will keep the message loop alive.
-    console.log(port);
+    // We explicitly convert the number to a string so that Node doesn't colorize the output.
+    console.log(port.toString());
 }
 
 main(process.argv.slice(2));

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -676,7 +676,8 @@ export async function main(provider: Provider, args: string[]) {
     server.start();
 
     // Emit the address so the monitor can read it to connect.  The gRPC server will keep the message loop alive.
-    console.log(port);
+    // We explicitly convert the number to a string so that Node doesn't colorize the output.
+    console.log(port.toString());
 }
 
 /**


### PR DESCRIPTION
Node's `console.log` colors numbers by default if it thinks that the output is a terminal (unless `NO_COLOR` is set). At least one user is running into a case where the port is being outputted surrounded with color codes, when using a dynamic provider on Node v20.3.0. To mitigate, we can update the places where we use `console.log(port)`, converting the number to a string first.

Fixes #13150