### PR TITLE
Change backend.CurrentUser to return service accounts

### DIFF
--- a/changelog/pending/20230712--cli-about--username-for-about-and-whoami-is-now-organization-for-filestate-backends-this-matches-the-expectation-for-their-fully-qualified-stack-references.yaml
+++ b/changelog/pending/20230712--cli-about--username-for-about-and-whoami-is-now-organization-for-filestate-backends-this-matches-the-expectation-for-their-fully-qualified-stack-references.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/about
+  description: Username for about and whoami is now 'organization' for filestate backends. This matches the expectation for their fully qualified stack references.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -212,7 +212,7 @@ type Backend interface {
 	// LogoutAll logs you out of all the backend and removes any stored credentials.
 	LogoutAll() error
 	// Returns the identity of the current user and any organizations they are in for the backend.
-	CurrentUser() (string, []string, error)
+	CurrentUser() (*workspace.Account, error)
 
 	// Cancel the current update for the given stack.
 	CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1274,12 +1274,8 @@ func (b *localBackend) LogoutAll() error {
 	return workspace.DeleteAllAccounts()
 }
 
-func (b *localBackend) CurrentUser() (string, []string, error) {
-	user, err := user.Current()
-	if err != nil {
-		return "", nil, err
-	}
-	return user.Username, nil, nil
+func (b *localBackend) CurrentUser() (*workspace.Account, error) {
+	return nil, nil
 }
 
 func (b *localBackend) getLocalStacks(ctx context.Context) ([]*localBackendReference, error) {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -64,9 +64,12 @@ func (c cloudBackendReference) String() string {
 				return string(c.name)
 			}
 		} else {
-			currentUser, _, userErr := c.b.CurrentUser()
-			if userErr == nil && c.owner == currentUser {
-				return string(c.name)
+			currentUser, userErr := c.b.CurrentUser()
+			if userErr == nil {
+				contract.Assertf(currentUser != nil, "cloudBackend returned nil user")
+				if c.owner == currentUser.Username {
+					return string(c.name)
+				}
 			}
 		}
 		return fmt.Sprintf("%s/%s", c.owner, c.name)

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -59,7 +59,7 @@ type MockBackend struct {
 	ImportDeploymentF       func(context.Context, Stack, *apitype.UntypedDeployment) error
 	LogoutF                 func() error
 	LogoutAllF              func() error
-	CurrentUserF            func() (string, []string, error)
+	CurrentUserF            func() (*workspace.Account, error)
 	PreviewF                func(context.Context, Stack,
 		UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
 	UpdateF func(context.Context, Stack,
@@ -358,7 +358,7 @@ func (be *MockBackend) LogoutAll() error {
 	panic("not implemented")
 }
 
-func (be *MockBackend) CurrentUser() (string, []string, error) {
+func (be *MockBackend) CurrentUser() (*workspace.Account, error) {
 	if be.CurrentUserF != nil {
 		return be.CurrentUserF()
 	}

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -307,15 +307,20 @@ type backendAbout struct {
 }
 
 func getBackendAbout(b backend.Backend) backendAbout {
-	currentUser, currentOrgs, err := b.CurrentUser()
-	if err != nil {
-		currentUser = "Unknown"
+	username := "organization"
+	orgs := []string{}
+
+	currentUser, err := b.CurrentUser()
+	if err == nil && currentUser != nil {
+		username = currentUser.Username
+		orgs = currentUser.Organizations
 	}
+
 	return backendAbout{
 		Name:          b.Name(),
 		URL:           b.URL(),
-		User:          currentUser,
-		Organizations: currentOrgs,
+		User:          username,
+		Organizations: orgs,
 	}
 }
 

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -163,8 +163,12 @@ func newLoginCmd() *cobra.Command {
 				return fmt.Errorf("problem logging in: %w", err)
 			}
 
-			if currentUser, _, err := be.CurrentUser(); err == nil {
-				fmt.Printf("Logged in to %s as %s (%s)\n", be.Name(), currentUser, be.URL())
+			if currentUser, err := be.CurrentUser(); err == nil {
+				if currentUser != nil {
+					fmt.Printf("Logged in to %s as %s (%s)\n", be.Name(), currentUser.Username, be.URL())
+				} else {
+					fmt.Printf("Logged in to %s (%s)\n", be.Name(), be.URL())
+				}
 			} else {
 				fmt.Printf("Logged in to %s (%s)\n", be.Name(), be.URL())
 			}

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -225,9 +225,12 @@ func currentUser(t *testing.T) string {
 	ctx := context.Background()
 	b, err := currentBackend(ctx, nil, display.Options{})
 	assert.NoError(t, err)
-	currentUser, _, err := b.CurrentUser()
+	currentUser, err := b.CurrentUser()
 	assert.NoError(t, err)
-	return currentUser
+	if currentUser == nil {
+		return "organization"
+	}
+	return currentUser.Username
 }
 
 func loadStackName(t *testing.T) string {

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -66,9 +66,13 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, _, err = b.CurrentUser()
+				orgName = "organization"
+				user, err := b.CurrentUser()
 				if err != nil {
 					return err
+				}
+				if user != nil {
+					orgName = user.Username
 				}
 			}
 

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -56,9 +56,13 @@ func newPolicyLsCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, _, err = b.CurrentUser()
+				orgName = "organization"
+				user, err := b.CurrentUser()
 				if err != nil {
 					return err
+				}
+				if user != nil {
+					orgName = user.Username
 				}
 			}
 

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -89,9 +89,16 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	name, orgs, err := b.CurrentUser()
+	name := "organization"
+	orgs := []string{}
+
+	user, err := b.CurrentUser()
 	if err != nil {
 		return err
+	}
+	if user != nil {
+		name = user.Username
+		orgs = user.Organizations
 	}
 
 	if cmd.jsonOut {

--- a/pkg/cmd/pulumi/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami_test.go
@@ -12,6 +12,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWhoAmICmd_none(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	cmd := whoAmICmd{
+		Stdout: &buff,
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return &backend.MockBackend{
+				CurrentUserF: func() (*workspace.Account, error) {
+					return nil, nil
+				},
+			}, nil
+		},
+	}
+
+	err := cmd.Run(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "organization", buff.String())
+}
+
 func TestWhoAmICmd_default(t *testing.T) {
 	t.Parallel()
 
@@ -20,8 +41,8 @@ func TestWhoAmICmd_default(t *testing.T) {
 		Stdout: &buff,
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, error) {
-					return "user1", []string{"org1", "org2"}, nil
+				CurrentUserF: func() (*workspace.Account, error) {
+					return &workspace.Account{Username: "user1", Organizations: []string{"org1", "org2"}}, nil
 				},
 			}, nil
 		},
@@ -42,8 +63,8 @@ func TestWhoAmICmd_verbose(t *testing.T) {
 		Stdout:  &buff,
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, error) {
-					return "user2", []string{"org1", "org2"}, nil
+				CurrentUserF: func() (*workspace.Account, error) {
+					return &workspace.Account{Username: "user2", Organizations: []string{"org1", "org2"}}, nil
 				},
 				URLF: func() string {
 					return "https://pulumi.example.com"
@@ -70,8 +91,8 @@ func TestWhoAmICmd_json(t *testing.T) {
 		Stdout:  &buff,
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 			return &backend.MockBackend{
-				CurrentUserF: func() (string, []string, error) {
-					return "user3", []string{"org1", "org2"}, nil
+				CurrentUserF: func() (*workspace.Account, error) {
+					return &workspace.Account{Username: "user3", Organizations: []string{"org1", "org2"}}, nil
 				},
 				URLF: func() string {
 					return "https://pulumi.example.com"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Change `about` and `whoami` to return the username as "organization" when using the filestate backend, this matches what's expected for their fully qualified stack references. 

As part of this we change the internal backend interface such that `CurrentUser` is service specific returning a full `workspace.Account` (see https://github.com/pulumi/pulumi/pull/13206#discussion_r1258716013 for some context on why we want to do this).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
