### PR TITLE
Don't discard `nil` panics

### DIFF
--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -24,8 +24,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func panicHandler() {
-	if panicPayload := recover(); panicPayload != nil {
+// panicHandler displays an emergency error message to the user and a stack trace to
+// report the panic.
+//
+// finished should be set to false when the handler is deferred and set to true as the
+// last statement in the scope. This trick is necessary to avoid catching and then
+// discarding a panic(nil).
+func panicHandler(finished *bool) {
+	if panicPayload := recover(); !*finished {
 		stack := string(debug.Stack())
 		fmt.Fprintln(os.Stderr, "================================================================================")
 		fmt.Fprintln(os.Stderr, "The Pulumi CLI encountered a fatal error. This is a bug!")
@@ -44,10 +50,12 @@ func panicHandler() {
 }
 
 func main() {
-	defer panicHandler()
+	finished := new(bool)
+	defer panicHandler(finished)
 	if err := NewPulumiCmd().Execute(); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)
 		os.Exit(1)
 	}
+	*finished = true
 }

--- a/pkg/cmd/pulumi/main_test.go
+++ b/pkg/cmd/pulumi/main_test.go
@@ -99,7 +99,8 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	defer panicHandler()
+	finished := new(bool)
+	defer panicHandler(finished)
 
 	// Copy the test flags into the Pulumi command's flags.
 	cmd := NewPulumiCmd()
@@ -116,4 +117,5 @@ func TestMain(m *testing.M) {
 		contract.IgnoreError(err)
 		os.Exit(1)
 	}
+	*finished = true
 }


### PR DESCRIPTION
Implement the necessary steps to avoid swallowing nil panics in out global recover statement. While we don't have any `panic(nil)` in our codebase right now, we should still handle this case correctly.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
