### PR TITLE
[convert] Consistently use the same non-strict bind options when applicable

### DIFF
--- a/changelog/pending/20230713--programgen--consistently-use-non-strict-bind-options-when-applicable.yaml
+++ b/changelog/pending/20230713--programgen--consistently-use-non-strict-bind-options-when-applicable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: programgen
+  description: Consistently use the same non-strict bind options when applicable

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -153,11 +153,7 @@ func safePclBindDirectory(sourceDirectory string, loader schema.ReferenceLoader,
 
 	extraOptions := make([]pcl.BindOption, 0)
 	if !strict {
-		extraOptions = append(extraOptions, []pcl.BindOption{
-			pcl.AllowMissingProperties,
-			pcl.AllowMissingVariables,
-			pcl.SkipResourceTypechecking,
-		}...)
+		extraOptions = append(extraOptions, pcl.NonStrictBindOptions()...)
 	}
 
 	program, diagnostics, err = pcl.BindDirectory(sourceDirectory, loader, extraOptions...)
@@ -191,13 +187,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 
 		extraOptions := make([]pcl.BindOption, 0)
 		if !strict {
-			extraOptions = append(extraOptions, []pcl.BindOption{
-				pcl.AllowMissingProperties,
-				pcl.AllowMissingVariables,
-				pcl.SkipResourceTypechecking,
-				pcl.SkipInvokeTypechecking,
-				pcl.SkipRangeTypechecking,
-			}...)
+			extraOptions = append(extraOptions, pcl.NonStrictBindOptions()...)
 		}
 
 		if targetLanguage == "python" {

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -141,6 +141,18 @@ func ComponentBinder(binder ComponentProgramBinder) BindOption {
 	}
 }
 
+// NonStrictBindOptions returns a set of bind options that make the binder lenient about type checking.
+// Changing errors into warnings when possible
+func NonStrictBindOptions() []BindOption {
+	return []BindOption{
+		AllowMissingVariables,
+		AllowMissingProperties,
+		SkipResourceTypechecking,
+		SkipInvokeTypechecking,
+		SkipRangeTypechecking,
+	}
+}
+
 // BindProgram performs semantic analysis on the given set of HCL2 files that represent a single program. The given
 // host, if any, is used for loading any resource plugins necessary to extract schema information.
 func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagnostics, error) {

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1019,11 +1019,7 @@ func (host *goLanguageHost) GenerateProject(
 
 	extraOptions := make([]pcl.BindOption, 0)
 	if !req.Strict {
-		extraOptions = append(extraOptions, []pcl.BindOption{
-			pcl.AllowMissingProperties,
-			pcl.AllowMissingVariables,
-			pcl.SkipResourceTypechecking,
-		}...)
+		extraOptions = append(extraOptions, pcl.NonStrictBindOptions()...)
 	}
 
 	program, diags, err := pcl.BindDirectory(req.SourceDirectory, loader, extraOptions...)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1035,11 +1035,7 @@ func (host *nodeLanguageHost) GenerateProject(
 	loader := schema.NewPluginLoader(pluginCtx.Host)
 	extraOptions := make([]pcl.BindOption, 0)
 	if !req.Strict {
-		extraOptions = append(extraOptions, []pcl.BindOption{
-			pcl.AllowMissingProperties,
-			pcl.AllowMissingVariables,
-			pcl.SkipResourceTypechecking,
-		}...)
+		extraOptions = append(extraOptions, pcl.NonStrictBindOptions()...)
 	}
 
 	// for nodejs, prefer output-versioned invokes


### PR DESCRIPTION
# Description

When using `pulumi convert` in non-strict mode, provide a single source of which bind options to use. The newly added options weren't being applied in a few places 


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
