### PR TITLE
{cli, httpstate}: Don't retry GetCLIVersionInfo

### DIFF
--- a/changelog/pending/20230620--cli--make-no-retry-attempts-for-the-pulumi-new-version-query.yaml
+++ b/changelog/pending/20230620--cli--make-no-retry-attempts-for-the-pulumi-new-version-query.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Make no retry attempts for the Pulumi new version query. This should speed up the CLI in certain environments.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -245,7 +245,18 @@ func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, error) {
 	var versionInfo apitype.CLIVersionResponse
 
-	if err := pc.restCall(ctx, "GET", "/api/cli/version", nil, nil, &versionInfo); err != nil {
+	err := pc.restCallWithOptions(
+		ctx,
+		"GET",
+		"/api/cli/version",
+		nil,          // query
+		nil,          // request
+		&versionInfo, // response
+		httpCallOptions{
+			RetryPolicy: retryNone,
+		},
+	)
+	if err != nil {
 		return semver.Version{}, semver.Version{}, err
 	}
 


### PR DESCRIPTION
Changes the httpstate client to not retry requests to
`GET /api/cli/version` so as not to block the CLI for 7 seconds
in airgapped environments and the like.

Testing:
Before this change, the accompanying test took 7 seconds to fail.
With this change, it succeeds nearly instantly.

Resolves #13166
