### PR TITLE
[program-gen/go] Fix aliasing package names using dashes when schema doesn't include package info

### DIFF
--- a/changelog/pending/20230620--programgen-go--fix-aliasing-package-names-using-dashes-when-schema-doesnt-include-go-package-info-override.yaml
+++ b/changelog/pending/20230620--programgen-go--fix-aliasing-package-names-using-dashes-when-schema-doesnt-include-go-package-info-override.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix aliasing package names using dashes when schema doesn't include go package info override

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -313,6 +313,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages,
 		BindOptions: []pcl.BindOption{pcl.SkipResourceTypechecking},
 	},
+	{
+		Directory:   "using-dashes",
+		Description: "Test program generation on packages with a dash in the name",
+		SkipCompile: allProgLanguages, // since we are using a synthetic schema
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/using-dashes-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/using-dashes-1.0.0.json
@@ -1,0 +1,34 @@
+{
+  "name": "using-dashes",
+  "version": "1.0.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "using-dashes:index:Dash": {
+      "properties": {
+        "stack": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "stack"
+      ],
+      "inputProperties": {
+        "stack": {
+          "type": "string",
+          "description": "The stack name for this AutoDeployer."
+        }
+      },
+      "requiredInputs": [
+        "stack"
+      ],
+      "isComponent": true
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/using-dashes-pp/dotnet/using-dashes.cs
+++ b/pkg/codegen/testing/test/testdata/using-dashes-pp/dotnet/using-dashes.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using UsingDashes = Pulumi.UsingDashes;
+
+return await Deployment.RunAsync(() => 
+{
+    var main = new UsingDashes.Dash("main", new()
+    {
+        Stack = "dev",
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/using-dashes-pp/go/using-dashes.go
+++ b/pkg/codegen/testing/test/testdata/using-dashes-pp/go/using-dashes.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	usingDashes "github.com/pulumi/pulumi-using-dashes/sdk/go/using-dashes"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := usingDashes.NewDash(ctx, "main", &usingDashes.DashArgs{
+			Stack: pulumi.String("dev"),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/using-dashes-pp/nodejs/using-dashes.ts
+++ b/pkg/codegen/testing/test/testdata/using-dashes-pp/nodejs/using-dashes.ts
@@ -1,0 +1,4 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as using_dashes from "@pulumi/using-dashes";
+
+const main = new using_dashes.Dash("main", {stack: "dev"});

--- a/pkg/codegen/testing/test/testdata/using-dashes-pp/python/using-dashes.py
+++ b/pkg/codegen/testing/test/testdata/using-dashes-pp/python/using-dashes.py
@@ -1,0 +1,4 @@
+import pulumi
+import pulumi_using_dashes as using_dashes
+
+main = using_dashes.Dash("main", stack="dev")

--- a/pkg/codegen/testing/test/testdata/using-dashes-pp/using-dashes.pp
+++ b/pkg/codegen/testing/test/testdata/using-dashes-pp/using-dashes.pp
@@ -1,0 +1,3 @@
+resource "main" "using-dashes:index:Dash" {
+    stack = "dev"
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -84,5 +84,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"remoteref", "1.0.0"},
 		SchemaProvider{"splat", "1.0.0"},
 		SchemaProvider{"snowflake", "0.66.1"},
+		SchemaProvider{"using-dashes", "1.0.0"},
 	)
 }


### PR DESCRIPTION
### Description

Fixes #13200 such that if a package doesn't have a specific go package override (like the one mentioned in the bug report) and needs an alias (because of using hypthens) then we apply aliasing for it. 

The PR adds a small synthetic schema called `using-dashes` that doesn't have any special go package info overrides and generates test programs from it. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
