### PR TITLE
Fix http source URL interpolation

### DIFF
--- a/changelog/pending/20230710--cli-plugin--fix-interpolation-of-vesion-into-http-plugin-source-urls.yaml
+++ b/changelog/pending/20230710--cli-plugin--fix-interpolation-of-vesion-into-http-plugin-source-urls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix interpolation of vesion into http plugin source URLs.

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -342,7 +342,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Custom http URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
 		spec := PluginSpec{
-			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
+			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name/v${VERSION}/${OS}/${ARCH}",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
@@ -352,7 +352,7 @@ func TestPluginDownload(t *testing.T) {
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
 				"http://customurl.jfrog.io/artifactory/pulumi-packages/"+
-					"package-name/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
+					"package-name/v4.32.0/darwin/amd64/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
@@ -366,7 +366,7 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Custom https URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
 		spec := PluginSpec{
-			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
+			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name/v${VERSION}/${OS}/${ARCH}/",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
@@ -376,7 +376,7 @@ func TestPluginDownload(t *testing.T) {
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
 				"https://customurl.jfrog.io/artifactory/pulumi-packages/"+
-					"package-name/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
+					"package-name/v4.32.0/darwin/amd64/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
@@ -726,24 +726,6 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Contains(t, err.Error(), "rate limit exceeded")
 		assert.Contains(t, err.Error(), "https://api.github.com/repos/pulumi/pulumi-mock-latest/releases/latest")
 	})
-}
-
-func TestInterpolateURL(t *testing.T) {
-	t.Parallel()
-
-	version := semver.MustParse("1.0.0")
-	const os = "linux"
-	const arch = "amd64"
-	assert.Equal(t, "", interpolateURL("", version, os, arch))
-	assert.Equal(t,
-		"https://get.pulumi.com/releases/plugins",
-		interpolateURL("https://get.pulumi.com/releases/plugins", version, os, arch))
-	assert.Equal(t,
-		"https://github.com/org/repo/releases/download/1.0.0",
-		interpolateURL("https://github.com/org/repo/releases/download/${VERSION}", version, os, arch))
-	assert.Equal(t,
-		"https://github.com/org/repo/releases/download/1.0.0/linux/amd64",
-		interpolateURL("https://github.com/org/repo/releases/download/${VERSION}/${OS}/${ARCH}", version, os, arch))
 }
 
 func TestParsePluginDownloadURLOverride(t *testing.T) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Turns out this wasn't tested and regressed in
https://github.com/pulumi/pulumi/commit/51cc6461df930b17e23d2d1408cc6110b1ede7be when we started URL parsing the input string and so ended up with a text string with "%7B" instead of "{" to replace.

This fixes the interpolation and changes a couple of the http tests to actually use this feature so it's tested.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
