### PR TITLE
fix(codegen/go): Use raw string literals for multiline-strings

### DIFF
--- a/changelog/pending/20230622--programgen-go--use-raw-string-literals-for-long-multi-line-strings.yaml
+++ b/changelog/pending/20230622--programgen-go--use-raw-string-literals-for-long-multi-line-strings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Use raw string literals for long, multi-line strings.

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -248,6 +248,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Generate RetainOnDelete option",
 	},
 	{
+		Directory:   "multiline-string",
+		Description: "Multiline string literals",
+	},
+	{
 		Directory:   "throw-not-implemented",
 		Description: "Function notImplemented is compiled to a runtime error at call-site",
 	},

--- a/pkg/codegen/testing/test/testdata/multiline-string-pp/dotnet/multiline-string.cs
+++ b/pkg/codegen/testing/test/testdata/multiline-string-pp/dotnet/multiline-string.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Random = Pulumi.Random;
+
+return await Deployment.RunAsync(() => 
+{
+    var foo = new Random.RandomShuffle("foo", new()
+    {
+        Inputs = new[]
+        {
+            @"just one
+newline",
+            @"foo
+bar
+baz
+qux
+quux
+qux",
+            @"{
+    ""a"": 1,
+    ""b"": 2,
+    ""c"": [
+      ""foo"",
+      ""bar"",
+      ""baz"",
+      ""qux"",
+      ""quux""
+    ]
+}
+",
+        },
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/multiline-string-pp/go/multiline-string.go
+++ b/pkg/codegen/testing/test/testdata/multiline-string-pp/go/multiline-string.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := random.NewRandomShuffle(ctx, "foo", &random.RandomShuffleArgs{
+			Inputs: pulumi.StringArray{
+				pulumi.String("just one\nnewline"),
+				pulumi.String("foo\nbar\nbaz\nqux\nquux\nqux"),
+				pulumi.String(`{
+    "a": 1,
+    "b": 2,
+    "c": [
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+      "quux"
+    ]
+}
+`),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/multiline-string-pp/multiline-string.pp
+++ b/pkg/codegen/testing/test/testdata/multiline-string-pp/multiline-string.pp
@@ -1,0 +1,19 @@
+resource foo "random:index/randomShuffle:RandomShuffle" {
+  inputs = [
+    "just one\nnewline",
+    "foo\nbar\nbaz\nqux\nquux\nqux",
+    <<-EOT
+      {
+          "a": 1,
+          "b": 2,
+          "c": [
+            "foo",
+            "bar",
+            "baz",
+            "qux",
+            "quux"
+          ]
+      }
+    EOT
+  ]
+}

--- a/pkg/codegen/testing/test/testdata/multiline-string-pp/nodejs/multiline-string.ts
+++ b/pkg/codegen/testing/test/testdata/multiline-string-pp/nodejs/multiline-string.ts
@@ -1,0 +1,25 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+const foo = new random.RandomShuffle("foo", {inputs: [
+    `just one
+newline`,
+    `foo
+bar
+baz
+qux
+quux
+qux`,
+    `{
+    "a": 1,
+    "b": 2,
+    "c": [
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+      "quux"
+    ]
+}
+`,
+]});

--- a/pkg/codegen/testing/test/testdata/multiline-string-pp/python/multiline-string.py
+++ b/pkg/codegen/testing/test/testdata/multiline-string-pp/python/multiline-string.py
@@ -1,0 +1,25 @@
+import pulumi
+import pulumi_random as random
+
+foo = random.RandomShuffle("foo", inputs=[
+    """just one
+newline""",
+    """foo
+bar
+baz
+qux
+quux
+qux""",
+    """{
+    "a": 1,
+    "b": 2,
+    "c": [
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+      "quux"
+    ]
+}
+""",
+])


### PR DESCRIPTION
We already have logic in place to generate mutliline strings with
backticks if they meet certain conditions in genTemplateExpression.
However, the logic came into effect only if the string was complex
enough to warrant use of `Sprintf`
because the function short circuits to just printing a string literal
if the string doesn't need a `Sprintf`.

This changes genStringLiteral to be responsible for the decision
of whether the string warrants backticks or not,
retaining the prior conditions on whether the string would benefit
from being split across multiple lines.

Resolves #12358
