### PR TITLE
Make pythons RPCManager a context variable

### DIFF
--- a/changelog/pending/20230713--sdk-python--move-some-global-state-to-context-state-for-parallel-updates.yaml
+++ b/changelog/pending/20230713--sdk-python--move-some-global-state-to-context-state-for-parallel-updates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Move some global state to context state for parallel updates.

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -17,14 +17,14 @@ import logging
 import sys
 import traceback
 from contextlib import suppress
+
 import grpc
 
-from ._workspace import PulumiFn
 from .. import log
-from ..runtime.proto import language_pb2, plugin_pb2, LanguageRuntimeServicer
-from ..runtime import run_in_stack, reset_options, set_all_config
-from ..runtime.rpc_manager import RPC_MANAGER
 from ..errors import RunError
+from ..runtime import reset_options, run_in_stack, set_all_config
+from ..runtime.proto import LanguageRuntimeServicer, language_pb2, plugin_pb2
+from ._workspace import PulumiFn
 
 _py_version_less_than_3_7 = sys.version_info[0] == 3 and sys.version_info[1] < 7
 
@@ -122,7 +122,6 @@ class LanguageServer(LanguageRuntimeServicer):
             loop.close()
             sys.stdout.flush()
             sys.stderr.flush()
-            RPC_MANAGER.clear()
 
         return result
 

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -22,8 +22,12 @@ from .. import _types, log
 from ..invoke import InvokeOptions
 from ..runtime.proto import provider_pb2, resource_pb2
 from . import rpc
-from .rpc_manager import RPC_MANAGER
-from .settings import get_monitor, grpc_error_to_exception, handle_grpc_error
+from .settings import (
+    _get_rpc_manager,
+    get_monitor,
+    grpc_error_to_exception,
+    handle_grpc_error,
+)
 from .sync_await import _sync_await
 
 if TYPE_CHECKING:
