### PR TITLE
cli: Fix Markdown reference formatting issues

### DIFF
--- a/changelog/pending/20230620--cli--fix-markdown-formatting-issues-in-command-usage.yaml
+++ b/changelog/pending/20230620--cli--fix-markdown-formatting-issues-in-command-usage.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix Markdown formatting issues in command usage.

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -43,7 +43,7 @@ func newLogoutCmd() *cobra.Command {
 			"a specific URL argument, formatted just as you logged in, to log out of a specific one.\n" +
 			"If no URL is provided, you will be logged out of the current backend." +
 			"\n\n" +
-			"If you would like to log out of all backends simultaneously, you can pass `--all`,\n" +
+			"If you would like to log out of all backends simultaneously, you can pass `--all`,\n\n" +
 			"    $ pulumi logout --all",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -45,11 +45,9 @@ Resources can't be deleted if there exist other resources that depend on it or a
 will not be deleted unless it is specifically requested using the --force flag.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
-
-Example:
-pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'
 `,
-		Args: cmdutil.ExactArgs(1),
+		Example: "pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'",
+		Args:    cmdutil.ExactArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -116,6 +116,7 @@ func stateRenameOperation(urn resource.URN, newResourceName string, opts display
 	return nil
 }
 
+//nolint:lll
 func newStateRenameCommand() *cobra.Command {
 	var stack string
 	var yes bool
@@ -129,11 +130,9 @@ This command renames a resource from a stack's state. The resource is specified
 by its Pulumi URN (use ` + "`pulumi stack --show-urns`" + ` to get it) and the new name of the resource.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
-
-Example:
-pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here
 `,
-		Args: cmdutil.ExactArgs(2),
+		Example: "pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here",
+		Args:    cmdutil.ExactArgs(2),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()


### PR DESCRIPTION
Fixes a couple of Markdown formatting issues
in the output of `gen-markdown`.

This is used as input to this section of the Pulumi website:
<https://www.pulumi.com/docs/cli/commands/>

Differences in gen-markdown output following this change:

    diff -u before/pulumi_logout.md after/pulumi_logout.md
    --- before/pulumi_logout.md	2023-06-20 15:20:06
    +++ after/pulumi_logout.md	2023-06-20 15:20:17
    @@ -19,6 +19,7 @@
     If no URL is provided, you will be logged out of the current backend.

     If you would like to log out of all backends simultaneously, you can pass `--all`,
    +
         $ pulumi logout --all

     ```
    diff -u before/pulumi_state_delete.md after/pulumi_state_delete.md
    --- before/pulumi_state_delete.md	2023-06-20 15:20:06
    +++ after/pulumi_state_delete.md	2023-06-20 15:20:17
    @@ -20,12 +20,15 @@

     Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.

    -Example:
    -pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'

    -
     ```
     pulumi state delete <resource URN> [flags]
    +```
    +
    +### Examples
    +
    +```
    +pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'
     ```

     ### Options
    diff -u before/pulumi_state_rename.md after/pulumi_state_rename.md
    --- before/pulumi_state_rename.md	2023-06-20 15:20:06
    +++ after/pulumi_state_rename.md	2023-06-20 15:20:17
    @@ -17,12 +17,15 @@

     Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.

    -Example:
    -pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here

    -
     ```
     pulumi state rename <resource URN> <new name> [flags]
    +```
    +
    +### Examples
    +
    +```
    +pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here
     ```

     ### Options

Resolves #11991
