### PR TITLE
Don't try to install provider during schema loading unless missing

### DIFF
--- a/changelog/pending/20230628--sdkgen--fix-loading-schemas-from-providers-on-path.yaml
+++ b/changelog/pending/20230628--sdkgen--fix-loading-schemas-from-providers-on-path.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: Fix loading schemas from providers on PATH.

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -24,11 +24,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pulumi/pulumi/pkg/v3/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -164,12 +165,16 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 					Name:    pkg,
 					Version: version,
 				}
-				util.SetKnownPluginDownloadURL(&spec)
 
-				err = host.InstallPlugin(spec)
+				log := func(sev diag.Severity, msg string) {
+					host.Log(sev, "", msg, 0)
+				}
+
+				_, err = pkgWorkspace.InstallPlugin(spec, log)
 				if err != nil {
 					return nil, err
 				}
+
 				p, err := host.Provider(tokens.Package(pkg), version)
 				if err != nil {
 					return nil, err

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,8 +29,8 @@ import (
 	"github.com/blang/semver"
 	"github.com/segmentio/encoding/json"
 
-	"github.com/pulumi/pulumi/pkg/v3/util"
-
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -212,21 +213,32 @@ func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (P
 }
 
 func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]byte, *semver.Version, error) {
-	spec := workspace.PluginSpec{
-		Kind:    workspace.ResourcePlugin,
-		Name:    pkg,
-		Version: version,
-	}
-	util.SetKnownPluginDownloadURL(&spec)
-
-	err := l.host.InstallPlugin(spec)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	pluginInfo, err := l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, version)
 	if err != nil {
-		return nil, nil, err
+		var missingError *workspace.MissingError
+		if errors.As(err, &missingError) {
+			spec := workspace.PluginSpec{
+				Kind:    workspace.ResourcePlugin,
+				Name:    pkg,
+				Version: version,
+			}
+
+			log := func(sev diag.Severity, msg string) {
+				l.host.Log(sev, "", msg, 0)
+			}
+
+			_, err = pkgWorkspace.InstallPlugin(spec, log)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			pluginInfo, err = l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, version)
+			if err != nil {
+				return nil, version, err
+			}
+		} else {
+			return nil, nil, err
+		}
 	}
 	contract.Assertf(pluginInfo != nil, "loading pkg %q: pluginInfo was unexpectedly nil", pkg)
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -426,10 +426,6 @@ func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plug
 	return nil
 }
 
-func (host *pluginHost) InstallPlugin(plugin workspace.PluginSpec) error {
-	return nil
-}
-
 func (host *pluginHost) ResolvePlugin(
 	kind workspace.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -91,10 +91,6 @@ func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds 
 	return nil
 }
 
-func (host *testPluginHost) InstallPlugin(plugin workspace.PluginSpec) error {
-	return nil
-}
-
 func (host *testPluginHost) ResolvePlugin(
 	kind workspace.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blang/semver"
 
+	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -64,6 +65,7 @@ func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, 
 			return nil, fmt.Errorf("could not find latest version for provider %s: %w", pluginSpec.Name, err)
 		}
 	}
+	util.SetKnownPluginDownloadURL(&pluginSpec)
 
 	wrapper := func(stream io.ReadCloser, size int64) io.ReadCloser {
 		log(diag.Info, fmt.Sprintf("Downloading provider: %s", pluginSpec.Name))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1247

When running tfgen the provider plugin is generally only available on PATH, not in the plugins directory. The schema loader was only checking the plugins directory to decided if it had a resource provider already installed, and so sent off lots of github requests to lookup latest versions of plugins while running example conversion.

This changes the schema loader to use the same logic we use elsewhere where we try to use the provider (which will also look at PATH) and then if we get a missing plugin error we'll do the install and then try again.

I've also moved the `SetKnownPluginDownloadURL` call into workspace.InstallPlugin so we don't forget to call it before passing specs in.

Finally I've also removed the InstallPlugin method from Host as the only place it was used was in the schema loader, which is now using workspace.InstallPlugin like everywhere else.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
