### PR TITLE
[pcl/binder] Allow generating code for unknown invokes in non-strict mode

### DIFF
--- a/changelog/pending/20230710--programgen-dotnet-go-nodejs-python--allow-generating-code-for-unknown-invokes-tf-data-sources-in-non-strict-mode.yaml
+++ b/changelog/pending/20230710--programgen-dotnet-go-nodejs-python--allow-generating-code-for-unknown-invokes-tf-data-sources-in-non-strict-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Allow generating code for unknown invokes (tf data sources) in non-strict mode

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -195,6 +195,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 				pcl.AllowMissingProperties,
 				pcl.AllowMissingVariables,
 				pcl.SkipResourceTypechecking,
+				pcl.SkipInvokeTypechecking,
 			}...)
 		}
 

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -107,6 +107,12 @@ func (g *generator) outputInvokes(x model.Expression) model.Expression {
 			return x, nil
 		}
 
+		if call.Type() == model.DynamicType {
+			// ignore if the return type of the invoke is dynamic
+			// this means that we are working with an unknown invoke
+			return x, nil
+		}
+
 		_, isOutput := call.Type().(*model.OutputType)
 		if isOutput {
 			return x, nil

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -716,6 +716,12 @@ func (g *generator) collectImports(program *pcl.Program) programImports {
 					token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
 					tokenRange := tokenArg.SyntaxNode().Range()
 					pkg, mod, name, diagnostics := pcl.DecomposeToken(token, tokenRange)
+					if call.Type() == model.DynamicType {
+						// then this is an unknown function, create a dummy import for it
+						dummyVersionPath := "/v1"
+						pulumiImports.Add(g.getPulumiImport(pkg, dummyVersionPath, mod, name))
+						return call, nil
+					}
 
 					contract.Assertf(len(diagnostics) == 0, "Expected no diagnostics, got %d", len(diagnostics))
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -275,7 +275,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		pkg, module, fn, diags := g.functionName(expr.Args[0])
 		contract.Assertf(len(diags) == 0, "We don't allow problems getting the function name")
-		if module == "" {
+		if module == "" || module == "index" {
 			module = pkg
 		}
 		isOut, outArgs, outArgsType := pcl.RecognizeOutputVersionedInvoke(expr)

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -39,6 +39,7 @@ type ComponentProgramBinderArgs struct {
 	AllowMissingVariables        bool
 	AllowMissingProperties       bool
 	SkipResourceTypecheck        bool
+	SkipInvokeTypecheck          bool
 	PreferOutputVersionedInvokes bool
 	BinderDirPath                string
 	BinderLoader                 schema.Loader
@@ -52,6 +53,7 @@ type bindOptions struct {
 	allowMissingVariables        bool
 	allowMissingProperties       bool
 	skipResourceTypecheck        bool
+	skipInvokeTypecheck          bool
 	preferOutputVersionedInvokes bool
 	loader                       schema.Loader
 	packageCache                 *PackageCache
@@ -96,6 +98,10 @@ func SkipResourceTypechecking(options *bindOptions) {
 
 func PreferOutputVersionedInvokes(options *bindOptions) {
 	options.preferOutputVersionedInvokes = true
+}
+
+func SkipInvokeTypechecking(options *bindOptions) {
+	options.skipInvokeTypecheck = true
 }
 
 func PluginHost(host plugin.Host) BindOption {

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -192,6 +192,9 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 		if args.PreferOutputVersionedInvokes {
 			opts = append(opts, PreferOutputVersionedInvokes)
 		}
+		if args.SkipInvokeTypecheck {
+			opts = append(opts, SkipInvokeTypechecking)
+		}
 
 		componentProgram, programDiags, err := BindProgram(parser.Files, opts...)
 
@@ -288,6 +291,7 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 		AllowMissingVariables:        b.options.allowMissingVariables,
 		AllowMissingProperties:       b.options.allowMissingProperties,
 		SkipResourceTypecheck:        b.options.skipResourceTypecheck,
+		SkipInvokeTypecheck:          b.options.skipInvokeTypecheck,
 		PreferOutputVersionedInvokes: b.options.preferOutputVersionedInvokes,
 		BinderLoader:                 b.options.loader,
 		BinderDirPath:                b.options.dirPath,

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -274,7 +274,7 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 
 		pkg, err := b.options.packageCache.loadPackageSchema(b.options.loader, name, pkgOpts.version)
 		if err != nil {
-			if b.options.skipResourceTypecheck {
+			if b.options.skipResourceTypecheck || b.options.skipInvokeTypecheck {
 				continue
 			}
 			return err

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -125,13 +125,24 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 	}
 	pkgSchema, ok := b.options.packageCache.entries[pkgInfo]
 	if !ok {
+		if b.options.skipInvokeTypecheck {
+			return b.zeroSignature(), nil
+		}
 		return b.zeroSignature(), hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
 	}
 
 	var fn *schema.Function
 	if f, tk, ok, err := pkgSchema.LookupFunction(token); err != nil {
+		if b.options.skipInvokeTypecheck {
+			return b.zeroSignature(), nil
+		}
+
 		return b.zeroSignature(), hcl.Diagnostics{functionLoadError(token, err, tokenRange)}
 	} else if !ok {
+		if b.options.skipInvokeTypecheck {
+			return b.zeroSignature(), nil
+		}
+
 		return b.zeroSignature(), hcl.Diagnostics{unknownFunction(token, tokenRange)}
 	} else {
 		fn = f

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -328,6 +328,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Test program generation on packages with a dash in the name",
 		SkipCompile: allProgLanguages, // since we are using a synthetic schema
 	},
+	{
+		Directory:   "unknown-invoke",
+		Description: "Tests generating code for unknown invokes when skipping invoke type checking",
+		SkipCompile: allProgLanguages,
+		BindOptions: []pcl.BindOption{pcl.SkipInvokeTypechecking},
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/unknown-invoke-pp/dotnet/unknown-invoke.cs
+++ b/pkg/codegen/testing/test/testdata/unknown-invoke-pp/dotnet/unknown-invoke.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Unknown = Pulumi.Unknown;
+
+return await Deployment.RunAsync(() => 
+{
+    var data = Unknown.Index.GetData.Invoke(new()
+    {
+        Input = "hello",
+    });
+
+    var values = Unknown.Eks.ModuleValues.Invoke();
+
+    return new Dictionary<string, object?>
+    {
+        ["content"] = data.Content,
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/unknown-invoke-pp/go/unknown-invoke.go
+++ b/pkg/codegen/testing/test/testdata/unknown-invoke-pp/go/unknown-invoke.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown"
+	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown/eks"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		data, err := unknown.GetData(ctx, map[string]interface{}{
+			"input": "hello",
+		}, nil)
+		if err != nil {
+			return err
+		}
+		_, err = eks.ModuleValues(ctx, nil, nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("content", data.Content)
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/unknown-invoke-pp/nodejs/unknown-invoke.ts
+++ b/pkg/codegen/testing/test/testdata/unknown-invoke-pp/nodejs/unknown-invoke.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as unknown from "@pulumi/unknown";
+
+const data = unknown.index.getData({
+    input: "hello",
+});
+const values = unknown.eks.moduleValues({});
+export const content = data.content;

--- a/pkg/codegen/testing/test/testdata/unknown-invoke-pp/python/unknown-invoke.py
+++ b/pkg/codegen/testing/test/testdata/unknown-invoke-pp/python/unknown-invoke.py
@@ -1,0 +1,6 @@
+import pulumi
+import pulumi_unknown as unknown
+
+data = unknown.index.get_data(input="hello")
+values = unknown.eks.module_values()
+pulumi.export("content", data["content"])

--- a/pkg/codegen/testing/test/testdata/unknown-invoke-pp/unknown-invoke.pp
+++ b/pkg/codegen/testing/test/testdata/unknown-invoke-pp/unknown-invoke.pp
@@ -1,0 +1,9 @@
+data = invoke("unknown:index:getData", {
+    input = "hello"
+})
+
+values = invoke("unknown:eks:moduleValues", {})
+
+output "content" {
+    value = data.content
+}


### PR DESCRIPTION
# Description

This PR implements a new PCL bind option: `SkipInvokeTypechecking` which for now makes the binder accept unknown invokes and allows generating code for them even if don't have a (bridged) package for that invoke. Enabled in non-strict mode for `pulumi convert`


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
