### PR TITLE
Support interactive state edits

### DIFF
--- a/changelog/pending/20230628--cli-state--add-interactive-urn-selection-to-pulumi-state-rename-unprotect-delete.yaml
+++ b/changelog/pending/20230628--cli-state--add-interactive-urn-selection-to-pulumi-state-rename-unprotect-delete.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Add interactive URN selection to `pulumi state {rename,unprotect,delete}`.

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -241,7 +241,6 @@ func getURNFromState(
 	contract.Assertf(result.IsValid(),
 		"Because we chose from an existing URN, it must be valid")
 	return result, nil
-
 }
 
 // Ask the user for a resource name.

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -200,8 +200,8 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 //
 // stackName is the name of the current stack.
 //
-// snap is the snapshot of the current stack. snap cannot be nil, but (*snap) may be nil.
-// (*snap) will be set to the retrieved snapshot value is it is nil.
+// snap is the snapshot of the current stack.  If (*snap) is not nil, it will be set to
+// the retrieved snapshot value. This allows caching between calls.
 //
 // Prompt is displayed to the user when selecting the URN.
 func getURNFromState(

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -22,6 +22,8 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -30,10 +32,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
-	"github.com/spf13/cobra"
 )
 
 func newStateCmd() *cobra.Command {
@@ -192,4 +194,72 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 		Deployment: bytes,
 	}
 	return result.WrapIfNonNil(s.ImportDeployment(ctx, &dep))
