### PR TITLE
programgen(go): Handle conflicting names in imported packages

### DIFF
--- a/changelog/pending/20230626--programgen-go--fix-conflicting-imports-generated-when-two-imported-packages-have-the-same-name.yaml
+++ b/changelog/pending/20230626--programgen-go--fix-conflicting-imports-generated-when-two-imported-packages-have-the-same-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix conflicting imports generated when two imported packages have the same name.

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -85,15 +85,378 @@ func TestCollectImports(t *testing.T) {
 	t.Parallel()
 
 	g := newTestGenerator(t, filepath.Join("aws-s3-logging-pp", "aws-s3-logging.pp"))
+	g.collectImports(g.program)
 
-	programImports := g.collectImports(g.program)
-	pulumiImports := programImports.pulumiImports
-	stdImports := programImports.stdImports
-	stdVals := stdImports.SortedValues()
-	pulumiVals := pulumiImports.SortedValues()
-	assert.Equal(t, 0, len(stdVals))
-	assert.Equal(t, 1, len(pulumiVals))
-	assert.Equal(t, "\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3\"", pulumiVals[0])
+	var allImports []string
+	for _, group := range g.importer.ImportGroups() {
+		allImports = append(allImports, group...)
+	}
+
+	assert.Equal(t, []string{
+		`"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"`,
+	}, allImports)
+}
+
+func TestFileImporter(t *testing.T) {
+	t.Parallel()
+
+	// importCall is a single call to fileImporter.Import.
+	type importCall struct {
+		// Import path to import.
+		importPath string
+
+		// Name of the package at the import path.
+		name string
+
+		// Expected name used to refer to the imported package.
+		want string
+	}
+
+	tests := []struct {
+		desc string
+
+		// List of Import method invocations made in-order.
+		imports []importCall
+
+		// List of import groups generated from the collective effect
+		// of all import calls in this test case.
+		wantGroups [][]string
+	}{
+		{desc: "no imports"},
+		{
+			desc: "single import/std",
+			imports: []importCall{
+				{importPath: "fmt", name: "fmt", want: "fmt"},
+			},
+			wantGroups: [][]string{
+				{`"fmt"`},
+			},
+		},
+		{
+			desc: "single import/pulumi",
+			imports: []importCall{
+				{importPath: "github.com/pulumi/pulumi/sdk/v3/go/pulumi", name: "pulumi", want: "pulumi"},
+			},
+			wantGroups: [][]string{
+				{`"github.com/pulumi/pulumi/sdk/v3/go/pulumi"`},
+			},
+		},
+		{
+			desc: "std and pulumi/no conflict",
+			imports: []importCall{
+				{importPath: "fmt", name: "fmt", want: "fmt"},
+				{importPath: "github.com/pulumi/pulumi/sdk/v3/go/pulumi", name: "pulumi", want: "pulumi"},
+			},
+			wantGroups: [][]string{
+				{`"fmt"`},
+				{`"github.com/pulumi/pulumi/sdk/v3/go/pulumi"`},
+			},
+		},
+		{
+			desc: "std and pulumi many imports, no conflict",
+			imports: []importCall{
+				{importPath: "fmt", name: "fmt", want: "fmt"},
+				{importPath: "github.com/pulumi/pulumi/sdk/v3/go/pulumi", name: "pulumi", want: "pulumi"},
+				{importPath: "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config", name: "config", want: "config"},
+				{importPath: "encoding/json", name: "json", want: "json"},
+				{importPath: "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3", name: "s3", want: "s3"},
+				{importPath: "io", name: "io", want: "io"},
+				{importPath: "github.com/pulumi/pulumi-awsx/sdk/v5/go/awsx", name: "awsx", want: "awsx"},
+			},
+			wantGroups: [][]string{
+				{
+					`"encoding/json"`,
+					`"fmt"`,
+					`"io"`,
+				},
+				{
+					`"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"`,
+					`"github.com/pulumi/pulumi-awsx/sdk/v5/go/awsx"`,
+					`"github.com/pulumi/pulumi/sdk/v3/go/pulumi"`,
+					`"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"`,
+				},
+			},
+		},
+		{
+			desc: "std and pulumi/conflict",
+			imports: []importCall{
+				{importPath: "encoding/json", name: "json", want: "json"},
+				{
+					// This doesn't actually exist yet,
+					// but it's conceivable that it might.
+					importPath: "github.com/pulumi/pulumi-std/sdk/go/std/encoding/json",
+					name:       "json",
+					want:       "encodingjson",
+				},
+			},
+			wantGroups: [][]string{
+				{`"encoding/json"`},
+				{`encodingjson "github.com/pulumi/pulumi-std/sdk/go/std/encoding/json"`},
+			},
+		},
+		{
+			desc: "std and pulumi/conflict repeated",
+			imports: []importCall{
+				{importPath: "encoding/json", name: "json", want: "json"},
+				{
+					importPath: "github.com/pulumi/pulumi-std/sdk/go/std/encoding/json",
+					name:       "json",
+					want:       "encodingjson",
+				},
+				{importPath: "encoding/json/v2", name: "json", want: "jsonv2"},
+				{
+					importPath: "github.com/pulumi/pulumi-std/sdk/v2/go/std/encoding/json",
+					name:       "json",
+					want:       "json2",
+				},
+			},
+			wantGroups: [][]string{
+				{
+					`"encoding/json"`,
+					`jsonv2 "encoding/json/v2"`,
+				},
+				{
+					`encodingjson "github.com/pulumi/pulumi-std/sdk/go/std/encoding/json"`,
+					`json2 "github.com/pulumi/pulumi-std/sdk/v2/go/std/encoding/json"`,
+				},
+			},
+		},
+		{
+			desc: "std and pulumi/conflict reverse",
+			imports: []importCall{
+				{
+					// This doesn't actually exist yet,
+					// but it's conceivable that it might.
+					importPath: "github.com/pulumi/pulumi-std/sdk/go/std/encoding/json",
+					name:       "json",
+					want:       "json",
+				},
+				{importPath: "encoding/json", name: "json", want: "json2"},
+			},
+			wantGroups: [][]string{
+				{`json2 "encoding/json"`},
+				{`"github.com/pulumi/pulumi-std/sdk/go/std/encoding/json"`},
+			},
+		},
+		{
+			desc: "pulumi aws awsx conflict",
+			imports: []importCall{
+				{importPath: "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs", name: "ecs", want: "ecs"},
+				{importPath: "github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs", name: "ecs", want: "awsxecs"},
+			},
+			wantGroups: [][]string{
+				{
+					`"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"`,
+					`awsxecs "github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"`,
+				},
+			},
+		},
+		{
+			desc: "basename mismatch/std",
+			imports: []importCall{
+				{importPath: "math/rand/v2", name: "rand", want: "rand"},
+			},
+			wantGroups: [][]string{
+				{`rand "math/rand/v2"`},
+			},
+		},
+		{
+			desc: "basename mismatch/pulumi",
+			imports: []importCall{
+				{importPath: "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1", name: "corev1", want: "corev1"},
+			},
+			wantGroups: [][]string{
+				{`corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"`},
+			},
+		},
+		{
+			desc: "basename mismatch/third party",
+			imports: []importCall{
+				{importPath: "gopkg.in/yaml.v3", name: "yaml", want: "yaml"},
+			},
+			wantGroups: [][]string{
+				{`yaml "gopkg.in/yaml.v3"`},
+			},
+		},
+		{
+			desc: "already imported",
+			imports: []importCall{
+				{importPath: "example.com/foo/bar", name: "bar", want: "bar"},
+				{importPath: "example.com/baz/bar", name: "bar", want: "bazbar"},
+
+				// Reimport should get existing resolved names.
+				{importPath: "example.com/foo/bar", name: "bar", want: "bar"},
+				{importPath: "example.com/baz/bar", name: "bar", want: "bazbar"},
+			},
+			wantGroups: [][]string{
+				{
+					// Note:
+					// Imports are sorted by import path,
+					// not the order they were imported.
+					`bazbar "example.com/baz/bar"`,
+					`"example.com/foo/bar"`,
+				},
+			},
+		},
+		{
+			desc: "many conflicts",
+			imports: []importCall{
+				{importPath: "example.com/foo/bar", name: "bar", want: "bar"},
+				{importPath: "example.com/baz/bar", name: "bar", want: "bazbar"},
+				{importPath: "example.com/qux/bar", name: "bar", want: "quxbar"},
+				{importPath: "example.com/quux/bar", name: "bar", want: "quuxbar"},
+			},
+			wantGroups: [][]string{
+				{
+					// Note:
+					// Imports are sorted by import path,
+					// not the order they were imported.
+					`bazbar "example.com/baz/bar"`,
+					`"example.com/foo/bar"`,
+					`quuxbar "example.com/quux/bar"`,
+					`quxbar "example.com/qux/bar"`,
+				},
+			},
+		},
+		{
+			desc: "conflict with special characters",
+			imports: []importCall{
+				{importPath: "example.com/foo/bar-go", name: "bar", want: "bar"},
+				{importPath: "example.com/foo/bar.go", name: "bar", want: "foobargo"},
+				{importPath: "example.com/bar", name: "bar", want: "bar2"}, // nothing to join with
+				{importPath: "example.com/f-o-o/bar", name: "bar", want: "foobar"},
+			},
+			wantGroups: [][]string{
+				{
+					`bar2 "example.com/bar"`,
+					`foobar "example.com/f-o-o/bar"`,
+					`bar "example.com/foo/bar-go"`,
+					`foobargo "example.com/foo/bar.go"`,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			fimp := newFileImporter()
+			for _, imp := range tt.imports {
+				gotName := fimp.Import(imp.importPath, imp.name)
+				assert.Equal(t, imp.want, gotName, "Import(%q, %q)", imp.importPath, imp.name)
+			}
+
+			assert.Equal(t, tt.wantGroups, fimp.ImportGroups())
+		})
+	}
+}
+
+func TestFileImporter_Reset(t *testing.T) {
+	t.Parallel()
+
+	fimp := newFileImporter()
+	assert.Empty(t, fimp.ImportGroups())
+
+	// Add imports.
+	assert.Equal(t, "bar", fimp.Import("example.com/foo/bar", "bar"))
+	assert.Equal(t, "bazbar", fimp.Import("example.com/baz/bar", "bar"))
+	assert.NotEmpty(t, fimp.ImportGroups()) // sanity check
+
+	// Reset and check that imports are gone.
+	fimp.Reset()
+	assert.Empty(t, fimp.ImportGroups())
+
+	// Import again in reverse order.
+	// Prior state shouldn't affect result.
+	assert.Equal(t, "bar", fimp.Import("example.com/baz/bar", "bar"),
+		"should not get alias after reset")
+	assert.Equal(t, "foobar", fimp.Import("example.com/foo/bar", "bar"))
+}
+
+func TestToIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		give string
+		want string
+		ok   bool
+	}{
+		{"foo", "foo", true},
+		{"foo-bar", "foobar", true},
+		{"foo_bar", "foo_bar", true},
+		{"foo.bar", "foobar", true},
+		{"foo/123", "foo123", true},
+		{"foo.123/bar", "foo123bar", true},
+		{"123", "", false},
+		{"1/foo", "", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.give, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := toIdentifier(tt.give)
+			require.Equal(t, tt.ok, ok)
+			if ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSecondLastIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		haystack string
+		needle   string
+		want     int
+	}{
+		{
+			desc:     "empty",
+			haystack: "",
+			needle:   "foo",
+			want:     -1,
+		},
+		{
+			desc:     "no match",
+			haystack: "foo",
+			needle:   "bar",
+			want:     -1,
+		},
+		{
+			desc:     "one match",
+			haystack: "a/b",
+			needle:   "/",
+			want:     -1,
+		},
+		{
+			desc:     "two matches",
+			haystack: "a/b/c",
+			needle:   "/",
+			want:     1,
+		},
+		{
+			desc:     "three matches",
+			haystack: "a/b/c/d",
+			needle:   "/",
+			want:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := secondLastIndex(tt.haystack, tt.needle)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func newTestGenerator(t *testing.T, testFile string) *generator {
@@ -127,6 +490,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 		optionalSpiller:     &optionalSpiller{},
 		scopeTraversalRoots: codegen.NewStringSet(),
 		arrayHelpers:        make(map[string]*promptToInputArrayHelper),
+		importer:            newFileImporter(),
 	}
 	g.Formatter = format.NewFormatter(g)
 	return g

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -258,6 +258,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Multiline string literals",
 	},
 	{
+		Directory:   "regress-11176",
+		Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
+		Skip:        allProgLanguages.Except("go"),
+	},
+	{
 		Directory:   "throw-not-implemented",
 		Description: "Function notImplemented is compiled to a runtime error at call-site",
 	},

--- a/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
+++ b/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"git.example.org/thirdparty/sdk/go/pkg"
+	other "git.example.org/thirdparty/sdk/go/pkg"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := pkg.NewThing(ctx, "thing", &pkg.ThingArgs{
+		_, err := other.NewThing(ctx, "thing", &other.ThingArgs{
 			Idea: pulumi.String("myIdea"),
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/regress-11176-pp/go/regress-11176.go
+++ b/pkg/codegen/testing/test/testdata/regress-11176-pp/go/regress-11176.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cluster, err := ecs.NewCluster(ctx, "cluster", nil)
+		if err != nil {
+			return err
+		}
+		_, err = ecs.NewFargateService(ctx, "nginx", &ecs.FargateServiceArgs{
+			Cluster: cluster.Arn,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/regress-11176-pp/go/regress-11176.go
+++ b/pkg/codegen/testing/test/testdata/regress-11176-pp/go/regress-11176.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
-	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
+	awsxecs "github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -12,7 +12,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = ecs.NewFargateService(ctx, "nginx", &ecs.FargateServiceArgs{
+		_, err = awsxecs.NewFargateService(ctx, "nginx", &awsxecs.FargateServiceArgs{
 			Cluster: cluster.Arn,
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/regress-11176-pp/regress-11176.pp
+++ b/pkg/codegen/testing/test/testdata/regress-11176-pp/regress-11176.pp
@@ -1,0 +1,4 @@
+resource cluster "aws:ecs/cluster:Cluster" {}
+resource nginx "awsx:ecs:FargateService" {
+    cluster = cluster.arn
+}

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	resourceProperties "git.example.org/pulumi-synthetic/resourceProperties"
+	"git.example.org/pulumi-synthetic/resourceProperties"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
+++ b/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"git.example.org/thirdparty/sdk/go/pkg"
+	other "git.example.org/thirdparty/sdk/go/pkg"
 	"git.example.org/thirdparty/sdk/go/pkg/module"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := pkg.NewThing(ctx, "Other", &pkg.ThingArgs{
+		_, err := other.NewThing(ctx, "Other", &other.ThingArgs{
 			Idea: pulumi.String("Support Third Party"),
 		})
 		if err != nil {
@@ -26,7 +26,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = pkg.NewProvider(ctx, "Provider", &pkg.ProviderArgs{
+		_, err = other.NewProvider(ctx, "Provider", &other.ProviderArgs{
 			ObjectProp: pulumi.StringMap{
 				"prop1": pulumi.String("foo"),
 				"prop2": pulumi.String("bar"),


### PR DESCRIPTION
This fixes how programgen generates import statements
to handle conflicting imports when two imported packages
have the same name, e.g.

    github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs
    github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs

To do this, we add a fileImporter type that tracks these imports.
It prefers unnamed imports for packages unless one of the following is
true:

- the name of the package has already been used by another import
- the name of the package does not match the last component
  of the import path (e.g., `example.com/foo-go` with `package foo`).

If the name has already been used by another import,
it attempts the following in-order:

- Combine the last two path components of the import path
  into an identifier and use that if available.
  e.g., `awsxs3` from `sdk/go/awsx/s3`.
- Append a number to the package name and increment it
  until an unused name is found.
  e.g. `ecs2`, `ecs3`, and so on.

There's a change in how this information is tracked as well.
Previously, this was a pull approach: various calls returned
programImports objects which all got merged together.

This change switches to a push approach:
as code is generated and imports are requested,
they're submitted to the fileImporter which keeps track of them
until the next `Reset()` call.
The above also has a nice side effect of dropping a parameter.

Another change worth explicitly calling out:
Previously, getModOrAlias partially duplicated some of the logic
implemented in getPulumiImport, and used `mod`, `originalMod`
in a non-obvious way.
This generated incorrect imports like the following
(note the two `/aws` at the end):

    github.com/pulumi/pulumi-aws/sdk/v5/go/aws/aws

This change replicates more of the logic of getPulumiImport
(now called addPulumiImport) into this function,
and addresses the discrepancy in codegen caused by `mod`/`originalMod`.
The result leaves most existing code unchanged,
except in a couple existing cases where the resulting changes make sense
given the logic for named imports outlined above.

Resolves #11176