### PR TITLE
[pcl/binder] Allow binding unsupported range and collection types in non-strict mode for pulumi convert

### DIFF
--- a/changelog/pending/20230712--programgen--allow-binding-unsupported-range-and-collection-types-in-non-strict-mode-for-pulumi-convert.yaml
+++ b/changelog/pending/20230712--programgen--allow-binding-unsupported-range-and-collection-types-in-non-strict-mode-for-pulumi-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Allow binding unsupported range and collection types in non-strict mode for pulumi convert

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -196,6 +196,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 				pcl.AllowMissingVariables,
 				pcl.SkipResourceTypechecking,
 				pcl.SkipInvokeTypechecking,
+				pcl.SkipRangeTypechecking,
 			}...)
 		}
 

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -726,6 +726,11 @@ type ForExpression struct {
 	// True if the value expression is being grouped.
 	Group bool
 
+	// Whether the collection type should be strictly type-checked
+	// When true, unsupported collection types will result in an error
+	// otherwise a warning will be emitted
+	StrictCollectionTypechecking bool
+
 	exprType Type
 }
 
@@ -761,7 +766,7 @@ func (x *ForExpression) typecheck(typecheckCollection, typecheckOperands bool) h
 	}
 
 	if typecheckCollection {
-		keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng)
+		keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng, x.StrictCollectionTypechecking)
 		diagnostics = append(diagnostics, kvDiags...)
 
 		if x.KeyVariable != nil {
@@ -1147,6 +1152,10 @@ type IndexExpression struct {
 	Collection Expression
 	// The index key.
 	Key Expression
+	// Whether the collection type should be strictly type-checked
+	// When true, unsupported collection types will result in an error
+	// otherwise a warning will be emitted
+	StrictCollectionTypechecking bool
 
 	keyType  Type
 	exprType Type
@@ -1191,7 +1200,7 @@ func (x *IndexExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 		rng = x.Syntax.Collection.Range()
 	}
 
-	keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng)
+	keyType, valueType, kvDiags := GetCollectionTypes(x.Collection.Type(), rng, x.StrictCollectionTypechecking)
 	diagnostics = append(diagnostics, kvDiags...)
 	x.keyType = keyType
 

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -260,7 +260,8 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 					// for any other generic type iterations
 					// we compute the range key and range value types
 					// and the variable type T of the component becomes List<T>
-					rangeKeyType, rangeValueType, _ = model.GetCollectionTypes(typ, rng.Range())
+					strict := !b.options.skipRangeTypecheck
+					rangeKeyType, rangeValueType, _ = model.GetCollectionTypes(typ, rng.Range(), strict)
 					transformComponentType = func(variableType model.Type) model.Type {
 						return model.NewListType(variableType)
 					}

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -193,7 +193,8 @@ func (b *binder) getPkgOpts(node *Resource) packageOpts {
 			if rng, hasRange := block.Body.Attributes["range"]; hasRange {
 				expr, _ := model.BindExpression(rng.Expr, b.root, b.tokens, b.options.modelOptions()...)
 				typ := model.ResolveOutputs(expr.Type())
-				rk, rv, _ := model.GetCollectionTypes(typ, rng.Range())
+				strict := !b.options.skipRangeTypecheck
+				rk, rv, _ := model.GetCollectionTypes(typ, rng.Range(), strict)
 				rangeKey, rangeValue = rk, rv
 			}
 		}

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -19,7 +19,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 
-func getEntriesSignature(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+func getEntriesSignature(
+	args []model.Expression,
+	options bindOptions) (model.StaticFunctionSignature, hcl.Diagnostics) {
 	var diagnostics hcl.Diagnostics
 
 	keyType, valueType := model.Type(model.DynamicType), model.Type(model.DynamicType)
@@ -31,8 +33,11 @@ func getEntriesSignature(args []model.Expression) (model.StaticFunctionSignature
 	}
 
 	if len(args) == 1 {
-		keyT, valueT, diags := model.GetCollectionTypes(model.ResolveOutputs(args[0].Type()),
-			args[0].SyntaxNode().Range())
+		strictCollectionTypechecking := !options.skipRangeTypecheck
+		keyT, valueT, diags := model.GetCollectionTypes(
+			model.ResolveOutputs(args[0].Type()),
+			args[0].SyntaxNode().Range(),
+			strictCollectionTypechecking)
 		keyType, valueType, diagnostics = keyT, valueT, append(diagnostics, diags...)
 	}
 
@@ -44,349 +49,355 @@ func getEntriesSignature(args []model.Expression) (model.StaticFunctionSignature
 	return signature, diagnostics
 }
 
-var pulumiBuiltins = map[string]*model.Function{
-	"element": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			var diagnostics hcl.Diagnostics
+func pulumiBuiltins(options bindOptions) map[string]*model.Function {
+	return map[string]*model.Function{
+		"element": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				var diagnostics hcl.Diagnostics
 
-			listType, returnType := model.Type(model.DynamicType), model.Type(model.DynamicType)
-			if len(args) > 0 {
-				switch t := model.ResolveOutputs(args[0].Type()).(type) {
-				case *model.ListType:
-					listType, returnType = args[0].Type(), t.ElementType
-				case *model.TupleType:
-					_, elementType := model.UnifyTypes(t.ElementTypes...)
-					listType, returnType = args[0].Type(), elementType
-				default:
-					rng := args[0].SyntaxNode().Range()
-					diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "the first argument to 'element' must be a list or tuple",
-						Subject:  &rng,
-					}}
-				}
-			}
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{
-					{
-						Name: "list",
-						Type: listType,
-					},
-					{
-						Name: "index",
-						Type: model.NumberType,
-					},
-				},
-				ReturnType: returnType,
-			}, diagnostics
-		})),
-	"entries": model.NewFunction(model.GenericFunctionSignature(getEntriesSignature)),
-	"fileArchive": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: ArchiveType,
-	}),
-	"remoteArchive": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "uri",
-			Type: model.StringType,
-		}},
-		ReturnType: ArchiveType,
-	}),
-	"assetArchive": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "assets",
-			Type: model.NewMapType(AssetOrArchiveType),
-		}},
-		ReturnType: ArchiveType,
-	}),
-	"fileAsset": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: AssetType,
-	}),
-	"stringAsset": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "value",
-			Type: model.StringType,
-		}},
-		ReturnType: AssetType,
-	}),
-	"remoteAsset": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "uri",
-			Type: model.StringType,
-		}},
-		ReturnType: AssetType,
-	}),
-	"join": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{
-			{
-				Name: "separator",
-				Type: model.StringType,
-			},
-			{
-				Name: "strings",
-				Type: model.NewListType(model.StringType),
-			},
-		},
-		ReturnType: model.StringType,
-	}),
-	"length": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			var diagnostics hcl.Diagnostics
-
-			valueType := model.Type(model.DynamicType)
-			if len(args) > 0 {
-				valueType = args[0].Type()
-				elementType := UnwrapOption(model.ResolveOutputs(valueType))
-				switch valueType := elementType.(type) {
-				case *model.ListType, *model.MapType, *model.ObjectType, *model.TupleType:
-					// OK
-				default:
-					if model.StringType.ConversionFrom(valueType) == model.NoConversion {
+				listType, returnType := model.Type(model.DynamicType), model.Type(model.DynamicType)
+				if len(args) > 0 {
+					switch t := model.ResolveOutputs(args[0].Type()).(type) {
+					case *model.ListType:
+						listType, returnType = args[0].Type(), t.ElementType
+					case *model.TupleType:
+						_, elementType := model.UnifyTypes(t.ElementTypes...)
+						listType, returnType = args[0].Type(), elementType
+					default:
 						rng := args[0].SyntaxNode().Range()
 						diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
 							Severity: hcl.DiagError,
-							Summary:  "the first argument to 'length' must be a list, map, object, tuple, or string",
+							Summary:  "the first argument to 'element' must be a list or tuple",
 							Subject:  &rng,
 						}}
 					}
 				}
-			}
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{{
-					Name: "value",
-					Type: valueType,
-				}},
-				ReturnType: model.IntType,
-			}, diagnostics
-		})),
-	"lookup": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			var diagnostics hcl.Diagnostics
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{
+						{
+							Name: "list",
+							Type: listType,
+						},
+						{
+							Name: "index",
+							Type: model.NumberType,
+						},
+					},
+					ReturnType: returnType,
+				}, diagnostics
+			})),
+		"entries": model.NewFunction(model.GenericFunctionSignature(
+			func(arguments []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				return getEntriesSignature(arguments, options)
+			})),
 
