### PR TITLE
Don't use printf without a fixed format string

### DIFF
--- a/changelog/pending/20230621--cli-display--fix-formatting-bugs-in-display-causing-text-like-missing-showing-in-output.yaml
+++ b/changelog/pending/20230621--cli-display--fix-formatting-bugs-in-display-causing-text-like-missing-showing-in-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix formatting bugs in display causing text like (MISSING) showing in output.

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -207,17 +207,17 @@ func renderSummaryEvent(event engine.SummaryEventPayload, wroteDiagnosticHeader 
 	}
 
 	if len(summaryPieces) > 0 {
-		fprintfIgnoreError(out, "    ")
+		fprintIgnoreError(out, "    ")
 
 		for i, piece := range summaryPieces {
 			if i > 0 {
-				fprintfIgnoreError(out, ". ")
+				fprintIgnoreError(out, ". ")
 			}
 
 			out.WriteString(opts.Color.Colorize(piece))
 		}
 
-		fprintfIgnoreError(out, "\n")
+		fprintIgnoreError(out, "\n")
 	}
 
 	// Print policy packs loaded. Data is rendered as a table of {policy-pack-name, version}.
@@ -377,7 +377,7 @@ func renderDiffResourceOutputsEvent(
 			if text != "" {
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
 					deploy.Color(payload.Metadata.Op), getIndentationString(indent+1, payload.Metadata.Op, false), colors.Reset)
-				fprintfIgnoreError(out, opts.Color.Colorize(header))
+				fprintIgnoreError(out, opts.Color.Colorize(header))
 				fprintIgnoreError(out, opts.Color.Colorize(text))
 			}
 		}

