### PR TITLE
Fixes for GoRelease v1.19.0

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -112,7 +112,7 @@ jobs:
           # shellcheck disable=SC2002
           cat .goreleaser.yml \
             | go run github.com/t0yv0/goreleaser-filter@v0.3.0 -goos ${{ inputs.os }} -goarch ${{ inputs.arch }} \
-            | goreleaser release -f - -p 5 --skip-validate --rm-dist --snapshot
+            | goreleaser release -f - -p 5 --skip-validate --clean --snapshot
       - uses: actions/upload-artifact@v2
         with:
           name: artifacts-cli-${{ inputs.os }}-${{ inputs.arch }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,6 @@ archives:
   format_overrides:
     - goos: windows
       format: zip
-  replacements:
-    amd64: x64
   files:
       # OS specific scripts, not compiled
     - src: bin/{{ .Os }}/*
@@ -53,7 +51,7 @@ archives:
     - src: bin/{{ .Os }}-{{ .Arch }}/*
       dst: '.'
       strip_parent: true
-  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ if eq .Arch "amd64" }}x64{{ else }}{{ .Arch }}{{ end }}"
 
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
   binary: pulumi
   dir: pkg
   main: ./cmd/pulumi
+  no_main_check: true
   gobinary: ../scripts/go-wrapper.sh
   env:
   - CGO_ENABLED=0
@@ -23,18 +24,21 @@ builds:
   binary: pulumi-language-go
   dir: sdk/go/pulumi-language-go
   main: ./
+  no_main_check: true
   gobinary: ../../../scripts/go-wrapper.sh
 - <<: *pulumibin
   id: pulumi-language-nodejs
   binary: pulumi-language-nodejs
   dir: sdk/nodejs/cmd/pulumi-language-nodejs
   main: ./
+  no_main_check: true
   gobinary: ../../../../scripts/go-wrapper.sh
 - <<: *pulumibin
   id: pulumi-language-python
   binary: pulumi-language-python
   dir: sdk
   main: ./python/cmd/pulumi-language-python
+  no_main_check: true
 
 archives:
 - id: pulumi


### PR DESCRIPTION
GoReleaser v1.19.0 was just released and removes support for `archives.replacements`. Instead, the recommended approach is to use the `name_template` section: https://goreleaser.com/deprecations/#archivesreplacements

The `--rm-dist` flag is also deprecated, so this change also updates it to use `--clean` per https://goreleaser.com/deprecations/#-rm-dist