### PR TITLE
ci: Include Go and NodeJS hosts in unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
             --version-set current \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
             --partition-module sdk 1 \
+            --partition-module sdk/go/pulumi-language-go 1 \
+            --partition-module sdk/nodejs/cmd/pulumi-language-nodejs 1 \
             --partition-module tests 2
           )
 


### PR DESCRIPTION
The CI test matrix generator expects every module that we want to test
to be provided explicitly.
Since the Go and Node hosts became independent Go modules,
we haven't been running their unit tests in CI.

Fortunately, the tests still pass today,
but we need to include these in the build.
