### PR TITLE
test(codegen/go): Fix broken TestLiteralExpression

### DIFF
--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -44,7 +44,7 @@ func TestLiteralExpression(t *testing.T) {
 		{hcl2Expr: "\"foo\"", goCode: "\"foo\""},
 		{hcl2Expr: `"foo: ${bar}"`, goCode: `fmt.Sprintf("foo: %v", bar)`},
 		{hcl2Expr: `"fizz${bar}buzz"`, goCode: `fmt.Sprintf("fizz%vbuzz", bar)`},
-		{hcl2Expr: `"foo ${bar} %baz"`, goCode: `fmt.Sprintf("foo %v %vbaz", bar, "%")`},
+		{hcl2Expr: `"foo ${bar} %baz"`, goCode: `fmt.Sprintf("foo %v%v", bar, " %baz")`},
 		{hcl2Expr: strings.ReplaceAll(`"{
     \"Version\": \"2008-10-17\",
     \"Statement\": [


### PR DESCRIPTION
TestLiteralExpression appears to be broken on master:

```
% go test -run TestLiteralExpression
--- FAIL: TestLiteralExpression (0.00s)
    --- FAIL: TestLiteralExpression/"foo_${bar}_%baz" (0.05s)
        gen_program_expression_test.go:252:
                Error Trace:    [..]/pulumi/pkg/codegen/go/gen_program_expression_test.go:252
                Error:          Not equal:
                                expected: "fmt.Sprintf(\"foo %v %vbaz\", bar, \"%\")"
                                actual  : "fmt.Sprintf(\"foo %v%v\", bar, \" %baz\")"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -fmt.Sprintf("foo %v %vbaz", bar, "%")
                                +fmt.Sprintf("foo %v%v", bar, " %baz")
                Test:           TestLiteralExpression/"foo_${bar}_%baz"
```

Both versions are a valid way to represent that information,
so I'm fixing the test case.

I'm not sure how this broken test ended on master, though.
