### PR TITLE
[sdk/python] remove deprecation warning on result types unless using getters.

### DIFF
--- a/changelog/pending/20230620--sdkgen-python--python-sdk-only-prints-a-function-invoke-results-deprecation-messages-when-using-getters-rather-than-on-instantiation.yaml
+++ b/changelog/pending/20230620--sdkgen-python--python-sdk-only-prints-a-function-invoke-results-deprecation-messages-when-using-getters-rather-than-on-instantiation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Python SDK only prints a Function Invoke result's deprecation messages when using getters rather than on instantiation.

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
@@ -50,7 +50,7 @@ def arg_function(name: Optional['pulumi_random.RandomPet'] = None,
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(
-        age=__ret__.age)
+        age=pulumi.get(__ret__, 'age'))
 
 
 @_utilities.lift_output_func(arg_function)

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/func_with_secrets.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/func_with_secrets.py
@@ -78,10 +78,10 @@ def func_with_secrets(crypto_key: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithSecrets', __args__, opts=opts, typ=FuncWithSecretsResult).value
 
     return AwaitableFuncWithSecretsResult(
-        ciphertext=__ret__.ciphertext,
-        crypto_key=__ret__.crypto_key,
-        id=__ret__.id,
-        plaintext=__ret__.plaintext)
+        ciphertext=pulumi.get(__ret__, 'ciphertext'),
+        crypto_key=pulumi.get(__ret__, 'crypto_key'),
+        id=pulumi.get(__ret__, 'id'),
+        plaintext=pulumi.get(__ret__, 'plaintext'))
 
 
 @_utilities.lift_output_func(func_with_secrets)

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
@@ -80,8 +80,8 @@ def list_configurations(configuration_filters: Optional[Sequence[pulumi.InputTyp
     __ret__ = pulumi.runtime.invoke('myedgeorder::listConfigurations', __args__, opts=opts, typ=ListConfigurationsResult).value
 
     return AwaitableListConfigurationsResult(
-        next_link=__ret__.next_link,
-        value=__ret__.value)
+        next_link=pulumi.get(__ret__, 'next_link'),
+        value=pulumi.get(__ret__, 'value'))
 
 
 @_utilities.lift_output_func(list_configurations)

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
@@ -83,8 +83,8 @@ def list_product_families(customer_subscription_details: Optional[pulumi.InputTy
     __ret__ = pulumi.runtime.invoke('myedgeorder::listProductFamilies', __args__, opts=opts, typ=ListProductFamiliesResult).value
 
     return AwaitableListProductFamiliesResult(
-        next_link=__ret__.next_link,
-        value=__ret__.value)
+        next_link=pulumi.get(__ret__, 'next_link'),
+        value=pulumi.get(__ret__, 'value'))
 
 
 @_utilities.lift_output_func(list_product_families)

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
@@ -136,13 +136,13 @@ def get_ami_ids(executable_users: Optional[Sequence[str]] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::getAmiIds', __args__, opts=opts, typ=GetAmiIdsResult).value
 
     return AwaitableGetAmiIdsResult(
-        executable_users=__ret__.executable_users,
-        filters=__ret__.filters,
-        id=__ret__.id,
-        ids=__ret__.ids,
-        name_regex=__ret__.name_regex,
-        owners=__ret__.owners,
-        sort_ascending=__ret__.sort_ascending)
+        executable_users=pulumi.get(__ret__, 'executable_users'),
+        filters=pulumi.get(__ret__, 'filters'),
+        id=pulumi.get(__ret__, 'id'),
+        ids=pulumi.get(__ret__, 'ids'),
+        name_regex=pulumi.get(__ret__, 'name_regex'),
+        owners=pulumi.get(__ret__, 'owners'),
+        sort_ascending=pulumi.get(__ret__, 'sort_ascending'))
 
 
 @_utilities.lift_output_func(get_ami_ids)

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
@@ -66,7 +66,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::listStorageAccountKeys', __args__, opts=opts, typ=ListStorageAccountKeysResult).value
 
     return AwaitableListStorageAccountKeysResult(
-        keys=__ret__.keys)
+        keys=pulumi.get(__ret__, 'keys'))
 
 
 @_utilities.lift_output_func(list_storage_account_keys)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
@@ -55,7 +55,7 @@ def func_with_all_optional_inputs(a: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
@@ -51,7 +51,7 @@ def func_with_default_value(a: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithDefaultValue', __args__, opts=opts, typ=FuncWithDefaultValueResult).value
 
     return AwaitableFuncWithDefaultValueResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_default_value)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
@@ -51,7 +51,7 @@ def func_with_dict_param(a: Optional[Mapping[str, str]] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithDictParam', __args__, opts=opts, typ=FuncWithDictParamResult).value
 
     return AwaitableFuncWithDictParamResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_dict_param)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
@@ -51,7 +51,7 @@ def func_with_list_param(a: Optional[Sequence[str]] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithListParam', __args__, opts=opts, typ=FuncWithListParamResult).value
 
     return AwaitableFuncWithListParamResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_list_param)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
@@ -66,7 +66,7 @@ def get_bastion_shareable_link(bastion_host_name: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::getBastionShareableLink', __args__, opts=opts, typ=GetBastionShareableLinkResult).value
 
     return AwaitableGetBastionShareableLinkResult(
-        next_link=__ret__.next_link)
+        next_link=pulumi.get(__ret__, 'next_link'))
 
 
 @_utilities.lift_output_func(get_bastion_shareable_link)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
@@ -88,7 +88,7 @@ def get_client_config(opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableG
     __ret__ = pulumi.runtime.invoke('mypkg::getClientConfig', __args__, opts=opts, typ=GetClientConfigResult).value
 
     return AwaitableGetClientConfigResult(
-        client_id=__ret__.client_id,
-        object_id=__ret__.object_id,
-        subscription_id=__ret__.subscription_id,
-        tenant_id=__ret__.tenant_id)
+        client_id=pulumi.get(__ret__, 'client_id'),
+        object_id=pulumi.get(__ret__, 'object_id'),
+        subscription_id=pulumi.get(__ret__, 'subscription_id'),
+        tenant_id=pulumi.get(__ret__, 'tenant_id'))

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -81,8 +81,8 @@ def get_integration_runtime_object_metadatum(factory_name: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::getIntegrationRuntimeObjectMetadatum', __args__, opts=opts, typ=GetIntegrationRuntimeObjectMetadatumResult).value
 
     return AwaitableGetIntegrationRuntimeObjectMetadatumResult(
-        next_link=__ret__.next_link,
-        value=__ret__.value)
+        next_link=pulumi.get(__ret__, 'next_link'),
+        value=pulumi.get(__ret__, 'value'))
 
 
 @_utilities.lift_output_func(get_integration_runtime_object_metadatum)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
@@ -66,7 +66,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('mypkg::listStorageAccountKeys', __args__, opts=opts, typ=ListStorageAccountKeysResult).value
 
     return AwaitableListStorageAccountKeysResult(
-        keys=__ret__.keys)
+        keys=pulumi.get(__ret__, 'keys'))
 
 
 @_utilities.lift_output_func(list_storage_account_keys)

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -56,7 +56,7 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
     __ret__ = pulumi.runtime.invoke('example::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -56,7 +56,7 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
@@ -55,7 +55,7 @@ def func_with_all_optional_inputs(a: Optional[str] = None,
     __ret__ = pulumi.runtime.invoke('configstation::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(
-        r=__ret__.r)
+        r=pulumi.get(__ret__, 'r'))
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
@@ -47,4 +47,4 @@ def get_custom_db_roles(opts: Optional[pulumi.InvokeOptions] = None) -> Awaitabl
     __ret__ = pulumi.runtime.invoke('mongodbatlas::getCustomDbRoles', __args__, opts=opts, typ=GetCustomDbRolesResult).value
 
     return AwaitableGetCustomDbRolesResult(
-        result=__ret__.result)
+        result=pulumi.get(__ret__, 'result'))

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -58,6 +58,9 @@ class RubberTreeArgs:
     @property
     @pulumi.getter
     def diameter(self) -> pulumi.Input['Diameter']:
+        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
+        pulumi.log.warn("""diameter is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+
         return pulumi.get(self, "diameter")
 
     @diameter.setter
@@ -67,6 +70,9 @@ class RubberTreeArgs:
     @property
     @pulumi.getter
     def type(self) -> pulumi.Input['RubberTreeVariety']:
+        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
+        pulumi.log.warn("""type is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+
         return pulumi.get(self, "type")
 
     @type.setter
@@ -85,6 +91,9 @@ class RubberTreeArgs:
     @property
     @pulumi.getter
     def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
+        pulumi.log.warn("""farm is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+
         return pulumi.get(self, "farm")
 
     @farm.setter
@@ -94,6 +103,9 @@ class RubberTreeArgs:
     @property
     @pulumi.getter
     def size(self) -> Optional[pulumi.Input['TreeSize']]:
+        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
+        pulumi.log.warn("""size is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+
         return pulumi.get(self, "size")
 
     @size.setter

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
@@ -68,9 +68,9 @@ def get_policy_document(statements: Optional[Sequence[pulumi.InputType['_x.GetPo
     __ret__ = pulumi.runtime.invoke('aws:x/iam/getPolicyDocument:getPolicyDocument', __args__, opts=opts, typ=GetPolicyDocumentResult).value
 
     return AwaitableGetPolicyDocumentResult(
-        id=__ret__.id,
-        json=__ret__.json,
-        statements=__ret__.statements)
+        id=pulumi.get(__ret__, 'id'),
+        json=pulumi.get(__ret__, 'json'),
+        statements=pulumi.get(__ret__, 'statements'))
 
 
 @_utilities.lift_output_func(get_policy_document)

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
@@ -50,7 +50,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(
-        result=__ret__.result)
+        result=pulumi.get(__ret__, 'result'))
 
 
 @_utilities.lift_output_func(arg_function)

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
@@ -50,7 +50,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(
-        result=__ret__.result)
+        result=pulumi.get(__ret__, 'result'))
 
 
 @_utilities.lift_output_func(arg_function)

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
@@ -50,7 +50,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(
-        result=__ret__.result)
+        result=pulumi.get(__ret__, 'result'))
 
 
 @_utilities.lift_output_func(arg_function)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
remove deprecation warning on result types unless using getters.

Fixes #11739 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