+}
+
+// Prompt the user to select a URN from the passed in state.
+//
+// stackName is the name of the current stack.
+//
+// snap is the snapshot of the current stack. snap cannot be nil, but (*snap) may be nil.
+// (*snap) will be set to the retrieved snapshot value is it is nil.
+//
+// Prompt is displayed to the user when selecting the URN.
+func getURNFromState(
+	ctx context.Context, stackName string, snap **deploy.Snapshot, prompt string,
+) (resource.URN, error) {
+	if snap == nil {
+		// This means we won't cache the value.
+		snap = new(*deploy.Snapshot)
+	}
+	if *snap == nil {
+		opts := display.Options{
+			Color: cmdutil.GetGlobalColorization(),
+		}
+
+		s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+		if err != nil {
+			return "", err
+		}
+		*snap, err = s.Snapshot(ctx, stack.DefaultSecretsProvider)
+		if err != nil {
+			return "", err
+		}
+	}
+	urnList := make([]string, len((*snap).Resources))
+	for i, r := range (*snap).Resources {
+		urnList[i] = string(r.URN)
+	}
+	var urn string
+	err := survey.AskOne(&survey.Select{
+		Message: prompt,
+		Options: urnList,
+	}, &urn, survey.WithValidator(survey.Required), surveyIcons(cmdutil.GetGlobalColorization()))
+	if err != nil {
+		return "", err
+	}
+	result := resource.URN(urn)
+	contract.Assertf(result.IsValid(),
+		"Because we chose from an existing URN, it must be valid")
+	return result, nil
+
+}
+
+// Ask the user for a resource name.
+func getNewResourceName() (tokens.QName, error) {
+	var resourceName string
+	err := survey.AskOne(&survey.Input{
+		Message: "Choose a new resource name:",
+	}, &resourceName, surveyIcons(cmdutil.GetGlobalColorization()),
+		survey.WithValidator(func(ans interface{}) error {
+			if tokens.IsQName(ans.(string)) {
+				return nil
+			}
+			return fmt.Errorf("resource names may only contain alphanumerics, underscores, hyphens, dots, and slashes")
+		}))
+	if err != nil {
+		return "", err
+	}
+	contract.Assertf(tokens.IsQName(resourceName),
+		"Survey validated that resourceName %q is a QName", resourceName)
+	return tokens.QName(resourceName), nil
 }

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -55,7 +55,7 @@ Make sure that URNs are single-quoted to avoid having characters unexpectedly in
 			var urn resource.URN
 			if len(args) == 0 {
 				if !cmdutil.Interactive() {
-					return result.Error("Must supply <resource URN> unless run in interactive mode")
+					return missingNonInteractiveArg("resource URN")
 				}
 
 				var err error

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -34,12 +34,12 @@ func newStateDeleteCommand() *cobra.Command {
 	var targetDepenedents bool
 
 	cmd := &cobra.Command{
-		Use:   "delete <resource URN>",
+		Use:   "delete [resource URN]",
 		Short: "Deletes a resource from a stack's state",
 		Long: `Deletes a resource from a stack's state
 
 This command deletes a resource from a stack's state, as long as it is safe to do so. The resource is specified
-by its Pulumi URN (use ` + "`pulumi stack --show-urns`" + ` to get it).
+by its Pulumi URN. If the URN is omitted, this command will prompt for it.
 
 Resources can't be deleted if there exist other resources that depend on it or are parented to it. Protected resources
 will not be deleted unless it is specifically requested using the --force flag.
@@ -47,11 +47,26 @@ will not be deleted unless it is specifically requested using the --force flag.
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
 `,
 		Example: "pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'",
-		Args:    cmdutil.ExactArgs(1),
+		Args:    cmdutil.MaximumNArgs(1),
+
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()
-			urn := resource.URN(args[0])
+			var urn resource.URN
+			if len(args) == 0 {
+				if !cmdutil.Interactive() {
+					return result.Error("Must supply <resource URN> unless run in interactive mode")
+				}
+
+				var err error
+				urn, err = getURNFromState(ctx, stack, nil,
+					"Select the resource to delete")
+				if err != nil {
+					return result.FromError(err)
+				}
+			} else {
+				urn = resource.URN(args[0])
+			}
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -45,6 +45,8 @@ Resources can't be deleted if there exist other resources that depend on it or a
 will not be deleted unless it is specifically requested using the --force flag.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
+
+To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 `,
 		Example: "pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider'",
 		Args:    cmdutil.MaximumNArgs(1),

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -45,7 +45,9 @@ func updateDependencies(dependencies []resource.URN, oldUrn resource.URN, newUrn
 }
 
 // stateRenameOperation renames a resource (or provider) and mutates/rewrites references to it in the snapshot.
-func stateRenameOperation(urn resource.URN, newResourceName tokens.QName, opts display.Options, snap *deploy.Snapshot) error {
+func stateRenameOperation(
+	urn resource.URN, newResourceName tokens.QName, opts display.Options, snap *deploy.Snapshot,
+) error {
 	// Check whether the input URN corresponds to an existing resource
 	existingResources := edit.LocateResource(snap, urn)
 	if len(existingResources) != 1 {
@@ -158,7 +160,7 @@ Make sure that URNs are single-quoted to avoid having characters unexpectedly in
 					},
 					func() (err error) {
 						newResourceName, err = getNewResourceName()
-						return err
+						return
 					},
 				)
 				if err != nil {

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -145,7 +145,7 @@ Make sure that URNs are single-quoted to avoid having characters unexpectedly in
 			yes = yes || skipConfirmations()
 
 			if len(args) < 2 && !cmdutil.Interactive() {
-				return result.Error("Must supply <resource URN> and <new name> unless in an interactive session")
+				return missingNonInteractiveArg("resource URN", "new name")
 			}
 
 			var urn resource.URN

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -55,7 +55,7 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 
 			if len(args) != 1 {
 				if !cmdutil.Interactive() {
-					return result.Error("Must supply <resource URN> unless in an interactive session")
+					return missingNonInteractiveArg("resource URN")
 				}
 				var err error
 				urn, err = getURNFromState(ctx, stack, nil, "Select a resource to unprotect:")

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -51,11 +51,20 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 				return unprotectAllResources(ctx, stack, showPrompt)
 			}
 
-			if len(args) != 1 {
-				return result.Error("must provide a URN corresponding to a resource")
-			}
+			var urn resource.URN
 
-			urn := resource.URN(args[0])
+			if len(args) != 1 {
+				if !cmdutil.Interactive() {
+					return result.Error("Must supply <resource URN> unless in an interactive session")
+				}
+				var err error
+				urn, err = getURNFromState(ctx, stack, nil, "Select a resource to unprotect:")
+				if err != nil {
+					return result.FromError(err)
+				}
+			} else {
+				urn = resource.URN(args[0])
+			}
 			return unprotectResource(ctx, stack, urn, showPrompt)
 		}),
 	}

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -35,11 +35,13 @@ func newStateUnprotectCommand() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "unprotect <resource URN>",
+		Use:   "unprotect [resource URN]",
 		Short: "Unprotect resources in a stack's state",
 		Long: `Unprotect resource in a stack's state
 
-This command clears the 'protect' bit on one or more resources, allowing those resources to be deleted.`,
+This command clears the 'protect' bit on one or more resources, allowing those resources to be deleted.
+
+To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -61,6 +61,7 @@ import (
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -1066,4 +1067,21 @@ func surveyStack(interactions ...func() error) error {
 		}
 	}
 	return nil
+}
+
+// Format a non-nil result.Result that indicates some arguments are missing for a
+// non-interactive session.
+func missingNonInteractiveArg(args ...string) result.Result {
+	switch len(args) {
+	case 0:
+		panic("cannot create an error message for missing zero args")
+	case 1:
+		return result.Errorf("Must supply <%s> unless pulumi is run interactively", args[0])
+	default:
+		for i, s := range args {
+			args[i] = "<" + s + ">"
+		}
+		return result.Errorf("Must supply %s and %s unless pulumi is run interactively",
+			strings.Join(args[:len(args)-1], ", "), args[len(args)-1])
+	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Using `pulumi state {delete,rename,unprotect}` to perform state edits requires knowing the relevant resource URN ahead of time. It's common to know part of the URN you want (say, the name) but not have the full URN memorized. 

We should allow the user to omit the URN, and then allow the user to select from the list of valid URNs in the current stack.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
