### PR TITLE
Always mark dynamic provider code as secret

### DIFF
--- a/changelog/pending/20230629--sdk-python--python-dynamic-provider-serialized-code-is-now-saved-to-state-as-secret.yaml
+++ b/changelog/pending/20230629--sdk-python--python-dynamic-provider-serialized-code-is-now-saved-to-state-as-secret.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Python dynamic provider serialized code is now saved to state as secret.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -15,13 +15,16 @@
 import asyncio
 import base64
 import pickle
-from typing import Any, ClassVar, Optional, List, TYPE_CHECKING, no_type_check, cast
+from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, cast, no_type_check
 
 import dill
+
+import pulumi
+
 from .. import CustomResource, ResourceOptions
 
 if TYPE_CHECKING:
-    from ..output import Output, Inputs
+    from ..output import Inputs, Output
 
 PROVIDER_KEY = "__provider"
 
@@ -278,6 +281,6 @@ class Resource(CustomResource):
             raise Exception("A dynamic resource must not define the __provider key")
 
         props = cast(dict, props)
-        props[PROVIDER_KEY] = serialize_provider(provider)
+        props[PROVIDER_KEY] = pulumi.Output.secret(serialize_provider(provider))
 
         super().__init__(f"pulumi-python:{self._resource_type_name}", name, props, opts)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Short term workaround for https://github.com/pulumi/pulumi/issues/8265

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
