### PR TITLE
CLI update summary now shows after non-mandatory policy events seen.

### DIFF
--- a/changelog/pending/20230620--cli-display--update-summary-is-now-correctly-shown-when-advisory-and-disabled-policy-events-are-encountered.yaml
+++ b/changelog/pending/20230620--cli-display--update-summary-is-now-correctly-shown-when-advisory-and-disabled-policy-events-are-encountered.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Update summary is now correctly shown when `advisory` and `disabled` policy events are encountered.

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -137,3 +137,51 @@ func TestDiffEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestHasMandatoryPolicyViolations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give []engine.PolicyViolationEventPayload
+		want bool
+	}{
+		{
+			name: "no policy violations",
+			give: []engine.PolicyViolationEventPayload{},
+			want: false,
+		},
+		{
+			name: "only advisory violations",
+			give: []engine.PolicyViolationEventPayload{
+				{EnforcementLevel: "advisory"},
+				{EnforcementLevel: "advisory"},
+			},
+			want: false,
+		},
+		{
+			name: "has 1 mandatory violation",
+			give: []engine.PolicyViolationEventPayload{
+				{EnforcementLevel: "mandatory"},
+				{EnforcementLevel: "advisory"},
+			},
+			want: true,
+		},
+		{
+			name: "has no mandatory violation",
+			give: []engine.PolicyViolationEventPayload{
+				{EnforcementLevel: "disabled"},
+				{EnforcementLevel: "advisory"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasMandatoryPolicyViolations(tt.give)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -464,10 +464,10 @@ func (display *ProgressDisplay) processEndSteps() {
 	// Render several "sections" of output based on available data as applicable.
 	display.println("")
 	wroteDiagnosticHeader := display.printDiagnostics()
-	wrotePolicyViolations := display.printPolicyViolations()
+	wroteMandatoryPolicyViolations := display.printPolicyViolations()
 	display.printOutputs()
-	// If no policies violated, print policy packs applied.
-	if !wrotePolicyViolations {
+	// If no mandatory policies violated, print policy packs applied.
+	if !wroteMandatoryPolicyViolations {
 		display.printSummary(wroteDiagnosticHeader)
 	}
 }
@@ -609,7 +609,16 @@ func (display *ProgressDisplay) printPolicyViolations() bool {
 		messageLine := fmt.Sprintf("    %s", message)
 		display.println(messageLine)
 	}
-	return true
+	return hasMandatoryPolicyViolations(policyEvents)
+}
+
+func hasMandatoryPolicyViolations(policyViolations []engine.PolicyViolationEventPayload) bool {
+	for _, policyEvent := range policyViolations {
+		if policyEvent.EnforcementLevel == apitype.Mandatory {
+			return true
+		}
+	}
+	return false
 }
 
 // printOutputs prints the Stack's outputs for the display in a new section, if appropriate.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This change causes only mandatory policy violations to skip the summary display causing the resources changed and duration details to not be printed.

Policy Violations are categorized as `mandatory`, `disabled`, and `advisory`. We were treating all 3 as policy violations to skip displaying the update summary. Now we only use `mandatory`.

Fixes #13109 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
