### PR TITLE
Add a better error message for invalid NodeJS AutoAPI workdir

### DIFF
--- a/changelog/pending/20230624--auto-nodejs--adds-a-better-error-message-for-invalid-nodejs-autoapi-workdir.yaml
+++ b/changelog/pending/20230624--auto-nodejs--adds-a-better-error-message-for-invalid-nodejs-autoapi-workdir.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Adds a better error message for invalid NodeJS AutoAPI workDir.

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -268,6 +268,10 @@ export class LocalWorkspace implements Workspace {
                 remoteSkipInstallDependencies,
             } = opts;
             if (workDir) {
+                // Verify that the workdir exists.
+                if (!fs.existsSync(workDir)) {
+                    throw new Error(`Invalid workDir passed to local workspace: '${workDir}' does not exist`);
+                }
                 dir = workDir;
             }
             this.pulumiHome = pulumiHome;

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -53,6 +53,18 @@ describe("LocalWorkspace", () => {
         }
     });
 
+    it(`fails gracefully for missing local workspace workDir`, async () => {
+        try {
+            const ws = await LocalWorkspace.create({ workDir: "invalid-missing-workdir" });
+            assert.fail("expected create with invalid workDir to throw");
+        } catch (err) {
+            assert.strictEqual(
+                err.toString(),
+                "Error: Invalid workDir passed to local workspace: 'invalid-missing-workdir' does not exist",
+            );
+        }
+    });
+
     it(`adds/removes/lists plugins successfully`, async () => {
         const ws = await LocalWorkspace.create({});
         await ws.installPlugin("aws", "v3.0.0");


### PR DESCRIPTION
If you supply a workDir to a NodeJS AutoAPI LocalWorkspace, it does not validate its correctness, and proceeds to use it when trying to spawn commands. That leads to misleading and confusing "Command failed with ENOENT: pulumi version" error messages, making it look like the issue is a missing `pulumi` binary on your PATH. This changes to eagerly check and issue a more friendly error message. Fixes #13274.

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change