### PR TITLE
Temporarily bump Windows runner size to unblock merging

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -414,7 +414,7 @@ def get_matrix(
         test_suites += run_gotestsum_ci_matrix_single_package(item, pkg_tests, tags)
 
     if kind == JobKind.ACCEPTANCE_TEST:
-        platforms = list(map(lambda p: "windows-8core-2022" if p == "windows-latest" else p, platforms))
+        platforms = list(map(lambda p: "windows-16core-2022" if p == "windows-latest" else p, platforms))
 
     return {
         "test-suite": test_suites,


### PR DESCRIPTION
Temporarily bump the Windows runner size to unblock merging. I'll open an issue to root cause the actual issue and then we can move back to a lower size.