### PR TITLE
fix(cli/stack output): Don't escape HTML characters

### DIFF
--- a/changelog/pending/20230622--cli--stack-output-on-the-console-no-longer-escapes-html-characters-inside-json-strings.yaml
+++ b/changelog/pending/20230622--cli--stack-output-on-the-console-no-longer-escapes-html-characters-inside-json-strings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Stack output on the console no longer escapes HTML characters inside JSON strings. This matches the behavior of the `--json` flag.

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -234,22 +232,12 @@ func stringifyOutput(v interface{}) string {
 		return s
 	}
 
-	// json.Marshal escapes HTML characters, which we don't want,
-	// so change that with json.NewEncoder.
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
+	o, err := makeJSONString(v, false /* single line */)
+	if err != nil {
 		return "error: could not format value"
 	}
 
-	// json.NewEncoder always adds a trailing newline. Remove it.
-	b := buf.Bytes()
-	if n := len(b); n > 0 && b[n-1] == '\n' {
-		b = b[:n-1]
-	}
-
-	return string(b)
+	return o
 }
 
 type treeNode struct {

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -31,26 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringifyOutput(t *testing.T) {
-	t.Parallel()
 
-	num := 42
-	str := "ABC"
-	arr := []string{"hello", "goodbye"}
-	obj := map[string]interface{}{
-		"foo": 42,
-		"bar": map[string]interface{}{
-			"baz": true,
-		},
-	}
-	specialChar := "pass&word"
-
-	assert.Equal(t, "42", stringifyOutput(num))
-	assert.Equal(t, "ABC", stringifyOutput(str))
-	assert.Equal(t, "[\"hello\",\"goodbye\"]", stringifyOutput(arr))
-	assert.Equal(t, "{\"bar\":{\"baz\":true},\"foo\":42}", stringifyOutput(obj))
-	assert.Equal(t, "pass&word", stringifyOutput(specialChar))
-}
 
 // Tests the output of 'pulumi stack output'
 // under different conditions.

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
-
 // Tests the output of 'pulumi stack output'
 // under different conditions.
 func TestStackOutputCmd_plainText(t *testing.T) {

--- a/pkg/cmd/pulumi/stack_test.go
+++ b/pkg/cmd/pulumi/stack_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2013, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringifyOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give any
+		want string
+	}{
+		{"int", 42, "42"},
+		{"string", "ABC", "ABC"},
+		{
+			desc: "array",
+			give: []string{"hello", "goodbye"},
+			want: `["hello","goodbye"]`,
+		},
+		{
+			desc: "object",
+			give: map[string]any{
+				"foo": 42,
+				"bar": map[string]any{
+					"baz": true,
+				},
+			},
+			want: `{"bar":{"baz":true},"foo":42}`,
+		},
+		{
+			desc: "special characters",
+			give: "pass&word",
+			want: "pass&word",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := stringifyOutput(tt.give)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/stack_test.go
+++ b/pkg/cmd/pulumi/stack_test.go
@@ -50,6 +50,26 @@ func TestStringifyOutput(t *testing.T) {
 			give: "pass&word",
 			want: "pass&word",
 		},
+		{
+			// https://github.com/pulumi/pulumi/issues/10561
+			desc: "html/string",
+			give: "<html>",
+			want: "<html>",
+		},
+		{
+			// https://github.com/pulumi/pulumi/issues/10561
+			desc: "html/list",
+			give: []string{"<html>"},
+			want: `["<html>"]`,
+		},
+		{
+			// https://github.com/pulumi/pulumi/issues/10561
+			desc: "html/object",
+			give: map[string]any{
+				"foo": "<html>",
+			},
+			want: `{"foo":"<html>"}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -223,32 +223,45 @@ func Test_makeJSONString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		input    interface{}
-		expected string
+		name      string
+		input     interface{}
+		multiline bool
+		expected  string
 	}{
 		{
-			"simple-string",
-			map[string]interface{}{"my_password": "password"},
-			`{
+			name:      "simple-string/multiline",
+			input:     map[string]interface{}{"my_password": "password"},
+			multiline: true,
+			expected: `{
   "my_password": "password"
 }
 `,
 		},
 		{
-			"special-char-string",
-			map[string]interface{}{"special_password": "pass&word"},
-			`{
+			name:     "simple-string",
+			input:    map[string]interface{}{"my_password": "password"},
+			expected: `{"my_password":"password"}`,
+		},
+		{
+			name:      "special-char-string/multiline",
+			input:     map[string]interface{}{"special_password": "pass&word"},
+			multiline: true,
+			expected: `{
   "special_password": "pass&word"
 }
 `,
+		},
+		{
+			name:     "special-char-string",
+			input:    map[string]interface{}{"special_password": "pass&word"},
+			expected: `{"special_password":"pass&word"}`,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := makeJSONString(tt.input)
+			got, err := makeJSONString(tt.input, tt.multiline)
 			if err != nil {
 				t.Errorf("makeJSONString() error = %v", err)
 				return


### PR DESCRIPTION
For the default `pulumi stack output` (writing to the console),
don't escape HTML characters inside JSON strings.

The only way to control this in Go is with `json.Encoder`.
However, that unconditionally places a newline at the end,
so we have to strip that for our use case.

Testing:
TestStringifyOutput was turned into a table test.
That's in an independent commit without any other changes.

Resolves #10561
