### PR TITLE
Fix `publish_npm.sh` script to handle `GITHUB_REF` without '/'

### DIFF
--- a/scripts/publish_npm.sh
+++ b/scripts/publish_npm.sh
@@ -10,7 +10,8 @@ NPM_TAG="dev"
 ## We need split the GITHUB_REF into the correct parts
 ## so that we can test for NPM Tags
 IFS='/' read -ra my_array <<< "${GITHUB_REF:-}"
-BRANCH_NAME="${my_array[2]}"
+last_index=$((${#my_array[@]} - 1))
+BRANCH_NAME="${my_array[last_index]}"
 
 echo $BRANCH_NAME
 if [[ "${BRANCH_NAME}" == features/* ]]; then


### PR DESCRIPTION
It looks like the intention of this script was to parse `GITHUB_REF` values in the form `refs/heads/<branch_name>` or `refs/tags/<tag_name>` per https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables, but we overwrite this envvar in the workflow:

https://github.com/pulumi/pulumi/blob/53e205f08fc08f3388e2a63d0335b8e3a8c93a71/.github/workflows/release.yml#L54

Which is passed along from here:

https://github.com/pulumi/pulumi/blob/53e205f08fc08f3388e2a63d0335b8e3a8c93a71/.github/workflows/on-release.yml#L37

Which is just the tag name.

Still unclear how this worked for previous releases, but the script errored for the latest release when `GITHUB_REF` was just `v3.74.0`.

This commit makes the script resilient to values of `GITHUB_REF` that don't have '/'.

Fixes #13338