### PR TITLE
ci(test): Fix setup-go caching

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -76,7 +76,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Configure Go Cache Key
         env:
-          CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.os }}-${{ inputs.arch }}"
+          CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"
         run: echo "$CACHE_KEY" > .gocache.tmp
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -144,7 +144,9 @@ jobs:
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
           cache: true
-          cache-dependency-path: '*/go.sum'
+          cache-dependency-path: |
+            pkg/go.sum
+            .gocache.tmp
       - name: Prime Go cache
         if: ${{ steps.setup-go.outputs.cache-hit != 'true' }}
         # Compile every test to ensure we populate a good cache entry.


### PR DESCRIPTION
The setup-go step in ci-run-test never has a successful cache hit.
As a result of this, it spends 5 minutes in each test runner
just filling up the cache.

Per discussion with @AaronFriel,
this is an attempt to fix this issue with two changes:

- Actually use the gocache.tmp we generate
  (this is used in other such jobs)
- Share the cache key with build-binaries.
  Most tests run after build-binaries,
  or begin running after build-binaries has finished.
  Sharing the cache key there will be useful.