### PR TITLE
feat: support package name override for dotnet

### DIFF
--- a/changelog/pending/20230711--sdkgen-dotnet--allows-packagename-override.yaml
+++ b/changelog/pending/20230711--sdkgen-dotnet--allows-packagename-override.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/dotnet
+  description: Allows PackageName Override

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -280,7 +280,12 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 		if langInfo, found := p.Language["csharp"]; found {
 			csharpInfo, ok := langInfo.(CSharpPackageInfo)
 			if ok {
-				namespace := namespaceName(csharpInfo.Namespaces, p.Name)
+				pkgName := p.Name
+				if name := csharpInfo.PackageName; name != "" {
+					pkgName = name
+				}
+
+				namespace := namespaceName(csharpInfo.Namespaces, pkgName)
 				packageName = fmt.Sprintf("%s.%s", csharpInfo.GetRootNamespace(), namespace)
 			}
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

Depends on:

https://github.com/pulumi/pulumi-terraform-bridge/pull/1288

# Description

Like Python and NodeJS, it can be useful to support package name overrides. This PR adds support for dotnet to do the same, making it possible for RedisCloud to have their package name RedisCloud rather than Rediscloud.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
