### PR TITLE
Pin GoReleaser to previous version

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -88,6 +88,10 @@ jobs:
         with:
           install-only: true
           distribution: goreleaser-pro
+          # TODO[pulumi/pulumi#13312: Change this to not pin to a version after
+          # addressing the root cause of why GoReleaser v1.19.0 fails to read
+          # the configuration.
+          version: v1.18.2
       - name: Set up bin dir
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
GoReleaser 1.19.0 was released earlier today and doesn't currently work. Pin to the previous version to unblock CI until we understand what the underlying problem is.