### PR TITLE
Improve the stack validation error message

### DIFF
--- a/changelog/pending/20230626--cli--improve-the-cli-stack-validation-error-message.yaml
+++ b/changelog/pending/20230626--cli--improve-the-cli-stack-validation-error-message.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Improve the CLI stack validation error message

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -9,6 +9,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateStackName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		stackName string
+		error     string
+	}{
+		{"empty", "", "a stack name may not be empty"},
+		{"valid", "foo", ""},
+		{
+			title:     "slash",
+			stackName: "foo/bar",
+			error: "a stack name may only contain alphanumeric, hyphens, " +
+				"underscores, or periods: invalid character '/'" +
+				" at position 3",
+		},
+		{"long", strings.Repeat("a", 100), ""},
+		{
+			title:     "too-long",
+			stackName: strings.Repeat("a", 101),
+			error:     "a stack name cannot exceed 100 characters",
+		},
+		{
+			title:     "first-char-invalid",
+			stackName: "@stack-name",
+			error: "a stack name may only contain alphanumeric, hyphens, " +
+				"underscores, or periods: invalid character '@' " +
+				"at position 0",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateStackName(tt.stackName)
+			if tt.error == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.error)
+			}
+		})
+	}
+}
+
 func TestValidateStackTag(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Previously, the error message was:

```
error: a stack name may only contain alphanumeric, hyphens, underscores, or periods
```

This wasn't great because it lacked specificity, but was especially bad if candidate stack name was >100 characters or empty.

The new error messages are as follows:

1. If empty: "a stack name may not be empty"
2. If >100 chars: "a stack name cannot exceed 100 characters"
3. If it contains invalid characters: "a stack name may only contain alphanumeric, hyphens, underscores, or periods: invalid character %q at position %d" (with the appropriate values filled in).

In addition, this PR unifies the http backend stack name validation into a single function.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
