### PR TITLE
cli(state/rename): Validate new name before renaming

### DIFF
--- a/changelog/pending/20230622--cli-state--disallow-renaming-resources-to-invalid-names-that-will-corrupt-the-state.yaml
+++ b/changelog/pending/20230622--cli-state--disallow-renaming-resources-to-invalid-names-that-will-corrupt-the-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Disallow renaming resources to invalid names that will corrupt the state.

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 
@@ -48,6 +49,11 @@ func stateRenameOperation(urn resource.URN, newResourceName string, opts display
 	existingResources := edit.LocateResource(snap, urn)
 	if len(existingResources) != 1 {
 		return errors.New("The input URN does not correspond to an existing resource")
+	}
+
+	if !tokens.IsQName(newResourceName) {
+		return fmt.Errorf("invalid name %q: "+
+			"resource names may only contain alphanumerics, underscores, hyphens, dots, and slashes", newResourceName)
 	}
 
 	inputResource := existingResources[0]

--- a/pkg/cmd/pulumi/state_rename_test.go
+++ b/pkg/cmd/pulumi/state_rename_test.go
@@ -67,6 +67,44 @@ func TestRenameProvider(t *testing.T) {
 	}
 }
 
+func TestStateRename_invalidName(t *testing.T) {
+	t.Parallel()
+
+	prov := resource.URN("urn:pulumi:dev::xxx-dev::kubernetes::provider")
+	res := resource.URN("urn:pulumi:dev::xxx-dev::kubernetes:core/v1:Namespace::amazon_cloudwatchNamespace")
+
+	snap := deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				URN:  prov,
+				ID:   "provider-id",
+				Type: "pulumi:provider:kubernetes",
+			},
+			{
+				URN:  res,
+				ID:   "res-id",
+				Type: "kubernetes:core/v1:Namespace",
+			},
+		},
+	}
+	require.NoError(t, snap.VerifyIntegrity(),
+		"invalid test: snapshot is already broken")
+
+	err := stateRenameOperation(
+		res,
+		"urn:pulumi:dev::xxx-dev::eks:index:Cluster$kubernetes:core/v1:Namespace::amazon_cloudwatchNamespace",
+		display.Options{},
+		&snap,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid name")
+	assert.ErrorContains(t, err, "names may only contain alphanumerics")
+
+	// The state must still be valid, and the resource name unchanged.
+	require.NoError(t, snap.VerifyIntegrity(), "snapshot is broken after rename")
+	assert.Equal(t, res, snap.Resources[1].URN)
+}
+
 // Regression test for https://github.com/pulumi/pulumi/issues/13179.
 //
 // Defines a state with a two resources, one parented to the other,


### PR DESCRIPTION
Check that resource names are valid
before renaming a resource and possibly corrupting the stack.

Resource names are `QName`s, so we rely on tokens.IsQName for this.

Resolves #11746
