### PR TITLE
[pcl/binder] Propagate SkipRangeTypechecking option down to components' programs

### DIFF
--- a/changelog/pending/20230714--programgen--propagate-skiprangetypechecking-option-down-to-program-components.yaml
+++ b/changelog/pending/20230714--programgen--propagate-skiprangetypechecking-option-down-to-program-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: programgen
+  description: Propagate SkipRangeTypechecking option down to program components

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -40,6 +40,7 @@ type ComponentProgramBinderArgs struct {
 	AllowMissingProperties       bool
 	SkipResourceTypecheck        bool
 	SkipInvokeTypecheck          bool
+	SkipRangeTypecheck           bool
 	PreferOutputVersionedInvokes bool
 	BinderDirPath                string
 	BinderLoader                 schema.Loader

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -195,6 +195,9 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 		if args.SkipInvokeTypecheck {
 			opts = append(opts, SkipInvokeTypechecking)
 		}
+		if args.SkipRangeTypecheck {
+			opts = append(opts, SkipRangeTypechecking)
+		}
 
 		componentProgram, programDiags, err := BindProgram(parser.Files, opts...)
 
@@ -293,6 +296,7 @@ func (b *binder) bindComponent(node *Component) hcl.Diagnostics {
 		AllowMissingProperties:       b.options.allowMissingProperties,
 		SkipResourceTypecheck:        b.options.skipResourceTypecheck,
 		SkipInvokeTypecheck:          b.options.skipInvokeTypecheck,
+		SkipRangeTypecheck:           b.options.skipRangeTypecheck,
 		PreferOutputVersionedInvokes: b.options.preferOutputVersionedInvokes,
 		BinderLoader:                 b.options.loader,
 		BinderDirPath:                b.options.dirPath,


### PR DESCRIPTION
# Description

The option was added only for top level programs but it should be propagated to component programs too.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
