### PR TITLE
test: Attempt to fix TestCreatingProjectWithEmptyConfig

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -563,7 +563,7 @@ func validateProjectName(ctx context.Context, b backend.Backend,
 		}
 
 		if exists {
-			return errors.New("A project with this name already exists")
+			return fmt.Errorf("a project with this name already exists: %s", projectName)
 		}
 	}
 

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -45,8 +45,7 @@ func chdir(t *testing.T, dir string) {
 func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	args := newArgs{
@@ -106,8 +105,8 @@ func TestCreatingStackWithNumericName(t *testing.T) {
 func TestCreatingStackWithPromptedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir)
 
@@ -129,8 +128,8 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 func TestCreatingProjectWithDefaultName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	defaultProjectName := filepath.Base(tempdir)
 
@@ -161,8 +160,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
 
-	fileStateDir, _ := os.MkdirTemp("", "local-state-dir")
-	defer os.RemoveAll(fileStateDir)
+	fileStateDir := t.TempDir()
 
 	// Now override to local filesystem backend
 	backendURL := "file://" + filepath.ToSlash(fileStateDir)
@@ -170,8 +168,8 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
 
 	backendInstance = nil
-	tempdir, _ := os.MkdirTemp("", "test-env-local")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	defaultProjectName := filepath.Base(tempdir)
 

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,8 +36,7 @@ import (
 func TestFailInInteractiveWithoutYes(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	args := newArgs{
@@ -55,8 +56,7 @@ func TestFailInInteractiveWithoutYes(t *testing.T) {
 func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
@@ -81,8 +81,8 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 
 	uniqueProjectName := filepath.Base(tempdir)
@@ -106,8 +106,8 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 
 	// the project name and the project name in the stack name must match
@@ -134,8 +134,8 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir) + "test"
 
@@ -162,8 +162,8 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 func TestCreatingProjectWithPromptedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir) + "test"
 
@@ -187,8 +187,7 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -215,8 +214,7 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -241,8 +239,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -273,8 +270,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -304,7 +300,8 @@ func TestCreatingProjectWithEmptyConfig(t *testing.T) {
 	// Regression test for https://github.com/pulumi/pulumi/issues/4081
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir := t.TempDir()
+	tempdir := filepath.Join(t.TempDir(), genUniqueName(t))
+	require.NoError(t, os.MkdirAll(tempdir, 0o700))
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir) + "test"
 
@@ -342,8 +339,7 @@ func TestCreatingProjectWithEmptyConfig(t *testing.T) {
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -372,8 +368,7 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := os.MkdirTemp("", "test-env")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 	chdir(t, tempdir)
 
 	backendInstance = &backend.MockBackend{
@@ -409,8 +404,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	t.Run("NoTemplateSpecified", func(t *testing.T) {
-		tempdir, _ := os.MkdirTemp("", "test-env")
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 		chdir(t, tempdir)
 
 		args := newArgs{
@@ -427,8 +421,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("RemoteTemplateNotFound", func(t *testing.T) {
-		tempdir, _ := os.MkdirTemp("", "test-env")
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 		chdir(t, tempdir)
 
 		// A template that will never exist.
@@ -448,8 +441,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("LocalTemplateNotFound", func(t *testing.T) {
-		tempdir, _ := os.MkdirTemp("", "test-env")
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 		chdir(t, tempdir)
 
 		// A template that will never exist remotely.
@@ -817,4 +809,14 @@ func TestErrorIfNotEmptyDirectory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func genUniqueName(t *testing.T) string {
+	t.Helper()
+
+	var bs [8]byte
+	_, err := rand.Read(bs[:])
+	require.NoError(t, err)
+
+	return hex.EncodeToString(bs[:])
 }


### PR DESCRIPTION
TestCreatingProjectWithEmptyConfig appears to be broken on master:

```
=== Failed
=== FAIL: cmd/pulumi TestCreatingProjectWithEmptyConfig (0.00s)
    new_test.go:330:
        	Error Trace:	/home/runner/work/pulumi/pulumi/pkg/cmd/pulumi/new_test.go:330
        	Error:      	Received unexpected error:
        	            	A project with this name already exists
        	Test:       	TestCreatingProjectWithEmptyConfig

=== FAIL: cmd/pulumi TestCreatingProjectWithEmptyConfig (re-run 1) (0.28s)
    new_test.go:330:
        	Error Trace:	/home/runner/work/pulumi/pulumi/pkg/cmd/pulumi/new_test.go:330
        	Error:      	Received unexpected error:
        	            	A project with this name already exists
        	Test:       	TestCreatingProjectWithEmptyConfig
```

As seen in #13323 and the attempts to land #13322.

To reduce likelihood of "name already exists" errors,
generate a random name for all tests where the name is currently based
on the name of the temporary directory.

Also, change all manually managed temporary directories
(with an unchecked error) to `t.TempDir()` -- making the testing package
handle cleanup of the temporary directories.

Note: The randomly generated directory name is used
only in cases where the name of the directory was used as input
in the rest of the test.