-			mapType, elementType := model.Type(model.DynamicType), model.Type(model.DynamicType)
-			if len(args) > 0 {
-				switch t := model.ResolveOutputs(args[0].Type()).(type) {
-				case *model.MapType:
-					mapType, elementType = args[0].Type(), t.ElementType
-				case *model.ObjectType:
-					var unifiedType model.Type
-					for _, t := range t.Properties {
-						_, unifiedType = model.UnifyTypes(unifiedType, t)
-					}
-					mapType, elementType = args[0].Type(), unifiedType
-				default:
-					rng := args[0].SyntaxNode().Range()
-					diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "the first argument to 'lookup' must be a map",
-						Subject:  &rng,
-					}}
-				}
-			}
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{
-					{
-						Name: "map",
-						Type: mapType,
-					},
-					{
-						Name: "key",
-						Type: model.StringType,
-					},
-					{
-						Name: "default",
-						Type: model.NewOptionalType(elementType),
-					},
+		"fileArchive": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: ArchiveType,
+		}),
+		"remoteArchive": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "uri",
+				Type: model.StringType,
+			}},
+			ReturnType: ArchiveType,
+		}),
+		"assetArchive": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "assets",
+				Type: model.NewMapType(AssetOrArchiveType),
+			}},
+			ReturnType: ArchiveType,
+		}),
+		"fileAsset": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: AssetType,
+		}),
+		"stringAsset": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "value",
+				Type: model.StringType,
+			}},
+			ReturnType: AssetType,
+		}),
+		"remoteAsset": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "uri",
+				Type: model.StringType,
+			}},
+			ReturnType: AssetType,
+		}),
+		"join": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{
+				{
+					Name: "separator",
+					Type: model.StringType,
 				},
-				ReturnType: elementType,
-			}, diagnostics
-		})),
-	"mimeType": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"range": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{
-			{
-				Name: "fromOrTo",
-				Type: model.NumberType,
+				{
+					Name: "strings",
+					Type: model.NewListType(model.StringType),
+				},
 			},
-			{
-				Name: "to",
-				Type: model.NewOptionalType(model.NumberType),
-			},
-		},
-		ReturnType: model.NewListType(model.IntType),
-	}),
-	"readDir": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: model.NewListType(model.StringType),
-	}),
-	"readFile": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"filebase64": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"filebase64sha256": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "path",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"secret": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			valueType := model.Type(model.DynamicType)
-			if len(args) == 1 {
-				valueType = args[0].Type()
-			}
+			ReturnType: model.StringType,
+		}),
+		"length": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				var diagnostics hcl.Diagnostics
 
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{{
-					Name: "value",
-					Type: valueType,
-				}},
-				ReturnType: model.NewOutputType(valueType),
-			}, nil
-		})),
-	"unsecret": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			valueType := model.Type(model.DynamicType)
-			if len(args) == 1 {
-				valueType = args[0].Type()
-			}
-
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{{
-					Name: "value",
-					Type: valueType,
-				}},
-				ReturnType: model.NewOutputType(valueType),
-			}, nil
-		})),
-	"sha1": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "input",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"split": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{
-			{
-				Name: "separator",
-				Type: model.StringType,
-			},
-			{
-				Name: "string",
-				Type: model.StringType,
-			},
-		},
-		ReturnType: model.NewListType(model.StringType),
-	}),
-	"toBase64": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "value",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"fromBase64": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "value",
-			Type: model.StringType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	"toJSON": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "value",
-			Type: model.DynamicType,
-		}},
-		ReturnType: model.StringType,
-	}),
-	// Returns the name of the current stack
-	"stack": model.NewFunction(model.StaticFunctionSignature{
-		ReturnType: model.StringType,
-	}),
-	// Returns the name of the current project
-	"project": model.NewFunction(model.StaticFunctionSignature{
-		ReturnType: model.StringType,
-	}),
-	// Returns the directory from which pulumi was run
-	"cwd": model.NewFunction(model.StaticFunctionSignature{
-		ReturnType: model.StringType,
-	}),
-	"notImplemented": model.NewFunction(model.StaticFunctionSignature{
-		Parameters: []model.Parameter{{
-			Name: "errorMessage",
-			Type: model.StringType,
-		}},
-		ReturnType: model.DynamicType,
-	}),
-	// Returns either the single item in a list, none if the list is empty or errors.
-	"singleOrNone": model.NewFunction(model.GenericFunctionSignature(
-		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
-			var diagnostics hcl.Diagnostics
-
-			valueType := model.Type(model.DynamicType)
-			if len(args) == 1 {
-				valueType = args[0].Type()
-			} else {
-				diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "'singleOrNone' only expects one argument",
-				}}
-			}
-
-			elementType := model.Type(model.DynamicType)
-
-			switch valueType := model.ResolveOutputs(valueType).(type) {
-			case *model.ListType:
-				elementType = valueType.ElementType
-			case *model.TupleType:
-				if len(valueType.ElementTypes) > 0 {
-					elementType = valueType.ElementTypes[0]
+				valueType := model.Type(model.DynamicType)
+				if len(args) > 0 {
+					valueType = args[0].Type()
+					elementType := UnwrapOption(model.ResolveOutputs(valueType))
+					switch valueType := elementType.(type) {
+					case *model.ListType, *model.MapType, *model.ObjectType, *model.TupleType:
+						// OK
+					default:
+						if model.StringType.ConversionFrom(valueType) == model.NoConversion {
+							rng := args[0].SyntaxNode().Range()
+							diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "the first argument to 'length' must be a list, map, object, tuple, or string",
+								Subject:  &rng,
+							}}
+						}
+					}
 				}
