### PR TITLE
[sdk/nodejs] Save pkg/mod registrations on async local store

### DIFF
--- a/changelog/pending/20240729--sdk-nodejs--fix-resource-reference-serialization-when-multiple-copies-of-atpulumi-pulumi-are-present.yaml
+++ b/changelog/pending/20240729--sdk-nodejs--fix-resource-reference-serialization-when-multiple-copies-of-atpulumi-pulumi-are-present.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix resource reference serialization when multiple copies of @pulumi/pulumi are present

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -838,13 +838,12 @@ export interface ResourcePackage {
     constructProvider(name: string, type: string, urn: string): ProviderResource;
 }
 
-const resourcePackages = new Map<string, ResourcePackage[]>();
-
 /**
  * @internal
  *  Used only for testing purposes.
  */
 export function _resetResourcePackages() {
+    const { resourcePackages } = getStore();
     resourcePackages.clear();
 }
 
@@ -854,10 +853,12 @@ export function _resetResourcePackages() {
  * current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourcePackage(pkg: string, resourcePackage: ResourcePackage) {
+    const { resourcePackages } = getStore();
     register(resourcePackages, "package", pkg, resourcePackage);
 }
 
 export function getResourcePackage(pkg: string, version: string | undefined): ResourcePackage | undefined {
+    const { resourcePackages } = getStore();
     return getRegistration(resourcePackages, pkg, version);
 }
 
@@ -870,8 +871,6 @@ export interface ResourceModule {
     construct(name: string, type: string, urn: string): Resource;
 }
 
-const resourceModules = new Map<string, ResourceModule[]>();
-
 function moduleKey(pkg: string, mod: string): string {
     return `${pkg}:${mod}`;
 }
@@ -881,6 +880,7 @@ function moduleKey(pkg: string, mod: string): string {
  *  Used only for testing purposes.
  */
 export function _resetResourceModules() {
+    const { resourceModules } = getStore();
     resourceModules.clear();
 }
 
@@ -891,10 +891,12 @@ export function _resetResourceModules() {
  */
 export function registerResourceModule(pkg: string, mod: string, module: ResourceModule) {
     const key = moduleKey(pkg, mod);
+    const { resourceModules } = getStore();
     register(resourceModules, "module", key, module);
 }
 
 export function getResourceModule(pkg: string, mod: string, version: string | undefined): ResourceModule | undefined {
     const key = moduleKey(pkg, mod);
+    const { resourceModules } = getStore();
     return getRegistration(resourceModules, key, version);
 }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -20,7 +20,7 @@ import { ComponentResource, CustomResource, DependencyResource, ProviderResource
 import { debuggablePromise, debugPromiseLeaks, errorString } from "./debuggable";
 import { getAllTransitivelyReferencedResourceURNs } from "./resource";
 import { excessiveDebugOutput, isDryRun } from "./settings";
-import { getStore } from "./state";
+import { getStore, getResourcePackages, getResourceModules } from "./state";
 
 import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 import * as semver from "semver";
@@ -843,7 +843,7 @@ export interface ResourcePackage {
  *  Used only for testing purposes.
  */
 export function _resetResourcePackages() {
-    const { resourcePackages } = getStore();
+    const resourcePackages = getResourcePackages();
     resourcePackages.clear();
 }
 
@@ -853,12 +853,12 @@ export function _resetResourcePackages() {
  * current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourcePackage(pkg: string, resourcePackage: ResourcePackage) {
-    const { resourcePackages } = getStore();
+    const resourcePackages = getResourcePackages();
     register(resourcePackages, "package", pkg, resourcePackage);
 }
 
 export function getResourcePackage(pkg: string, version: string | undefined): ResourcePackage | undefined {
-    const { resourcePackages } = getStore();
+    const resourcePackages = getResourcePackages();
     return getRegistration(resourcePackages, pkg, version);
 }
 
@@ -880,7 +880,7 @@ function moduleKey(pkg: string, mod: string): string {
  *  Used only for testing purposes.
  */
 export function _resetResourceModules() {
-    const { resourceModules } = getStore();
+    const resourceModules = getResourceModules();
     resourceModules.clear();
 }
 
@@ -891,12 +891,12 @@ export function _resetResourceModules() {
  */
 export function registerResourceModule(pkg: string, mod: string, module: ResourceModule) {
     const key = moduleKey(pkg, mod);
-    const { resourceModules } = getStore();
+    const resourceModules = getResourceModules();
     register(resourceModules, "module", key, module);
 }
 
 export function getResourceModule(pkg: string, mod: string, version: string | undefined): ResourceModule | undefined {
     const key = moduleKey(pkg, mod);
-    const { resourceModules } = getStore();
+    const resourceModules = getResourceModules();
     return getRegistration(resourceModules, key, version);
 }

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -332,7 +332,7 @@ export const getStore = () => {
     return localStore;
 };
 
-export const getGlobalStore =() => {
+export const getGlobalStore = () => {
     if (global.globalStore === undefined) {
         global.globalStore = new LocalStore();
     }

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -19,6 +19,7 @@ import { Stack } from "./stack";
 
 import * as engrpc from "../proto/engine_grpc_pb";
 import * as resrpc from "../proto/resource_grpc_pb";
+import type { ResourceModule, ResourcePackage } from "./rpc";
 
 const nodeEnvKeys = {
     project: "PULUMI_NODEJS_PROJECT",
@@ -188,6 +189,9 @@ export interface Store {
      * callbacks and forwards them to the engine.
      */
     callbacks?: ICallbackServer;
+
+    resourcePackages: Map<string, ResourcePackage[]>;
+    resourceModules: Map<string, ResourceModule[]>;
 }
 
 /**
@@ -231,6 +235,8 @@ export class LocalStore implements Store {
     supportsAliasSpecs = false;
     supportsTransforms = false;
     supportsInvokeTransforms = false;
+    resourcePackages = new Map<string, ResourcePackage[]>();
+    resourceModules = new Map<string, ResourceModule[]>();
 }
 
 /**

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -262,13 +262,13 @@ export function getStackResource(): Stack | undefined {
  * @internal
  */
 export function getResourcePackages(): Map<string, ResourcePackage[]> {
-    let { resourcePackages } = getStore();
-    if (resourcePackages === undefined) {
+    const store = getStore();
+    if (store.resourcePackages === undefined) {
         // resourcePackages can be undefined if an older SDK where it was not defined is created it.
         // In this case, we should initialize it to an empty map.
-        resourcePackages = new Map<string, ResourcePackage[]>();
+        store.resourcePackages = new Map<string, ResourcePackage[]>();
     }
-    return resourcePackages;
+    return store.resourcePackages;
 }
 
 /**
@@ -277,13 +277,13 @@ export function getResourcePackages(): Map<string, ResourcePackage[]> {
  * @internal
  */
 export function getResourceModules(): Map<string, ResourceModule[]> {
-    let { resourceModules } = getStore();
-    if (resourceModules === undefined) {
+    const store = getStore();
+    if (store.resourceModules === undefined) {
         // resourceModules can be undefined if an older SDK where it was not defined is created it.
         // In this case, we should initialize it to an empty map.
-        resourceModules = new Map<string, ResourceModule[]>();
+        store.resourceModules = new Map<string, ResourceModule[]>();
     }
-    return resourceModules;
+    return store.resourceModules;
 }
 
 /**

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -257,6 +257,36 @@ export function getStackResource(): Stack | undefined {
 }
 
 /**
+ * Get the resource package map for the current stack deployment.
+ *
+ * @internal
+ */
+export function getResourcePackages(): Map<string, ResourcePackage[]> {
+    let { resourcePackages } = getStore();
+    if (resourcePackages === undefined) {
+        // resourcePackages can be undefined if an older SDK where it was not defined is created it.
+        // In this case, we should initialize it to an empty map.
+        resourcePackages = new Map<string, ResourcePackage[]>();
+    }
+    return resourcePackages;
+}
+
+/**
+ * Get the resource module map for the current stack deployment.
+ *
+ * @internal
+ */
+export function getResourceModules(): Map<string, ResourceModule[]> {
+    let { resourceModules } = getStore();
+    if (resourceModules === undefined) {
+        // resourceModules can be undefined if an older SDK where it was not defined is created it.
+        // In this case, we should initialize it to an empty map.
+        resourceModules = new Map<string, ResourceModule[]>();
+    }
+    return resourceModules;
+}
+
+/**
  * @internal
  */
 export function setStackResource(newStackResource?: Stack) {

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -262,7 +262,7 @@ export function getStackResource(): Stack | undefined {
  * @internal
  */
 export function getResourcePackages(): Map<string, ResourcePackage[]> {
-    const store = getStore();
+    const store = getGlobalStore();
     if (store.resourcePackages === undefined) {
         // resourcePackages can be undefined if an older SDK where it was not defined is created it.
         // In this case, we should initialize it to an empty map.
@@ -277,7 +277,7 @@ export function getResourcePackages(): Map<string, ResourcePackage[]> {
  * @internal
  */
 export function getResourceModules(): Map<string, ResourceModule[]> {
-    const store = getStore();
+    const store = getGlobalStore();
     if (store.resourceModules === undefined) {
         // resourceModules can be undefined if an older SDK where it was not defined is created it.
         // In this case, we should initialize it to an empty map.
@@ -330,6 +330,13 @@ export const getStore = () => {
         return global.globalStore;
     }
     return localStore;
+};
+
+export const getGlobalStore =() => {
+    if (global.globalStore === undefined) {
+        global.globalStore = new LocalStore();
+    }
+    return global.globalStore;
 };
 
 (<any>getStore).captureReplacement = () => {

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -190,7 +190,14 @@ export interface Store {
      */
     callbacks?: ICallbackServer;
 
+    /**
+     * Tracks the list of resource packages that have been registered.
+     */
     resourcePackages: Map<string, ResourcePackage[]>;
+
+    /**
+     * Tracks the list of resource modules that have been registered.
+     */
     resourceModules: Map<string, ResourceModule[]>;
 }
 

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -332,13 +332,6 @@ export const getStore = () => {
     return localStore;
 };
 
-export const getGlobalStore = () => {
-    if (global.globalStore === undefined) {
-        global.globalStore = new LocalStore();
-    }
-    return global.globalStore;
-};
-
 (<any>getStore).captureReplacement = () => {
     const returnFunc = () => {
         if (global.globalStore === undefined) {
@@ -347,4 +340,14 @@ export const getGlobalStore = () => {
         return global.globalStore;
     };
     return returnFunc;
+};
+
+/**
+ * @internal
+ */
+export const getGlobalStore = () => {
+    if (global.globalStore === undefined) {
+        global.globalStore = new LocalStore();
+    }
+    return global.globalStore;
 };

--- a/sdk/nodejs/tests/runtime/langhost/cases/015.runtime_sxs/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/015.runtime_sxs/index.js
@@ -83,3 +83,18 @@ res1.runtime1.apply((value) => assert.strictEqual(value, 1));
 res1.runtime2.apply((value) => assert.strictEqual(value, 2));
 res2.runtime1.apply((value) => assert.strictEqual(value, 1));
 res2.runtime2.apply((value) => assert.strictEqual(value, 2));
+
+pulumi1.runtime.registerResourcePackage("test1", {
+    version: "0.0.1",
+});
+pulumi2.runtime.registerResourcePackage("test2", {
+    version: "0.0.2",
+});
+let test1pulumi1 = pulumi1.runtime.getResourcePackage("test1");
+assert.strictEqual(test1pulumi1.version, "0.0.1");
+let test1pulumi2 = pulumi2.runtime.getResourcePackage("test1");
+assert.strictEqual(test1pulumi2.version, "0.0.1");
+let test2pulumi1 = pulumi1.runtime.getResourcePackage("test2");
+assert.strictEqual(test2pulumi1.version, "0.0.2");
+let test2pulumi2 = pulumi2.runtime.getResourcePackage("test2");
+assert.strictEqual(test2pulumi2.version, "0.0.2");


### PR DESCRIPTION
Rather than saving package/module registrations in a module variable, save them in the store where other state is stored. This way, if there are multiple copies of `@pulumi/pulumi`, they'll use the same store, rather than having separate copies of registrations.

Fixes #13223