### PR TITLE
Don't print large integers in scientfic notation

### DIFF
--- a/changelog/pending/20230620--cli-display--fix-large-integers-displaying-in-scientific-notation.yaml
+++ b/changelog/pending/20230620--cli-display--fix-large-integers-displaying-in-scientific-notation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix large integers displaying in scientific notation.

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -15,8 +15,10 @@
 package display
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,6 +90,42 @@ func Test_decodeValue(t *testing.T) {
 				require.Equal(t, c.kind, kind)
 				assert.True(t, resource.NewPropertyValue(c.expected).DeepEquals(actual))
 			}
+		})
+	}
+}
+
+func Test_PrintObject(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		object   resource.PropertyMap
+		expected string
+	}{
+		{
+			"numbers",
+			resource.NewPropertyMapFromMap(map[string]interface{}{
+				"int":         1,
+				"float":       2.3,
+				"large_int":   1234567,
+				"large_float": 1234567.1234567,
+			}),
+			`<{%reset%}>float      : <{%reset%}><{%reset%}>2.3<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>int        : <{%reset%}><{%reset%}>1<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_float: <{%reset%}><{%reset%}>1.2345671234567e+06<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>large_int  : <{%reset%}><{%reset%}>1234567<{%reset%}><{%reset%}>
+<{%reset%}>`,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			PrintObject(&buf, c.object, false, 0, deploy.OpSame, false, false, false)
+			assert.Equal(t, c.expected, buf.String())
 		})
 	}
 }


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13016

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
