### PR TITLE
[sdk/go] Fix the `dist` make target

### DIFF
--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -40,6 +40,7 @@ test_auto:: $(TEST_ALL_DEPS)
 	@$(GO_TEST) $(TEST_AUTO_PKGS)
 
 dist::
+	cd pulumi-language-go && \
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)


### PR DESCRIPTION
`pulumi-language-go` was changed to be an independent go module, and `go install` needs to be run from the module directory. We updated the other targets, but missed updating `dist`, which this commit does.

Fixes #13335