-			default:
-				if valueType != model.DynamicType {
-					rng := args[0].SyntaxNode().Range()
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{{
+						Name: "value",
+						Type: valueType,
+					}},
+					ReturnType: model.IntType,
+				}, diagnostics
+			})),
+		"lookup": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				var diagnostics hcl.Diagnostics
+
+				mapType, elementType := model.Type(model.DynamicType), model.Type(model.DynamicType)
+				if len(args) > 0 {
+					switch t := model.ResolveOutputs(args[0].Type()).(type) {
+					case *model.MapType:
+						mapType, elementType = args[0].Type(), t.ElementType
+					case *model.ObjectType:
+						var unifiedType model.Type
+						for _, t := range t.Properties {
+							_, unifiedType = model.UnifyTypes(unifiedType, t)
+						}
+						mapType, elementType = args[0].Type(), unifiedType
+					default:
+						rng := args[0].SyntaxNode().Range()
+						diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "the first argument to 'lookup' must be a map",
+							Subject:  &rng,
+						}}
+					}
+				}
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{
+						{
+							Name: "map",
+							Type: mapType,
+						},
+						{
+							Name: "key",
+							Type: model.StringType,
+						},
+						{
+							Name: "default",
+							Type: model.NewOptionalType(elementType),
+						},
+					},
+					ReturnType: elementType,
+				}, diagnostics
+			})),
+		"mimeType": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"range": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{
+				{
+					Name: "fromOrTo",
+					Type: model.NumberType,
+				},
+				{
+					Name: "to",
+					Type: model.NewOptionalType(model.NumberType),
+				},
+			},
+			ReturnType: model.NewListType(model.IntType),
+		}),
+		"readDir": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: model.NewListType(model.StringType),
+		}),
+		"readFile": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"filebase64": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"filebase64sha256": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "path",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"secret": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				valueType := model.Type(model.DynamicType)
+				if len(args) == 1 {
+					valueType = args[0].Type()
+				}
+
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{{
+						Name: "value",
+						Type: valueType,
+					}},
+					ReturnType: model.NewOutputType(valueType),
+				}, nil
+			})),
+		"unsecret": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				valueType := model.Type(model.DynamicType)
+				if len(args) == 1 {
+					valueType = args[0].Type()
+				}
+
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{{
+						Name: "value",
+						Type: valueType,
+					}},
+					ReturnType: model.NewOutputType(valueType),
+				}, nil
+			})),
+		"sha1": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "input",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"split": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{
+				{
+					Name: "separator",
+					Type: model.StringType,
+				},
+				{
+					Name: "string",
+					Type: model.StringType,
+				},
+			},
+			ReturnType: model.NewListType(model.StringType),
+		}),
+		"toBase64": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "value",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"fromBase64": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "value",
+				Type: model.StringType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		"toJSON": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "value",
+				Type: model.DynamicType,
+			}},
+			ReturnType: model.StringType,
+		}),
+		// Returns the name of the current stack
+		"stack": model.NewFunction(model.StaticFunctionSignature{
+			ReturnType: model.StringType,
+		}),
+		// Returns the name of the current project
+		"project": model.NewFunction(model.StaticFunctionSignature{
+			ReturnType: model.StringType,
+		}),
+		// Returns the directory from which pulumi was run
+		"cwd": model.NewFunction(model.StaticFunctionSignature{
+			ReturnType: model.StringType,
+		}),
+		"notImplemented": model.NewFunction(model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "errorMessage",
+				Type: model.StringType,
+			}},
+			ReturnType: model.DynamicType,
+		}),
+		// Returns either the single item in a list, none if the list is empty or errors.
+		"singleOrNone": model.NewFunction(model.GenericFunctionSignature(
+			func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+				var diagnostics hcl.Diagnostics
+
+				valueType := model.Type(model.DynamicType)
+				if len(args) == 1 {
+					valueType = args[0].Type()
+				} else {
 					diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "the first argument to 'singleOrNone' must be a list or tuple",
-						Subject:  &rng,
+						Summary:  "'singleOrNone' only expects one argument",
 					}}
 				}
