### PR TITLE
[convert] Prefer output-versioned invokes in generated programs for nodejs and python

### DIFF
--- a/changelog/pending/20230622--programgen-nodejs-python--prefer-output-versioned-invokes-in-generated-programs-for-nodejs-and-python.yaml
+++ b/changelog/pending/20230622--programgen-nodejs-python--prefer-output-versioned-invokes-in-generated-programs-for-nodejs-and-python.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/nodejs,python
+  description: Prefer output-versioned invokes in generated programs for nodejs and python

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -152,7 +152,7 @@ func safePclBindDirectory(sourceDirectory string, loader schema.ReferenceLoader,
 	}()
 
 	extraOptions := make([]pcl.BindOption, 0)
-	if strict {
+	if !strict {
 		extraOptions = append(extraOptions, []pcl.BindOption{
 			pcl.AllowMissingProperties,
 			pcl.AllowMissingVariables,
@@ -190,7 +190,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 		contract.Requiref(proj != nil, "proj", "must not be nil")
 
 		extraOptions := make([]pcl.BindOption, 0)
-		if strict {
+		if !strict {
 			extraOptions = append(extraOptions, []pcl.BindOption{
 				pcl.AllowMissingProperties,
 				pcl.AllowMissingVariables,

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -189,6 +189,9 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 		if args.SkipResourceTypecheck {
 			opts = append(opts, SkipResourceTypechecking)
 		}
+		if args.PreferOutputVersionedInvokes {
+			opts = append(opts, PreferOutputVersionedInvokes)
+		}
 
 		componentProgram, programDiags, err := BindProgram(parser.Files, opts...)
 
@@ -282,13 +285,14 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 	}
 
 	componentProgram, programDiags, err := b.options.componentProgramBinder(ComponentProgramBinderArgs{
-		AllowMissingVariables:  b.options.allowMissingVariables,
-		AllowMissingProperties: b.options.allowMissingProperties,
-		SkipResourceTypecheck:  b.options.skipResourceTypecheck,
-		BinderLoader:           b.options.loader,
-		BinderDirPath:          b.options.dirPath,
-		ComponentSource:        node.source,
-		ComponentNodeRange:     node.SyntaxNode().Range(),
+		AllowMissingVariables:        b.options.allowMissingVariables,
+		AllowMissingProperties:       b.options.allowMissingProperties,
+		SkipResourceTypecheck:        b.options.skipResourceTypecheck,
+		PreferOutputVersionedInvokes: b.options.preferOutputVersionedInvokes,
+		BinderLoader:                 b.options.loader,
+		BinderDirPath:                b.options.dirPath,
+		ComponentSource:              node.source,
+		ComponentNodeRange:           node.SyntaxNode().Range(),
 	})
 	if err != nil {
 		diagnostics = diagnostics.Append(errorf(node.SyntaxNode().Range(), err.Error()))

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -190,13 +190,17 @@ func (b *binder) signatureForArgs(fn *schema.Function, args model.Expression) (m
 }
 
 // Heuristic to decide when to use `fnOutput` form of a function. Will
-// conservatively prefer `false`. It only decides to return `true` if
-// doing so avoids the need to introduce an `apply` form to
+// conservatively prefer `false` unless bind option choose to prefer otherwise.
+// It decides to return `true` if doing so avoids the need to introduce an `apply` form to
 // accommodate `Output` args (`Promise` args do not count).
 func (b *binder) useOutputVersion(fn *schema.Function, args model.Expression) bool {
 	if !fn.NeedsOutputVersion() {
 		// No code emitted for an `fnOutput` form, impossible.
 		return false
+	}
+
+	if b.options.preferOutputVersionedInvokes {
+		return true
 	}
 
 	outputFormParamType := b.schemaTypeToType(fn.Inputs.InputShape)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -82,6 +82,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "AWS Fargate",
 	},
 	{
+		Directory:   "aws-fargate-output-versioned",
+		Description: "AWS Fargate Using Output-versioned invokes for python and typescript",
+		Skip:        codegen.NewStringSet("go", "dotnet"),
+		BindOptions: []pcl.BindOption{pcl.PreferOutputVersionedInvokes},
+	},
+	{
 		Directory:   "aws-s3-logging",
 		Description: "AWS S3 with logging",
 		SkipCompile: codegen.NewStringSet("go"),

--- a/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/aws-fargate-output-versioned.pp
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/aws-fargate-output-versioned.pp
@@ -1,0 +1,108 @@
+// Read the default VPC and public subnets, which we will use.
+vpc = invoke("aws:ec2:getVpc", {
+	default = true
+})
+subnets = invoke("aws:ec2:getSubnetIds", {
+	vpcId = vpc.id
+})
+
+// Create a security group that permits HTTP ingress and unrestricted egress.
+resource webSecurityGroup "aws:ec2:SecurityGroup" {
+	vpcId = vpc.id
+	egress = [{
+		protocol = "-1"
+		fromPort = 0
+		toPort = 0
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+	ingress = [{
+		protocol = "tcp"
+		fromPort = 80
+		toPort = 80
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+}
+
+// Create an ECS cluster to run a container-based service.
+resource cluster "aws:ecs:Cluster" {}
+
+// Create an IAM role that can be used by our service's task.
+resource taskExecRole "aws:iam:Role" {
+	assumeRolePolicy = toJSON({
+		Version = "2008-10-17"
+		Statement = [{
+			Sid = ""
+			Effect = "Allow"
+			Principal = {
+				Service = "ecs-tasks.amazonaws.com"
+			}
+			Action = "sts:AssumeRole"
+		}]
+	})
+}
+resource taskExecRolePolicyAttachment "aws:iam:RolePolicyAttachment" {
+	role = taskExecRole.name
+	policyArn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+// Create a load balancer to listen for HTTP traffic on port 80.
+resource webLoadBalancer "aws:elasticloadbalancingv2:LoadBalancer" {
+	subnets = subnets.ids
+	securityGroups = [webSecurityGroup.id]
+}
+resource webTargetGroup "aws:elasticloadbalancingv2:TargetGroup" {
+	port = 80
+	protocol = "HTTP"
+	targetType = "ip"
+	vpcId = vpc.id
+}
+resource webListener "aws:elasticloadbalancingv2:Listener" {
+	loadBalancerArn = webLoadBalancer.arn
+	port = 80
+	defaultActions = [{
+		type = "forward"
+		targetGroupArn = webTargetGroup.arn
+	}]
+}
+
+// Spin up a load balanced service running NGINX
+resource appTask "aws:ecs:TaskDefinition" {
+	family = "fargate-task-definition"
+	cpu = "256"
+	memory = "512"
+	networkMode = "awsvpc"
+	requiresCompatibilities = ["FARGATE"]
+	executionRoleArn = taskExecRole.arn
+	containerDefinitions = toJSON([{
+		name = "my-app"
+		image = "nginx"
+		portMappings = [{
+			containerPort = 80
+			hostPort = 80
+			protocol = "tcp"
+		}]
+	}])
+}
+resource appService "aws:ecs:Service" {
+	cluster = cluster.arn
+	desiredCount = 5
+	launchType = "FARGATE"
+	taskDefinition = appTask.arn
+	networkConfiguration = {
+		assignPublicIp = true
+		subnets = subnets.ids
+		securityGroups = [webSecurityGroup.id]
+	}
+	loadBalancers = [{
+		targetGroupArn = webTargetGroup.arn
+		containerName = "my-app"
+		containerPort = 80
+	}]
+
+	options {
+		dependsOn = [webListener]
+	}
+}
+
+// Export the resulting web address.
+output url { value = webLoadBalancer.dnsName }

--- a/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/nodejs/aws-fargate-output-versioned.ts
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/nodejs/aws-fargate-output-versioned.ts
@@ -1,0 +1,99 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const vpc = aws.ec2.getVpcOutput({
+    "default": true,
+});
+const subnets = aws.ec2.getSubnetIdsOutput({
+    vpcId: vpc.id,
+});
+// Create a security group that permits HTTP ingress and unrestricted egress.
+const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {
+    vpcId: vpc.id,
+    egress: [{
+        protocol: "-1",
+        fromPort: 0,
+        toPort: 0,
+        cidrBlocks: ["0.0.0.0/0"],
+    }],
+    ingress: [{
+        protocol: "tcp",
+        fromPort: 80,
+        toPort: 80,
+        cidrBlocks: ["0.0.0.0/0"],
+    }],
+});
+// Create an ECS cluster to run a container-based service.
+const cluster = new aws.ecs.Cluster("cluster", {});
+// Create an IAM role that can be used by our service's task.
+const taskExecRole = new aws.iam.Role("taskExecRole", {assumeRolePolicy: JSON.stringify({
+    Version: "2008-10-17",
+    Statement: [{
+        Sid: "",
+        Effect: "Allow",
+        Principal: {
+            Service: "ecs-tasks.amazonaws.com",
+        },
+        Action: "sts:AssumeRole",
+    }],
+})});
+const taskExecRolePolicyAttachment = new aws.iam.RolePolicyAttachment("taskExecRolePolicyAttachment", {
+    role: taskExecRole.name,
+    policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+});
+// Create a load balancer to listen for HTTP traffic on port 80.
+const webLoadBalancer = new aws.elasticloadbalancingv2.LoadBalancer("webLoadBalancer", {
+    subnets: subnets.ids,
+    securityGroups: [webSecurityGroup.id],
+});
+const webTargetGroup = new aws.elasticloadbalancingv2.TargetGroup("webTargetGroup", {
+    port: 80,
+    protocol: "HTTP",
+    targetType: "ip",
+    vpcId: vpc.id,
+});
+const webListener = new aws.elasticloadbalancingv2.Listener("webListener", {
+    loadBalancerArn: webLoadBalancer.arn,
+    port: 80,
+    defaultActions: [{
+        type: "forward",
+        targetGroupArn: webTargetGroup.arn,
+    }],
+});
+// Spin up a load balanced service running NGINX
+const appTask = new aws.ecs.TaskDefinition("appTask", {
+    family: "fargate-task-definition",
+    cpu: "256",
+    memory: "512",
+    networkMode: "awsvpc",
+    requiresCompatibilities: ["FARGATE"],
+    executionRoleArn: taskExecRole.arn,
+    containerDefinitions: JSON.stringify([{
+        name: "my-app",
+        image: "nginx",
+        portMappings: [{
+            containerPort: 80,
+            hostPort: 80,
+            protocol: "tcp",
+        }],
+    }]),
+});
+const appService = new aws.ecs.Service("appService", {
+    cluster: cluster.arn,
+    desiredCount: 5,
+    launchType: "FARGATE",
+    taskDefinition: appTask.arn,
+    networkConfiguration: {
+        assignPublicIp: true,
+        subnets: subnets.ids,
+        securityGroups: [webSecurityGroup.id],
+    },
+    loadBalancers: [{
+        targetGroupArn: webTargetGroup.arn,
+        containerName: "my-app",
+        containerPort: 80,
+    }],
+}, {
+    dependsOn: [webListener],
+});
+export const url = webLoadBalancer.dnsName;

--- a/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/python/aws-fargate-output-versioned.py
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/python/aws-fargate-output-versioned.py
@@ -1,0 +1,88 @@
+import pulumi
+import json
+import pulumi_aws as aws
+
+vpc = aws.ec2.get_vpc_output(default=True)
+subnets = aws.ec2.get_subnet_ids_output(vpc_id=vpc.id)
+# Create a security group that permits HTTP ingress and unrestricted egress.
+web_security_group = aws.ec2.SecurityGroup("webSecurityGroup",
+    vpc_id=vpc.id,
+    egress=[aws.ec2.SecurityGroupEgressArgs(
+        protocol="-1",
+        from_port=0,
+        to_port=0,
+        cidr_blocks=["0.0.0.0/0"],
+    )],
+    ingress=[aws.ec2.SecurityGroupIngressArgs(
+        protocol="tcp",
+        from_port=80,
+        to_port=80,
+        cidr_blocks=["0.0.0.0/0"],
+    )])
+# Create an ECS cluster to run a container-based service.
+cluster = aws.ecs.Cluster("cluster")
+# Create an IAM role that can be used by our service's task.
+task_exec_role = aws.iam.Role("taskExecRole", assume_role_policy=json.dumps({
+    "Version": "2008-10-17",
+    "Statement": [{
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "ecs-tasks.amazonaws.com",
+        },
+        "Action": "sts:AssumeRole",
+    }],
+}))
+task_exec_role_policy_attachment = aws.iam.RolePolicyAttachment("taskExecRolePolicyAttachment",
+    role=task_exec_role.name,
+    policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+# Create a load balancer to listen for HTTP traffic on port 80.
+web_load_balancer = aws.elasticloadbalancingv2.LoadBalancer("webLoadBalancer",
+    subnets=subnets.ids,
+    security_groups=[web_security_group.id])
+web_target_group = aws.elasticloadbalancingv2.TargetGroup("webTargetGroup",
+    port=80,
+    protocol="HTTP",
+    target_type="ip",
+    vpc_id=vpc.id)
+web_listener = aws.elasticloadbalancingv2.Listener("webListener",
+    load_balancer_arn=web_load_balancer.arn,
+    port=80,
+    default_actions=[aws.elasticloadbalancingv2.ListenerDefaultActionArgs(
+        type="forward",
+        target_group_arn=web_target_group.arn,
+    )])
+# Spin up a load balanced service running NGINX
+app_task = aws.ecs.TaskDefinition("appTask",
+    family="fargate-task-definition",
+    cpu="256",
+    memory="512",
+    network_mode="awsvpc",
+    requires_compatibilities=["FARGATE"],
+    execution_role_arn=task_exec_role.arn,
+    container_definitions=json.dumps([{
+        "name": "my-app",
+        "image": "nginx",
+        "portMappings": [{
+            "containerPort": 80,
+            "hostPort": 80,
+            "protocol": "tcp",
+        }],
+    }]))
+app_service = aws.ecs.Service("appService",
+    cluster=cluster.arn,
+    desired_count=5,
+    launch_type="FARGATE",
+    task_definition=app_task.arn,
+    network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+        assign_public_ip=True,
+        subnets=subnets.ids,
+        security_groups=[web_security_group.id],
+    ),
+    load_balancers=[aws.ecs.ServiceLoadBalancerArgs(
+        target_group_arn=web_target_group.arn,
+        container_name="my-app",
+        container_port=80,
+    )],
+    opts=pulumi.ResourceOptions(depends_on=[web_listener]))
+pulumi.export("url", web_load_balancer.dns_name)

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -830,7 +830,7 @@ func (host *goLanguageHost) GenerateProject(
 	loader := schema.NewPluginLoader(pluginCtx.Host)
 
 	extraOptions := make([]pcl.BindOption, 0)
-	if req.Strict {
+	if !req.Strict {
 		extraOptions = append(extraOptions, []pcl.BindOption{
 			pcl.AllowMissingProperties,
 			pcl.AllowMissingVariables,

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -828,7 +828,17 @@ func (host *goLanguageHost) GenerateProject(
 	}
 
 	loader := schema.NewPluginLoader(pluginCtx.Host)
-	program, diags, err := pcl.BindDirectory(req.SourceDirectory, loader, req.Strict)
+
+	extraOptions := make([]pcl.BindOption, 0)
+	if req.Strict {
+		extraOptions = append(extraOptions, []pcl.BindOption{
+			pcl.AllowMissingProperties,
+			pcl.AllowMissingVariables,
+			pcl.SkipResourceTypechecking,
+		}...)
+	}
+
+	program, diags, err := pcl.BindDirectory(req.SourceDirectory, loader, extraOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1034,7 +1034,7 @@ func (host *nodeLanguageHost) GenerateProject(
 
 	loader := schema.NewPluginLoader(pluginCtx.Host)
 	extraOptions := make([]pcl.BindOption, 0)
-	if req.Strict {
+	if !req.Strict {
 		extraOptions = append(extraOptions, []pcl.BindOption{
 			pcl.AllowMissingProperties,
 			pcl.AllowMissingVariables,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1033,7 +1033,19 @@ func (host *nodeLanguageHost) GenerateProject(
 	}
 
 	loader := schema.NewPluginLoader(pluginCtx.Host)
-	program, diags, err := pcl.BindDirectory(req.SourceDirectory, loader, req.Strict)
+	extraOptions := make([]pcl.BindOption, 0)
+	if req.Strict {
+		extraOptions = append(extraOptions, []pcl.BindOption{
+			pcl.AllowMissingProperties,
+			pcl.AllowMissingVariables,
+			pcl.SkipResourceTypechecking,
+		}...)
+	}
+
+	// for nodejs, prefer output-versioned invokes
+	extraOptions = append(extraOptions, pcl.PreferOutputVersionedInvokes)
+
+	program, diags, err := pcl.BindDirectory(req.SourceDirectory, loader, extraOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -1098,7 +1110,9 @@ func (host *nodeLanguageHost) GenerateProgram(
 	}
 
 	loader := schema.NewPluginLoader(pluginCtx.Host)
-	program, pdiags, err := pcl.BindProgram(parser.Files, pcl.Loader(loader))
+	program, pdiags, err := pcl.BindProgram(parser.Files,
+		pcl.Loader(loader),
+		pcl.PreferOutputVersionedInvokes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

This PR implements a new PCL bind option called `PreferOutputVersionedInvokes` which as the name suggests gives higher priority to using output-versioned invokes in generated programs if they exist* but only for python and nodejs. Previously we have enabled this for all languages but it breaks go and dotnet programs so here it is only applied to python and typescript. 

Binding component programs carry over this option if the main program has it too. 

This work is a continuation of #13051

<details>
   <summary>PCL program example</summary>

```
vpc = invoke("aws:ec2:getVpc", {
	default = true
})
subnets = invoke("aws:ec2:getSubnetIds", {
	vpcId = vpc.id
})

resource webSecurityGroup "aws:ec2:SecurityGroup" {
	vpcId = vpc.id
	egress = [{
		protocol = "-1"
		fromPort = 0
		toPort = 0
		cidrBlocks = ["0.0.0.0/0"]
	}]
	ingress = [{
		protocol = "tcp"
		fromPort = 80
		toPort = 80
		cidrBlocks = ["0.0.0.0/0"]
	}]
}
```

</details>

<details>
   <summary>Generated TypeScript Before</summary>

```typescript
const vpc = aws.ec2.getVpc({
    "default": true,
});
const subnets = vpc.then(vpc => aws.ec2.getSubnetIds({
    vpcId: vpc.id,
}));
const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {
    vpcId: vpc.then(vpc => vpc.id),
    egress: [{
        protocol: "-1",
        fromPort: 0,
        toPort: 0,
        cidrBlocks: ["0.0.0.0/0"],
    }],
    ingress: [{
        protocol: "tcp",
        fromPort: 80,
        toPort: 80,
        cidrBlocks: ["0.0.0.0/0"],
    }],
});
```

</details>

<details>
   <summary>Generated TypeScript After</summary>

```typescript
const vpc = aws.ec2.getVpcOutput({
    "default": true,
});
const subnets = aws.ec2.getSubnetIdsOutput({
    vpcId: vpc.id,
});
const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {
    vpcId: vpc.id,
    egress: [{
        protocol: "-1",
        fromPort: 0,
        toPort: 0,
        cidrBlocks: ["0.0.0.0/0"],
    }],
    ingress: [{
        protocol: "tcp",
        fromPort: 80,
        toPort: 80,
        cidrBlocks: ["0.0.0.0/0"],
    }],
});
```

</details>

> * The existence of output-versioned invokes depends on whether they have any arguments. The idea is to change that later such that every function invoke emits an output-versioned invoke regardless of whether it has input args or not. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
