### PR TITLE
Print update summary in preview even if there are diagnostics.

### DIFF
--- a/changelog/pending/20230623--cli-display--print-the-summary-event-for-previews-that-contain-non-error-level-diagnostic-messages.yaml
+++ b/changelog/pending/20230623--cli-display--print-the-summary-event-for-previews-that-contain-non-error-level-diagnostic-messages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Print the summary event for previews that contain non-error level diagnostic messages.

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -141,7 +141,7 @@ func renderStdoutColorEvent(payload engine.StdoutEventPayload, opts Options) str
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(event engine.SummaryEventPayload, wroteDiagnosticHeader bool, opts Options) string {
+func renderSummaryEvent(event engine.SummaryEventPayload, hasError bool, opts Options) string {
 	changes := event.ResourceChanges
 
 	out := &bytes.Buffer{}
@@ -149,7 +149,7 @@ func renderSummaryEvent(event engine.SummaryEventPayload, wroteDiagnosticHeader 
 	// If this is a failed preview, we only render the Policy Packs that ran. This is because rendering the summary
 	// for a failed preview may be surprising/misleading, as it does not describe the totality of the proposed changes
 	// (as the preview may have aborted when the error occurred).
-	if event.IsPreview && wroteDiagnosticHeader {
+	if event.IsPreview && hasError {
 		renderPolicyPacks(out, event.PolicyPacks, opts)
 		return out.String()
 	}

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -188,6 +189,46 @@ func TestStatusDisplayFlags(t *testing.T) {
 				assert.NotContains(t, doneStatus, "[retain]", "%s should NOT contain [retain] (done)", step.Op)
 				assert.NotContains(t, inProgressStatus, "[retain]", "%s should NOT contain [retain] (in-progress)", step.Op)
 			}
+		})
+	}
+}
+
+func TestPrintDiagnosticsIsTolerantOfDiagnostics(t *testing.T) {
+	t.Parallel()
+	makeDisplayWithDiagnostic := func(sev diag.Severity) *ProgressDisplay {
+		return &ProgressDisplay{
+			eventUrnToResourceRow: map[resource.URN]ResourceRow{
+				"urn:pulumi:test::test::pulumi:pulumi:Stack::test": &resourceRowData{
+					diagInfo: &DiagInfo{
+						StreamIDToDiagPayloads: map[int32][]engine.DiagEventPayload{
+							0: {
+								{
+									Severity: sev,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		give diag.Severity
+		want bool
+	}{
+		{"info", diag.Info, false},
+		{"warning", diag.Warning, false},
+		{"error", diag.Error, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := makeDisplayWithDiagnostic(tt.give)
+			got := d.printDiagnostics()
+			assert.Equal(t, tt.want, got, "printDiagnostics(%v) = %v, want %v", tt.give, got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Pulumi previews now print the summary event if there are diagnostic messages. The display will not print the summary if there are error diagnostics.

Fixes #10880

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
