### PR TITLE
Toward accepting Input<Resource> in provider and providers for node

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -269,8 +269,9 @@ export abstract class Resource {
         return utils.isInstance<Resource>(obj, "__pulumiResource");
     }
 
-    // getProvider fetches the provider for the given module member, if any.
-    public getProvider(moduleMember: string): ProviderResource | undefined {
+    // getProviderInput fetches the provider for the given module member, if any. The result is Input to account for
+    // the possibility of Input values used to configure ResourceOptions.provider or ComponentResourceOptions.providers.
+    public getProviderInput(moduleMember: string): Input<ProviderResource|undefined> {
         const memComponents = moduleMember.split(":");
         if (memComponents.length !== 3) {
             return undefined;
@@ -278,6 +279,18 @@ export abstract class Resource {
         const pkg = memComponents[0];
 
         return this.__providers[pkg];
+    }
+
+    // Deprecated. getProviderInput fetches the provider for the given module member, if any. Prefer getProviderInput.
+    public getProvider(moduleMember: string): ProviderResource | undefined {
+        let p = this.getProviderInput(moduleMember);
+        if (p instanceof ProviderResource) {
+            return p;
+        }
+        const message = `getProvider cannot resolve ProviderResource promptly, since Input<ProviderResource> was used `+
+            `to configure ResourceOptions; please refactor the use of getProvider to getProviderInput`;
+        log.warn(message);
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Would like to enable passing Input<Resource> to provider and providers options.

Tentative

- Resource.getProvider -> Resource.getProviderInput
- Replace private readonly __providers with a collection that can do Input
- Figure out mergeOptions specifically for provider and providers
- Defer resolving provider from the constructor to the readResource/registerResource where promises can be awaited
- Figure out implications for secret/dep/known flags on the Output option
- Add tests

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
