### PR TITLE
fix `pulumi new` creates new project when stack reference project name and project name don't match

### DIFF
--- a/changelog/pending/20230622--cli-new--when-providing-a-stack-and-name-to-pulumi-new-the-project-names-must-match-before-creating-pulumi-yaml.yaml
+++ b/changelog/pending/20230622--cli-new--when-providing-a-stack-and-name-to-pulumi-new-the-project-names-must-match-before-creating-pulumi-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: When providing a `--stack` and `--name` to `pulumi new`, the project names must match before creating Pulumi.yaml.

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -16,6 +16,7 @@ package backend
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -139,7 +140,28 @@ func (be *MockBackend) ParseStackReference(s string) (StackReference, error) {
 	if be.ParseStackReferenceF != nil {
 		return be.ParseStackReferenceF(s)
 	}
-	panic("not implemented")
+
+	// default implementation
+	split := strings.Split(s, "/")
+	var project, name tokens.Name
+	switch len(split) {
+	case 1:
+		name = tokens.Name(split[0])
+	case 2:
+		project = tokens.Name(split[0])
+		name = tokens.Name(split[1])
+	case 3:
+		// org is unused
+		project = tokens.Name(split[1])
+		name = tokens.Name(split[2])
+	}
+
+	return &MockStackReference{
+		StringV:             s,
+		NameV:               name,
+		ProjectV:            project,
+		FullyQualifiedNameV: tokens.QName(s),
+	}, nil
 }
 
 func (be *MockBackend) ValidateStackName(s string) error {

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1118,14 +1118,17 @@ func containsWhiteSpace(value string) bool {
 	return false
 }
 
+// validateStackProjectName takes a stack name and a project name and returns an error if they are not the same.
+//   - projectName comes from the --name flag.
+//   - stackName comes from the --stack flag. stackName can be a stack name or a fully qualified stack reference
+//     i.e org/project/stack
 func validateStackProjectName(b backend.Backend, stackName, projectName string) error {
-	if stackName == "" {
-		return nil
-	}
-	if projectName == "" {
+	if stackName == "" || projectName == "" {
+		// No potential for conflicting project names.
 		return nil
 	}
 
+	// Catch the case where the user has specified a fully qualified stack reference.
 	if strings.Count(stackName, "/") == 2 {
 		ref, err := b.ParseStackReference(stackName)
 		if err != nil {
@@ -1138,8 +1141,10 @@ func validateStackProjectName(b backend.Backend, stackName, projectName string) 
 		if projectName == stackProjectName.String() {
 			return nil
 		}
-		return fmt.Errorf("project name (%s) and stack reference project name (%s) must be the same",
+		return fmt.Errorf("project name (--name %s) and stack reference project name (--stack %s) must be the same",
 			projectName, stackProjectName)
 	}
+
+	// No conflict as the stack reference does not have a project name.
 	return nil
 }

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -820,3 +820,49 @@ func genUniqueName(t *testing.T) string {
 
 	return hex.EncodeToString(bs[:])
 }
+
+func TestValidateStackRefAndProjectName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		projectName string
+		stackRef    string
+		valid       bool
+	}{
+		{
+			projectName: "foo",
+			stackRef:    "foo",
+			valid:       true,
+		},
+		{
+			projectName: "fooo",
+			stackRef:    "org/foo/dev",
+			valid:       false,
+		},
+		{
+			projectName: "",
+			stackRef:    "org/foo/dev",
+			valid:       true,
+		},
+		{
+			projectName: "foo",
+			stackRef:    "",
+			valid:       true,
+		},
+		{
+			projectName: "foo",
+			stackRef:    "org/foo/dev",
+			valid:       true,
+		},
+	}
+	b, err := currentBackend(context.Background(), nil, display.Options{})
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		err := validateStackProjectName(b, tt.stackRef, tt.projectName)
+		if tt.valid {
+			assert.NoError(t, err, "projectName: %s, stackRef: %s", tt.projectName, tt.stackRef)
+		} else {
+			assert.Error(t, err, "projectName: %s, stackRef: %s", tt.projectName, tt.stackRef)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -858,11 +858,15 @@ func TestValidateStackRefAndProjectName(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tt := range tests {
-		err := validateStackProjectName(b, tt.stackRef, tt.projectName)
-		if tt.valid {
-			assert.NoError(t, err, "projectName: %s, stackRef: %s", tt.projectName, tt.stackRef)
-		} else {
-			assert.Error(t, err, "projectName: %s, stackRef: %s", tt.projectName, tt.stackRef)
-		}
+		tt := tt
+		t.Run(fmt.Sprintf("project=%q/stackRef=%q", tt.projectName, tt.stackRef), func(t *testing.T) {
+			t.Parallel()
+			err := validateStackProjectName(b, tt.stackRef, tt.projectName)
+			if tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
 	}
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/natefinch/atomic v1.0.1
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
+	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-java/pkg v0.9.4
 	github.com/pulumi/pulumi-yaml v1.1.1
 	github.com/segmentio/encoding v0.3.5
@@ -201,7 +202,6 @@ require (
 	github.com/pgavlin/text v0.0.0-20230428184845-84c285f11d2f // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`pulumi new` `--stack` and `--name` check that the project name matches before creating a new project.

Fixes #13248 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