--- a/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/stack-output-resource-diff.json.stdout.txt
@@ -1,7 +1,7 @@
 <{%reset%}>Configuration:<{%reset%}>
 <{%reset%}>  pulumi:pulumi:Stack: (same)
 <{%reset%}>    [urn=urn:pulumi:dev::pulumi-stack-output-diff::pulumi:pulumi:Stack::pulumi-stack-output-diff-dev]
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>    --outputs:--<{%reset%}>
 <{%reset%}>    vehicles: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>        taxi: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            color: <{%reset%}><{%reset%}>"yellow"<{%reset%}><{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.stdout.txt
@@ -2,7 +2,7 @@
     aws:region: us-west-2
 <{%reset%}>  pulumi:pulumi:Stack: (same)
 <{%reset%}>    [urn=urn:pulumi:dev::aws-ts-eks::pulumi:pulumi:Stack::aws-ts-eks-dev]
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>    --outputs:--<{%reset%}>
 <{%reset%}>    kubeconfig: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>        apiVersion     : <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        clusters       : <{%reset%}><{%reset%}>[
@@ -643,7 +643,7 @@
 <{%reset%}><{%reset%}>            }<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            version   : <{%reset%}><{%reset%}>"3.18.2"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>    --outputs:--<{%reset%}>
 <{%reset%}>    kubeconfig: <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>        apiVersion     : <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        clusters       : <{%reset%}><{%reset%}>[

--- a/pkg/backend/display/testdata/not-truncated/up-2.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-2.json.stdout.txt
@@ -24,7 +24,7 @@
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
@@ -59,7 +59,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSServicePolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452499500000001"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
 <{%reset%}>        [id=eks-role-24b1266-20220209231452597100000002]
@@ -67,7 +67,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452597100000002"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)
 <{%reset%}>        [id=sg-0e760e824fba2d002]
@@ -99,7 +99,7 @@
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-sg-8cab9e0"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        revokeRulesOnDelete: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        vpcId              : <{%reset%}><{%reset%}>"vpc-4b82e033"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        egress             : <{%reset%}><{%reset%}>[
 <{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}>{
@@ -155,7 +155,7 @@
 <{%reset%}><{%reset%}>                [3]: <{%reset%}><{%reset%}>"subnet-43f43a1e"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                    : <{%reset%}><{%reset%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        certificateAuthority   : <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/up-3.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-3.json.stdout.txt
@@ -52,7 +52,7 @@
 <{%reset%}><{%fg 2%}>        name               : <{%reset%}><{%fg 2%}>"eks-sg-b3dbcb0"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        revokeRulesOnDelete: <{%reset%}><{%fg 2%}>false<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        vpcId              : <{%reset%}><{%fg 2%}>"vpc-4b82e033"<{%reset%}><{%fg 2%}>
-<{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        arn                : <{%reset%}><{%fg 2%}>"arn:aws:iam::616138583583:role/eks-role-be36613"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        assumeRolePolicy   : <{%reset%}><{%fg 2%}>(json) <{%reset%}><{%fg 2%}>{
 <{%reset%}><{%fg 2%}>            Statement: <{%reset%}><{%fg 2%}>[
@@ -87,11 +87,11 @@
 <{%reset%}><{%fg 2%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
 <{%reset%}><{%fg 2%}>        policyArn : <{%reset%}><{%fg 2%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        role      : <{%reset%}><{%fg 2%}>"eks-role-be36613"<{%reset%}><{%fg 2%}>
-<{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        id       : <{%reset%}><{%fg 2%}>"eks-role-be36613-20220401073059037900000001"<{%reset%}><{%fg 2%}>
-<{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        id       : <{%reset%}><{%fg 2%}>"eks-role-be36613-20220401073059129000000002"<{%reset%}><{%fg 2%}>
-<{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        arn                : <{%reset%}><{%fg 2%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0d1f8bb63e78926f4"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        egress             : <{%reset%}><{%fg 2%}>[
 <{%reset%}><{%fg 2%}>            [0]: <{%reset%}><{%fg 2%}>{
@@ -146,7 +146,7 @@
 <{%reset%}><{%fg 2%}>                [3]: <{%reset%}><{%fg 2%}>"subnet-43f43a1e"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>            ]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        }<{%reset%}><{%fg 2%}>
-<{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        arn                    : <{%reset%}><{%fg 2%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        certificateAuthority   : <{%reset%}><{%fg 2%}>{
 <{%reset%}><{%fg 2%}>            data: <{%reset%}><{%fg 2%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTXpZeU5Gb1hEVE15TURNeU9UQTNNell5TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBWCjRhZUVwNGgrcWcwbDhYeDQ4WlZ1eHlrc3IySFZyUWhkOTVsSm05WnRHUlB3Y2wzelAzNWtKVWV0dWdsMWtWVVkKcmRkc3NnNVBYdEtNK1lwdUlOQldDNTR5ZU14QzczcnpoU2hsYXAwMzliTExWcDI0WDFHQjJobWI3NDliN1JYZworNDRvdjVuRUFWTnc4SWgwU1FXL3g1bXBQNHBNTHVSNlFqOVpJZ3NXSTlDUGJCdG10RGphbHB4U1J3SWs3dXloCjZzOXhIUmFxNE95bmtCdFZ3OWNmd1pBdU5FeXFYbnppN0lrOW1Dc2hOWENuUXJScmFSWmhoMzdtUGVBS3RmdHIKdGV5UkNmQXo4U1UzREQrK0Z0SkJiSVdSZWFhVHBpU2NMclVXU21hQ0xSNlVpOXVhMEg5S2ttRUhZcHI3VGhFdQpMeHYrcnRFVnNxakZSOGhjN1VrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZBRUlTUWNrVnQyZ0l5bzRRSVJ2eWZFcUQvNDJNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDUVI2emtsRGIwRDd0ZXF2bEFHVzU3Q0xtWnp2MzRWWVRTRTlXQkcyTmRQcEJ5VFJCcQpZejBvb05VamNqclg2NE94dlZEY1N5MXdoMlQzbU5nYi95ZVQ3ZlhLMU8xMEN2bXRHUWU3UU1kMEEwOUVDNElqCndyWDJjUTRObVEzRVd6Mkc3SW9tSFlNMjQyaUNFRHNtL3pqVm5hK0ZDeVpPdy9yUnE0V2NycEFYL085djR5Z3cKMStPNUJlOFVBYUV5ZzJSZ1RHQ0g4VEp5ZW94cnhnOXJCcnRvNmpUTmVpYXB5djVsRktrK1ZCd3N4dXdicjN2MworWmNlQXpkOWFhc2l5QW9OeEV0V3FIYmN6Mmp6S1dvazBpTWpUUk9iQ1NJQXhCUzhhRWhlejhYOXQxbzVZa0VJCmhNK1BtcUIzbVF2aEhWblJZVWdySUh0MnBneVJXZ1FmaG9SNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%fg 2%}>

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.stdout.txt
@@ -24,7 +24,7 @@
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-be36613"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-be36613"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
@@ -55,7 +55,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSServicePolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-be36613"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-be36613-20220401073059037900000001"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
 <{%reset%}>        [id=eks-role-be36613-20220401073059129000000002]
@@ -63,7 +63,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-be36613"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-be36613-20220401073059129000000002"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%fg 3%}>~ aws:ec2/securityGroup:SecurityGroup: (update)
 <{%reset%}>        [id=sg-0d1f8bb63e78926f4]
@@ -80,7 +80,7 @@
 <{%reset%}><{%fg 2%}>                  + toPort    : <{%reset%}><{%fg 2%}>22<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>                }<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 3%}>        ]
-<{%reset%}><{%reset%}><{%!f(MISSING)g 3%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 3%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0d1f8bb63e78926f4"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        egress             : <{%reset%}><{%reset%}>[
 <{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}>{
@@ -149,7 +149,7 @@
 <{%reset%}><{%reset%}>                [3]: <{%reset%}><{%reset%}>"subnet-43f43a1e"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                    : <{%reset%}><{%reset%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-dc83353"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        certificateAuthority   : <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTXpZeU5Gb1hEVE15TURNeU9UQTNNell5TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBWCjRhZUVwNGgrcWcwbDhYeDQ4WlZ1eHlrc3IySFZyUWhkOTVsSm05WnRHUlB3Y2wzelAzNWtKVWV0dWdsMWtWVVkKcmRkc3NnNVBYdEtNK1lwdUlOQldDNTR5ZU14QzczcnpoU2hsYXAwMzliTExWcDI0WDFHQjJobWI3NDliN1JYZworNDRvdjVuRUFWTnc4SWgwU1FXL3g1bXBQNHBNTHVSNlFqOVpJZ3NXSTlDUGJCdG10RGphbHB4U1J3SWs3dXloCjZzOXhIUmFxNE95bmtCdFZ3OWNmd1pBdU5FeXFYbnppN0lrOW1Dc2hOWENuUXJScmFSWmhoMzdtUGVBS3RmdHIKdGV5UkNmQXo4U1UzREQrK0Z0SkJiSVdSZWFhVHBpU2NMclVXU21hQ0xSNlVpOXVhMEg5S2ttRUhZcHI3VGhFdQpMeHYrcnRFVnNxakZSOGhjN1VrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZBRUlTUWNrVnQyZ0l5bzRRSVJ2eWZFcUQvNDJNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDUVI2emtsRGIwRDd0ZXF2bEFHVzU3Q0xtWnp2MzRWWVRTRTlXQkcyTmRQcEJ5VFJCcQpZejBvb05VamNqclg2NE94dlZEY1N5MXdoMlQzbU5nYi95ZVQ3ZlhLMU8xMEN2bXRHUWU3UU1kMEEwOUVDNElqCndyWDJjUTRObVEzRVd6Mkc3SW9tSFlNMjQyaUNFRHNtL3pqVm5hK0ZDeVpPdy9yUnE0V2NycEFYL085djR5Z3cKMStPNUJlOFVBYUV5ZzJSZ1RHQ0g4VEp5ZW94cnhnOXJCcnRvNmpUTmVpYXB5djVsRktrK1ZCd3N4dXdicjN2MworWmNlQXpkOWFhc2l5QW9OeEV0V3FIYmN6Mmp6S1dvazBpTWpUUk9iQ1NJQXhCUzhhRWhlejhYOXQxbzVZa0VJCmhNK1BtcUIzbVF2aEhWblJZVWdySUh0MnBneVJXZ1FmaG9SNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.stdout.txt
@@ -11,7 +11,7 @@
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
@@ -46,7 +46,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSServicePolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452499500000001"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
 <{%reset%}>        [id=eks-role-24b1266-20220209231452597100000002]
@@ -54,7 +54,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452597100000002"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)
 <{%reset%}>        [id=sg-0e760e824fba2d002]
@@ -86,7 +86,7 @@
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-sg-8cab9e0"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        revokeRulesOnDelete: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        vpcId              : <{%reset%}><{%reset%}>"vpc-4b82e033"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        egress             : <{%reset%}><{%reset%}>[
 <{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}>{
@@ -141,7 +141,7 @@
 <{%reset%}><{%fg 2%}>                [3]: <{%reset%}><{%fg 2%}>"subnet-43f43a1e"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>            ]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        }<{%reset%}><{%fg 2%}>
-<{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        arn                    : <{%reset%}><{%fg 2%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        certificateAuthority   : <{%reset%}><{%fg 2%}>{
 <{%reset%}><{%fg 2%}>            data: <{%reset%}><{%fg 2%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%fg 2%}>

--- a/pkg/backend/display/testdata/not-truncated/up.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.stdout.txt
@@ -11,7 +11,7 @@
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
@@ -46,7 +46,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSServicePolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452499500000001"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
 <{%reset%}>        [id=eks-role-24b1266-20220209231452597100000002]
@@ -54,7 +54,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452597100000002"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)
 <{%reset%}>        [id=sg-0e760e824fba2d002]
@@ -86,7 +86,7 @@
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-sg-8cab9e0"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        revokeRulesOnDelete: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        vpcId              : <{%reset%}><{%reset%}>"vpc-4b82e033"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        egress             : <{%reset%}><{%reset%}>[
 <{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}>{
@@ -141,7 +141,7 @@
 <{%reset%}><{%fg 2%}>                [3]: <{%reset%}><{%fg 2%}>"subnet-43f43a1e"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>            ]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        }<{%reset%}><{%fg 2%}>
-<{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%fg 2%}>        --outputs:--<{%reset%}>
 <{%fg 2%}>        arn                    : <{%reset%}><{%fg 2%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        certificateAuthority   : <{%reset%}><{%fg 2%}>{
 <{%reset%}><{%fg 2%}>            data: <{%reset%}><{%fg 2%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%fg 2%}>

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.stdout.txt
@@ -2,7 +2,7 @@
     aws:region: us-west-2
 <{%reset%}>  pulumi:pulumi:Stack: (same)
 <{%reset%}>    [urn=urn:pulumi:dev::aws-ts-webserver::pulumi:pulumi:Stack::aws-ts-webserver-dev]
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>    --outputs:--<{%reset%}>
 <{%reset%}>    publicHostName: <{%reset%}><{%reset%}>"ec2-34-211-56-110.us-west-2.compute.amazonaws.com"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>    publicIp      : <{%reset%}><{%reset%}>"34.211.56.110"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)

--- a/pkg/backend/display/testdata/truncated/up-truncate.json.stdout.txt
+++ b/pkg/backend/display/testdata/truncated/up-truncate.json.stdout.txt
@@ -3,7 +3,7 @@
 <{%reset%}>  pulumi:pulumi:Stack: (same)
 <{%reset%}>    [urn=urn:pulumi:dev::eks::pulumi:pulumi:Stack::eks-dev]
 <{%reset%}><{%reset%}>    readme: <{%reset%}><{%reset%}>"line 1\nline2\nline3\nline4"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>    --outputs:--<{%reset%}>
 <{%reset%}>    readme: <{%reset%}><{%reset%}>"line 1\nline2\nline3\nline4"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/role:Role: (same)
 <{%reset%}>        [id=eks-role-24b1266]
@@ -27,7 +27,7 @@
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
@@ -62,7 +62,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSServicePolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452499500000001"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:iam/rolePolicyAttachment:RolePolicyAttachment: (same)
 <{%reset%}>        [id=eks-role-24b1266-20220209231452597100000002]
@@ -70,7 +70,7 @@
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
 <{%reset%}><{%reset%}>        policyArn : <{%reset%}><{%reset%}>"arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        role      : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        id       : <{%reset%}><{%reset%}>"eks-role-24b1266-20220209231452597100000002"<{%reset%}><{%reset%}>
 <{%reset%}>    <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)
 <{%reset%}>        [id=sg-0e760e824fba2d002]
@@ -102,7 +102,7 @@
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-sg-8cab9e0"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        revokeRulesOnDelete: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        vpcId              : <{%reset%}><{%reset%}>"vpc-4b82e033"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:ec2:us-west-2:616138583583:security-group/sg-0e760e824fba2d002"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        egress             : <{%reset%}><{%reset%}>[
 <{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}>{
@@ -158,7 +158,7 @@
 <{%reset%}><{%reset%}>                [3]: <{%reset%}><{%reset%}>"subnet-43f43a1e"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
+<{%reset%}><{%reset%}><{%reset%}>        --outputs:--<{%reset%}>
 <{%reset%}>        arn                    : <{%reset%}><{%reset%}>"arn:aws:eks:us-west-2:616138583583:cluster/eks-cluster-fb2cd6e"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        certificateAuthority   : <{%reset%}><{%reset%}>{
 <{%reset%}><{%reset%}>            data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdNVEEzTVRVeE0xb1hEVE15TURNeU9UQTNNVFV4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHBPClE3b2FhMjl2ck1VU2hrMVUyRFluQ2F4RVEwMmFOVWZCdGlNZEQ5dC91eXRvb2l5SFNsMGlLNVdOK1pkc0R3ckMKNE9iWERJbk82WFE0V3YybkNiUTFkVU90MlNENTdBVkpaa2h3aStGcFZrcTN5c0ZDZklZWTJndXdnYVFZRTI2NQpLdVFWRitvS2l5TFJRcm9IYm92b0V2S05CZzllaUtMSEkvNW9YNW5CTEFTTmpxcFg1SER1QmRudWc2bTRMeVVYCkhyMlJScnlYUWthRUVudk9NLzR0dnlQQ1hZNWxVMUZEM09NVXNKRU5LNllCeGJDZjNjZHBGZFhaMmtpOXZrcGwKZ3ZiK2liLzZacE5oZ1U1SHViMkI3T0VJSHltZ1JSSks3T2luTUQxV2xOb1k5Q2hXT2tMVHNST1RJSVpma2VHegpWaVNVU2N0aEIzbnNBVzN6bDRFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZINmpuckovUE9sSFNERDdTNWFEeU5xMEZoWkVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBMDJoWmlOSFZpZ2R5WXQ3NVFFVkpCV1psRnF0cHRXc0xud25FVTlxdm9sdmNvVC9yeApKWXU3b2RVZFhuQmlVRXZMZ3RwRUpMZmwrZG5BdTg5TXJKSUpKQzNLTEN1YkFmQnUzUTNCRzk0MG93cEFXMzk0ClNNSEx6TDNLNHlTN1p2L091WXhhS0w0bWcvY1lsQ0xuczdIRkppZWZ3L3JDeHhieitWTmFFOUFqVFRUVWNuSWwKZWswQlU5SWYrbWR2aUZ3YW15b3p4L2VWYWZtMlVXUWlxVTFtWFFDUUw2aXl3S1I0aTFZRk84VzNDdUdlRHZLbQplUjJSaUtROW8vdEdXSGFZeTliR01rdmZsWGZ1RTBUTG94NFgwb1hGdGF5cWxHSDBwNG1YamV0ekw3a243SmFqCm1yNFY4bkZZdEtleWZ5M2M2Z2duSHFINmJoZEc3aTVqaG50awotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11990

There were a few places we were passing an already formatted string in as the format argument for printf. This replaces those calls with non-formatting print calls.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