@@ -128,7 +132,7 @@ def invoke(
         return None, None
 
     async def do_rpc():
-        resp, exn = await RPC_MANAGER.do_rpc("invoke", do_invoke)()
+        resp, exn = await _get_rpc_manager().do_rpc("invoke", do_invoke)()
         # If there was an RPC level exception, we will raise it. Note that this will also crash the
         # process because it will have been considered "unhandled". For semantic level errors, such
         # as errors from the data source itself, we return that as part of the returned tuple instead.
@@ -282,6 +286,6 @@ def call(
             resolve_deps.set_result(set())
             raise
 
-    asyncio.ensure_future(RPC_MANAGER.do_rpc("call", do_call)())
+    asyncio.ensure_future(_get_rpc_manager().do_rpc("call", do_call)())
 
     return out

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -16,45 +16,46 @@ Support for serializing and deserializing properties going into or flowing
 out of RPC calls.
 """
 import asyncio
-from collections import abc
 import functools
 import inspect
 from abc import ABC, abstractmethod
+from collections import abc
+from enum import Enum
 from typing import (
-    List,
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Iterable,
+    List,
     Mapping,
     Optional,
     Sequence,
     Set,
     Union,
-    TYPE_CHECKING,
     cast,
 )
-from enum import Enum
 
+import six
 from google.protobuf import struct_pb2
 from semver import VersionInfo as Version
-import six
-from . import known_types, settings
-from .resource import _expand_dependencies
-from .. import log
-from .. import _types
+
+from .. import _types, log
 from .. import urn as urn_util
+from . import known_types, settings
+from .resource_cycle_breaker import declare_dependency
 
 if TYPE_CHECKING:
-    from ..output import Inputs, Input, Output
-    from ..resource import Resource, CustomResource, ProviderResource
     from ..asset import (
+        AssetArchive,
+        FileArchive,
         FileAsset,
+        RemoteArchive,
         RemoteAsset,
         StringAsset,
-        FileArchive,
-        RemoteArchive,
-        AssetArchive,
     )
+    from ..output import Input, Inputs, Output
+    from ..resource import CustomResource, ProviderResource, Resource
 
 UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 """If a value is None, we serialize as UNKNOWN, which tells the engine that it may be computed later."""
@@ -224,6 +225,78 @@ async def serialize_properties(
             property_deps[translated_name] = deps
 
     return struct
+
+
+async def _add_dependency(
+    deps: Set[str], res: "Resource", from_resource: Optional["Resource"]
+):
+    """
+    _add_dependency adds a dependency on the given resource to the set of deps.
+
+    The behavior of this method depends on whether or not the resource is a custom resource, a local component resource,
+    or a remote component resource:
+
+    - Custom resources are added directly to the set, as they are "real" nodes in the dependency graph.
+    - Local component resources act as aggregations of their descendents. Rather than adding the component resource
+      itself, each child resource is added as a dependency.
+    - Remote component resources are added directly to the set, as they naturally act as aggregations of their children
+      with respect to dependencies: the construction of a remote component always waits on the construction of its
+      children.
+
+    In other words, if we had:
+
+                     Comp1
+                 |     |     |
+             Cust1   Comp2  Remote1
+                     |   |       |
+                 Cust2   Cust3  Comp3
+                 |                 |
+             Cust4                Cust5
+
+    Then the transitively reachable resources of Comp1 will be [Cust1, Cust2, Cust3, Remote1].
+    It will *not* include:
+    * Cust4 because it is a child of a custom resource
+    * Comp2 because it is a non-remote component resoruce
+    * Comp3 and Cust5 because Comp3 is a child of a remote component resource
+    """
+
+    # Exit early if there are cycles to avoid hangs.
+    no_cycles = declare_dependency(from_resource, res) if from_resource else True
+    if not no_cycles:
+        return
+
+    from .. import ComponentResource  # pylint: disable=import-outside-toplevel
+
+    # Local component resources act as aggregations of their descendents.
+    # Rather than adding the component resource itself, each child resource
+    # is added as a dependency.
+    if isinstance(res, ComponentResource) and not res._remote:
+        # Copy the set before iterating so that any concurrent child additions during
+        # the dependency computation (which is async, so can be interleaved with other
+        # operations including child resource construction which adds children to this
+        # resource) do not trigger modification during iteration errors.
+        child_resources = res._childResources.copy()
+        for child in child_resources:
+            await _add_dependency(deps, child, from_resource)
+        return
+
+    urn = await res.urn.future()
+    if urn:
+        deps.add(urn)
+
+
+async def _expand_dependencies(
+    deps: Iterable["Resource"], from_resource: Optional["Resource"]
+) -> Set[str]:
+    """
+    _expand_dependencies expands the given iterable of Resources into a set of URNs.
+    """
+
+    urns: Set[str] = set()
+    for d in deps:
+        await _add_dependency(urns, d, from_resource)
+
+    return urns
 
 
 # pylint: disable=too-many-return-statements, too-many-branches
@@ -508,12 +581,12 @@ def deserialize_properties(
     # which has type `Struct` in our gRPC proto definition.
     if _special_sig_key in props_struct:
         from .. import (  # pylint: disable=import-outside-toplevel
-            FileAsset,
-            StringAsset,
-            RemoteAsset,
             AssetArchive,
             FileArchive,
+            FileAsset,
             RemoteArchive,
+            RemoteAsset,
+            StringAsset,
         )
 
         if props_struct[_special_sig_key] == _special_asset_sig:

--- a/sdk/python/lib/pulumi/runtime/rpc_manager.py
+++ b/sdk/python/lib/pulumi/runtime/rpc_manager.py
@@ -88,9 +88,3 @@ class RPCManager:
         self.rpcs = []
         self.exception_traceback = None
         self.unhandled_exception = None
-
-
-RPC_MANAGER: RPCManager = RPCManager()
-"""
-Singleton RPC manager responsible for coordinating RPC calls to the engine.
-"""

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -19,10 +19,11 @@
 
 import asyncio
 import os
-import pytest
 import sys
 import typing
 import uuid
+
+import pytest
 
 import pulumi
 from pulumi import automation

--- a/sdk/python/lib/test/provider/test_server.py
+++ b/sdk/python/lib/test/provider/test_server.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 import functools
-from typing import Dict, Any, Optional, Tuple, List, Set, Callable, Awaitable
-from semver import VersionInfo as Version
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 
-import pytest
-
-from pulumi.runtime.settings import Settings, configure
-from pulumi.provider.server import ProviderServicer
-from pulumi.runtime import proto, rpc, rpc_manager, ResourceModule, Mocks
-from pulumi.resource import CustomResource, ResourceOptions
-from pulumi.runtime.proto.provider_pb2 import ConstructRequest
-from google.protobuf import struct_pb2
 import pulumi.output
+import pytest
+from google.protobuf import struct_pb2
+from pulumi.provider.server import ProviderServicer
+from pulumi.resource import CustomResource, ResourceOptions
+from pulumi.runtime import Mocks, ResourceModule, proto, rpc, rpc_manager
+from pulumi.runtime.proto.provider_pb2 import ConstructRequest
+from pulumi.runtime.settings import Settings, configure
+from semver import VersionInfo as Version
 
 
 def pulumi_test(coro):
@@ -35,7 +34,6 @@ def pulumi_test(coro):
         configure(Settings("project", "stack"))
         rpc._RESOURCE_PACKAGES.clear()
         rpc._RESOURCE_MODULES.clear()
-        rpc_manager.RPC_MANAGER = rpc_manager.RPCManager()
 
         wrapped(*args, **kwargs)
 

--- a/sdk/python/lib/test/runtime/test_stack.py
+++ b/sdk/python/lib/test/runtime/test_stack.py
@@ -14,10 +14,10 @@
 
 import sys
 import traceback
-import pytest
 
+import pytest
 from pulumi.runtime import stack
-from pulumi.runtime.rpc_manager import RPC_MANAGER
+from pulumi.runtime.settings import _get_rpc_manager
 
 
 async def _explode(n = 10):
@@ -34,7 +34,7 @@ async def test_wait_for_rpcs():
     rather than wait_for_rpcs's own stack trace.
     """
 
-    await RPC_MANAGER.do_rpc("sadness", _explode)()
+    await _get_rpc_manager().do_rpc("sadness", _explode)()
     try:
         await stack.wait_for_rpcs()
     except Exception:

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -16,20 +16,17 @@ import unittest
 from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, cast
 
-from google.protobuf import struct_pb2
-from google.protobuf import json_format
-from pulumi.resource import ComponentResource, CustomResource, DependencyResource, Resource, ResourceOptions
-from pulumi.runtime import Mocks, MockCallArgs, MockResourceArgs, ResourceModule, mocks, rpc, rpc_manager, set_mocks, settings
-from pulumi import Input, Output, UNKNOWN, input_type
-from pulumi.asset import (
-    FileAsset,
-    RemoteAsset,
-    StringAsset,
-    AssetArchive,
-    FileArchive,
-    RemoteArchive
-)
+from google.protobuf import json_format, struct_pb2
+from pulumi.asset import (AssetArchive, FileArchive, FileAsset, RemoteArchive,
+                          RemoteAsset, StringAsset)
+from pulumi.resource import (ComponentResource, CustomResource,
+                             DependencyResource, Resource, ResourceOptions)
+from pulumi.runtime import (MockCallArgs, MockResourceArgs, Mocks,
+                            ResourceModule, mocks, rpc, rpc_manager, set_mocks,
+                            settings)
+
 import pulumi
+from pulumi import UNKNOWN, Input, Output, input_type
 
 
 class FakeCustomResource(CustomResource):
@@ -116,7 +113,6 @@ def pulumi_test(coro):
         settings.configure(mocks.MockSettings(dry_run=False))
         rpc._RESOURCE_PACKAGES.clear()
         rpc._RESOURCE_MODULES.clear()
-        rpc_manager.RPC_MANAGER = rpc_manager.RPCManager()
 
         wrapped(*args, **kwargs)
 

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -29,7 +29,6 @@ def pulumi_test(coro):
         settings.configure(settings.Settings("project", "stack"))
         rpc._RESOURCE_PACKAGES.clear()
         rpc._RESOURCE_MODULES.clear()
-        rpc_manager.RPC_MANAGER = rpc_manager.RPCManager()
 
         wrapped(*args, **kwargs)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Global variables cause issues when running programs in the same process in parallel which we can do with automation api, but also in the test framework. This changes the RPCManager to be a context variable on Settings, along with other "program global" data like the resource monitor and engine logger.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
