### PR TITLE
[convert/go] Fix panic in GenerateProject when version is not set in schema

### DIFF
--- a/changelog/pending/20230713--programgen-go--fix-panic-in-generateproject-when-version-is-not-set-in-schema.yaml
+++ b/changelog/pending/20230713--programgen-go--fix-panic-in-generateproject-when-version-is-not-set-in-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix panic in GenerateProject when version is not set in schema

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
@@ -127,4 +130,40 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 	}
 	g.Formatter = format.NewFormatter(g)
 	return g
+}
+
+func parseAndBindProgram(t *testing.T,
+	text string,
+	name string,
+	options ...pcl.BindOption,
+) (*pcl.Program, hcl.Diagnostics, error) {
+	parser := syntax.NewParser()
+	err := parser.ParseFile(strings.NewReader(text), name)
+	if err != nil {
+		t.Fatalf("could not read %v: %v", name, err)
+	}
+	if parser.Diagnostics.HasErrors() {
+		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
+	}
+
+	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+
+	return pcl.BindProgram(parser.Files, options...)
+}
+
+func TestGenerateProjectDoesNotPanicWhenMissingVersion(t *testing.T) {
+	t.Parallel()
+
+	source := `	
+resource main "auto-deploy:index:AutoDeployer" {
+    project = "example"
+}`
+
+	program, diags, err := parseAndBindProgram(t, source, "main.pp")
+
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors())
+
+	files, diags, err := GenerateProjectFiles(workspace.Project{}, program)
+	assert.NotNil(t, files, "Files were generated")
 }

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -166,4 +166,6 @@ resource main "auto-deploy:index:AutoDeployer" {
 
 	files, diags, err := GenerateProjectFiles(workspace.Project{}, program)
 	assert.NotNil(t, files, "Files were generated")
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors())
 }

--- a/pkg/codegen/testing/test/testdata/auto-deploy-0.0.1.json
+++ b/pkg/codegen/testing/test/testdata/auto-deploy-0.0.1.json
@@ -1,0 +1,30 @@
+{
+  "name": "auto-deploy",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "auto-deploy:index:AutoDeployer": {
+      "description": "Automatically trigger downstream updates on dependent stacks via Pulumi Deployments.\nAutoDeployer requires that stacks have Deployment Settings configured.",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "The project name for the AutoDeployer stack."
+        }
+      },
+      "type": "object",
+      "inputProperties": {
+        "project": {
+          "type": "string",
+          "description": "The project name for the AutoDeployer stack."
+        }
+      },
+      "requiredInputs": ["project"],
+      "isComponent": true
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -86,5 +86,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"splat", "1.0.0"},
 		SchemaProvider{"snowflake", "0.66.1"},
 		SchemaProvider{"using-dashes", "1.0.0"},
+		SchemaProvider{"auto-deploy", "0.0.1"},
 	)
 }


### PR DESCRIPTION
# Description

When using `GenerateProject` from go codegen against an example using a schema _without_ a version, the code hit the path:
```go
fmt.Fprintf(&gomod, "	%s v%s\n", packageName, p.Version.String())
```
Where `p.Version` is nil. 

This PR fixes this issue by defaulting to an empty string when version isn't available. 

I wasn't able to use `ProgramTest` to test the new behavior because `ProgramTest` uses `GenerateProgram` rather than `GenerateProject` in the test body. Instead I made `GenerateProject` unit testable by separating the part where we generate files into `GenerateProjectFiles` from the part where we write them out to the file system and subsequently testing that `GenerateProjectFiles` doesn't panic against the newly added test schema. Confirmed that the code in `master` fails and panics on this test. 

Fixes #13199 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
