### PR TITLE
Allow Node.js dynamic providers to capture secrets

### DIFF
--- a/changelog/pending/20230630--sdk-nodejs--node-js-dynamic-providers-mark-serialized-functions-as-secret-if-they-capture-any-secrets.yaml
+++ b/changelog/pending/20230630--sdk-nodejs--node-js-dynamic-providers-mark-serialized-functions-as-secret-if-they-capture-any-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Node.js dynamic providers mark serialized functions as secret if they capture any secrets

--- a/tests/examples/dynamic-provider/secrets/.config/Pulumi.dev.yaml
+++ b/tests/examples/dynamic-provider/secrets/.config/Pulumi.dev.yaml
@@ -1,0 +1,2 @@
+config:
+  dynamic-provider-secret:password: s3cret2

--- a/tests/examples/dynamic-provider/secrets/.gitignore
+++ b/tests/examples/dynamic-provider/secrets/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+

--- a/tests/examples/dynamic-provider/secrets/Pulumi.yaml
+++ b/tests/examples/dynamic-provider/secrets/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: dynamic-provider-secret
+description: test for dynamic provider secret capture
+runtime: nodejs
+config: ./.config/

--- a/tests/examples/dynamic-provider/secrets/index.ts
+++ b/tests/examples/dynamic-provider/secrets/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2023, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+const config = new pulumi.Config();
+const password = config.requireSecret("password");
+
+class SimpleProvider implements pulumi.dynamic.ResourceProvider {
+    async create(inputs: any) {
+        // Need to use `password.get()` to get the underlying value of the secret from within the serialzied code.  
+        // This simulates using this as a credential to talk to an external system.
+        return { id: "0", outs: { authenticated: password.get() == "s3cret" ? "200" : "401" } };
+    }
+}
+
+class SimpleResource extends dynamic.Resource {
+    authenticated!: pulumi.Output<string>;
+    constructor(name: string) {
+        super(new SimpleProvider(), name, { authenticated: undefined }, undefined);
+    }
+}
+
+let r = new SimpleResource("foo");
+export const out = r.authenticated;
+

--- a/tests/examples/dynamic-provider/secrets/package.json
+++ b/tests/examples/dynamic-provider/secrets/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "minimal",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.73.0"
+    }
+}

--- a/tests/examples/dynamic-provider/secrets/package.json
+++ b/tests/examples/dynamic-provider/secrets/package.json
@@ -1,13 +1,10 @@
 {
-    "name": "minimal",
+    "name": "secrets",
     "license": "Apache-2.0",
     "devDependencies": {
-        "typescript": "^3.0.0"
+        "typescript": "^4.5.4"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"
-    },
-    "dependencies": {
-        "@pulumi/pulumi": "^3.73.0"
     }
 }

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -152,14 +152,15 @@ func TestAccDynamicProviderSecrets(t *testing.T) {
 				"password": "s3cret",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-				// Ensure the __provider input was marked secret
+				// Ensure the __provider input (and corresponding output) was marked secret
 				dynRes := stackInfo.Deployment.Resources[2]
-				providerVal := dynRes.Inputs["__provider"]
-				switch v := providerVal.(type) {
-				case string:
-					assert.Fail(t, "__provider was not a secret")
-				case map[string]interface{}:
-					assert.Equal(t, resource.SecretSig, v[resource.SigKey])
+				for _, providerVal := range []interface{}{dynRes.Inputs["__provider"], dynRes.Outputs["__provider"]} {
+					switch v := providerVal.(type) {
+					case string:
+						assert.Fail(t, "__provider was not a secret")
+					case map[string]interface{}:
+						assert.Equal(t, resource.SecretSig, v[resource.SigKey])
+					}
 				}
 				// Ensure the resulting output had the expected value
 				code, ok := stackInfo.Outputs["out"].(string)

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -144,6 +144,34 @@ func TestAccDynamicProviderMultipleTurns2_withLocalState(t *testing.T) {
 }
 
 //nolint:paralleltest // uses parallel programtest
+func TestAccDynamicProviderSecrets(t *testing.T) {
+	test := getBaseOptions().
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "dynamic-provider/secrets"),
+			Secrets: map[string]string{
+				"password": "s3cret",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Ensure the __provider input was marked secret
+				dynRes := stackInfo.Deployment.Resources[2]
+				providerVal := dynRes.Inputs["__provider"]
+				switch v := providerVal.(type) {
+				case string:
+					assert.Fail(t, "__provider was not a secret")
+				case map[string]interface{}:
+					assert.Equal(t, resource.SecretSig, v[resource.SigKey])
+				}
+				// Ensure the resulting output had the expected value
+				code, ok := stackInfo.Outputs["out"].(string)
+				assert.True(t, ok)
+				assert.Equal(t, "200", code)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+//nolint:paralleltest // uses parallel programtest
 func TestAccDynamicProviderDerivedInputs(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{


### PR DESCRIPTION
This allows the function serialization used by dynamic providers to capture secrets, and if so, marks the resulting input value as a secret so that the `__provider` property will be a secret in the state.

Fixes https://github.com/pulumi/pulumi/issues/8265.