### PR TITLE
pulumi state unprotect command now uses OS specific quoting

### DIFF
--- a/changelog/pending/20230621--cli-display--on-windows-make-pulumi-state-unprotect-command-suggestion-use-double-quotes-instead-of-single-quotes.yaml
+++ b/changelog/pending/20230621--cli-display--on-windows-make-pulumi-state-unprotect-command-suggestion-use-double-quotes-instead-of-single-quotes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: On Windows, make `pulumi state unprotect` command suggestion use double-quotes instead of single-quotes.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -389,7 +389,7 @@ func (d deleteProtectedError) Error() string {
 		"because it is protected. To unprotect the resource, "+
 		"either remove the `protect` flag from the resource in your Pulumi "+
 		"program and run `pulumi up`, or use the command:\n"+
-		"`pulumi state unprotect '%[1]s'`", d.urn)
+		"`pulumi state unprotect %[2]s`", d.urn, d.urn.Quote())
 }
 
 func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error) {

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -15,6 +15,7 @@
 package deploy
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -480,4 +481,26 @@ func TestGenerateAliases(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestDeleteProtectedErrorUsesCorrectQuotesOnOS(t *testing.T) {
+	t.Parallel()
+	err := deleteProtectedError{urn: "resource:urn"}
+
+	expectations := map[string]string{
+		`windows`: `"`,
+		`linux`:   `'`,
+		`darwin`:  `'`,
+	}
+
+	t.Run(runtime.GOOS, func(t *testing.T) {
+		t.Parallel()
+		gotErrMsg := err.Error()
+		contains, ok := expectations[runtime.GOOS]
+		if !ok {
+			t.Skipf("no quoting expectation for %s", runtime.GOOS)
+			return
+		}
+		assert.Contains(t, gotErrMsg, contains)
+	})
 }

--- a/sdk/go/common/resource/urn.go
+++ b/sdk/go/common/resource/urn.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"runtime"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -66,6 +67,16 @@ func NewURN(stack tokens.QName, proj tokens.PackageName, parentType, baseType to
 			URNNameDelimiter + typ +
 			URNNameDelimiter + string(name),
 	)
+}
+
+// Quote returns the quoted form of the URN appropriate for use as a command line argument for the current OS.
+func (urn URN) Quote() string {
+	quote := `'`
+	if runtime.GOOS == "windows" {
+		// Windows uses double-quotes instead of single-quotes.
+		quote = `"`
+	}
+	return quote + string(urn) + quote
 }
 
 // IsValid returns true if the URN is well-formed.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Error messages would suggest the command `pulumi state unprotect 'urn'` on Windows which was not a valid quoting and now windows displays: `pulumi state unprotect "urn"`.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13045 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
