### PR TITLE
[pcl/binder] Simplify semantics of conditional expressions

### DIFF
--- a/changelog/pending/20230709--programgen--simplify-semantics-of-pcl-conditional-expressions.yaml
+++ b/changelog/pending/20230709--programgen--simplify-semantics-of-pcl-conditional-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Simplify semantics of PCL conditional expressions


### PR DESCRIPTION
# Description

Today when using conditional expressions in PCL:
```
<expr> = <condition ∈ bool> ? <leftOperand ∈ T> : <rightOperand ∈ U>
``` 
The type of the `<expr>` is computed to be `Union[T, U]` and then reduced if possible. This however leads to complications when the expression is used subsequently in the program in places that either don't expect unions or don't know how to handle unions which lead to PCL bind errors. We have encountered several of such bind errors when trying to convert terraform programs that use the value of a conditional expression in a resource range:

Take for example https://github.com/pulumi/pulumi/issues/13191 where a value of type `union(dynamic, object({}))` could not be iterated over. I believe this is due to a value that is declared as a conditional expression and one of the operands is a call to `notImplemented(...)` of type `dynamic`. Then that value is being iterated. 

Similar issue also seen in https://github.com/pulumi/pulumi-terraform-bridge/issues/1134 and several other places.

The solution I propose here is to simplify the inference rules of the conditional expressions down to be very basic ones:
 - if either of the operands is `dynamic`, then `<expr>` is `dynamic` too
 - if either of the operands is `null` then the `<expr>` is `option(T)` where `T` is the type of the other operand if it is not already optional
 - if either of the operands is an empty list `[]` then the `<expr>` takes the type of the other operand
 - if none of the above, then `<expr>` takes the type of the first operand (while assuming both operands are of the same type which is what most languages expect and can handle)

Probably fixes https://github.com/pulumi/pulumi/issues/13318, https://github.com/pulumi/pulumi-terraform-bridge/issues/1134 (partially), https://github.com/pulumi/pulumi/issues/13191 and more similar ones

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
