### PR TITLE
[programgen/typescript] Improve static typing of config variables in main program

### DIFF
--- a/changelog/pending/20230714--programgen-nodejs--improve-static-typing-of-config-variables-in-main-program.yaml
+++ b/changelog/pending/20230714--programgen-nodejs--improve-static-typing-of-config-variables-in-main-program.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/nodejs
+  description: Improve static typing of config variables in main program

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1135,7 +1135,7 @@ func computeConfigTypeParam(configType model.Type) string {
 			}
 			// get deterministically sorted attribute keys
 			sort.Strings(attributeKeys)
-			
+
 			var elementTypes []string
 			for _, propertyName := range attributeKeys {
 				propertyType := complexType.Properties[propertyName]

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1135,19 +1135,15 @@ func computeConfigTypeParam(configType model.Type) string {
 			}
 			// get deterministically sorted attribute keys
 			sort.Strings(attributeKeys)
-
-			objectType := "{"
-			for index, propertyName := range attributeKeys {
+			
+			var elementTypes []string
+			for _, propertyName := range attributeKeys {
 				propertyType := complexType.Properties[propertyName]
-				if index != len(attributeKeys)-1 {
-					objectType += fmt.Sprintf("%s?: %s, ", propertyName, computeConfigTypeParam(propertyType))
-				} else {
-					// last element, do not add a comma
-					objectType += fmt.Sprintf("%s?: %s", propertyName, computeConfigTypeParam(propertyType))
-				}
+				elementType := fmt.Sprintf("%s?: %s", propertyName, computeConfigTypeParam(propertyType))
+				elementTypes = append(elementTypes, elementType)
 			}
-			objectType += "}"
-			return objectType
+
+			return fmt.Sprintf("{%s}", strings.Join(elementTypes, ", "))
 		default:
 			return "any"
 		}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1108,16 +1108,60 @@ func (g *generator) genComponent(w io.Writer, component *pcl.Component) {
 	g.genTrivia(w, component.Definition.Tokens.GetCloseBrace())
 }
 
-func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
-	// TODO(pdg): trivia
+func computeConfigTypeParam(configType model.Type) string {
+	switch pcl.UnwrapOption(configType) {
+	case model.StringType:
+		return "string"
+	case model.NumberType, model.IntType:
+		return "number"
+	case model.BoolType:
+		return "boolean"
+	case model.DynamicType:
+		return "any"
+	default:
+		switch complexType := pcl.UnwrapOption(configType).(type) {
+		case *model.ListType:
+			return fmt.Sprintf("Array<%s>", computeConfigTypeParam(complexType.ElementType))
+		case *model.MapType:
+			return fmt.Sprintf("Record<string, %s>", computeConfigTypeParam(complexType.ElementType))
+		case *model.ObjectType:
+			if len(complexType.Properties) == 0 {
+				return "any"
+			}
 
+			attributeKeys := []string{}
+			for attributeKey := range complexType.Properties {
+				attributeKeys = append(attributeKeys, attributeKey)
+			}
+			// get deterministically sorted attribute keys
+			sort.Strings(attributeKeys)
+
+			objectType := "{"
+			for index, propertyName := range attributeKeys {
+				propertyType := complexType.Properties[propertyName]
+				if index != len(attributeKeys)-1 {
+					objectType += fmt.Sprintf("%s?: %s, ", propertyName, computeConfigTypeParam(propertyType))
+				} else {
+					// last element, do not add a comma
+					objectType += fmt.Sprintf("%s?: %s", propertyName, computeConfigTypeParam(propertyType))
+				}
+			}
+			objectType += "}"
+			return objectType
+		default:
+			return "any"
+		}
+	}
+}
+
+func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	if !g.configCreated {
 		g.Fprintf(w, "%sconst config = new pulumi.Config();\n", g.Indent)
 		g.configCreated = true
 	}
 
 	getType := "Object"
-	switch v.Type() {
+	switch pcl.UnwrapOption(v.Type()) {
 	case model.StringType:
 		getType = ""
 	case model.NumberType, model.IntType:
@@ -1126,8 +1170,18 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 		getType = "Boolean"
 	}
 
+	typeParam := ""
+	if getType == "Object" {
+		// compute the type parameter T for the call to config.getObject<T>(...)
+		computedTypeParam := computeConfigTypeParam(v.Type())
+		if computedTypeParam != "any" {
+			// any is redundant
+			typeParam = fmt.Sprintf("<%s>", computedTypeParam)
+		}
+	}
+
 	getOrRequire := "get"
-	if v.DefaultValue == nil {
+	if v.DefaultValue == nil && !model.IsOptionalType(v.Type()) {
 		getOrRequire = "require"
 	}
 
@@ -1138,9 +1192,9 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	}
 
 	name := makeValidIdentifier(v.Name())
-	g.Fgenf(w, "%[1]sconst %[2]s = config.%[3]s%[4]s(\"%[5]s\")",
-		g.Indent, name, getOrRequire, getType, v.LogicalName())
-	if v.DefaultValue != nil {
+	g.Fgenf(w, "%[1]sconst %[2]s = config.%[3]s%[4]s%[5]s(\"%[6]s\")",
+		g.Indent, name, getOrRequire, getType, typeParam, v.LogicalName())
+	if v.DefaultValue != nil && !model.IsOptionalType(v.Type()) {
 		g.Fgenf(w, " || %.v", g.lowerExpression(v.DefaultValue, v.DefaultValue.Type()))
 	}
 	g.Fgenf(w, ";\n")

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -334,6 +334,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		SkipCompile: allProgLanguages,
 		BindOptions: []pcl.BindOption{pcl.SkipInvokeTypechecking},
 	},
+	{
+		Directory:   "optional-complex-config",
+		Description: "Tests generating code for optional and complex config values",
+		Skip:        allProgLanguages.Except("nodejs"),
+		SkipCompile: allProgLanguages.Except("nodejs"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
+++ b/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
@@ -5,9 +5,9 @@ import * as std from "@pulumi/std";
 export = async () => {
     const config = new pulumi.Config();
     // A list of availability zones names or ids in the region
-    const azs = config.getObject("azs") || [];
+    const azs = config.getObject<Array<string>>("azs") || [];
     // Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list
-    const publicSubnetIpv6Prefixes = config.getObject("publicSubnetIpv6Prefixes") || [];
+    const publicSubnetIpv6Prefixes = config.getObject<Array<string>>("publicSubnetIpv6Prefixes") || [];
     // Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`
     const oneNatGatewayPerAz = config.getBoolean("oneNatGatewayPerAz") || false;
     // Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block

--- a/pkg/codegen/testing/test/testdata/optional-complex-config-pp/nodejs/optional-complex-config.ts
+++ b/pkg/codegen/testing/test/testdata/optional-complex-config-pp/nodejs/optional-complex-config.ts
@@ -1,0 +1,22 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+// The tag of the VPC
+const vpcTag = config.get("vpcTag");
+// The id of a VPC to use instead of creating a new one
+const vpcId = config.get("vpcId");
+// The list of subnets to use
+const subnets = config.getObject<Array<string>>("subnets");
+// Additional tags to add to the VPC
+const moreTags = config.getObject<Record<string, string>>("moreTags");
+// The userdata to use for the instances
+const userdata = config.getObject<{content?: string, path?: string}>("userdata");
+// A complex object
+const complexUserdata = config.getObject<Array<{content?: string, path?: string}>>("complexUserdata");
+const main = new aws.ec2.Vpc("main", {
+    cidrBlock: "10.100.0.0/16",
+    tags: {
+        Name: vpcTag,
+    },
+});

--- a/pkg/codegen/testing/test/testdata/optional-complex-config-pp/optional-complex-config.pp
+++ b/pkg/codegen/testing/test/testdata/optional-complex-config-pp/optional-complex-config.pp
@@ -1,0 +1,36 @@
+config "vpcTag" "string" {
+    default = null
+    description = "The tag of the VPC"
+}
+
+config "vpcId" "string" {
+    default = null
+    description = "The id of a VPC to use instead of creating a new one"
+}
+
+config "subnets" "list(string)" {
+    default = null
+    description = "The list of subnets to use"
+}
+
+config moreTags "map(string)" {
+    default = null
+    description = "Additional tags to add to the VPC"
+}
+
+config userdata "object({path=string, content=string})" {
+    default = null
+    description = "The userdata to use for the instances"
+}
+
+config complexUserdata "list(object({path=string, content=string}))" {
+    default = null
+    description = "A complex object"
+}
+
+resource main "aws:ec2:Vpc" {
+	cidrBlock = "10.100.0.0/16"
+	tags = {
+		"Name": vpcTag
+	}
+}


### PR DESCRIPTION
# Description

Right now when generating `config.getObject(...)` calls in for typescript, we miss a lot of provided static types from the program: optional types, lists, maps and objects. This PR improves the static typing of config variables _in the main program_ 

Fixes #13498

<details>
<summary>Example PCL program</summary>

```tf
config "vpcTag" "string" {
    default = null
    description = "The tag of the VPC"
}

config "vpcId" "string" {
    default = null
    description = "The id of a VPC to use instead of creating a new one"
}

config "subnets" "list(string)" {
    default = null
    description = "The list of subnets to use"
}

config moreTags "map(string)" {
    default = null
    description = "Additional tags to add to the VPC"
}

config userdata "object({path=string, content=string})" {
    default = null
    description = "The userdata to use for the instances"
}

config complexUserdata "list(object({path=string, content=string}))" {
    default = null
    description = "A complex object"
}

resource main "aws:ec2:Vpc" {
	cidrBlock = "10.100.0.0/16"
	tags = {
		"Name": vpcTag
	}
}
```

</details>

<details>
<summary>Generated Typescript before</summary>

```ts
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";

const config = new pulumi.Config();
// The tag of the VPC
const vpcTag = config.getObject("vpcTag") || undefined;
// The id of a VPC to use instead of creating a new one
const vpcId = config.getObject("vpcId") || undefined;
// The list of subnets to use
const subnets = config.getObject("subnets") || undefined;
// Additional tags to add to the VPC
const moreTags = config.getObject("moreTags") || undefined;
// The userdata to use for the instances
const userdata = config.getObject("userdata") || undefined;
// A complex object
const complexUserdata = config.getObject("complexUserdata") || undefined;
const main = new aws.ec2.Vpc("main", {
    cidrBlock: "10.100.0.0/16",
    tags: {
        Name: vpcTag,
    },
});

```

</details>

<details>
<summary>Generated Typescript after</summary>

```ts
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";

const config = new pulumi.Config();
// The tag of the VPC
const vpcTag = config.get("vpcTag");
// The id of a VPC to use instead of creating a new one
const vpcId = config.get("vpcId");
// The list of subnets to use
const subnets = config.getObject<Array<string>>("subnets");
// Additional tags to add to the VPC
const moreTags = config.getObject<Record<string, string>>("moreTags");
// The userdata to use for the instances
const userdata = config.getObject<{content?: string, path?: string}>("userdata");
// A complex object
const complexUserdata = config.getObject<Array<{content?: string, path?: string}>>("complexUserdata");
const main = new aws.ec2.Vpc("main", {
    cidrBlock: "10.100.0.0/16",
    tags: {
        Name: vpcTag,
    },
});

```

</details>

> Note that for optional config variables, we no longer generate `|| undefined` because that is redundant AFAIC when the config variables aren't provided

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
