### PR TITLE
Use slice.Prealloc instead of make([]T, 0, ...)

### DIFF
--- a/changelog/pending/20230628--cli-display--fix-diffs-sometimes-not-showing-even-in-details-view.yaml
+++ b/changelog/pending/20230628--cli-display--fix-diffs-sometimes-not-showing-even-in-details-view.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix diffs sometimes not showing even in details view.

--- a/developer-docs/go.mod
+++ b/developer-docs/go.mod
@@ -2,4 +2,9 @@ module github.com/pulumi/pulumi/developer-docs
 
 go 1.18
 
-require github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
+replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
+
+require (
+	github.com/pulumi/pulumi/sdk/v3 v3.73.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
+)

--- a/developer-docs/utils/jsonschema2md.go
+++ b/developer-docs/utils/jsonschema2md.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -289,7 +290,7 @@ func (c *converter) convertSchemaObject(schema *jsonschema.Schema, level int) {
 		required[name] = true
 	}
 
-	properties := make([]string, 0, len(schema.Properties))
+	properties := slice.Prealloc[string](len(schema.Properties))
 	for name, schema := range schema.Properties {
 		if schema.Always != nil && !*schema.Always {
 			continue
@@ -347,7 +348,7 @@ func (c *converter) convertRootSchema(schema *jsonschema.Schema) {
 
 	c.convertSchema(schema, level)
 
-	defs := make([]*jsonschema.Schema, 0, len(c.defs))
+	defs := slice.Prealloc[*jsonschema.Schema](len(c.defs))
 	for _, def := range c.defs {
 		defs = append(defs, def)
 	}
@@ -405,7 +406,7 @@ func main() {
 		return jsonschema.LoadURL(s)
 	}
 
-	schemas := make([]*jsonschema.Schema, 0, len(ids))
+	schemas := slice.Prealloc[*jsonschema.Schema](len(ids))
 	for id := range ids {
 		schema, err := compiler.Compile(id)
 		if err != nil {

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -313,7 +313,7 @@ func createDiff(updateKind apitype.UpdateKind, events []engine.Event, displayOpt
 	seen := make(map[resource.URN]engine.StepEventMetadata)
 	displayOpts.SummaryDiff = true
 
-	outputEventsDiff := make([]string, 0)
+	var outputEventsDiff []string
 	for _, e := range events {
 		if e.Type == engine.SummaryEvent {
 			continue

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -274,7 +275,7 @@ func renderPreludeEvent(event engine.PreludeEventPayload, opts Options) string {
 	fprintIgnoreError(out, opts.Color.Colorize(
 		fmt.Sprintf("%sConfiguration:%s\n", colors.SpecUnimportant, colors.Reset)))
 
-	keys := make([]string, 0, len(event.Config))
+	keys := slice.Prealloc[string](len(event.Config))
 	for key := range event.Config {
 		keys = append(keys, key)
 	}

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -155,10 +156,12 @@ func convertStepEventMetadata(md engine.StepEventMetadata, showSecrets bool) api
 	for i, v := range md.Keys {
 		keys[i] = string(v)
 	}
-	diffs := make([]string, 0, len(md.Diffs))
+
+	diffs := slice.Prealloc[string](len(md.Diffs))
 	for _, v := range md.Diffs {
 		diffs = append(diffs, string(v))
 	}
+
 	var detailedDiff map[string]apitype.PropertyDiff
 	if md.DetailedDiff != nil {
 		detailedDiff = make(map[string]apitype.PropertyDiff)
@@ -338,11 +341,7 @@ func convertJSONStepEventMetadata(md apitype.StepEventMetadata) engine.StepEvent
 	for i, v := range md.Keys {
 		keys[i] = resource.PropertyKey(v)
 	}
-	//nolint:prealloc
-	var diffs []resource.PropertyKey
-	if len(md.Diffs) > 0 {
-		diffs = make([]resource.PropertyKey, 0, len(md.Diffs))
-	}
+	diffs := slice.Prealloc[resource.PropertyKey](len(md.Diffs))
 	for _, v := range md.Diffs {
 		diffs = append(diffs, resource.PropertyKey(v))
 	}

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"gopkg.in/yaml.v3"
@@ -912,8 +913,8 @@ func (p *propertyPrinter) printAssetsDiff(oldAssets, newAssets map[string]interf
 	// as an add.  For any asset in both we print out of it is unchanged or not.  If so, we
 	// recurse on that data to print out how it changed.
 
-	oldNames := make([]string, 0, len(oldAssets))
-	newNames := make([]string, 0, len(newAssets))
+	oldNames := slice.Prealloc[string](len(oldAssets))
+	newNames := slice.Prealloc[string](len(newAssets))
 
 	for name := range oldAssets {
 		oldNames = append(oldNames, name)
@@ -929,7 +930,7 @@ func (p *propertyPrinter) printAssetsDiff(oldAssets, newAssets map[string]interf
 	i := 0
 	j := 0
 
-	keys := make([]resource.PropertyKey, 0, len(oldNames)+len(newNames))
+	keys := slice.Prealloc[resource.PropertyKey](len(oldNames) + len(newNames))
 	for _, name := range oldNames {
 		keys = append(keys, "\""+resource.PropertyKey(name)+"\"")
 	}

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type Row interface {
@@ -465,7 +466,7 @@ func getDiffInfo(step engine.StepEventMetadata, action apitype.UpdateKind) strin
 			}
 
 			filteredKeys := func(m resource.PropertyMap) []string {
-				keys := make([]string, 0, len(m))
+				keys := slice.Prealloc[string](len(m))
 				for k := range m {
 					keys = append(keys, string(k))
 				}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -765,7 +766,7 @@ func (b *localBackend) ListStacks(
 
 	// Note that the provided stack filter is only partially honored, since fields like organizations and tags
 	// aren't persisted in the local backend.
-	results := make([]backend.StackSummary, 0, len(stacks))
+	results := slice.Prealloc[backend.StackSummary](len(stacks))
 	for _, stackRef := range stacks {
 		// We can check for project name filter here, but be careful about legacy stores where project is always blank.
 		stackProject, hasProject := stackRef.Project()

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
@@ -209,7 +210,7 @@ func (p *projectReferenceStore) ListProjects(ctx context.Context) ([]tokens.Name
 		return nil, fmt.Errorf("error listing stacks: %w", err)
 	}
 
-	projects := make([]tokens.Name, 0, len(files))
+	projects := slice.Prealloc[tokens.Name](len(files))
 	for _, file := range files {
 		if !file.IsDir {
 			continue // ignore files
@@ -368,7 +369,7 @@ func (p *legacyReferenceStore) ListReferences(ctx context.Context) ([]*localBack
 	if err != nil {
 		return nil, fmt.Errorf("error listing stacks: %w", err)
 	}
-	stacks := make([]*localBackendReference, 0, len(files))
+	stacks := slice.Prealloc[*localBackendReference](len(files))
 
 	for _, file := range files {
 		if file.IsDir {

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -312,7 +312,7 @@ func TestProjectReferenceStore_List(t *testing.T) {
 		{
 			desc:     "empty",
 			stacks:   []tokens.QName{},
-			projects: []tokens.Name{},
+			projects: nil,
 		},
 		{
 			desc: "json",

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -51,6 +51,7 @@ import (
 	sdkDisplay "github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -869,7 +870,7 @@ func (b *cloudBackend) ListStacks(
 	}
 
 	// Convert []apitype.StackSummary into []backend.StackSummary.
-	backendSummaries := make([]backend.StackSummary, 0, len(apiSummaries))
+	backendSummaries := slice.Prealloc[backend.StackSummary](len(apiSummaries))
 	for _, apiSummary := range apiSummaries {
 		backendSummary := cloudStackSummary{
 			summary: apiSummary,
@@ -1267,7 +1268,7 @@ func (b *cloudBackend) GetHistory(
 	}
 
 	// Convert apitype.UpdateInfo objects to the backend type.
-	beUpdates := make([]backend.UpdateInfo, 0, len(updates))
+	beUpdates := slice.Prealloc[backend.UpdateInfo](len(updates))
 	for _, update := range updates {
 		// Convert types from the apitype package into their internal counterparts.
 		cfg, err := convertConfig(update.Config)

--- a/pkg/backend/httpstate/diffs_post_1.20.go
+++ b/pkg/backend/httpstate/diffs_post_1.20.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hexops/gotextdiff/span"
 	"github.com/pgavlin/diff/lcs"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	segmentio_json "github.com/segmentio/encoding/json"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -51,8 +52,8 @@ type spans struct {
 
 func newSpans(capacity int) spans {
 	return spans{
-		offsets: make([]int, 0, capacity),
-		spans:   make([][]byte, 0, capacity),
+		offsets: slice.Prealloc[int](capacity),
+		spans:   slice.Prealloc[[]byte](capacity),
 	}
 }
 

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -533,7 +534,7 @@ func (runtime projectRuntimeAbout) MarshalJSON() ([]byte, error) {
 }
 
 func (runtime projectRuntimeAbout) String() string {
-	params := make([]string, 0, len(runtime.other))
+	params := slice.Prealloc[string](len(runtime.other))
 
 	if r := runtime.Executable; r != "" {
 		params = append(params, fmt.Sprintf("executable='%s'", r))

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -122,7 +123,7 @@ func newLogsCmd() *cobra.Command {
 
 				// When we are emitting a fixed number of log entries, and outputing JSON, wrap them in an array.
 				if !follow && jsonOut {
-					entries := make([]logEntryJSON, 0, len(logs))
+					entries := slice.Prealloc[logEntryJSON](len(logs))
 
 					for _, logEntry := range logs {
 						if _, shownAlready := shown[logEntry]; !shownAlready {

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -52,6 +52,7 @@ func panicHandler(finished *bool) {
 func main() {
 	finished := new(bool)
 	defer panicHandler(finished)
+
 	if err := NewPulumiCmd().Execute(); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -206,7 +207,7 @@ func fprintStackOutputs(w io.Writer, outputs map[string]interface{}) error {
 		return err
 	}
 
-	outKeys := make([]string, 0, len(outputs))
+	outKeys := slice.Prealloc[string](len(outputs))
 	for v := range outputs {
 		outKeys = append(outKeys, v)
 	}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -214,7 +215,7 @@ func (w *bashStackOutputWriter) WriteOne(k string, v interface{}) error {
 }
 
 func (w *bashStackOutputWriter) WriteMany(outputs map[string]interface{}) error {
-	keys := make([]string, 0, len(outputs))
+	keys := slice.Prealloc[string](len(outputs))
 	for v := range outputs {
 		keys = append(keys, v)
 	}
@@ -245,7 +246,7 @@ func (w *powershellStackOutputWriter) WriteOne(k string, v interface{}) error {
 }
 
 func (w *powershellStackOutputWriter) WriteMany(outputs map[string]interface{}) error {
-	keys := make([]string, 0, len(outputs))
+	keys := slice.Prealloc[string](len(outputs))
 	for v := range outputs {
 		keys = append(keys, v)
 	}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -125,13 +126,13 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 }
 
 func printStackTags(tags map[apitype.StackTagName]string) {
-	names := make([]string, 0, len(tags))
+	names := slice.Prealloc[string](len(tags))
 	for n := range tags {
 		names = append(names, n)
 	}
 	sort.Strings(names)
 
-	rows := make([]cmdutil.TableRow, 0, len(names))
+	rows := slice.Prealloc[cmdutil.TableRow](len(names))
 	for _, name := range names {
 		rows = append(rows, cmdutil.TableRow{Columns: []string{name, tags[name]}})
 	}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -83,7 +84,7 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 	prompt := "Multiple resources with the given URN exist, please select the one to edit:"
 	prompt = opts.Color.Colorize(colors.SpecPrompt + prompt + colors.Reset)
 
-	options := make([]string, 0, len(candidateResources))
+	options := slice.Prealloc[string](len(candidateResources))
 	optionMap := make(map[string]*resource.State)
 	for _, ambiguousResource := range candidateResources {
 		// Prompt the user to select from a list of IDs, since these resources are known to all have the same URN.

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -54,6 +54,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -397,7 +398,7 @@ func chooseStack(ctx context.Context,
 		inContToken = outContToken
 	}
 
-	options := make([]string, 0, len(allSummaries))
+	options := slice.Prealloc[string](len(allSummaries))
 	for _, summary := range allSummaries {
 		name := summary.Name().String()
 		options = append(options, name)

--- a/pkg/codegen/cgstrings/cgstrings.go
+++ b/pkg/codegen/cgstrings/cgstrings.go
@@ -4,6 +4,8 @@ package cgstrings
 import (
 	"strings"
 	"unicode"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // Unhyphenate removes all hyphens from s, then uppercasing the letter following each hyphen.
@@ -19,7 +21,7 @@ func Camel(s string) string {
 	}
 	s = Unhyphenate(s)
 	runes := []rune(s)
-	res := make([]rune, 0, len(runes))
+	res := slice.Prealloc[rune](len(runes))
 	for i, r := range runes {
 		if unicode.IsLower(r) {
 			res = append(res, runes[i:]...)

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -431,7 +432,7 @@ func (mod *modContext) withDocGenContext(dctx *docGenContext) *modContext {
 	}
 	newctx := *mod
 	newctx.docGenContext = dctx
-	children := make([]*modContext, 0, len(newctx.children))
+	children := slice.Prealloc[*modContext](len(newctx.children))
 	for _, c := range newctx.children {
 		children = append(children, c.withDocGenContext(dctx))
 	}
@@ -904,7 +905,7 @@ func (mod *modContext) genConstructorPython(r *schema.Resource, argsOptional, ar
 	}
 
 	// We perform at least three appends before iterating over input types.
-	params := make([]formalParam, 0, 3+len(r.InputProperties))
+	params := slice.Prealloc[formalParam](3 + len(r.InputProperties))
 
 	params = append(params, formalParam{
 		Name: "resource_name",
@@ -988,7 +989,7 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 	// and if it appears in an input object and/or output object.
 	mod.getTypes(member, tokens)
 
-	sortedTokens := make([]string, 0, len(tokens))
+	sortedTokens := slice.Prealloc[string](len(tokens))
 	for token := range tokens {
 		sortedTokens = append(sortedTokens, token)
 	}
@@ -1076,7 +1077,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 	if len(properties) == 0 {
 		return nil
 	}
-	docProperties := make([]property, 0, len(properties))
+	docProperties := slice.Prealloc[property](len(properties))
 	for _, prop := range properties {
 		if prop == nil {
 			continue
@@ -1474,7 +1475,7 @@ func (mod *modContext) getPythonLookupParams(r *schema.Resource, stateParam stri
 	// The input properties for a resource needs to be exploded as
 	// individual constructor params.
 	docLanguageHelper := dctx.getLanguageDocHelper("python")
-	params := make([]formalParam, 0, len(r.StateInputs.Properties))
+	params := slice.Prealloc[formalParam](len(r.StateInputs.Properties))
 	for _, p := range r.StateInputs.Properties {
 		def, err := mod.pkg.Definition()
 		contract.AssertNoErrorf(err, "failed to get definition for package %q", mod.pkg.Name())
@@ -1839,7 +1840,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 	}
 
 	// If there are submodules, list them.
-	modules := make([]indexEntry, 0, len(mod.children))
+	modules := slice.Prealloc[indexEntry](len(mod.children))
 	for _, mod := range mod.children {
 		modName := mod.getModuleFileName()
 		displayName := modFilenameToDisplayName(modName)
@@ -1855,7 +1856,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 	sortIndexEntries(modules)
 
 	// If there are resources in the root, list them.
-	resources := make([]indexEntry, 0, len(mod.resources))
+	resources := slice.Prealloc[indexEntry](len(mod.resources))
 	for _, r := range mod.resources {
 		title := resourceName(r)
 		link := getResourceLink(title)
@@ -1877,7 +1878,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 	sortIndexEntries(resources)
 
 	// If there are functions in the root, list them.
-	functions := make([]indexEntry, 0, len(mod.functions))
+	functions := slice.Prealloc[indexEntry](len(mod.functions))
 	for _, f := range mod.functions {
 		name := tokenToName(f.Token)
 		link := getFunctionLink(name)

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -27,6 +27,7 @@ import (
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -292,7 +293,7 @@ func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string
 			inputs = inputs.InputShape
 		}
 
-		params = make([]formalParam, 0, len(inputs.Properties))
+		params = slice.Prealloc[formalParam](len(inputs.Properties))
 		for _, prop := range inputs.Properties {
 
 			var schemaType schema.Type
@@ -316,7 +317,7 @@ func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string
 			})
 		}
 	} else {
-		params = make([]formalParam, 0, 1)
+		params = slice.Prealloc[formalParam](1)
 	}
 
 	params = append(params, formalParam{

--- a/pkg/codegen/docs/gen_method.go
+++ b/pkg/codegen/docs/gen_method.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -56,7 +57,7 @@ type methodDocArgs struct {
 }
 
 func (mod *modContext) genMethods(r *schema.Resource) []methodDocArgs {
-	methods := make([]methodDocArgs, 0, len(r.Methods))
+	methods := slice.Prealloc[methodDocArgs](len(r.Methods))
 	for _, m := range r.Methods {
 		methods = append(methods, mod.genMethod(r, m))
 	}
@@ -201,7 +202,7 @@ func (mod *modContext) genMethodPython(f *schema.Function) []formalParam {
 
 	if f.Inputs != nil {
 		// Filter out the __self__ argument from the inputs.
-		args := make([]*schema.Property, 0, len(f.Inputs.InputShape.Properties)-1)
+		args := slice.Prealloc[*schema.Property](len(f.Inputs.InputShape.Properties) - 1)
 		for _, arg := range f.Inputs.InputShape.Properties {
 			if arg.Name == "__self__" {
 				continue

--- a/pkg/codegen/docs/package_tree.go
+++ b/pkg/codegen/docs/package_tree.go
@@ -3,6 +3,8 @@ package docs
 import (
 	"fmt"
 	"sort"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type entryType string
@@ -28,7 +30,7 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 	numFunctions := len(rootMod.functions)
 	// +1 to add the module itself as an entry.
 	size := numResources + numFunctions + 1
-	packageTree := make([]PackageTreeItem, 0, size)
+	packageTree := slice.Prealloc[PackageTreeItem](size)
 
 	conflictResolver := rootMod.docGenContext.newModuleConflictResolver()
 

--- a/pkg/codegen/docs/utils.go
+++ b/pkg/codegen/docs/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -39,7 +40,7 @@ func isPythonTypeNameBoundary(prev rune, next rune) bool {
 
 // wbr inserts HTML <wbr> in between case changes, e.g. "fooBar" becomes "foo<wbr>Bar".
 func wbr(s string) string {
-	runes := make([]rune, 0, len(s))
+	runes := slice.Prealloc[rune](len(s))
 	var prev rune
 	for i, r := range s {
 		if i != 0 &&

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -1245,7 +1246,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		var args []*schema.Property
 		if fun.Inputs != nil {
 			// Filter out the __self__ argument from the inputs.
-			args = make([]*schema.Property, 0, len(fun.Inputs.InputShape.Properties)-1)
+			args = slice.Prealloc[*schema.Property](len(fun.Inputs.InputShape.Properties) - 1)
 			for _, arg := range fun.Inputs.InputShape.Properties {
 				if arg.Name == "__self__" {
 					continue

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -3631,7 +3632,7 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 	}
 
 	// emit each package
-	pkgMods := make([]string, 0, len(packages))
+	pkgMods := slice.Prealloc[string](len(packages))
 	for mod := range packages {
 		pkgMods = append(pkgMods, mod)
 	}
@@ -3714,7 +3715,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 	}
 
 	// emit each package
-	pkgMods := make([]string, 0, len(packages))
+	pkgMods := slice.Prealloc[string](len(packages))
 	for mod := range packages {
 		pkgMods = append(pkgMods, mod)
 	}
@@ -3855,7 +3856,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 		}
 
 		// Types
-		sortedKnownTypes := make([]schema.Type, 0, len(knownTypes))
+		sortedKnownTypes := slice.Prealloc[schema.Type](len(knownTypes))
 		for k := range knownTypes {
 			sortedKnownTypes = append(sortedKnownTypes, k)
 		}

--- a/pkg/codegen/go/gen_crd2pulumi.go
+++ b/pkg/codegen/go/gen_crd2pulumi.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // CRDTypes returns a map from each module name to a buffer containing the
@@ -23,7 +24,7 @@ func CRDTypes(tool string, pkg *schema.Package) (map[string]*bytes.Buffer, error
 		return nil, err
 	}
 
-	pkgMods := make([]string, 0, len(packages))
+	pkgMods := slice.Prealloc[string](len(packages))
 	for mod := range packages {
 		pkgMods = append(pkgMods, mod)
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -996,7 +997,7 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type) (
 	expr, oTemps, optDiags := g.rewriteOptionals(expr, g.optionalSpiller)
 
 	bufferSize := len(tTemps) + len(jTemps) + len(rTemps) + len(sTemps) + len(oTemps)
-	temps := make([]interface{}, 0, bufferSize)
+	temps := slice.Prealloc[interface{}](bufferSize)
 	for _, t := range tTemps {
 		temps = append(temps, t)
 	}
@@ -1082,7 +1083,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 func (g *generator) rewriteThenForAllApply(
 	then *model.AnonymousFunctionExpression,
 ) (*model.AnonymousFunctionExpression, []string) {
-	typeConvDecls := make([]string, 0, len(then.Parameters))
+	typeConvDecls := slice.Prealloc[string](len(then.Parameters))
 	for i, v := range then.Parameters {
 		typ := g.argumentTypeName(nil, v.VariableType, false)
 		decl := fmt.Sprintf("%s := _args[%d].(%s)", v.Name, i, typ)

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
 )
 
@@ -211,7 +212,7 @@ func TestPackageNaming(t *testing.T) {
 			}
 			files, err := GeneratePackage("test", schema)
 			require.NoError(t, err)
-			ordering := make([]string, 0, len(files))
+			ordering := slice.Prealloc[string](len(files))
 			for k := range files {
 				ordering = append(ordering, k)
 			}

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -1310,7 +1311,7 @@ func escapeString(s string) string {
 
 	// Escape `${`
 	runes := []rune(s)
-	out := make([]rune, 0, len(runes))
+	out := slice.Prealloc[rune](len(runes))
 	for i, r := range runes {
 		next := func() rune {
 			if i >= len(runes)-1 {
@@ -1506,7 +1507,7 @@ func (x *ObjectConsExpression) WithType(updateType func(Type) *ObjectConsExpress
 func (x *ObjectConsExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
-	keys := make([]Expression, 0, len(x.Items))
+	keys := slice.Prealloc[Expression](len(x.Items))
 	for _, item := range x.Items {
 		if typecheckOperands {
 			keyDiags := item.Key.Typecheck(true)

--- a/pkg/codegen/hcl2/model/pretty/display.go
+++ b/pkg/codegen/hcl2/model/pretty/display.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 const (
@@ -391,7 +393,7 @@ func (o *Object) hash(seen map[Formatter]bool) string {
 	defer func() { seen[o] = false }()
 	seen[o] = true
 	s := "o("
-	keys := make([]string, 0, len(o.Properties))
+	keys := slice.Prealloc[string](len(o.Properties))
 	for key := range o.Properties {
 		keys = append(keys, key)
 	}
@@ -413,7 +415,7 @@ func (o *Object) visit(visiter func(Formatter) func()) {
 	}
 	defer leave()
 	// Check if we can do the whole object in a single line
-	keys := make([]string, 0, len(o.Properties))
+	keys := slice.Prealloc[string](len(o.Properties))
 	for key := range o.Properties {
 		keys = append(keys, key)
 	}
@@ -442,7 +444,7 @@ func (o *Object) string(tg *tagGenerator) string {
 	}
 
 	// Check if we can do the whole object in a single line
-	keys := make([]string, 0, len(o.Properties))
+	keys := slice.Prealloc[string](len(o.Properties))
 	for key := range o.Properties {
 		keys = append(keys, key)
 	}

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // unwrapIterableSourceType removes any eventual types that wrap a type intended for iteration.
@@ -76,7 +77,7 @@ func GetCollectionTypes(collectionType Type, rng hcl.Range) (Type, Type, hcl.Dia
 	case *ObjectType:
 		keyType = StringType
 
-		types := make([]Type, 0, len(collectionType.Properties))
+		types := slice.Prealloc[Type](len(collectionType.Properties))
 		for _, t := range collectionType.Properties {
 			types = append(types, t)
 		}

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -88,7 +89,7 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 
 	if key == cty.DynamicVal {
 		if t.propertyUnion == nil {
-			types := make([]Type, 0, len(t.Properties))
+			types := slice.Prealloc[Type](len(t.Properties))
 			for _, t := range t.Properties {
 				types = append(types, t)
 			}
@@ -121,7 +122,7 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 				},
 			}
 		}
-		props := make([]string, 0, len(t.Properties))
+		props := slice.Prealloc[string](len(t.Properties))
 		for k := range t.Properties {
 			props = append(props, k)
 		}
@@ -304,7 +305,7 @@ func (t *ObjectType) string(seen map[Type]struct{}) string {
 	}
 	seen[t] = struct{}{}
 
-	properties := make([]string, 0, len(t.Properties))
+	properties := slice.Prealloc[string](len(t.Properties))
 	for k, v := range t.Properties {
 		properties = append(properties, fmt.Sprintf("%s = %s", k, v.string(seen)))
 	}

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // UnionType represents values that may be any one of a specified set of types.
@@ -108,7 +109,7 @@ func (*UnionType) SyntaxNode() hclsyntax.Node {
 }
 
 func (t *UnionType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Formatter {
-	elements := make([]pretty.Formatter, 0, len(t.ElementTypes))
+	elements := slice.Prealloc[pretty.Formatter](len(t.ElementTypes))
 	isOptional := false
 	unionFormatter := &pretty.List{
 		Separator: " | ",
@@ -320,7 +321,7 @@ func (t *UnionType) unifyTo(other Type) (Type, ConversionKind) {
 	switch other := other.(type) {
 	case *UnionType:
 		// If the other type is also a union type, produce a new type that is the union of their elements.
-		elements := make([]Type, 0, len(t.ElementTypes)+len(other.ElementTypes))
+		elements := slice.Prealloc[Type](len(t.ElementTypes) + len(other.ElementTypes))
 		elements = append(elements, t.ElementTypes...)
 		elements = append(elements, other.ElementTypes...)
 		return NewUnionType(elements...), SafeConversion

--- a/pkg/codegen/hcl2/model/utilities.go
+++ b/pkg/codegen/hcl2/model/utilities.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -39,7 +40,7 @@ func SourceOrderLess(a, b hcl.Range) bool {
 
 // SourceOrderBody sorts the contents of an HCL2 body in source order.
 func SourceOrderBody(body *hclsyntax.Body) []hclsyntax.Node {
-	items := make([]hclsyntax.Node, 0, len(body.Attributes)+len(body.Blocks))
+	items := slice.Prealloc[hclsyntax.Node](len(body.Attributes) + len(body.Blocks))
 	for _, attr := range body.Attributes {
 		items = append(items, attr)
 	}

--- a/pkg/codegen/hcl2/model/visitor.go
+++ b/pkg/codegen/hcl2/model/visitor.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -282,7 +283,7 @@ func visitExpressions(ns []Expression, pre, post ExpressionVisitor) ([]Expressio
 		return []Expression{}, diagnostics
 	}
 
-	nns := make([]Expression, 0, len(ns)-nils)
+	nns := slice.Prealloc[Expression](len(ns) - nils)
 	for _, e := range ns {
 		if e != nil {
 			nns = append(nns, e)

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -481,7 +482,7 @@ func (m *tokenMapper) Exit(n hclsyntax.Node) hcl.Diagnostics {
 		}
 	case *hclsyntax.FunctionCallExpr:
 		args := n.Args
-		commas := make([]Token, 0, len(args))
+		commas := slice.Prealloc[Token](len(args))
 		if len(args) > 0 {
 			for _, ex := range args[:len(args)-1] {
 				commas = append(commas, m.tokens.atPos(m.nodeRange(ex).End))
@@ -596,7 +597,7 @@ func (m *tokenMapper) Exit(n hclsyntax.Node) hcl.Diagnostics {
 		}
 	case *hclsyntax.TupleConsExpr:
 		exprs := n.Exprs
-		commas := make([]Token, 0, len(exprs))
+		commas := slice.Prealloc[Token](len(exprs))
 		if len(exprs) > 0 {
 			for _, ex := range exprs[:len(exprs)-1] {
 				commas = append(commas, m.tokens.atPos(m.nodeRange(ex).End))

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -84,7 +85,7 @@ func camel(s string) string {
 		return ""
 	}
 	runes := []rune(s)
-	res := make([]rune, 0, len(runes))
+	res := slice.Prealloc[rune](len(runes))
 	for i, r := range runes {
 		if unicode.IsLower(r) {
 			res = append(res, runes[i:]...)
@@ -953,7 +954,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		argsOptional := true
 		if fun.Inputs != nil {
 			// Filter out the __self__ argument from the inputs.
-			args = make([]*schema.Property, 0, len(fun.Inputs.InputShape.Properties))
+			args = slice.Prealloc[*schema.Property](len(fun.Inputs.InputShape.Properties))
 			for _, arg := range fun.Inputs.InputShape.Properties {
 				if arg.Name == "__self__" {
 					continue
@@ -1047,7 +1048,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		fun := method.Function
 		methodName := title(method.Name)
 		if fun.Inputs != nil {
-			args := make([]*schema.Property, 0, len(fun.Inputs.InputShape.Properties))
+			args := slice.Prealloc[*schema.Property](len(fun.Inputs.InputShape.Properties))
 			for _, arg := range fun.Inputs.InputShape.Properties {
 				if arg.Name == "__self__" {
 					continue
@@ -1889,7 +1890,7 @@ func (mod *modContext) isReservedSourceFileName(name string) bool {
 }
 
 func (mod *modContext) gen(fs codegen.Fs) error {
-	files := make([]fileInfo, 0, len(mod.extraSourceFiles))
+	files := slice.Prealloc[fileInfo](len(mod.extraSourceFiles))
 	for _, path := range mod.extraSourceFiles {
 		files = append(files, fileInfo{
 			fileType:         otherFileType,

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/zclconf/go-cty/cty"
@@ -366,7 +367,7 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 	}
 
 	sortedValues := importSet.SortedValues()
-	imports := make([]string, 0, len(sortedValues))
+	imports := slice.Prealloc[string](len(sortedValues))
 	for _, pkg := range sortedValues {
 		if pkg == "@pulumi/pulumi" {
 			continue

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -482,7 +483,7 @@ func GetSchemaForType(t model.Type) (schema.Type, bool) {
 		if len(schemas) == 0 {
 			return nil, false
 		}
-		schemaTypes := make([]schema.Type, 0, len(schemas))
+		schemaTypes := slice.Prealloc[schema.Type](len(schemas))
 		for t := range schemas {
 			schemaTypes = append(schemaTypes, t.(schema.Type))
 		}

--- a/pkg/codegen/pcl/program.go
+++ b/pkg/codegen/pcl/program.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/spf13/afero"
 )
 
@@ -120,13 +121,13 @@ func (p *Program) Packages() []*schema.Package {
 
 // PackageReferences returns the list of package referenced used by this program.
 func (p *Program) PackageReferences() []schema.PackageReference {
-	keys := make([]string, 0, len(p.binder.referencedPackages))
+	keys := slice.Prealloc[string](len(p.binder.referencedPackages))
 	for k := range p.binder.referencedPackages {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	values := make([]schema.PackageReference, 0, len(p.binder.referencedPackages))
+	values := slice.Prealloc[schema.PackageReference](len(p.binder.referencedPackages))
 	for _, k := range keys {
 		values = append(values, p.binder.referencedPackages[k])
 	}
@@ -137,13 +138,13 @@ func (p *Program) PackageReferences() []schema.PackageReference {
 // its returned value is a snapshot that contains only the package members referenced by the program. Otherwise, its
 // returned value is the full package definition.
 func (p *Program) PackageSnapshots() ([]*schema.Package, error) {
-	keys := make([]string, 0, len(p.binder.referencedPackages))
+	keys := slice.Prealloc[string](len(p.binder.referencedPackages))
 	for k := range p.binder.referencedPackages {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	values := make([]*schema.Package, 0, len(p.binder.referencedPackages))
+	values := slice.Prealloc[*schema.Package](len(p.binder.referencedPackages))
 	for _, k := range keys {
 		ref := p.binder.referencedPackages[k]
 

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // titleCase replaces the first character in the given string with its upper-case equivalent.
@@ -87,7 +88,7 @@ func Linearize(p *Program) []Node {
 	}
 
 	// Now build a worklist out of the set of files, sorting the nodes in each file in source order as we go.
-	worklist := make([]*file, 0, len(files))
+	worklist := slice.Prealloc[*file](len(files))
 	for _, f := range files {
 		SourceOrderNodes(f.nodes)
 		worklist = append(worklist, f)
@@ -95,7 +96,7 @@ func Linearize(p *Program) []Node {
 
 	// While the worklist is not empty, add the nodes in the file with the fewest unsatisfied dependencies on nodes in
 	// other files.
-	doneNodes, nodes := codegen.Set{}, make([]Node, 0, len(p.Nodes))
+	doneNodes, nodes := codegen.Set{}, slice.Prealloc[Node](len(p.Nodes))
 	for len(worklist) > 0 {
 		// Recalculate file weights and find the file with the lowest weight.
 		var next *file

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -81,7 +82,7 @@ func (imports imports) addResource(mod *modContext, r *schema.ResourceType) {
 }
 
 func (imports imports) strings() []string {
-	result := make([]string, 0, len(imports))
+	result := slice.Prealloc[string](len(imports))
 	for imp := range imports {
 		result = append(result, imp)
 	}
@@ -1591,7 +1592,7 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 		var args []*schema.Property
 		if fun.Inputs != nil {
 			// Filter out the __self__ argument from the inputs.
-			args = make([]*schema.Property, 0, len(fun.Inputs.InputShape.Properties)-1)
+			args = slice.Prealloc[*schema.Property](len(fun.Inputs.InputShape.Properties) - 1)
 			for _, arg := range fun.Inputs.InputShape.Properties {
 				if arg.Name == "__self__" {
 					continue
@@ -2173,7 +2174,7 @@ func genPackageMetadata(
 	fmt.Fprintf(w, "      install_requires=[\n          ")
 	// Concat the first and second element together,
 	// and break each element apart with a comman and a newline.
-	depStrings := make([]string, 0, len(deps))
+	depStrings := slice.Prealloc[string](len(deps))
 	for _, dep := range deps {
 		concat := fmt.Sprintf("'%s%s'", dep[0], dep[1])
 		depStrings = append(depStrings, concat)
@@ -2374,7 +2375,7 @@ func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool) stri
 		}
 
 		elementTypeSet := codegen.NewStringSet()
-		elements := make([]string, 0, len(t.ElementTypes))
+		elements := slice.Prealloc[string](len(t.ElementTypes))
 		for _, e := range t.ElementTypes {
 			et := mod.typeString(e, input, acceptMapping)
 			if !elementTypeSet.Has(et) {
@@ -3155,7 +3156,7 @@ func ensureValidPulumiVersion(requires map[string]string) (map[string]string, er
 // dep fails to validate.
 func calculateDeps(requires map[string]string) ([][2]string, error) {
 	var err error
-	result := make([][2]string, 0, len(requires))
+	result := slice.Prealloc[[2]string](len(requires))
 	if requires, err = ensureValidPulumiVersion(requires); err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/python/gen_resource_mappings.go
+++ b/pkg/codegen/python/gen_resource_mappings.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // Generates code to build and regsiter ResourceModule and
@@ -125,7 +126,7 @@ func collectResourceModuleInfos(mctx *modContext) []resourceModuleInfo {
 		}
 	}
 
-	result := make([]resourceModuleInfo, 0, len(byMod))
+	result := slice.Prealloc[resourceModuleInfo](len(byMod))
 	for _, rmi := range byMod {
 		result = append(result, rmi)
 	}

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // isLegalIdentifierStart returns true if it is legal for c to be the first character of a Python identifier as per
@@ -112,7 +113,7 @@ var pypiPost = regexp.MustCompile("^post[0-9]+$")
 // Details can be found here: https://www.python.org/dev/peps/pep-0440/#version-scheme
 // [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
 func pypiVersion(v semver.Version) string {
-	localList := make([]string, 0, len(pypiReleaseTranslations))
+	localList := slice.Prealloc[string](len(pypiReleaseTranslations))
 
 	getRelease := func(maybeRelease string) string {
 		for _, tup := range pypiReleaseTranslations {

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/segmentio/encoding/json"
 )
@@ -500,7 +501,7 @@ func (p *PartialPackage) Snapshot() (*Package, error) {
 	config := p.config
 	provider := p.types.resourceDefs["pulumi:providers:"+p.spec.Name]
 
-	resources := make([]*Resource, 0, len(p.types.resourceDefs))
+	resources := slice.Prealloc[*Resource](len(p.types.resourceDefs))
 	resourceDefs := make(map[string]*Resource, len(p.types.resourceDefs))
 	for token, res := range p.types.resourceDefs {
 		resources, resourceDefs[token] = append(resources, res), res
@@ -509,7 +510,7 @@ func (p *PartialPackage) Snapshot() (*Package, error) {
 		return resources[i].Token < resources[j].Token
 	})
 
-	functions := make([]*Function, 0, len(p.types.functionDefs))
+	functions := slice.Prealloc[*Function](len(p.types.functionDefs))
 	functionDefs := make(map[string]*Function, len(p.types.functionDefs))
 	for token, fn := range p.types.functionDefs {
 		functions, functionDefs[token] = append(functions, fn), fn

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 
 	"gopkg.in/yaml.v3"
 )
@@ -649,7 +650,7 @@ type Language interface {
 }
 
 func sortedLanguageNames(metadata map[string]interface{}) []string {
-	names := make([]string, 0, len(metadata))
+	names := slice.Prealloc[string](len(metadata))
 	for lang := range metadata {
 		names = append(names, lang)
 	}
@@ -1107,7 +1108,7 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 		stateInputs = &o.ObjectTypeSpec
 	}
 
-	aliases := make([]AliasSpec, 0, len(r.Aliases))
+	aliases := slice.Prealloc[AliasSpec](len(r.Aliases))
 	for _, a := range r.Aliases {
 		aliases = append(aliases, AliasSpec{
 			Name:    a.Name,

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -6,6 +6,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
@@ -27,7 +28,7 @@ func NewHostWithProviders(schemaDirectoryPath string, providers ...SchemaProvide
 		}, deploytest.WithPath(schemaDirectoryPath))
 	}
 
-	pluginLoaders := make([]*deploytest.PluginLoader, 0, len(providers))
+	pluginLoaders := slice.Prealloc[*deploytest.PluginLoader](len(providers))
 
 	for _, v := range providers {
 		pluginLoaders = append(pluginLoaders, mockProvider(tokens.Package(v.name), v.version))

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -56,7 +57,7 @@ func (ss StringSet) Except(s string) StringSet {
 }
 
 func (ss StringSet) SortedValues() []string {
-	values := make([]string, 0, len(ss))
+	values := slice.Prealloc[string](len(ss))
 	for v := range ss {
 		values = append(values, v)
 	}
@@ -114,7 +115,7 @@ func (s Set) Has(v interface{}) bool {
 
 // SortedKeys returns a sorted list of keys for the given map.
 func SortedKeys[T any](m map[string]T) []string {
-	keys := make([]string, 0, len(m))
+	keys := slice.Prealloc[string](len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -98,7 +99,7 @@ func (p pluginSet) Deduplicate() pluginSet {
 
 // Values returns a slice of all of the plugins contained within this set.
 func (p pluginSet) Values() []workspace.PluginSpec {
-	plugins := make([]workspace.PluginSpec, 0, len(p))
+	plugins := slice.Prealloc[workspace.PluginSpec](len(p))
 	for _, value := range p {
 		plugins = append(plugins, value)
 	}

--- a/pkg/graph/dotconv/print.go
+++ b/pkg/graph/dotconv/print.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/graph"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -41,7 +42,7 @@ func Print(g graph.Graph, w io.Writer) error {
 
 	// Initialize the frontier with unvisited graph vertices.
 	queued := make(map[graph.Vertex]bool)
-	frontier := make([]graph.Vertex, 0, len(g.Roots()))
+	frontier := slice.Prealloc[graph.Vertex](len(g.Roots()))
 	for _, root := range g.Roots() {
 		to := root.To()
 		queued[to] = true

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
@@ -620,7 +621,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 		}, nil
 	case value.IsObject():
 		obj := value.ObjectValue()
-		items := make([]model.ObjectConsItem, 0, len(obj))
+		items := slice.Prealloc[model.ObjectConsItem](len(obj))
 
 		switch arg := typ.(type) {
 		case *schema.ObjectType:

--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -196,9 +197,9 @@ func (ops *resourceOperations) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	// Sort
 	sort.SliceStable(logs, func(i, j int) bool { return logs[i].Timestamp < logs[j].Timestamp })
 	// Remove duplicates
-	retLogs := make([]LogEntry, 0, len(logs))
+	retLogs := slice.Prealloc[LogEntry](len(logs))
 	var lastLogTimestamp int64
-	lastLogs := make([]LogEntry, 0, len(logs))
+	lastLogs := slice.Prealloc[LogEntry](len(logs))
 	for _, log := range logs {
 		shouldContinue := false
 		if log.Timestamp == lastLogTimestamp {

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -563,7 +564,7 @@ func (ex *deploymentExecutor) rebuildBaseState(resourceToStep map[*resource.Stat
 
 		// Remove any deleted resources from this resource's dependency list.
 		if len(new.Dependencies) != 0 {
-			deps := make([]resource.URN, 0, len(new.Dependencies))
+			deps := slice.Prealloc[resource.URN](len(new.Dependencies))
 			for _, d := range new.Dependencies {
 				if referenceable[d] {
 					deps = append(deps, d)

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +48,7 @@ func (nl *nodeList) AsRefreshSteps() map[*resource.State]Step {
 func (nl *nodeList) sorted() []*resource.State {
 	// Since we add elements before we add their parents, we are guaranteed a reverse
 	// topological sort. We can retrieve a topological sort by reversing the list.
-	l := make([]*resource.State, 0, len(*nl))
+	l := slice.Prealloc[*resource.State](len(*nl))
 	for i := len(*nl) - 1; i >= 0; i-- {
 		l = append(l, (*nl)[i])
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
@@ -429,7 +430,7 @@ func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plug
 func (host *pluginHost) ResolvePlugin(
 	kind workspace.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
-	plugins := make([]workspace.PluginInfo, 0, len(host.pluginLoaders))
+	plugins := slice.Prealloc[workspace.PluginInfo](len(host.pluginLoaders))
 
 	for _, v := range host.pluginLoaders {
 		p := workspace.PluginInfo{

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -182,7 +183,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 	//
 	// NOTE: what if the configuration for an existing default provider has changed? If it has, we should diff it and
 	// replace it appropriately or we should not use the ambient config at all.
-	defaultProviderRequests := make([]providers.ProviderRequest, 0, len(i.deployment.imports))
+	defaultProviderRequests := slice.Prealloc[providers.ProviderRequest](len(i.deployment.imports))
 	defaultProviders := map[resource.URN]struct{}{}
 	for _, imp := range i.deployment.imports {
 		if imp.Provider != "" {
@@ -302,7 +303,7 @@ func (i *importer) importResources(ctx context.Context) result.Result {
 
 	// Create a step per resource to import and execute them in parallel. If there are duplicates, fail the import.
 	urns := map[resource.URN]struct{}{}
-	steps := make([]Step, 0, len(i.deployment.imports))
+	steps := slice.Prealloc[Step](len(i.deployment.imports))
 	for _, imp := range i.deployment.imports {
 		parent := imp.Parent
 		if parent == "" {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -747,7 +748,7 @@ func (rm *resmon) Invoke(ctx context.Context, req *pulumirpc.ResourceInvokeReque
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal %v return: %w", tok, err)
 	}
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(failures))
 	for _, failure := range failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),
@@ -833,7 +834,7 @@ func (rm *resmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*pulumi
 		returnDependencies[string(name)] = &pulumirpc.CallResponse_ReturnDependencies{Urns: urns}
 	}
 
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(ret.Failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(ret.Failures))
 	for _, failure := range ret.Failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),
@@ -888,7 +889,7 @@ func (rm *resmon) StreamInvoke(
 		return fmt.Errorf("streaming invocation of %v returned an error: %w", tok, err)
 	}
 
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(failures))
 	for _, failure := range failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),
@@ -933,7 +934,7 @@ func (rm *resmon) ReadResource(ctx context.Context,
 
 	id := resource.ID(req.GetId())
 	label := fmt.Sprintf("ResourceMonitor.ReadResource(%s, %s, %s, %s)", id, t, name, provider)
-	deps := make([]resource.URN, 0, len(req.GetDependencies()))
+	deps := slice.Prealloc[resource.URN](len(req.GetDependencies()))
 	for _, depURN := range req.GetDependencies() {
 		deps = append(deps, resource.URN(depURN))
 	}
@@ -948,7 +949,7 @@ func (rm *resmon) ReadResource(ctx context.Context,
 		return nil, err
 	}
 
-	additionalSecretOutputs := make([]resource.PropertyKey, 0, len(req.GetAdditionalSecretOutputs()))
+	additionalSecretOutputs := slice.Prealloc[resource.PropertyKey](len(req.GetAdditionalSecretOutputs()))
 	for _, name := range req.GetAdditionalSecretOutputs() {
 		additionalSecretOutputs = append(additionalSecretOutputs, resource.PropertyKey(name))
 	}
@@ -1291,7 +1292,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			outputDeps[string(k)] = &pulumirpc.RegisterResourceResponse_PropertyDependencies{Urns: urns}
 		}
 	} else {
-		additionalSecretKeys := make([]resource.PropertyKey, 0, len(additionalSecretOutputs))
+		additionalSecretKeys := slice.Prealloc[resource.PropertyKey](len(additionalSecretOutputs))
 		for _, name := range additionalSecretOutputs {
 			additionalSecretKeys = append(additionalSecretKeys, resource.PropertyKey(name))
 		}

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -366,7 +367,7 @@ func (rm *queryResmon) Invoke(
 		return nil, fmt.Errorf("failed to marshal return: %w", err)
 	}
 
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(failures))
 	for _, failure := range failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),
@@ -417,7 +418,7 @@ func (rm *queryResmon) StreamInvoke(
 		return fmt.Errorf("streaming invocation of %v returned an error: %w", tok, err)
 	}
 
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(failures))
 	for _, failure := range failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),
@@ -494,7 +495,7 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 		returnDependencies[string(name)] = &pulumirpc.CallResponse_ReturnDependencies{Urns: urns}
 	}
 
-	chkfails := make([]*pulumirpc.CheckFailure, 0, len(ret.Failures))
+	chkfails := slice.Prealloc[*pulumirpc.CheckFailure](len(ret.Failures))
 	for _, failure := range ret.Failures {
 		chkfails = append(chkfails, &pulumirpc.CheckFailure{
 			Property: string(failure.Property),

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -1679,7 +1680,7 @@ func applyReplaceOnChanges(diff plugin.DiffResult,
 		return diff, nil
 	}
 
-	replaceOnChangePaths := make([]resource.PropertyPath, 0, len(replaceOnChanges))
+	replaceOnChangePaths := slice.Prealloc[resource.PropertyPath](len(replaceOnChanges))
 	for _, p := range replaceOnChanges {
 		path, err := resource.ParsePropertyPath(p)
 		if err != nil {
@@ -1727,7 +1728,7 @@ func applyReplaceOnChanges(diff plugin.DiffResult,
 			}
 		}
 	}
-	modifiedReplaceKeys := make([]resource.PropertyKey, 0, len(modifiedReplaceKeysMap))
+	modifiedReplaceKeys := slice.Prealloc[resource.PropertyKey](len(modifiedReplaceKeysMap))
 	for k := range modifiedReplaceKeysMap {
 		modifiedReplaceKeys = append(modifiedReplaceKeys, k)
 	}

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -147,34 +147,22 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 		expected         plugin.DiffResult
 	}{
 		{
-			name: "Empty diff and replaceOnChanges",
-			diff: plugin.DiffResult{
-				StableKeys:  []resource.PropertyKey{},
-				ChangedKeys: []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
-			},
+			name:             "Empty diff and replaceOnChanges",
+			diff:             plugin.DiffResult{},
 			replaceOnChanges: []string{},
 			hasInitErrors:    false,
-			expected: plugin.DiffResult{
-				StableKeys:  []resource.PropertyKey{},
-				ChangedKeys: []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
-			},
+			expected:         plugin.DiffResult{},
 		},
 		{
 			name: "DiffSome and empty replaceOnChanges",
 			diff: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
 			},
 			replaceOnChanges: []string{},
 			hasInitErrors:    false,
 			expected: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
 			},
 		},
@@ -182,9 +170,7 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 			name: "DiffSome and non-empty replaceOnChanges",
 			diff: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
-				ReplaceKeys: []resource.PropertyKey{},
 			},
 			replaceOnChanges: []string{"a"},
 			hasInitErrors:    false,
@@ -192,38 +178,25 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 				Changes:     plugin.DiffSome,
 				ChangedKeys: []resource.PropertyKey{"a"},
 				ReplaceKeys: []resource.PropertyKey{"a"},
-				StableKeys:  []resource.PropertyKey{},
 			},
 		},
 		{
-			name: "Empty diff and replaceOnChanges w/ init errors",
-			diff: plugin.DiffResult{
-				StableKeys:  []resource.PropertyKey{},
-				ChangedKeys: []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
-			},
+			name:             "Empty diff and replaceOnChanges w/ init errors",
+			diff:             plugin.DiffResult{},
 			replaceOnChanges: []string{},
 			hasInitErrors:    true,
-			expected: plugin.DiffResult{
-				StableKeys:  []resource.PropertyKey{},
-				ChangedKeys: []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
-			},
+			expected:         plugin.DiffResult{},
 		},
 		{
 			name: "DiffSome and empty replaceOnChanges w/ init errors",
 			diff: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
 			},
 			replaceOnChanges: []string{},
 			hasInitErrors:    true,
 			expected: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
-				ReplaceKeys: []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
 			},
 		},
@@ -231,7 +204,6 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 			name: "DiffSome and non-empty replaceOnChanges w/ init errors",
 			diff: plugin.DiffResult{
 				Changes:     plugin.DiffSome,
-				StableKeys:  []resource.PropertyKey{},
 				ChangedKeys: []resource.PropertyKey{"a"},
 			},
 			replaceOnChanges: []string{"a"},
@@ -240,7 +212,6 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 				Changes:     plugin.DiffSome,
 				ChangedKeys: []resource.PropertyKey{"a"},
 				ReplaceKeys: []resource.PropertyKey{"a"},
-				StableKeys:  []resource.PropertyKey{},
 			},
 		},
 		{

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -95,7 +96,7 @@ func DeleteResource(
 
 	// If there are no resources that depend on condemnedRes, iterate through the snapshot and keep everything that's
 	// not condemnedRes.
-	newSnapshot := make([]*resource.State, 0, len(snapshot.Resources))
+	newSnapshot := slice.Prealloc[*resource.State](len(snapshot.Resources))
 	var children []*resource.State
 	for _, res := range snapshot.Resources {
 		if res == condemnedRes {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype/migrate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
@@ -121,7 +122,7 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets 
 	}
 
 	// Serialize all vertices and only include a vertex section if non-empty.
-	resources := make([]apitype.ResourceV3, 0, len(snap.Resources))
+	resources := slice.Prealloc[apitype.ResourceV3](len(snap.Resources))
 	for _, res := range snap.Resources {
 		sres, err := SerializeResource(res, enc, showSecrets)
 		if err != nil {
@@ -130,7 +131,7 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets 
 		resources = append(resources, sres)
 	}
 
-	operations := make([]apitype.OperationV2, 0, len(snap.PendingOperations))
+	operations := slice.Prealloc[apitype.OperationV2](len(snap.PendingOperations))
 	for _, op := range snap.PendingOperations {
 		sop, err := SerializeOperation(op, enc, showSecrets)
 		if err != nil {
@@ -258,7 +259,7 @@ func DeserializeDeploymentV3(
 	}
 
 	// For every serialized resource vertex, create a ResourceDeployment out of it.
-	resources := make([]*resource.State, 0, len(deployment.Resources))
+	resources := slice.Prealloc[*resource.State](len(deployment.Resources))
 	for _, res := range deployment.Resources {
 		desres, err := DeserializeResource(res, dec, enc)
 		if err != nil {
@@ -267,7 +268,7 @@ func DeserializeDeploymentV3(
 		resources = append(resources, desres)
 	}
 
-	ops := make([]resource.Operation, 0, len(deployment.PendingOperations))
+	ops := slice.Prealloc[resource.Operation](len(deployment.PendingOperations))
 	for _, op := range deployment.PendingOperations {
 		desop, err := DeserializeOperation(op, dec, enc)
 		if err != nil {

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -65,7 +66,7 @@ func (c *serviceCrypter) DecryptValue(ctx context.Context, cipherstring string) 
 }
 
 func (c *serviceCrypter) BulkDecrypt(ctx context.Context, secrets []string) (map[string]string, error) {
-	secretsToDecrypt := make([][]byte, 0, len(secrets))
+	secretsToDecrypt := slice.Prealloc[[]byte](len(secrets))
 	for _, val := range secrets {
 		ciphertext, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 const unknownErrorCode = -2
@@ -58,7 +60,7 @@ func runPulumiCommandSync(
 }
 
 func withNonInteractiveArg(args []string) []string {
-	out := make([]string, 0, len(args))
+	out := slice.Prealloc[string](len(args))
 	seen := false
 	for _, a := range args {
 		out = append(out, a)

--- a/sdk/go/auto/example_test.go
+++ b/sdk/go/auto/example_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -499,7 +500,7 @@ func ExampleLocalWorkspace_RemoveAllConfig() {
 	stackName := FullyQualifiedStackName("org", "proj", "stackA")
 	// get all config currently set in the workspace
 	cfg, _ := w.GetAllConfig(ctx, stackName)
-	keys := make([]string, 0, len(cfg))
+	keys := slice.Prealloc[string](len(cfg))
 	for k := range cfg {
 		keys = append(keys, k)
 	}

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -122,6 +122,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -215,7 +216,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 
 	bufferSizeHint := len(preOpts.Replace) + len(preOpts.Target) +
 		len(preOpts.PolicyPacks) + len(preOpts.PolicyPackConfigs)
-	sharedArgs := make([]string, 0, bufferSizeHint)
+	sharedArgs := slice.Prealloc[string](bufferSizeHint)
 
 	sharedArgs = debug.AddArgs(&preOpts.DebugLogOpts, sharedArgs)
 	if preOpts.Message != "" {
@@ -337,7 +338,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	}
 
 	bufferSizeHint := len(upOpts.Replace) + len(upOpts.Target) + len(upOpts.PolicyPacks) + len(upOpts.PolicyPackConfigs)
-	sharedArgs := make([]string, 0, bufferSizeHint)
+	sharedArgs := slice.Prealloc[string](bufferSizeHint)
 
 	sharedArgs = debug.AddArgs(&upOpts.DebugLogOpts, sharedArgs)
 	if upOpts.Message != "" {
@@ -450,7 +451,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		o.ApplyOption(refreshOpts)
 	}
 
-	args := make([]string, 0, len(refreshOpts.Target))
+	args := slice.Prealloc[string](len(refreshOpts.Target))
 
 	args = debug.AddArgs(&refreshOpts.DebugLogOpts, args)
 	args = append(args, "refresh", "--yes", "--skip-preview")
@@ -538,7 +539,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		o.ApplyOption(destroyOpts)
 	}
 
-	args := make([]string, 0, len(destroyOpts.Target))
+	args := slice.Prealloc[string](len(destroyOpts.Target))
 
 	args = debug.AddArgs(&destroyOpts.DebugLogOpts, args)
 	args = append(args, "destroy", "--yes", "--skip-preview")
@@ -1005,7 +1006,7 @@ func (s *Stack) remoteArgs() []string {
 		return nil
 	}
 
-	args := make([]string, 0, len(envvars)+len(preRunCommands))
+	args := slice.Prealloc[string](len(envvars) + len(preRunCommands))
 	args = append(args, "--remote")
 	if repo != nil {
 		if repo.URL != "" {

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 )
@@ -757,7 +758,7 @@ func (a *Archive) readAssets() (ArchiveReader, error) {
 	contract.Assertf(isassets, "Expected an asset map-based archive")
 
 	// Calculate and sort the list of member names s.t. it is deterministically orderered.
-	keys := make([]string, 0, len(m))
+	keys := slice.Prealloc[string](len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -228,7 +229,7 @@ func (a *analyzer) AnalyzeStack(resources []AnalyzerStackResource) ([]AnalyzeDia
 				continue
 			}
 
-			pdeps := make([]string, 0, 1)
+			pdeps := slice.Prealloc[string](1)
 			for _, d := range pd {
 				pdeps = append(pdeps, string(d))
 			}

--- a/sdk/go/common/resource/plugin/converter_server.go
+++ b/sdk/go/common/resource/plugin/converter_server.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"context"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
@@ -71,7 +72,7 @@ func (c *converterServer) ConvertProgram(ctx context.Context,
 	}
 
 	// Translate the hcl.Diagnostics into rpc diagnostics.
-	diags := make([]*codegenrpc.Diagnostic, 0, len(resp.Diagnostics))
+	diags := slice.Prealloc[*codegenrpc.Diagnostic](len(resp.Diagnostics))
 	for _, diag := range resp.Diagnostics {
 		diags = append(diags, HclDiagnosticToRPCDiagnostic(diag))
 	}

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -108,7 +109,7 @@ func buildArgsForNewPlugin(host Host, root string, options map[string]interface{
 	if err != nil {
 		return nil, err
 	}
-	args := make([]string, 0, len(options))
+	args := slice.Prealloc[string](len(options))
 
 	for k, v := range options {
 		args = append(args, fmt.Sprintf("-%s=%v", k, v))
@@ -154,7 +155,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 		return nil, rpcError
 	}
 
-	results := make([]workspace.PluginSpec, 0, len(resp.GetPlugins()))
+	results := slice.Prealloc[workspace.PluginSpec](len(resp.GetPlugins()))
 	for _, info := range resp.GetPlugins() {
 		var version *semver.Version
 		if v := info.GetVersion(); v != "" {
@@ -347,7 +348,7 @@ func (h *langhost) GetProgramDependencies(info ProgInfo, transitiveDependencies 
 		return nil, rpcError
 	}
 
-	results := make([]DependencyInfo, 0, len(resp.GetDependencies()))
+	results := slice.Prealloc[DependencyInfo](len(resp.GetDependencies()))
 	for _, dep := range resp.GetDependencies() {
 		var version semver.Version
 		if v := dep.Version; v != "" {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -396,7 +397,7 @@ func (p *provider) CheckConfig(urn resource.URN, olds,
 	}
 
 	// And now any properties that failed verification.
-	failures := make([]CheckFailure, 0, len(resp.GetFailures()))
+	failures := slice.Prealloc[CheckFailure](len(resp.GetFailures()))
 	for _, failure := range resp.GetFailures() {
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}
@@ -505,15 +506,15 @@ func (p *provider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs
 		return DiffResult{}, nil
 	}
 
-	replaces := make([]resource.PropertyKey, 0, len(resp.GetReplaces()))
+	replaces := slice.Prealloc[resource.PropertyKey](len(resp.GetReplaces()))
 	for _, replace := range resp.GetReplaces() {
 		replaces = append(replaces, resource.PropertyKey(replace))
 	}
-	stables := make([]resource.PropertyKey, 0, len(resp.GetStables()))
+	stables := slice.Prealloc[resource.PropertyKey](len(resp.GetStables()))
 	for _, stable := range resp.GetStables() {
 		stables = append(stables, resource.PropertyKey(stable))
 	}
-	diffs := make([]resource.PropertyKey, 0, len(resp.GetDiffs()))
+	diffs := slice.Prealloc[resource.PropertyKey](len(resp.GetDiffs()))
 	for _, diff := range resp.GetDiffs() {
 		diffs = append(diffs, resource.PropertyKey(diff))
 	}
@@ -753,7 +754,7 @@ func (p *provider) Check(urn resource.URN,
 	}
 
 	// And now any properties that failed verification.
-	failures := make([]CheckFailure, 0, len(resp.GetFailures()))
+	failures := slice.Prealloc[CheckFailure](len(resp.GetFailures()))
 	for _, failure := range resp.GetFailures() {
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}
@@ -841,15 +842,16 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 		return DiffResult{}, rpcError
 	}
 
-	replaces := make([]resource.PropertyKey, 0, len(resp.GetReplaces()))
+	// nil is semantically important to a lot of the pulumi system so we only pre-allocate if we have non-zero length.
+	replaces := slice.Prealloc[resource.PropertyKey](len(resp.GetReplaces()))
 	for _, replace := range resp.GetReplaces() {
 		replaces = append(replaces, resource.PropertyKey(replace))
 	}
-	stables := make([]resource.PropertyKey, 0, len(resp.GetStables()))
+	stables := slice.Prealloc[resource.PropertyKey](len(resp.GetStables()))
 	for _, stable := range resp.GetStables() {
 		stables = append(stables, resource.PropertyKey(stable))
 	}
-	diffs := make([]resource.PropertyKey, 0, len(resp.GetDiffs()))
+	diffs := slice.Prealloc[resource.PropertyKey](len(resp.GetDiffs()))
 	for _, diff := range resp.GetDiffs() {
 		diffs = append(diffs, resource.PropertyKey(diff))
 	}
@@ -1455,7 +1457,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 	}
 
 	// And now any properties that failed verification.
-	failures := make([]CheckFailure, 0, len(resp.GetFailures()))
+	failures := slice.Prealloc[CheckFailure](len(resp.GetFailures()))
 	for _, failure := range resp.GetFailures() {
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}
@@ -1633,7 +1635,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 	}
 
 	// And now any properties that failed verification.
-	failures := make([]CheckFailure, 0, len(resp.GetFailures()))
+	failures := slice.Prealloc[CheckFailure](len(resp.GetFailures()))
 	for _, failure := range resp.GetFailures() {
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
@@ -203,7 +204,7 @@ func (props PropertyMap) Copy() PropertyMap {
 
 // StableKeys returns all of the map's keys in a stable order.
 func (props PropertyMap) StableKeys() []PropertyKey {
-	sorted := make([]PropertyKey, 0, len(props))
+	sorted := slice.Prealloc[PropertyKey](len(props))
 	for k := range props {
 		sorted = append(sorted, k)
 	}

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -16,6 +16,8 @@ package resource
 
 import (
 	"sort"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // ObjectDiff holds the results of diffing two object property maps.
@@ -63,7 +65,7 @@ func (diff *ObjectDiff) AnyChanges() bool {
 // Keys returns a stable snapshot of all keys known to this object, across adds, deletes, sames, and updates.
 func (diff *ObjectDiff) Keys() []PropertyKey {
 	bufferSize := len(diff.Adds) + len(diff.Deletes) + len(diff.Sames) + len(diff.Updates)
-	ks := make([]PropertyKey, 0, bufferSize)
+	ks := slice.Prealloc[PropertyKey](bufferSize)
 	for k := range diff.Adds {
 		ks = append(ks, k)
 	}

--- a/sdk/go/common/slice/slice.go
+++ b/sdk/go/common/slice/slice.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slice
+
+// Preallocates a slice of type T of a given length. If the input length is 0 then the returned slice will be
+// nil. We prefer this over `make([]T, 0, length)` because nil is often treated semantically different from an
+// empty slice.
+func Prealloc[T any](capacity int) []T {
+	if capacity == 0 {
+		return nil
+	}
+	return make([]T, 0, capacity)
+}

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rivo/uniseg"
 	"golang.org/x/term"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
 )
 
@@ -165,7 +166,7 @@ func MeasureText(text string) int {
 //
 // A row is considered normalized if and only if it has no new lines in any of its fields.
 func (table *Table) normalizedRows() []TableRow {
-	rows := make([]TableRow, 0, len(table.Rows))
+	rows := slice.Prealloc[TableRow](len(table.Rows))
 	for _, row := range table.Rows {
 		info := row.AdditionalInfo
 		buckets := make([][]string, len(row.Columns))

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type Filter interface {
@@ -162,7 +163,7 @@ func AddGlobalFilter(filter Filter) {
 }
 
 func CreateFilter(secrets []string, replacement string) Filter {
-	items := make([]string, 0, len(secrets))
+	items := slice.Prealloc[string](len(secrets))
 	for _, secret := range secrets {
 		// For short secrets, don't actually add them to the filter, this is a trade-off we make to prevent
 		// displaying `[secret]`. Travis does a similar thing, for example.

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/rogpeppe/go-internal/lockedfile"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -208,7 +209,7 @@ func GetStoredCredentials() (Credentials, error) {
 			"`pulumi login` to reset your credentials file: %w", err)
 	}
 
-	secrets := make([]string, 0, len(creds.AccessTokens))
+	secrets := slice.Prealloc[string](len(creds.AccessTokens))
 	for _, v := range creds.AccessTokens {
 		secrets = append(secrets, v)
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/buildutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -434,7 +435,7 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 		return &pulumirpc.GetRequiredPluginsResponse{}, nil
 	}
 
-	args := make([]string, 0, len(gomod.Require)+3)
+	args := slice.Prealloc[string](len(gomod.Require) + 3)
 	args = append(args, "list", "-m", "-json")
 	for _, req := range gomod.Require {
 		args = append(args, req.Mod.Path)
@@ -757,7 +758,7 @@ func (host *goLanguageHost) GetProgramDependencies(
 		return nil, fmt.Errorf("load go.mod: %w", err)
 	}
 
-	result := make([]*pulumirpc.DependencyInfo, 0, len(gomod.Require))
+	result := slice.Prealloc[*pulumirpc.DependencyInfo](len(gomod.Require))
 	for _, d := range gomod.Require {
 		if !d.Indirect || req.TransitiveDependencies {
 			datum := pulumirpc.DependencyInfo{

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -30,6 +30,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -454,7 +455,7 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 		for k, deps := range argDeps {
 			sort.Slice(deps, func(i, j int) bool { return deps[i] < deps[j] })
 
-			urns := make([]string, 0, len(deps))
+			urns := slice.Prealloc[string](len(deps))
 			for i, d := range deps {
 				if i > 0 && urns[i-1] == string(d) {
 					continue
@@ -1085,7 +1086,7 @@ func getPackage(t string) string {
 func (ctx *Context) collapseAliases(aliases []Alias, t, name string, parent Resource) ([]URNOutput, error) {
 	project, stack := ctx.Project(), ctx.Stack()
 
-	aliasURNs := make([]URNOutput, 0, len(aliases))
+	aliasURNs := slice.Prealloc[URNOutput](len(aliases))
 
 	for _, alias := range aliases {
 		urn, err := alias.collapseToURN(name, t, parent, project, stack)
@@ -1394,7 +1395,7 @@ func (ctx *Context) mapAliases(aliases []Alias,
 	name string,
 	parent Resource,
 ) ([]*pulumirpc.Alias, error) {
-	aliasSpecs := make([]*pulumirpc.Alias, 0, len(aliases))
+	aliasSpecs := slice.Prealloc[*pulumirpc.Alias](len(aliases))
 	await := func(input StringInput) (string, error) {
 		if input == nil {
 			return "", nil

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -363,7 +364,7 @@ func TestMergeProviders(t *testing.T) {
 					return err
 				}
 
-				result := make([]string, 0, len(provMap))
+				result := slice.Prealloc[string](len(provMap))
 				for k, p := range provMap {
 					assert.Equal(t, k, p.getPackage(), "pkg should match map key")
 					result = append(result, strings.TrimPrefix(p.getName(), "pulumi:providers:"))

--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"text/template"
 	"unicode"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type builtin struct {
@@ -210,7 +212,7 @@ var funcs = template.FuncMap{
 
 func makeBuiltins(primitives []*builtin) []*builtin {
 	// Augment primitives with array and map types.
-	builtins := make([]*builtin, 0, len(primitives))
+	builtins := slice.Prealloc[*builtin](len(primitives))
 	for _, p := range primitives {
 		p.Strategy = "primitive"
 		name := ""

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -91,7 +92,7 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 		aliases[i] = Alias{URN: URN(urn)}
 	}
 
-	dependencies := make([]Resource, 0, len(req.GetDependencies()))
+	dependencies := slice.Prealloc[Resource](len(req.GetDependencies()))
 	for _, urn := range req.GetDependencies() {
 		dependencies = append(dependencies, pulumiCtx.newDependencyResource(URN(urn)))
 	}
@@ -169,7 +170,7 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 	for k, deps := range propertyDeps {
 		sort.Slice(deps, func(i, j int) bool { return deps[i] < deps[j] })
 
-		urns := make([]string, 0, len(deps))
+		urns := slice.Prealloc[string](len(deps))
 		for i, d := range deps {
 			if i > 0 && urns[i-1] == string(d) {
 				continue
@@ -822,7 +823,7 @@ func call(ctx context.Context, req *pulumirpc.CallRequest, engineConn *grpc.Clie
 	for k, deps := range propertyDeps {
 		sort.Slice(deps, func(i, j int) bool { return deps[i] < deps[j] })
 
-		urns := make([]string, 0, len(deps))
+		urns := slice.Prealloc[string](len(deps))
 		for i, d := range deps {
 			if i > 0 && urns[i-1] == string(d) {
 				continue

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -80,7 +81,7 @@ func (s *ResourceState) getChildren() []Resource {
 
 	var children []Resource
 	if len(s.children) != 0 {
-		children = make([]Resource, 0, len(s.children))
+		children = slice.Prealloc[Resource](len(s.children))
 		for r := range s.children {
 			children = append(children, r)
 		}
@@ -436,7 +437,7 @@ func resourceOptionsSnapshot(ro *resourceOptions) *ResourceOptions {
 
 	var providers []ProviderResource
 	if len(ro.Providers) > 0 {
-		providers = make([]ProviderResource, 0, len(ro.Providers))
+		providers = slice.Prealloc[ProviderResource](len(ro.Providers))
 		for _, p := range ro.Providers {
 			providers = append(providers, p)
 		}

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -28,6 +28,7 @@ import (
 	grpc "google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -1216,7 +1217,7 @@ func assertHasDeps(
 	name := res.getName()
 	resDeps := depTracker.dependencies(urn(t, ctx, res))
 
-	expDeps := make([]URN, 0, len(expectedDeps))
+	expDeps := slice.Prealloc[URN](len(expectedDeps))
 	for _, expDepRes := range expectedDeps {
 		expDep := urn(t, ctx, expDepRes)
 		expDeps = append(expDeps, expDep)

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -1770,7 +1770,7 @@ func TestMarshalInputsPropertyDependencies(t *testing.T) {
 		"s": resource.NewStringProperty("a string"),
 		"a": resource.NewBoolProperty(true),
 	}, pmap)
-	assert.Equal(t, []URN{}, deps)
+	assert.Nil(t, deps)
 	// Expect a non-empty property deps map, even when there aren't any deps.
-	assert.Equal(t, map[string][]URN{"s": {}, "a": {}}, pdeps)
+	assert.Equal(t, map[string][]URN{"s": nil, "a": nil}, pdeps)
 }

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -211,12 +212,12 @@ func mergeDependencies(ours []Resource, theirs []Resource) []Resource {
 	if len(ours) == 0 && len(theirs) == 0 {
 		return nil
 	} else if len(theirs) == 0 {
-		return append(make([]Resource, 0, len(ours)), ours...)
+		return append(slice.Prealloc[Resource](len(ours)), ours...)
 	} else if len(ours) == 0 {
-		return append(make([]Resource, 0, len(theirs)), theirs...)
+		return append(slice.Prealloc[Resource](len(theirs)), theirs...)
 	}
 	depSet := make(map[Resource]struct{})
-	mergedDeps := make([]Resource, 0, len(ours)+len(theirs))
+	mergedDeps := slice.Prealloc[Resource](len(ours) + len(theirs))
 	for _, d := range ours {
 		depSet[d] = struct{}{}
 	}
@@ -478,7 +479,7 @@ func newApplier(fn interface{}, elemType reflect.Type) (_ *applier, err error) {
 
 // Call executes the applier on the provided value and returns the result.
 func (ap *applier) Call(ctx context.Context, in reflect.Value) (reflect.Value, error) {
-	args := make([]reflect.Value, 0, 2) // ([ctx], in)
+	args := slice.Prealloc[reflect.Value](2) // ([ctx], in)
 	if ap.ctx {
 		args = append(args, reflect.ValueOf(ctx))
 	}
@@ -742,7 +743,7 @@ func gatherJoins(v interface{}) workGroups {
 
 	var joins workGroups
 	if len(joinSet) > 0 {
-		joins = make([]*workGroup, 0, len(joinSet))
+		joins = slice.Prealloc[*workGroup](len(joinSet))
 		for j := range joinSet {
 			joins = append(joins, j)
 		}

--- a/sdk/go/pulumi/types_contravariance_test.go
+++ b/sdk/go/pulumi/types_contravariance_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func asAnySlice(t *testing.T, values interface{}) []interface{} {
 	// use reflect.valueOf to iterate over items of values
 	require.Equalf(t, v.Kind(), reflect.Slice, "expected a slice, got %v", v.Type())
 
-	out := make([]interface{}, 0, v.Len())
+	out := slice.Prealloc[interface{}](v.Len())
 	for i := 0; i < v.Len(); i++ {
 		out = append(out, v.Index(i).Interface())
 	}

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -896,11 +897,11 @@ func assertResult(t *testing.T, o Output, expectedValue interface{}, expectedKno
 	assert.Equal(t, expectedValue, v, "values do not match")
 	assert.Equal(t, expectedKnown, known, "known-ness does not match")
 	assert.Equal(t, expectedSecret, secret, "secret-ness does not match")
-	depUrns := make([]URN, 0, len(deps))
+	depUrns := slice.Prealloc[URN](len(deps))
 	for _, v := range deps {
 		depUrns = append(depUrns, v.URN().value.(URN))
 	}
-	expectedUrns := make([]URN, 0, len(expectedDeps))
+	expectedUrns := slice.Prealloc[URN](len(expectedDeps))
 	for _, v := range expectedDeps {
 		expectedUrns = append(expectedUrns, v.URN().value.(URN))
 	}

--- a/sdk/go/pulumi/urnset.go
+++ b/sdk/go/pulumi/urnset.go
@@ -16,6 +16,8 @@ package pulumi
 
 import (
 	"sort"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type urnSet map[URN]struct{}
@@ -45,7 +47,7 @@ func (s urnSet) union(other urnSet) {
 }
 
 func (s urnSet) values() []URN {
-	values := make([]URN, 0, len(s))
+	values := slice.Prealloc[URN](len(s))
 	for v := range s {
 		values = append(values, v)
 	}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
@@ -415,7 +416,7 @@ func determinePulumiPackages(ctx context.Context, virtualenv, cwd string) ([]pyt
 	}
 
 	// Only return Pulumi packages.
-	pulumiPackages := make([]pythonPackage, 0, len(packages))
+	pulumiPackages := slice.Prealloc[pythonPackage](len(packages))
 	for _, pkg := range packages {
 		if !pkg.isPulumiPackage() {
 			continue

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -712,7 +713,7 @@ func TestLocalStateGzip(t *testing.T) { //nolint:paralleltest
 }
 
 func getFileNames(infos []os.DirEntry) []string {
-	result := make([]string, 0, len(infos))
+	result := slice.Prealloc[string](len(infos))
 	for _, i := range infos {
 		result = append(result, i.Name())
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12738

https://github.com/pulumi/pulumi/pull/11834 turned on the prealloc linter and changed a load of slice uses from just `var x T[]` to `x := make([]T, 0, preallocSize)`. This was good for performance but it turns out there are a number of places in the codebase that treat a `nil` slice as semnatically different to an empty slice.

Trying to test that, or even reason that through for every callsite is untractable, so this PR replaces all expressions of the form `make([]T, 0, size)` with a call to `slice.Prealloc[T](size)`. When size is 0 that returns a nil array, rather than an empty array.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