-			}
 
-			return model.StaticFunctionSignature{
-				Parameters: []model.Parameter{{
-					Name: "value",
-					Type: valueType,
-				}},
-				ReturnType: model.NewOptionalType(elementType),
-			}, diagnostics
-		})),
+				elementType := model.Type(model.DynamicType)
+
+				switch valueType := model.ResolveOutputs(valueType).(type) {
+				case *model.ListType:
+					elementType = valueType.ElementType
+				case *model.TupleType:
+					if len(valueType.ElementTypes) > 0 {
+						elementType = valueType.ElementTypes[0]
+					}
+				default:
+					if valueType != model.DynamicType {
+						rng := args[0].SyntaxNode().Range()
+						diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "the first argument to 'singleOrNone' must be a list or tuple",
+							Subject:  &rng,
+						}}
+					}
+				}
+
+				return model.StaticFunctionSignature{
+					Parameters: []model.Parameter{{
+						Name: "value",
+						Type: valueType,
+					}},
+					ReturnType: model.NewOptionalType(elementType),
+				}, diagnostics
+			})),
+	}
 }

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -21,7 +21,8 @@ import (
 
 func getEntriesSignature(
 	args []model.Expression,
-	options bindOptions) (model.StaticFunctionSignature, hcl.Diagnostics) {
+	options bindOptions,
+) (model.StaticFunctionSignature, hcl.Diagnostics) {
 	var diagnostics hcl.Diagnostics
 
 	keyType, valueType := model.Type(model.DynamicType), model.Type(model.DynamicType)

--- a/pkg/codegen/pcl/rewrite_apply_test.go
+++ b/pkg/codegen/pcl/rewrite_apply_test.go
@@ -153,8 +153,9 @@ func TestApplyRewriter(t *testing.T) {
 		Name:         "resourcesOutput",
 		VariableType: model.NewOutputType(model.NewListType(resourceType)),
 	})
-	scope.DefineFunction("element", pulumiBuiltins["element"])
-	scope.DefineFunction("toJSON", pulumiBuiltins["toJSON"])
+	functions := pulumiBuiltins(bindOptions{})
+	scope.DefineFunction("element", functions["element"])
+	scope.DefineFunction("toJSON", functions["toJSON"])
 	scope.DefineFunction("getPromise", model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{{
 			Name: "p",


### PR DESCRIPTION

# Description

This PR implements a new PCL option called `SkipRangeTypechecking` and using it for `pulumi convert` in non-strict mode. It allows unsupported range types such as unions to be bound while emitting a warning instead of an error. The same applies for `ForExpression` and `IndexExpression`

Supersedes #13446 and #13450 

Fixes a whole category of bind errors where the collection being iterated is not a supported type 
  -  #13318 
  -  #13430 partially
  -  #13191
  - #13440 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
