### PR TITLE
Fix `stack rm` removing config files for the wrong project

### DIFF
--- a/changelog/pending/20230621--cli--fix-stack-rm-removing-config-files-for-the-wrong-project.yaml
+++ b/changelog/pending/20230621--cli--fix-stack-rm-removing-config-files-for-the-wrong-project.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `stack rm` removing config files for the wrong project.

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -44,7 +44,7 @@ type Environment struct {
 
 	// RootPath is a new temp directory where the environment starts.
 	RootPath string
-	// Current working directory.
+	// Current working directory, defaults to the root path.
 	CWD string
 	// Backend to use for commands
 	Backend string
@@ -119,7 +119,7 @@ func (e *Environment) SetEnvVars(env ...string) {
 
 // ImportDirectory copies a folder into the test environment.
 func (e *Environment) ImportDirectory(path string) {
-	err := fsutil.CopyFile(e.RootPath, path, nil)
+	err := fsutil.CopyFile(e.CWD, path, nil)
 	if err != nil {
 		e.T.Fatalf("error importing directory: %v", err)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12246

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
