### PR TITLE
ci(lint): Upgrade golangci-lint to v1.53.3

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.52
+  GOLANGCI_LINT_VERSION: v1.53.3
 
 jobs:
   golangci:

--- a/pkg/codegen/hcl2/model/type_eventuals.go
+++ b/pkg/codegen/hcl2/model/type_eventuals.go
@@ -151,21 +151,21 @@ func containsEventualsImpl(t Type, seen map[Type]struct{}) (containsOutputs, con
 			containsOutputs = outputs || containsOutputs
 			containsPromises = promises || containsPromises
 		}
-		return
+		return containsOutputs, containsPromises
 	case *ObjectType:
 		for _, t := range t.Properties {
 			outputs, promises := containsEventualsImpl(t, seen)
 			containsOutputs = outputs || containsOutputs
 			containsPromises = promises || containsPromises
 		}
-		return
+		return containsOutputs, containsPromises
 	case *TupleType:
 		for _, t := range t.ElementTypes {
 			outputs, promises := containsEventualsImpl(t, seen)
 			containsOutputs = outputs || containsOutputs
 			containsPromises = promises || containsPromises
 		}
-		return
+		return containsOutputs, containsPromises
 	default:
 		return false, false
 	}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1198,7 +1198,7 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 	err error,
 ) {
 	if len(props) == 0 {
-		return
+		return nil, nil, nil
 	}
 
 	specs = make(map[string]PropertySpec, len(props))


### PR DESCRIPTION
Upgrades to the latest golangci-lint, fixing the following lint issues:

```
codegen/hcl2/model/type_eventuals.go:154:3: naked return in func `containsEventualsImpl` with 41 lines of code (nakedret)
codegen/hcl2/model/type_eventuals.go:161:3: naked return in func `containsEventualsImpl` with 41 lines of code (nakedret)
codegen/hcl2/model/type_eventuals.go:168:3: naked return in func `containsEventualsImpl` with 41 lines of code (nakedret)
codegen/schema/schema.go:1201:3: naked return in func `marshalProperties` with 50 lines of code (nakedret)
```
