### PR TITLE
httpstate/client: Support no retries

### DIFF
--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryPolicy_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		give retryPolicy
+		want string
+	}{
+		{give: retryNone, want: "none"},
+		{give: retryGetMethod, want: "get"},
+		{give: retryAllMethods, want: "all"},
+		{give: retryPolicy(42), want: "retryPolicy(42)"}, // unknown
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.give.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRetryPolicy_shouldRetry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc   string
+		policy retryPolicy
+		method string // HTTP method
+		want   bool
+	}{
+		{
+			desc:   "none/GET",
+			policy: retryNone,
+			method: http.MethodGet,
+			want:   false,
+		},
+		{
+			desc:   "none/POST",
+			policy: retryNone,
+			method: http.MethodPost,
+			want:   false,
+		},
+		{
+			desc:   "get/GET",
+			policy: retryGetMethod,
+			method: http.MethodGet,
+			want:   true,
+		},
+		{
+			desc:   "get/POST",
+			policy: retryGetMethod,
+			method: http.MethodPost,
+			want:   false,
+		},
+		{
+			desc:   "all/GET",
+			policy: retryAllMethods,
+			method: http.MethodGet,
+			want:   true,
+		},
+		{
+			desc:   "all/POST",
+			policy: retryAllMethods,
+			method: http.MethodPost,
+			want:   true,
+		},
+
+		// Sanity check: default is get
+		{
+			desc: "default/GET",
+			// Don't set policy field;
+			// zero value should be retryGetMethod.
+			method: http.MethodGet,
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.policy.shouldRetry(&http.Request{
+				Method: tt.method,
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Switches the httpClient interface in httpstate
from accepting a `retryAllMethods` boolean
to an enum capable of representing another state: retry nothing.

With this, it's possible to call `httpClient.Do(..)`
and make a request without any retries.

Step towards #13166
