### PR TITLE
Increase nakedret limit to 60

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.52
+  GOLANGCI_LINT_VERSION: v1.53
 
 jobs:
   golangci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,10 @@ linters:
     - paralleltest
 
 linters-settings:
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 60
   nolintlint:
     # Some linter exclusions are added to generated or templated files
     # pre-emptively.


### PR DESCRIPTION

# Description

Upgrade the version of `golangci-lint` used in CI from `v1.52` to `v1.53` (latest).

This requires to a small adjustment to `nakedret` to keep our code passing `golangci-lint`. I think 60 lines is a reasonable limit, since a 60 line function still fits on a laptop screen.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
