### PR TITLE
[cli] Add project root update metadata

### DIFF
--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -17,7 +17,6 @@ package backend
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -225,7 +224,7 @@ func GetEnvironmentTagsForCurrentStack(root string,
 // addGitMetadataToStackTags fetches the git repository from the directory, and attempts to detect
 // and add any relevant git metadata as stack tags.
 func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath string) error {
-	repo, err := gitutil.GetGitRepository(filepath.Dir(projPath))
+	repo, err := gitutil.GetGitRepository(projPath)
 	if repo == nil {
 		return fmt.Errorf("no git repository found from %v", projPath)
 	}

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -65,6 +65,8 @@ const (
 	VCSRepoName = "vcs.repo"
 	// VCSRepoKind is the cloud host where the repo is hosted.
 	VCSRepoKind = "vcs.kind"
+	// VCSRepoRoot is the root directory of the project in the repo.
+	VCSRepoRoot = "vcs.root"
 
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -406,6 +406,9 @@ const (
 	// VCSRepositoryKindTag is a tag that represents the kind of the cloud VCS that this stack
 	// may be associated with (inferred by the CLI based on the git remote info).
 	VCSRepositoryKindTag StackTagName = "vcs:kind"
+	// VCSRepositoryRootTag is a tag that represents the root directory of the repository on the cloud VCS that
+	// this stack may be associated with (pulled from git by the CLI)
+	VCSRepositoryRootTag StackTagName = "vcs:root"
 )
 
 // Stack describes a Stack running on a Pulumi Cloud.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -84,7 +84,9 @@ func GetGitRepository(dir string) (*git.Repository, error) {
 	}
 
 	// Open the git repo in the .git folder's parent, not the .git folder itself.
-	repo, err := git.PlainOpen(filepath.Dir(gitRoot))
+	repo, err := git.PlainOpenWithOptions(filepath.Dir(gitRoot), &git.PlainOpenOptions{
+		EnableDotGitCommonDir: true,
+	})
 	if err == git.ErrRepositoryNotExists {
 		return nil, nil
 	}


### PR DESCRIPTION
These changes add the path to the current project relative to the root of the VCS repository to update metadata. If VCS info is not available, this metadata is not added.

Part of https://github.com/pulumi/home/issues/2946.