### PR TITLE
[sdk/*] Add support for resource source positions

### DIFF
--- a/changelog/pending/20230712--sdk-go-nodejs-python--add-support-for-reporting-resource-source-positions.yaml
+++ b/changelog/pending/20230712--sdk-go-nodejs-python--add-support-for-reporting-resource-source-positions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go,nodejs,python
+  description: Add support for reporting resource source positions

--- a/sdk/nodejs/tests/runtime/langhost/cases/074.source_position/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/074.source_position/index.js
@@ -1,0 +1,17 @@
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyCustomResource extends pulumi.CustomResource {
+    constructor(name, opts) {
+        super("test:index:MyCustomResource", name, {}, opts);
+    }
+}
+
+class MyComponentResource extends pulumi.ComponentResource {
+    constructor(name, opts) {
+        super("test:index:MyComponentResource", name, {}, opts);
+    }
+}
+
+const custom = new MyCustomResource("custom");
+const component = new MyComponentResource("component");

--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -182,7 +182,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=empty_pb2.Empty,struct_pb2.Struct,struct_pb2.ListValue,resource_pb2.*,provider_pb2.*,engine_pb2.*,language_pb2.*,plugin_pb2.*,alias_pb2.*,proto.*
+generated-members=empty_pb2.Empty,struct_pb2.Struct,struct_pb2.ListValue,resource_pb2.*,provider_pb2.*,engine_pb2.*,language_pb2.*,plugin_pb2.*,alias_pb2.*,source_pb2.*,proto.*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/sdk/python/lib/test/langhost/aliases/test_aliases.py
+++ b/sdk/python/lib/test/langhost/aliases/test_aliases.py
@@ -21,7 +21,7 @@ class AliasesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, _protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         return {
             "urn": f"urn:pulumi:stack::project::{ty}::{name}",
             "id": "myID",

--- a/sdk/python/lib/test/langhost/asset/test_asset.py
+++ b/sdk/python/lib/test/langhost/asset/test_asset.py
@@ -24,7 +24,7 @@ class AssetTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "file":
             self.assertIsInstance(_resource["asset"], FileAsset)

--- a/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
+++ b/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
@@ -32,7 +32,7 @@ class ChainedFailureTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if ty == "test:index:ResourceA":
             self.assertEqual(name, "resourceA")
             self.assertDictEqual(_resource, {"inprop": 777})

--- a/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
@@ -24,7 +24,7 @@ class ComponentDependenciesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
 
         if name == "resD":
             self.assertListEqual(_dependencies, ["resA"], msg=f"{name}._dependencies")

--- a/sdk/python/lib/test/langhost/component_provider_resolution/test_component_provider_resolution.py
+++ b/sdk/python/lib/test/langhost/component_provider_resolution/test_component_provider_resolution.py
@@ -24,7 +24,7 @@ class ComponentDependenciesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "combined-mine":
             self.assertTrue(protect)
             self.assertEqual(_provider, "")

--- a/sdk/python/lib/test/langhost/component_resource_list_of_providers/test_component_resource_list_of_providers.py
+++ b/sdk/python/lib/test/langhost/component_resource_list_of_providers/test_component_resource_list_of_providers.py
@@ -31,7 +31,7 @@ class ComponentResourceListOfProvidersTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if _custom and not ty.startswith("pulumi:providers:"):
             expect_protect = False
             expect_provider_name = ""

--- a/sdk/python/lib/test/langhost/component_resource_single_provider/test_component_resource_single_provider.py
+++ b/sdk/python/lib/test/langhost/component_resource_single_provider/test_component_resource_single_provider.py
@@ -31,7 +31,7 @@ class ComponentResourceSingleProviderTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if _custom and not ty.startswith("pulumi:providers:"):
             expect_protect = False
             expect_provider_name = ""

--- a/sdk/python/lib/test/langhost/config/test_config.py
+++ b/sdk/python/lib/test/langhost/config/test_config.py
@@ -29,7 +29,7 @@ class ConfigTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         self.assertEqual("myname", name)
         return {

--- a/sdk/python/lib/test/langhost/delete_before_replace/test_delete_before_replace.py
+++ b/sdk/python/lib/test/langhost/delete_before_replace/test_delete_before_replace.py
@@ -26,7 +26,7 @@ class DeleteBeforeReplaceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("foo", name)
         self.assertTrue(_delete_before_replace)
         return {

--- a/sdk/python/lib/test/langhost/first_class_provider/test_first_class_provider.py
+++ b/sdk/python/lib/test/langhost/first_class_provider/test_first_class_provider.py
@@ -30,7 +30,7 @@ class FirstClassProviderTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "testprov":
             # Provider resource.
             self.assertEqual("pulumi:providers:test", ty)

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
@@ -53,7 +53,7 @@ class TestFirstClassProviderInvoke(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "testprov":
             self.assertEqual("pulumi:providers:test", ty)
             self.prov_urn = self.make_urn(ty, name)

--- a/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
@@ -32,7 +32,7 @@ class FirstClassProviderUnknown(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "testprov":
             self.assertEqual("pulumi:providers:test", ty)
             # Only provide an ID when doing an update. When doing a preview the ID will be unknown

--- a/sdk/python/lib/test/langhost/future_failure/test_future_failure.py
+++ b/sdk/python/lib/test/langhost/future_failure/test_future_failure.py
@@ -28,7 +28,7 @@ class TestFutureFailure(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         return {
             "urn": self.make_urn(ty, name),

--- a/sdk/python/lib/test/langhost/future_input/test_future_input.py
+++ b/sdk/python/lib/test/langhost/future_input/test_future_input.py
@@ -27,7 +27,7 @@ class FutureInputTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:FileResource")
         self.assertEqual(name, "file")
         self.assertDictEqual(_resource, {

--- a/sdk/python/lib/test/langhost/ignore_changes/test_ignore_changes.py
+++ b/sdk/python/lib/test/langhost/ignore_changes/test_ignore_changes.py
@@ -26,7 +26,7 @@ class TestIgnoreChanges(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
 
         # Note that here we expect to receive `ignoredProperty`, even though the user provided `ignored_property`.
         self.assertListEqual(_ignore_changes, ["ignoredProperty", "ignored_property_other"])

--- a/sdk/python/lib/test/langhost/inherit_defaults/test_inherit_defaults.py
+++ b/sdk/python/lib/test/langhost/inherit_defaults/test_inherit_defaults.py
@@ -31,7 +31,7 @@ class InheritDefaultsTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if _custom and not ty.startswith("pulumi:providers:"):
             expect_protect = False
             expect_provider_name = ""

--- a/sdk/python/lib/test/langhost/inheritance_translation/test_inheritance_translation.py
+++ b/sdk/python/lib/test/langhost/inheritance_translation/test_inheritance_translation.py
@@ -23,7 +23,7 @@ class InheritanceTranslationTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         return {
             "urn": self.make_urn(ty, name),

--- a/sdk/python/lib/test/langhost/input_type_mismatch/test_input_type_mismatch.py
+++ b/sdk/python/lib/test/langhost/input_type_mismatch/test_input_type_mismatch.py
@@ -25,7 +25,7 @@ class InputTypeMismatchTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
 
         policy = _resource["policy"]

--- a/sdk/python/lib/test/langhost/input_values_for_outputs/test_input_values_for_outputs.py
+++ b/sdk/python/lib/test/langhost/input_values_for_outputs/test_input_values_for_outputs.py
@@ -26,7 +26,7 @@ class InputValuesForOutputsTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         return {
             "urn": self.make_urn(ty, name),
             "id": name,

--- a/sdk/python/lib/test/langhost/invalid_property_dependency/test_invalid_property_dependency.py
+++ b/sdk/python/lib/test/langhost/invalid_property_dependency/test_invalid_property_dependency.py
@@ -25,7 +25,7 @@ class InvalidPropertyDependencyTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
             self.assertListEqual(_dependencies, [])

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -35,7 +35,7 @@ class TestInvoke(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         self.assertEqual(_resource["value"], 42)
 

--- a/sdk/python/lib/test/langhost/invoke_types/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke_types/test_invoke.py
@@ -44,7 +44,7 @@ class TestInvoke(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "resourceA":
             self.assertEqual({
                 "first_value": "hellohello",

--- a/sdk/python/lib/test/langhost/large_resource/test_large_resource.py
+++ b/sdk/python/lib/test/langhost/large_resource/test_large_resource.py
@@ -29,7 +29,7 @@ class LargeResourceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyLargeStringResource")
         self.assertEqual(name, "testResource1")
 

--- a/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
+++ b/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
@@ -28,7 +28,7 @@ class TestMarshalFailure(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         return {
             "urn": self.make_urn(ty, name),

--- a/sdk/python/lib/test/langhost/one_complex_resource/test_one_complex_resource.py
+++ b/sdk/python/lib/test/langhost/one_complex_resource/test_one_complex_resource.py
@@ -24,7 +24,7 @@ class OneComplexResourceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "testres")
         self.assertEqual(_resource["falseprop"], False)

--- a/sdk/python/lib/test/langhost/one_resource/test_one_resource.py
+++ b/sdk/python/lib/test/langhost/one_resource/test_one_resource.py
@@ -23,7 +23,7 @@ class OneResourceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "testResource1")
         return {

--- a/sdk/python/lib/test/langhost/output_all/test_output_all.py
+++ b/sdk/python/lib/test/langhost/output_all/test_output_all.py
@@ -25,7 +25,7 @@ class OutputAllTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         number = 0
         if name == "testResource1":
             self.assertEqual(ty, "test:index:MyResource")

--- a/sdk/python/lib/test/langhost/output_nested/test_output_nested.py
+++ b/sdk/python/lib/test/langhost/output_nested/test_output_nested.py
@@ -23,7 +23,7 @@ class OutputNestedTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         nested_numbers = None
         if name == "testResource1":
             self.assertEqual(ty, "test:index:MyResource")

--- a/sdk/python/lib/test/langhost/output_property_dependencies/test_output_property_dependencies.py
+++ b/sdk/python/lib/test/langhost/output_property_dependencies/test_output_property_dependencies.py
@@ -24,7 +24,7 @@ class OutputPropertyDependenciesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
             return {

--- a/sdk/python/lib/test/langhost/preview/test_preview.py
+++ b/sdk/python/lib/test/langhost/preview/test_preview.py
@@ -26,7 +26,7 @@ class PreviewTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "foo")
         if _dry_run:

--- a/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
+++ b/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
@@ -24,7 +24,7 @@ class PropertyDependenciesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
             self.assertListEqual(_dependencies, [], msg=f"{name}._dependencies")

--- a/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
+++ b/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
@@ -27,7 +27,7 @@ class PropertyRenamingTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         # Test:
         #  1. Everything that we receive from the running program is in camel-case. The engine never sees
         # the pre-translated names of the input properties.

--- a/sdk/python/lib/test/langhost/protect/test_protect.py
+++ b/sdk/python/lib/test/langhost/protect/test_protect.py
@@ -26,7 +26,7 @@ class ProtectTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("foo", name)
         self.assertTrue(protect)
         return {

--- a/sdk/python/lib/test/langhost/read/test_read.py
+++ b/sdk/python/lib/test/langhost/read/test_read.py
@@ -23,7 +23,7 @@ class ReadTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "foo2")
         return {

--- a/sdk/python/lib/test/langhost/remote_component_dependencies/test_remote_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/remote_component_dependencies/test_remote_component_dependencies.py
@@ -42,6 +42,7 @@ class RemoteComponentDependenciesTest(LanghostTest):
         _import,
         _replace_on_changes,
         _providers,
+        source_position,
     ):
 
         if name == "resA":

--- a/sdk/python/lib/test/langhost/remote_component_providers/test_remote_component_providers.py
+++ b/sdk/python/lib/test/langhost/remote_component_providers/test_remote_component_providers.py
@@ -42,6 +42,7 @@ class RemoteComponentProvidersTest(LanghostTest):
         _import,
         _replace_on_changes,
         providers,
+        source_position,
     ):
         if name == "singular" or name == "map" or name == "array":
             self.assertEqual(provider, "myprovider::myprovider")

--- a/sdk/python/lib/test/langhost/replace_on_changes/test_replace_on_changes.py
+++ b/sdk/python/lib/test/langhost/replace_on_changes/test_replace_on_changes.py
@@ -26,7 +26,7 @@ class TestReplaceOnChanges(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
 
         print(f'register_resource args: {locals()}')
         self.assertEqual("testResource", name)

--- a/sdk/python/lib/test/langhost/resource_op_bad_inputs/test_resource_op_bad_inputs.py
+++ b/sdk/python/lib/test/langhost/resource_op_bad_inputs/test_resource_op_bad_inputs.py
@@ -23,5 +23,5 @@ class UnhandledExceptionTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         raise Exception("oh no")

--- a/sdk/python/lib/test/langhost/resource_op_fail/test_resource_op_fail.py
+++ b/sdk/python/lib/test/langhost/resource_op_fail/test_resource_op_fail.py
@@ -23,5 +23,5 @@ class UnhandledExceptionTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         raise Exception("oh no")

--- a/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
+++ b/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
@@ -31,7 +31,7 @@ class ResourceThensTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if ty == "test:index:ResourceA":
             self.assertEqual(name, "resourceA")
             self.assertDictEqual(_resource, {"inprop": 777, "inprop_2": 42})

--- a/sdk/python/lib/test/langhost/source_position/__main__.py
+++ b/sdk/python/lib/test/langhost/source_position/__main__.py
@@ -1,0 +1,25 @@
+# Copyright 2016-2019, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import ComponentResource, CustomResource
+
+class MyResource(CustomResource):
+    def __init__(self, name, opts=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={}, opts=opts)
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        ComponentResource.__init__(self, "test:index:MyComponent", name, props={}, opts=opts)
+
+custom = MyResource("custom")
+component = MyComponent("component")

--- a/sdk/python/lib/test/langhost/source_position/test_source_position.py
+++ b/sdk/python/lib/test/langhost/source_position/test_source_position.py
@@ -15,22 +15,26 @@ from os import path
 from ..util import LanghostTest
 
 
-class InheritanceTypesTest(LanghostTest):
-    def test_inheritance_types(self):
+class SourcePositionTest(LanghostTest):
+    def test_source_position(self):
         self.run_test(
-            program=path.join(self.base_path(), "inheritance_types"),
-            expected_resource_count=1)
+            program=path.join(self.base_path(), "source_position"),
+            expected_resource_count=2)
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
                           _replace_on_changes, _providers, source_position):
-        self.assertEqual("test:index:MyResource", ty)
+
+        assert source_position is not None
+        assert source_position.uri.endswith("__main__.py")
+
+        if name == "custom":
+            self.assertEqual(source_position.line, 24)
+        elif name == "component":
+            self.assertEqual(source_position.line, 25)
+        else:
+            assert False
+
         return {
             "urn": self.make_urn(ty, name),
-            "id": name,
-            "object": {"foo": {"bar": "hello", "baz": "world"}},
         }
-
-    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
-        self.assertEqual("pulumi:pulumi:Stack", ty)
-        self.assertEqual({"combined_values": "hello world"}, outputs)

--- a/sdk/python/lib/test/langhost/ten_resources/test_ten_resources.py
+++ b/sdk/python/lib/test/langhost/ten_resources/test_ten_resources.py
@@ -26,7 +26,7 @@ class TenResourcesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         self.assertEqual("test:index:MyResource", ty)
         if not _dry_run:
             self.assertIsNone(

--- a/sdk/python/lib/test/langhost/types/test_types.py
+++ b/sdk/python/lib/test/langhost/types/test_types.py
@@ -24,7 +24,7 @@ class TestTypes(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name in ["testres", "testres2", "testres3", "testres4"]:
             self.assertIn("additional", _resource)
             self.assertEqual({

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -100,6 +100,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         import_ = request.importId
         replace_on_changes = sorted(list(request.replaceOnChanges))
         providers = request.providers
+        source_position = request.sourcePosition
 
         property_dependencies = {}
         for key, value in request.propertyDependencies.items():
@@ -109,7 +110,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
             outs = self.langhost_test.register_resource(
                 context, self.dryrun, type_, name, props, deps, parent, custom, protect, provider,
                 property_dependencies, delete_before_replace, ignore_changes, version, import_, replace_on_changes,
-                providers,
+                providers, source_position,
             )
             if outs.get("urn"):
                 urn = outs["urn"]
@@ -282,7 +283,7 @@ class LanghostTest(unittest.TestCase):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         """
         Method corresponding to the `RegisterResource` resource monitor RPC call.
         Override for custom behavior or assertions.

--- a/sdk/python/lib/test/langhost/versions/test_versions.py
+++ b/sdk/python/lib/test/langhost/versions/test_versions.py
@@ -23,7 +23,7 @@ class TestVersions(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
-                          _replace_on_changes, _providers):
+                          _replace_on_changes, _providers, source_position):
         if name == "testres":
             self.assertEqual(_version, "0.19.1")
         elif name == "testres2":


### PR DESCRIPTION
Add support to the core SDKs for reporting resource source positions.

In each SDK, this is implemented by crawling the stack when a resource
is registered in order to determine the position of the user code that
registered the resource.

This is somewhat brittle in that it expects a call stack of the form:
- Resource class constructor
- abstract Resource subclass constructor
- concrete Resource subclass constructor
- user code

This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".

For example, consider the AWS S3 Bucket resource. When user code instantiates a Bucket, the stack will look like
this in NodeJS:

    new Resource (/path/to/resource.ts:123:45)
    new CustomResource (/path/to/resource.ts:678:90)
    new Bucket (/path/to/bucket.ts:987:65)
    <user code> (/path/to/index.ts:4:3)

In order to determine the source position, we locate the fourth frame (the `<user code>` frame).