### PR TITLE
`pulumi new` now supports numeric stack names.

### DIFF
--- a/changelog/pending/20230620--cli-new--pulumi-new-now-correctly-supports-numeric-stack-names.yaml
+++ b/changelog/pending/20230620--cli-new--pulumi-new-now-correctly-supports-numeric-stack-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: `pulumi new` now correctly supports numeric stack names.

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -65,6 +65,33 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 }
 
 //nolint:paralleltest // changes directory for process
+func TestCreatingStackWithNumericName(t *testing.T) {
+	tempdir := t.TempDir()
+	chdir(t, tempdir)
+
+	args := newArgs{
+		interactive:       false,
+		yes:               true,
+		name:              "123456", // Should be serialized as a string.
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "yaml",
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	p := loadProject(t, tempdir)
+	assert.NotNil(t, p)
+
+	assert.Equal(t, p.Name.String(), "123456")
+
+	assert.Equal(t, stackName, loadStackName(t))
+	removeStack(t, tempdir, stackName)
+}
+
+//nolint:paralleltest // changes directory for process
 func TestCreatingStackWithPromptedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`pulumi new` now correctly serializes a stack name of 123456 as a string in the `Pulumi.yaml` file.

Previously `123456` is interpreted as a number in YAML by default.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12136 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
