### PR TITLE
Fix isInstance methods on generated provider types in the nodejs sdks

### DIFF
--- a/changelog/pending/20230624--sdkgen-nodejs--fix-isinstance-methods-for-generated-provider-types.yaml
+++ b/changelog/pending/20230624--sdkgen-nodejs--fix-isinstance-methods-for-generated-provider-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/nodejs
+  description: Fix isInstance methods for generated provider types.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -691,7 +691,17 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	fmt.Fprintf(w, "        if (obj === undefined || obj === null) {\n")
 	fmt.Fprintf(w, "            return false;\n")
 	fmt.Fprintf(w, "        }\n")
-	fmt.Fprintf(w, "        return obj['__pulumiType'] === %s.__pulumiType;\n", name)
+
+	typeExpression := fmt.Sprintf("%s.__pulumiType", name)
+	if r.IsProvider {
+		// We pass __pulumiType to the ProviderResource constructor as the "type" for this provider, the
+		// ProviderResource constructor in the SDK then prefixes "pulumi:providers:" to that token and passes that
+		// down to the CustomResource constructor, which then assigns that type token to the newly constructed
+		// objects __pulumiType field. As such we also need to prefix "pulumi:providers:" when doing the equality
+		// check here.
+		typeExpression = "\"pulumi:providers:\" + " + typeExpression
+	}
+	fmt.Fprintf(w, "        return obj['__pulumiType'] === %s;\n", typeExpression)
 	fmt.Fprintf(w, "    }\n")
 	fmt.Fprintf(w, "\n")
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/cyclic-types/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/different-enum/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/different-enum/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/enum-reference/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/enum-reference/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/external-enum/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/external-enum/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/external-node-compatibility/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/external-node-compatibility/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/nested-module/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/nested-module/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
@@ -21,7 +21,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
@@ -21,7 +21,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
@@ -19,7 +19,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/regress-8403/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/regress-8403/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/secrets/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/secrets/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs-extras/tests/codegen.spec.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs-extras/tests/codegen.spec.ts
@@ -1,0 +1,46 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as assert from "assert";
+import "mocha";
+import * as sut from "..";
+
+pulumi.runtime.setMocks({
+    newResource: function(_: pulumi.runtime.MockResourceArgs): {id: string, state: any} {
+        return {id: "", state: {}};
+    },
+    call: function(args: pulumi.runtime.MockCallArgs) {
+        throw new Error("call not implemented");
+    },
+});
+
+
+describe("simple-resource-schema", () => {
+    const p = new sut.Provider("my-p");
+    const r = new sut.Resource("my-r", {});
+    const c = new sut.FooResource("my-c", {})
+
+    assert.deepStrictEqual(sut.Provider.isInstance(p), true);
+    assert.deepStrictEqual(sut.Provider.isInstance(r), false);
+    assert.deepStrictEqual(sut.Provider.isInstance(c), false);
+
+    assert.deepStrictEqual(sut.Resource.isInstance(p), false);
+    assert.deepStrictEqual(sut.Resource.isInstance(r), true);
+    assert.deepStrictEqual(sut.Resource.isInstance(c), false);
+
+    assert.deepStrictEqual(sut.FooResource.isInstance(p), false);
+    assert.deepStrictEqual(sut.FooResource.isInstance(r), false);
+    assert.deepStrictEqual(sut.FooResource.isInstance(c), true);
+ });

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
@@ -6,11 +6,14 @@
         "install": "node scripts/install-pulumi-plugin.js resource example 3.2.1"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.12"
+        "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "^14",
-        "typescript": "^3.7.0"
+        "@types/mocha": "latest",
+        "@types/node": "ts4.3",
+        "mocha": "latest",
+        "ts-node": "latest",
+        "typescript": "^4.3.5"
     },
     "pulumi": {
         "resource": true,

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/tsconfig.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/tsconfig.json
@@ -20,6 +20,7 @@
         "otherResource.ts",
         "provider.ts",
         "resource.ts",
+        "tests/codegen.spec.ts",
         "typeUses.ts",
         "types/index.ts",
         "types/input.ts",

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
@@ -260,12 +260,15 @@
       "respectSchemaVersion": true
     },
     "nodejs": {
-      "dependencies": {
-        "@pulumi/pulumi": "^3.12"
-      },
       "devDependencies": {
-        "typescript": "^3.7.0"
+        "@types/mocha": "latest",
+        "@types/node": "ts4.3",
+        "mocha": "latest",
+        "ts-node": "latest"
       },
+      "extraTypeScriptFiles": [
+        "tests/codegen.spec.ts"
+      ],
       "respectSchemaVersion": true,
       "pluginVersion": "3.2.1"
     },

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/nodejs/provider.ts
@@ -16,7 +16,7 @@ export class Provider extends pulumi.ProviderResource {
         if (obj === undefined || obj === null) {
             return false;
         }
-        return obj['__pulumiType'] === Provider.__pulumiType;
+        return obj['__pulumiType'] === "pulumi:providers:" + Provider.__pulumiType;
     }
 
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import { ResourceError } from "./errors";
+import * as log from "./log";
 import { Input, Inputs, interpolate, Output, output } from "./output";
 import { getResource, readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
+import { unknownValue } from "./runtime/rpc";
 import { getProject, getStack } from "./runtime/settings";
 import { getStackResource } from "./runtime/state";
-import { unknownValue } from "./runtime/rpc";
 import * as utils from "./utils";
-import * as log from "./log";
 
 export type ID = string; // a provider-assigned ID.
 export type URN = string; // an automatically generated logical URN, used to stably identify resources.
@@ -265,6 +265,14 @@ export abstract class Resource {
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     readonly __pluginDownloadURL?: string;
 
+    /**
+     * Private field containing the type ID for this object. Useful for implementing `isInstance` on
+     * classes that inherit from `Resource`.
+     * @internal
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
+    public readonly __pulumiType: string;
+
     public static isInstance(obj: any): obj is Resource {
         return utils.isInstance<Resource>(obj, "__pulumiResource");
     }
@@ -303,6 +311,8 @@ export abstract class Resource {
         remote: boolean = false,
         dependency: boolean = false,
     ) {
+        this.__pulumiType = t;
+
         if (dependency) {
             this.__protect = false;
             this.__providers = {};
@@ -764,14 +774,6 @@ export abstract class CustomResource extends Resource {
     public readonly __pulumiCustomResource: boolean;
 
     /**
-     * Private field containing the type ID for this object. Useful for implementing `isInstance` on
-     * classes that inherit from `CustomResource`.
-     * @internal
-     */
-    // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
-    public readonly __pulumiType: string;
-
-    /**
      * id is the provider-assigned unique ID for this managed resource.  It is set during
      * deployments and may be missing (undefined) during planning phases.
      */
@@ -809,7 +811,6 @@ export abstract class CustomResource extends Resource {
 
         super(t, name, true, props, opts, false, dependency);
         this.__pulumiCustomResource = true;
-        this.__pulumiType = t;
     }
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12584

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
