### PR TITLE
Fill in default plugin download URL before looking up version

### DIFF
--- a/changelog/pending/20230713--cli-plugin--automatically-install-pulumiverse-provider-plugins-during-convert.yaml
+++ b/changelog/pending/20230713--cli-plugin--automatically-install-pulumiverse-provider-plugins-during-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Automatically install pulumiverse provider plugins during convert.

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -58,6 +58,7 @@ func (err *InstallPluginError) Unwrap() error {
 }
 
 func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, msg string)) (*semver.Version, error) {
+	util.SetKnownPluginDownloadURL(&pluginSpec)
 	if pluginSpec.Version == nil {
 		var err error
 		pluginSpec.Version, err = pluginSpec.GetLatestVersion()
@@ -65,7 +66,6 @@ func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, 
 			return nil, fmt.Errorf("could not find latest version for provider %s: %w", pluginSpec.Name, err)
 		}
 	}
-	util.SetKnownPluginDownloadURL(&pluginSpec)
 
 	wrapper := func(stream io.ReadCloser, size int64) io.ReadCloser {
 		log(diag.Info, fmt.Sprintf("Downloading provider: %s", pluginSpec.Name))


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This enables the automatic install of pulumiverse plugins even without a version set, as the DownloadURL is now set before we try to do a version lookup allowing the version lookup to now query github.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
