### PR TITLE
deps(py): upgrade to latest grpcio

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -44,7 +44,7 @@ setup(name='pulumi',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',
-          'grpcio==1.51.3',
+          'grpcio==1.56.0',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.13',

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,7 +1,7 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
 protobuf~=4.21
-grpcio==1.51.3
+grpcio==1.56.0
 dill~=0.3
 six~=1.12
 semver~=2.13


### PR DESCRIPTION
Upgrades to the latest release of grpcio for the Python SDK.

Supersedes #13421, #13425
Fixes CVE-2023-32731