### PR TITLE
[sdk/python] Fix comment about `ROOT_STACK_RESOURCE`

### DIFF
--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -139,7 +139,7 @@ class Alias:
     parent of the resource is used (`opts.parent` if provided, else the implicit stack resource
     parent).
 
-    To specify no original parent, use `Alias(parent=pulumi.rootStackResource)`.
+    To specify no original parent, use `Alias(parent=pulumi.ROOT_STACK_RESOURCE)`.
     """
 
     stack: Optional["Input[str]"]


### PR DESCRIPTION
Looks like this was copied from the Node.js SDK. It should be `ROOT_STACK_RESOURCE` not `rootStackResource` for Python.