### PR TITLE
Allow tuples as sequences in Python serialization

### DIFF
--- a/changelog/pending/20230620--sdk-python--allow-tuples-as-sequence-input-values-to-resources.yaml
+++ b/changelog/pending/20230620--sdk-python--allow-tuples-as-sequence-input-values-to-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Allow tuples as Sequence input values to resources.

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -255,7 +255,7 @@ async def serialize_property(
     # Exclude some built-in types that are instances of Sequence that we don't want to treat as sequences here.
     # From: https://github.com/python/cpython/blob/master/Lib/_collections_abc.py
     if isinstance(value, abc.Sequence) and not isinstance(
-        value, (tuple, str, range, memoryview, bytes, bytearray)
+        value, (str, range, memoryview, bytes, bytearray)
     ):
         element_type = _get_list_element_type(typ)
         props = []

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -131,6 +131,12 @@ class NextSerializationTests(unittest.TestCase):
         self.assertEqual(test_list, props)
 
     @pulumi_test
+    async def test_tuple(self):
+        test_tuple = tuple([1, 2, 3])
+        props = await rpc.serialize_property(test_tuple, [])
+        self.assertEqual([1, 2, 3], props)
+
+    @pulumi_test
     async def test_future(self):
         fut = asyncio.Future()
         fut.set_result(42)
@@ -462,7 +468,6 @@ class NextSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_unsupported_sequences(self):
         cases = [
-            ("hi", 42),
             range(10),
             memoryview(bytes(10)),
             bytes(10),


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/7029

For some reason the python RPC serializer explictly disallowed tuple, despite python codegen outputing types using `Sequence` rather than `List` suggesting that `tuple` would be acceptable.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
