### PR TITLE
Temp changes to unblock the release

### DIFF
--- a/.github/workflows/on-release-manual-dispatch.yml
+++ b/.github/workflows/on-release-manual-dispatch.yml
@@ -1,0 +1,50 @@
+name: Release Dispatch
+
+permissions:
+  # To create the follow-up PR.
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        description: "Git Tag"
+        type: string
+      release_notes:
+        required: true
+        description: "Release Notes"
+        type: string
+
+concurrency: release
+
+jobs:
+  info:
+    name: gather
+    runs-on: ubuntu-latest
+    outputs:
+      version: "${{ fromJSON(steps.version.outputs.version) }}"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.tag_name }}
+      - name: Info
+        id: version
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          PULUMI_VERSION="${TAG#v}" # remove prefix
+
+          ./.github/scripts/set-output version "${PULUMI_VERSION}"
+
+  release:
+    name: release
+    needs: [info]
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ inputs.tag_name }}
+      version: ${{ needs.info.outputs.version }}
+      release-notes: ${{ inputs.release_notes }}
+      queue-merge: true
+      run-dispatch-commands: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["nodejs", "python", "go"]
+        #language: ["nodejs", "python", "go"]
+        language: ["nodejs"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -99,32 +100,32 @@ jobs:
         run: |
           make -C sdk/${{ matrix.language}} publish
 
-  s3-blobs:
-    name: s3 blobs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Download release artifacts
-        run: |
-          mkdir -p artifacts
-          gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'pulumi-*'
-          find artifacts
-      - name: Publish Blobs
-        run: |
-          aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
+  # s3-blobs:
+  #   name: s3 blobs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ inputs.ref }}
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-region: us-east-2
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         role-duration-seconds: 3600
+  #         role-external-id: upload-pulumi-release
+  #         role-session-name: pulumi@githubActions
+  #         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+  #     - name: Download release artifacts
+  #       run: |
+  #         mkdir -p artifacts
+  #         gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'pulumi-*'
+  #         find artifacts
+  #     - name: Publish Blobs
+  #       run: |
+  #         aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
 
   pr:
     # Relies on the Go SDK being published to update pkg
@@ -181,14 +182,14 @@ jobs:
         run: ${{ matrix.job.run-command }}
 
 
-  update-homebrew-tap:
-    name: Update Homebrew Tap
-    if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
-    uses: ./.github/workflows/release-homebrew-tap.yml
-    permissions:
-      contents: read
-    with:
-      ref: ${{ inputs.ref }}
-      version: ${{ inputs.version }}
-      dry-run: false
-    secrets: inherit
+  # update-homebrew-tap:
+  #   name: Update Homebrew Tap
+  #   if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
+  #   uses: ./.github/workflows/release-homebrew-tap.yml
+  #   permissions:
+  #     contents: read
+  #   with:
+  #     ref: ${{ inputs.ref }}
+  #     version: ${{ inputs.version }}
+  #     dry-run: false
+  #   secrets: inherit

--- a/scripts/publish_npm.sh
+++ b/scripts/publish_npm.sh
@@ -9,8 +9,9 @@ NPM_TAG="dev"
 
 ## We need split the GITHUB_REF into the correct parts
 ## so that we can test for NPM Tags
-IFS='/' read -ra my_array <<< "${GITHUB_REF:-}"
-BRANCH_NAME="${my_array[2]}"
+# IFS='/' read -ra my_array <<< "${GITHUB_REF:-}"
+# BRANCH_NAME="${my_array[2]}"
+BRANCH_NAME="${GITHUB_REF}"
 
 echo $BRANCH_NAME
 if [[ "${BRANCH_NAME}" == features/* ]]; then


### PR DESCRIPTION
Publishing v3.74.0 to npm failed with `../../scripts/publish_npm.sh: line 13: my_array[2]: unbound variable`.

<img width="996" alt="Screen Shot 2023-06-30 at 7 42 54 AM" src="https://github.com/pulumi/pulumi/assets/710598/4c856fb8-227f-4c0c-9d80-118eda341d5f">

This commit temporarily changes the `publish_npm.sh` script to not have the unbound variable and comments out jobs in the release workflow that already succeeded, and adds a way to manually dispatch the release workflow to unblock the release. Will use that to re-run the release workflow.

Afterwords, we can revert and address the actual issue.