### PR TITLE
ci(lint): Disable setup-go cache for golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          # golangci-lint-action handles all the caching for Go.
+          cache: false
 
       # We leverage the golangci-lint action to install
       # and maintain the cache,


### PR DESCRIPTION
The golangci-lint-action comes with its own caching logic,
which includes caching Go build data.
We should not have setup-go caching enabled in that case.

ref: https://github.com/golangci/golangci-lint-action#how-to-use
Note the `cache: false`.

Note that usually setup-go doesn't take much time,
but sometimes it fails while downloading or uploading the cache.
This just drops an occasional source of flakiness in the job.
