### PR TITLE
Fix links to outputs docs

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -106,7 +106,7 @@ class OutputImpl<T> implements OutputInstance<T> {
      * 2. `pulumi.interpolate ``prefix${v}suffix`` `
      *
      * This will return an Output with the inner computed value and all resources still tracked. See
-     * https://pulumi.io/help/outputs for more details
+     * https://www.pulumi.com/docs/concepts/inputs-outputs for more details
      * @internal
      */
     public toString: () => string;
@@ -123,7 +123,7 @@ class OutputImpl<T> implements OutputInstance<T> {
      * 2. `o.apply(v => JSON.stringify(v))`
      *
      * This will return an Output with the inner computed value and all resources still tracked.
-     * See https://pulumi.io/help/outputs for more details
+     * See https://www.pulumi.com/docs/concepts/inputs-outputs for more details
      * @internal
      */
     public toJSON: () => any;
@@ -202,7 +202,7 @@ To get the value of an Output<T> as an Output<string> consider either:
 1: o.apply(v => \`prefix\${v}suffix\`)
 2: pulumi.interpolate \`prefix\${v}suffix\`
 
-See https://pulumi.io/help/outputs for more details.
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.
 This function may throw in a future version of @pulumi/pulumi.`;
             return message;
         };
@@ -214,7 +214,7 @@ To get the value of an Output as a JSON value or JSON string consider either:
     1: o.apply(v => v.toJSON())
     2: o.apply(v => JSON.stringify(v))
 
-See https://pulumi.io/help/outputs for more details.
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.
 This function may throw in a future version of @pulumi/pulumi.`;
             return message;
         };

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -721,7 +721,7 @@ class Output(Generic[T_co]):
 To get the value of an Output[T] as an Output[str] consider:
 1. o.apply(lambda v: f"prefix{v}suffix")
 
-See https://pulumi.io/help/outputs for more details.
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.
 This function may throw in a future version of Pulumi."""
 
 

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -247,7 +247,7 @@ class OutputStrTests(unittest.TestCase):
 To get the value of an Output[T] as an Output[str] consider:
 1. o.apply(lambda v: f"prefix{v}suffix")
 
-See https://pulumi.io/help/outputs for more details.
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.
 This function may throw in a future version of Pulumi.""")
 
 


### PR DESCRIPTION
Fixes some broken links pointing to the Inputs & Outputs docs.

Fixes #13461.