### PR TITLE
ci/build-binaries: Don't enable cgo for Darwin

### DIFF
--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -23,17 +23,6 @@ COVER_PACKAGES=( \
 # Join COVER_PACKAGES with commas.
 COVERPKG=$(IFS=,; echo "${COVER_PACKAGES[*]}")
 
-# If it's a production or local build - building for macOS on macOS - use CGO for DNS resolver functionality.
-#
-# See: https://github.com/golang/go/issues/12524
-if [ "$(go env GOOS)" = "darwin" ] && [ "$(uname)" = "Darwin" ]; then
-    # `go env GOOS` returns "darwin" when cross-compiling to macOS
-    # `uname` returns "Darwin" on macOS
-    export CGO_ENABLED=1
-else
-    export CGO_ENABLED=0
-fi
-
 case "$1" in
     build)
         MODE="$PULUMI_BUILD_MODE"


### PR DESCRIPTION
Previously, it was necessary to enable cgo
and use the system's DNS resolver on macOS.
In Go 1.20, the `net` package was rewritten
to not use cgo at all,
so CGO_ENABLED no longer has any effect there.

In fact, ever since 389860058dd6be35e1adf27b74b062ac180d819d,
this setting has been meaningless
because we've been building Darwin binaries
on Ubuntu machines (so cgo can't be enabled anyway).

This commit just deletes this now-unused block.
