### PR TITLE
[cli] make `pulumi new` properly check for project name existence at org level.

### DIFF
--- a/changelog/pending/20230622--cli-new--pulumi-new-s-org-project-stack-checks-the-specified-organization-for-project-existence-rather-than-the-currentuser.yaml
+++ b/changelog/pending/20230622--cli-new--pulumi-new-s-org-project-stack-checks-the-specified-organization-for-project-existence-rather-than-the-currentuser.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: `pulumi new -s 'org/project/stack'` checks the specified organization for project existence rather than the currentUser.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -155,7 +155,7 @@ type Backend interface {
 	ValidateStackName(s string) error
 
 	// DoesProjectExist returns true if a project with the given name exists in this backend, or false otherwise.
-	DoesProjectExist(ctx context.Context, projectName string) (bool, error)
+	DoesProjectExist(ctx context.Context, orgName string, projectName string) (bool, error)
 
 	// GetStack returns a stack object tied to this backend with the given name, or nil if it cannot be found.
 	GetStack(ctx context.Context, stackRef StackReference) (Stack, error)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -654,7 +654,7 @@ func (b *localBackend) ValidateStackName(stackRef string) error {
 	return err
 }
 
-func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {
+func (b *localBackend) DoesProjectExist(ctx context.Context, _ string, projectName string) (bool, error) {
 	projStore, ok := b.store.(*projectReferenceStore)
 	if !ok {
 		// Legacy stores don't have projects

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -778,7 +778,7 @@ func TestProjectFolderStructure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that testproj is reported as existing
-	exists, err := b.DoesProjectExist(ctx, "testproj")
+	exists, err := b.DoesProjectExist(ctx, "", "testproj")
 	assert.NoError(t, err)
 	assert.True(t, exists)
 

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -43,7 +43,7 @@ type MockBackend struct {
 	SupportsOrganizationsF func() bool
 	ParseStackReferenceF   func(s string) (StackReference, error)
 	ValidateStackNameF     func(s string) error
-	DoesProjectExistF      func(context.Context, string) (bool, error)
+	DoesProjectExistF      func(context.Context, string, string) (bool, error)
 	GetStackF              func(context.Context, StackReference) (Stack, error)
 	CreateStackF           func(context.Context, StackReference, string, *CreateStackOptions) (Stack, error)
 	RemoveStackF           func(context.Context, Stack, bool) (bool, error)
@@ -171,9 +171,9 @@ func (be *MockBackend) ValidateStackName(s string) error {
 	panic("not implemented")
 }
 
-func (be *MockBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {
+func (be *MockBackend) DoesProjectExist(ctx context.Context, orgName string, projectName string) (bool, error) {
 	if be.DoesProjectExistF != nil {
-		return be.DoesProjectExistF(ctx, projectName)
+		return be.DoesProjectExistF(ctx, orgName, projectName)
 	}
 	panic("not implemented")
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`pulumi new -s 'org/project/stack'` checks the proper organization for project existence rather than `backend.currentUser()`'s org.

Fixes #7423
Fixes #10748 

TODO
- [x] Integration Test with multiple orgs with 2 projects of the same name.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
