### PR TITLE
Fix type description for AWS codebuild

### DIFF
--- a/changelog/pending/20230623--pkg--fix-type-description-of-aws-package.yaml
+++ b/changelog/pending/20230623--pkg--fix-type-description-of-aws-package.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Fix type description of aws package


### PR DESCRIPTION
# Description

While working on aws using pulumi's nodejs package, I found that the type description of few codebuild types were interchanged in the type description file input.d.ts.

I couldn't locate the same format file in this repository but located it in the json files for codegen. 

I have fixed aws:codebuild/ProjectSourceAuth:ProjectSourceAuth's type property description. Apart from that in the actual node package the description of aws:codebuild/ProjectSource:ProjectSource's type property is also wrong however in the json file, I found it to be correct.
## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
No tests required
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change

