### PR TITLE
[pcl/binder] Implement parseInt PCL function and allow range expression to be of type string

### DIFF
--- a/changelog/pending/20230710--programgen-dotnet-go-nodejs-python--implement-parseint-function-and-allow-range-expression-to-be-of-type-string.yaml
+++ b/changelog/pending/20230710--programgen-dotnet-go-nodejs-python--implement-parseint-function-and-allow-range-expression-to-be-of-type-string.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Implement parseInt function and allow range expression to be of type string

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -519,6 +519,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "NotImplemented(%v)", expr.Args[0])
 	case "singleOrNone":
 		g.Fgenf(w, "Enumerable.Single(%v)", expr.Args[0])
+	case "parseInt":
+		g.Fgenf(w, "int.Parse(%v)", expr.Args[0])
 	case pcl.Invoke:
 		_, fullFunctionName := g.functionName(expr.Args[0])
 		functionParts := strings.Split(fullFunctionName, ".")

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -267,6 +267,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "notImplemented(%v)", expr.Args[0])
 	case "singleOrNone":
 		g.Fgenf(w, "singleOrNone(%v)", expr.Args[0])
+	case "parseInt":
+		g.Fgenf(w, "parseInt(%v)", expr.Args[0])
 	case pcl.Invoke:
 		if expr.Signature.MultiArgumentInputs {
 			panic(fmt.Errorf("go program-gen does not implement MultiArgumentInputs for function '%v'",
@@ -1219,6 +1221,7 @@ var functionPackages = map[string][]string{
 	"filebase64sha256": {"fmt", "crypto/sha256", "os"},
 	"cwd":              {"os"},
 	"singleOrNone":     {"fmt"},
+	"parseInt":         {"strconv"},
 }
 
 func (g *generator) genFunctionPackages(x *model.FunctionCallExpression) []string {

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -103,6 +103,14 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 %s	}
 %s	return elements[0]
 %s}`, indent, indent, indent, indent, indent, indent), true
+	case "parseInt":
+		return fmt.Sprintf(`%sfunc parseInt(input string) int {
+%s	value, err := strconv.Atoi(input)
+%s	if err != nil {
+%s		panic(err)
+%s	}
+%s	return value
+%s}`, indent, indent, indent, indent, indent, indent, indent), true
 	default:
 		return "", false
 	}

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -417,6 +417,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "notImplemented(%v)", expr.Args[0])
 	case "singleOrNone":
 		g.Fgenf(w, "singleOrNone(%v)", expr.Args[0])
+	case "parseInt":
+		g.Fgenf(w, "parseInt(%v, 10)", expr.Args[0])
 	case pcl.Invoke:
 		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -346,6 +346,13 @@ var pulumiBuiltins = map[string]*model.Function{
 		}},
 		ReturnType: model.DynamicType,
 	}),
+	"parseInt": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{{
+			Name: "input",
+			Type: model.StringType,
+		}},
+		ReturnType: model.IntType,
+	}),
 	// Returns either the single item in a list, none if the list is empty or errors.
 	"singleOrNone": model.NewFunction(model.GenericFunctionSignature(
 		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -300,6 +300,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "not_implemented(%v)", expr.Args[0])
 	case "singleOrNone":
 		g.Fgenf(w, "single_or_none(%v)", expr.Args[0])
+	case "parseInt":
+		g.Fgenf(w, "int(%v)", expr.Args[0])
 	case pcl.Invoke:
 		if expr.Signature.MultiArgumentInputs {
 			err := fmt.Errorf("python program-gen does not implement MultiArgumentInputs for function '%v'",

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -334,6 +334,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages,
 		BindOptions: []pcl.BindOption{pcl.SkipInvokeTypechecking},
 	},
+	{
+		Directory:   "implicit-string-range",
+		Description: "Tests that we can use implicit string as integer in resource ranges",
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/implicit-string-range-pp/dotnet/implicit-string-range.cs
+++ b/pkg/codegen/testing/test/testdata/implicit-string-range-pp/dotnet/implicit-string-range.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var config = new Config();
+    // Number of AZs to cover in a given region
+    var azCount = config.Get("azCount") ?? "10";
+    var bucketsPerAvailabilityZone = new List<Aws.S3.Bucket>();
+    for (var rangeIndex = 0; rangeIndex < int.Parse(azCount); rangeIndex++)
+    {
+        var range = new { Value = rangeIndex };
+        bucketsPerAvailabilityZone.Add(new Aws.S3.Bucket($"bucketsPerAvailabilityZone-{range.Value}", new()
+        {
+            Website = new Aws.S3.Inputs.BucketWebsiteArgs
+            {
+                IndexDocument = "index.html",
+            },
+        }));
+    }
+});
+

--- a/pkg/codegen/testing/test/testdata/implicit-string-range-pp/go/implicit-string-range.go
+++ b/pkg/codegen/testing/test/testdata/implicit-string-range-pp/go/implicit-string-range.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func parseInt(input string) int {
+	value, err := strconv.Atoi(input)
+	if err != nil {
+		panic(err)
+	}
+	return value
+}
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		// Number of AZs to cover in a given region
+		azCount := "10"
+		if param := cfg.Get("azCount"); param != "" {
+			azCount = param
+		}
+		var bucketsPerAvailabilityZone []*s3.Bucket
+		for index := 0; index < parseInt(azCount); index++ {
+			key0 := index
+			__res, err := s3.NewBucket(ctx, fmt.Sprintf("bucketsPerAvailabilityZone-%v", key0), &s3.BucketArgs{
+				Website: &s3.BucketWebsiteArgs{
+					IndexDocument: pulumi.String("index.html"),
+				},
+			})
+			if err != nil {
+				return err
+			}
+			bucketsPerAvailabilityZone = append(bucketsPerAvailabilityZone, __res)
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/implicit-string-range-pp/implicit-string-range.pp
+++ b/pkg/codegen/testing/test/testdata/implicit-string-range-pp/implicit-string-range.pp
@@ -1,0 +1,15 @@
+config "azCount" "string" {
+  default     = "10"
+  description = "Number of AZs to cover in a given region"
+}
+
+resource bucketsPerAvailabilityZone "aws:s3:Bucket" {
+    options {
+        // using the azCount config variable which is a string
+        range = azCount
+    }
+
+    website = {
+    	indexDocument = "index.html"
+    }
+}

--- a/pkg/codegen/testing/test/testdata/implicit-string-range-pp/nodejs/implicit-string-range.ts
+++ b/pkg/codegen/testing/test/testdata/implicit-string-range-pp/nodejs/implicit-string-range.ts
@@ -1,0 +1,12 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// Number of AZs to cover in a given region
+const azCount = config.get("azCount") || "10";
+const bucketsPerAvailabilityZone: aws.s3.Bucket[] = [];
+for (const range = {value: 0}; range.value < parseInt(azCount, 10); range.value++) {
+    bucketsPerAvailabilityZone.push(new aws.s3.Bucket(`bucketsPerAvailabilityZone-${range.value}`, {website: {
+        indexDocument: "index.html",
+    }}));
+}

--- a/pkg/codegen/testing/test/testdata/implicit-string-range-pp/python/implicit-string-range.py
+++ b/pkg/codegen/testing/test/testdata/implicit-string-range-pp/python/implicit-string-range.py
@@ -1,0 +1,13 @@
+import pulumi
+import pulumi_aws as aws
+
+config = pulumi.Config()
+# Number of AZs to cover in a given region
+az_count = config.get("azCount")
+if az_count is None:
+    az_count = "10"
+buckets_per_availability_zone = []
+for range in [{"value": i} for i in range(0, int(az_count))]:
+    buckets_per_availability_zone.append(aws.s3.Bucket(f"bucketsPerAvailabilityZone-{range['value']}", website=aws.s3.BucketWebsiteArgs(
+        index_document="index.html",
+    )))

--- a/pkg/codegen/testing/test/testdata/unknown-resource-pp/go/unknown-resource.go
+++ b/pkg/codegen/testing/test/testdata/unknown-resource-pp/go/unknown-resource.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown"
 	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown/eks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -24,7 +26,6 @@ func main() {
 		var fromModule []*eks.Example
 		for index := 0; index < 10; index++ {
 			key0 := index
-			_ := index
 			__res, err := eks.NewExample(ctx, fmt.Sprintf("fromModule-%v", key0), &eks.ExampleArgs{
 				AssociatedMain: main.Id,
 			})


### PR DESCRIPTION
# Description

This PR implements the `parseInt` function in PCL and subsequently generates its code within dotnet, nodejs, python and go program-gen. The PR uses this function to allow the `range` expression option in resources and components to be of type `string`, in which case it gets wrapped inside a function call to `parseInt` and used as if it was a integer. 

We want to support implicit conversions from string to int in multiple places and this is one them since terraform allows it too (see mentioned issue below)

Fixes #13440 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
