### PR TITLE
[sdk/nodejs] Add explicit dependency on @opentelemetry/instrumentation

### DIFF
--- a/changelog/pending/20230624--sdk-nodejs--add-dependency-on-atopentelemetry-instrumentation.yaml
+++ b/changelog/pending/20230624--sdk-nodejs--add-dependency-on-atopentelemetry-instrumentation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Add dependency on @opentelemetry/instrumentation

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,6 +13,7 @@
         "@logdna/tail-file": "^2.0.6",
         "@opentelemetry/api": "^1.2.0",
         "@opentelemetry/exporter-zipkin": "^1.6.0",
+        "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/instrumentation-grpc": "^0.32.0",
         "@opentelemetry/resources": "^1.6.0",
         "@opentelemetry/sdk-trace-base": "^1.6.0",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -368,7 +368,7 @@
     "@opentelemetry/instrumentation" "0.32.0"
     "@opentelemetry/semantic-conventions" "1.6.0"
 
-"@opentelemetry/instrumentation@0.32.0":
+"@opentelemetry/instrumentation@0.32.0", "@opentelemetry/instrumentation@^0.32.0":
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz#27c5975a323a2ba83d9bf2ea8b11faaab37c5827"
   integrity sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==


### PR DESCRIPTION
The Node.js SDK makes use of `@opentelemetry/instrumentation` directly in https://github.com/pulumi/pulumi/blob/2a69c252410a2d6ffd0bf48dc2c215f51317da0c/sdk/nodejs/cmd/run/tracing.ts#L24, but it is not specified as an explicit dependency in `package.json` -- we're relying on the indirect dependency from `@opentelemetry/instrumentation-grpc`.

This can break monorepo setups using npm workspaces. If there is another version of `@opentelemtry/instrumentation`, it is not hoisted for use by the Pulumi program, resulting in pulumi crashing with `error: Error: Cannot find module '@opentelemetry/instrumentation'`.

This change fixes this by explicitly declaring the version of `@opentelemetry/instrumentation` the SDK needs in `package.json`.

Fixes #13104