### PR TITLE
Split user output for plugin rm to confirmation and result log

### DIFF
--- a/changelog/pending/20230620--cli-plugin--plugin-rm-yes-command-to-say-plugins-were-removed.yaml
+++ b/changelog/pending/20230620--cli-plugin--plugin-rm-yes-command-to-say-plugins-were-removed.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fixes the output of plugin rm --yes command to explicitly say that plugins were removed

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -118,7 +118,7 @@ func newPluginRmCmd() *cobra.Command {
 			var result error
 			for _, plugin := range deletes {
 				if err := plugin.Delete(); err == nil {
-					fmt.Printf("%s %s removed.\n", plugin.Kind, plugin.String())
+					fmt.Printf("removed: %s %v\n", plugin.Kind, plugin)
 				} else {
 					result = multierror.Append(
 						result, fmt.Errorf("failed to delete %s plugin %s: %w", plugin.Kind, plugin, err))

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -96,32 +96,35 @@ func newPluginRmCmd() *cobra.Command {
 				return nil
 			}
 
-			// Confirm that the user wants to do this (unless --yes was passed), and do the deletes.
-			var suffix string
-			if len(deletes) != 1 {
-				suffix = "s"
-			}
-			fmt.Print(
-				opts.Color.Colorize(
-					fmt.Sprintf("%sThis will remove %d plugin%s from the cache:%s\n",
-						colors.SpecAttention, len(deletes), suffix, colors.Reset)))
-			for _, del := range deletes {
-				fmt.Printf("    %s %s\n", del.Kind, del.String())
-			}
-			if yes || confirmPrompt("", "yes", opts) {
-				var result error
-				for _, plugin := range deletes {
-					if err := plugin.Delete(); err != nil {
-						result = multierror.Append(
-							result, fmt.Errorf("failed to delete %s plugin %s: %w", plugin.Kind, plugin, err))
-					}
+			// Confirm that the user wants to do this (unless --yes was passed).
+			if !yes {
+				var suffix string
+				if len(deletes) != 1 {
+					suffix = "s"
 				}
-				if result != nil {
-					return result
+				fmt.Print(
+					opts.Color.Colorize(
+						fmt.Sprintf("%sThis will remove %d plugin%s from the cache:%s\n",
+							colors.SpecAttention, len(deletes), suffix, colors.Reset)))
+				for _, del := range deletes {
+					fmt.Printf("    %s %s\n", del.Kind, del.String())
+				}
+				if !confirmPrompt("", "yes", opts) {
+					return nil
 				}
 			}
 
-			return nil
+			// Run the actual delete operations.
+			var result error
+			for _, plugin := range deletes {
+				if err := plugin.Delete(); err == nil {
+					fmt.Printf("%s %s removed.\n", plugin.Kind, plugin.String())
+				} else {
+					result = multierror.Append(
+						result, fmt.Errorf("failed to delete %s plugin %s: %w", plugin.Kind, plugin, err))
+				}
+			}
+			return result
 		}),
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12719

Previously, deleting all plugins with the `--yes` flag prints this message:

```
𝛌 pulumi plugin rm -ay                    
This will remove 2 plugins from the cache:
    resource cloudflare-5.0.0
    resource gcp-5.0.0
```

After this change, we output the list of removed plugins explicitly:

```
𝛌 pulumi plugin rm -ay                    
resource aws-5.24.0 removed.
resource aws-5.25.0 removed.
```

The prompt still works, and we list plugins twice to confirm that deletion was successful:

```
𝛌 pulumi plugin rm -a
This will remove 2 plugins from the cache:
    resource aws-5.24.0
    resource aws-5.25.0
Please confirm that this is what you'd like to do by typing `yes`: yes
resource aws-5.24.0 removed.
resource aws-5.25.0 removed.
```

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
