### PR TITLE
ci(new workflow): Run tests on master every 12 hours

### DIFF
--- a/.github/workflows/periodic-coverage.yml
+++ b/.github/workflows/periodic-coverage.yml
@@ -1,0 +1,48 @@
+# Periodically runs the tests on master and posts coverage results to codecov.
+
+name: Test with coverage
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Run every 12 hours.
+    - cron: '0 */12 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  info:
+    name: info
+    uses: ./.github/workflows/ci-info.yml
+    permissions:
+      contents: read
+    with:
+      ref: master
+      is-snapshot: true
+    secrets: inherit
+
+  ci:
+    name: CI
+    needs: [info]
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+      # To sign artifacts.
+      id-token: write
+    with:
+      ref: master
+      version: ${{ needs.info.outputs.version }}
+      lint: true
+      build-all-targets: true
+      test-codegen:  true
+      test-version-sets: current
+      integration-test-platforms: ubuntu-latest
+      acceptance-test-platforms: macos-latest windows-latest
+      enable-coverage: true
+    secrets: inherit


### PR DESCRIPTION
We recently started capturing coverage data for Pull Requests again
but we omitted tracking for master.

Part of the reason for this is that the our CI setup uses the same
binaries that were used for the end-to-end tests as part of the release.
And we don't want to upload the coverage-instrumented binaries for a
release.

This is fixable, but instead of making our CI set up even more complex,
this introduces a new workflow to test master periodically.

This workflow will run every 12 hours, running all tests on master,
with acceptance tests on both Windows and macOS,
track coverage for all of this, and post that to codecov.

We'll be able to track code coverage trends on master in Codecov.
