### PR TITLE
Remove extra tab that convert TS outputs in JSON file

### DIFF
--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -184,13 +184,13 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	// Build the pacakge.json
 	var packageJSON bytes.Buffer
 	fmt.Fprintf(&packageJSON, `{
-		"name": "%s",
-		"devDependencies": {
-			"@types/node": "^14"
-		},
-		"dependencies": {
-			"typescript": "^4.0.0",
-			"@pulumi/pulumi": "^3.0.0"`, project.Name.String())
+	"name": "%s",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "^3.0.0"`, project.Name.String())
 
 	// For each package add a dependency line
 	packages, err := program.CollectNestedPackageSnapshots()
@@ -216,7 +216,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 				packageName = nodeInfo.PackageName
 			}
 		}
-		dependencyTemplate := ",\n			\"%s\": \"%s\""
+		dependencyTemplate := ",\n		\"%s\": \"%s\""
 		if p.Version != nil {
 			fmt.Fprintf(&packageJSON, dependencyTemplate, packageName, p.Version.String())
 		} else {
@@ -224,7 +224,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 		}
 	}
 	packageJSON.WriteString(`
-		}
+	}
 }`)
 
 	files["package.json"] = packageJSON.Bytes()
@@ -236,26 +236,26 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	// Add the basic tsconfig
 	var tsConfig bytes.Buffer
 	tsConfig.WriteString(`{
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
 `)
 
 	fileCounter := 0
 	for file := range files {
 		if strings.HasSuffix(file, ".ts") {
-			tsConfig.WriteString("			\"" + file + "\"")
+			tsConfig.WriteString("		\"" + file + "\"")
 			lastFile := fileCounter == len(files)-1
 			if !lastFile {
 				tsConfig.WriteString(",\n")
@@ -267,7 +267,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 		fileCounter = fileCounter + 1
 	}
 
-	tsConfig.WriteString(`		]
+	tsConfig.WriteString(`	]
 }`)
 	files["tsconfig.json"] = tsConfig.Bytes()
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10776

Examples of generated files:

tsconfig.js:

```json
{
	"compilerOptions": {
		"strict": true,
		"outDir": "bin",
		"target": "es2016",
		"module": "commonjs",
		"moduleResolution": "node",
		"sourceMap": true,
		"experimentalDecorators": true,
		"pretty": true,
		"noFallthroughCasesInSwitch": true,
		"noImplicitReturns": true,
		"forceConsistentCasingInFileNames": true
	},
	"files": [
		"index.ts",
	]
}
```

package.json

```json
{
	"name": "simple-yaml",
	"devDependencies": {
		"@types/node": "^14"
	},
	"dependencies": {
		"typescript": "^4.0.0",
		"@pulumi/pulumi": "^3.0.0",
		"@pulumi/aws-native": "*"
	}
}
```

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
