### PR TITLE
Add the ability to verify an expected log message was written

### DIFF
--- a/sdk/python/lib/test/langhost/resource_op_bad_inputs/test_resource_op_bad_inputs.py
+++ b/sdk/python/lib/test/langhost/resource_op_bad_inputs/test_resource_op_bad_inputs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from os import path
+
 from ..util import LanghostTest
 
 
@@ -19,6 +20,7 @@ class UnhandledExceptionTest(LanghostTest):
     def test_unhandled_exception(self):
         self.run_test(
             program=path.join(self.base_path(), "resource_op_bad_inputs"),
+            expected_log_message="unexpected input of type MyClass",
             expected_bail=True)
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,


### PR DESCRIPTION
We used to test that various errors we're written out to the user in these langhost tests, but at some point those test were removed (I suspect because we stopped printing them to stderr).

This adds in the ability to check for a log message in the engine diagnostics stream, and makes use of that in one of the tests.