### PR TITLE
codegen/go: Implement pux.Input[T] for generated types

### DIFF
--- a/changelog/pending/20230717--sdkgen-go--generate-types-that-are-compatible-with-pulumix.yaml
+++ b/changelog/pending/20230717--sdkgen-go--generate-types-that-are-compatible-with-pulumix.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: Generate types that are compatible with sdk/go/pulumix's type-safe APIs.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -994,6 +994,7 @@ func genInputImplementationWithArgs(w io.Writer, genArgs genInputImplementationA
 	fmt.Fprintf(w, "\treturn reflect.TypeOf((*%s)(nil)).Elem()\n", elementType)
 	fmt.Fprintf(w, "}\n\n")
 
+	var hasToOutput bool
 	if genArgs.toOutputMethods {
 		fmt.Fprintf(w, "func (i %s) To%sOutput() %sOutput {\n", receiverType, Title(name), name)
 		fmt.Fprintf(w, "\treturn i.To%sOutputWithContext(context.Background())\n", Title(name))
@@ -1002,6 +1003,15 @@ func genInputImplementationWithArgs(w io.Writer, genArgs genInputImplementationA
 		fmt.Fprintf(w, "func (i %s) To%sOutputWithContext(ctx context.Context) %sOutput {\n", receiverType, Title(name), name)
 		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sOutput)\n", name)
 		fmt.Fprintf(w, "}\n\n")
+
+		// Generate 'ToOuput(context.Context) pux.Output[T]' method
+		// to satisfy pux.Input[T].
+		fmt.Fprintf(w, "func (i %s) ToOutput(ctx context.Context) pulumix.Output[%s] {\n", receiverType, elementType)
+		fmt.Fprintf(w, "\treturn pulumix.Output[%s]{\n", elementType)
+		fmt.Fprintf(w, "\t\tOutputState: i.To%sOutputWithContext(ctx).OutputState,\n", Title(name))
+		fmt.Fprintf(w, "\t}\n")
+		fmt.Fprintf(w, "}\n\n")
+		hasToOutput = true
 	}
 
 	if genArgs.ptrMethods {
@@ -1016,6 +1026,16 @@ func genInputImplementationWithArgs(w io.Writer, genArgs genInputImplementationA
 			fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sPtrOutput)\n", name)
 		}
 		fmt.Fprintf(w, "}\n\n")
+
+		if !hasToOutput {
+			// Generate 'ToOuput(context.Context) pux.Output[*T]' method
+			// to satisfy pux.Input[*T].
+			fmt.Fprintf(w, "func (i %s) ToOutput(ctx context.Context) pulumix.Output[*%s] {\n", receiverType, elementType)
+			fmt.Fprintf(w, "\treturn pulumix.Output[*%s]{\n", elementType)
+			fmt.Fprintf(w, "\t\tOutputState: i.To%sPtrOutputWithContext(ctx).OutputState,\n", Title(name))
+			fmt.Fprintf(w, "\t}\n")
+			fmt.Fprintf(w, "}\n\n")
+		}
 	}
 }
 
@@ -1045,6 +1065,14 @@ func genOutputType(w io.Writer, baseName, elementType string, ptrMethods bool) {
 		fmt.Fprintf(w, "\t}).(%sPtrOutput)\n", baseName)
 		fmt.Fprintf(w, "}\n\n")
 	}
+
+	// Generate 'ToOuput(context.Context) pux.Output[T]' method
+	// to satisfy pux.Input[T].
+	fmt.Fprintf(w, "func (o %sOutput) ToOutput(ctx context.Context) pulumix.Output[%s] {\n", baseName, elementType)
+	fmt.Fprintf(w, "\treturn pulumix.Output[%s]{\n", elementType)
+	fmt.Fprintf(w, "\t\tOutputState: o.OutputState,\n")
+	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "}\n\n")
 }
 
 func genArrayOutput(w io.Writer, baseName, elementType string) {
@@ -1242,6 +1270,13 @@ func (pkg *pkgContext) genEnumInputTypes(w io.Writer, name string, enumType *sch
 	fmt.Fprintf(w, "return pulumi.ToOutputWithContext(ctx, in).(%sPtrOutput)\n", name)
 	fmt.Fprintf(w, "}\n")
 	fmt.Fprintln(w)
+
+	// ToOutput implementation for pux.Input.
+	fmt.Fprintf(w, "func (in *%sPtr) ToOutput(ctx context.Context) pulumix.Output[*%s] {\n", typeName, name)
+	fmt.Fprintf(w, "\treturn pulumix.Output[*%s]{\n", name)
+	fmt.Fprintf(w, "\t\tOutputState: in.To%sPtrOutputWithContext(ctx).OutputState,\n", name)
+	fmt.Fprintf(w, "\t}\n")
+	fmt.Fprintf(w, "}\n\n")
 }
 
 func (pkg *pkgContext) genEnumInputFuncs(w io.Writer, typeName string, enum *schema.EnumType, elementArgsType, inputType, asFuncName string) {
@@ -2154,6 +2189,7 @@ func (pkg *pkgContext) genFunctionCodeFile(f *schema.Function) (string, error) {
 	var imports []string
 	if NeedsGoOutputVersion(f) {
 		imports = []string{"context", "reflect"}
+		importsAndAliases["github.com/pulumi/pulumi/sdk/v3/go/pulumix"] = ""
 	}
 
 	pkg.genHeader(buffer, imports, importsAndAliases, false /* isUtil */)
@@ -3796,6 +3832,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			pkg.getImports(r, importsAndAliases)
 			importsAndAliases["github.com/pulumi/pulumi/sdk/v3/go/pulumi"] = ""
 			importsAndAliases[path.Join(pkg.importBasePath, pkg.internalModuleName)] = ""
+			importsAndAliases["github.com/pulumi/pulumi/sdk/v3/go/pulumix"] = ""
 			buffer := &bytes.Buffer{}
 			pkg.genHeader(buffer, []string{"context", "reflect"}, importsAndAliases, false /* isUtil */)
 
@@ -3837,6 +3874,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			if hasOutputs {
 				goImports = []string{"context", "reflect"}
 				imports["github.com/pulumi/pulumi/sdk/v3/go/pulumi"] = ""
+				imports["github.com/pulumi/pulumi/sdk/v3/go/pulumix"] = ""
 			}
 
 			buffer := &bytes.Buffer{}
@@ -3948,6 +3986,7 @@ func generateTypes(w io.Writer, pkg *pkgContext, types []*schema.ObjectType, kno
 	if hasOutputs {
 		goImports = []string{"context", "reflect"}
 		importsAndAliases["github.com/pulumi/pulumi/sdk/v3/go/pulumi"] = ""
+		importsAndAliases["github.com/pulumi/pulumi/sdk/v3/go/pulumix"] = ""
 	}
 
 	importsAndAliases[path.Join(pkg.importBasePath, pkg.internalModuleName)] = ""

--- a/pkg/codegen/testing/test/testdata/cyclic-types/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/go/example/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"cyclic-types/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/cyclic-types/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/go/example/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"cyclic-types/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -48,6 +49,12 @@ func (i AcyclicReferentArgs) ToAcyclicReferentOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(AcyclicReferentOutput)
 }
 
+func (i AcyclicReferentArgs) ToOutput(ctx context.Context) pulumix.Output[AcyclicReferent] {
+	return pulumix.Output[AcyclicReferent]{
+		OutputState: i.ToAcyclicReferentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type AcyclicReferentOutput struct{ *pulumi.OutputState }
 
 func (AcyclicReferentOutput) ElementType() reflect.Type {
@@ -60,6 +67,12 @@ func (o AcyclicReferentOutput) ToAcyclicReferentOutput() AcyclicReferentOutput {
 
 func (o AcyclicReferentOutput) ToAcyclicReferentOutputWithContext(ctx context.Context) AcyclicReferentOutput {
 	return o
+}
+
+func (o AcyclicReferentOutput) ToOutput(ctx context.Context) pulumix.Output[AcyclicReferent] {
+	return pulumix.Output[AcyclicReferent]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o AcyclicReferentOutput) Bar() IndirectCycleSOutput {
@@ -105,6 +118,12 @@ func (i AcyclicSArgs) ToAcyclicSOutputWithContext(ctx context.Context) AcyclicSO
 	return pulumi.ToOutputWithContext(ctx, i).(AcyclicSOutput)
 }
 
+func (i AcyclicSArgs) ToOutput(ctx context.Context) pulumix.Output[AcyclicS] {
+	return pulumix.Output[AcyclicS]{
+		OutputState: i.ToAcyclicSOutputWithContext(ctx).OutputState,
+	}
+}
+
 type AcyclicSOutput struct{ *pulumi.OutputState }
 
 func (AcyclicSOutput) ElementType() reflect.Type {
@@ -117,6 +136,12 @@ func (o AcyclicSOutput) ToAcyclicSOutput() AcyclicSOutput {
 
 func (o AcyclicSOutput) ToAcyclicSOutputWithContext(ctx context.Context) AcyclicSOutput {
 	return o
+}
+
+func (o AcyclicSOutput) ToOutput(ctx context.Context) pulumix.Output[AcyclicS] {
+	return pulumix.Output[AcyclicS]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o AcyclicSOutput) Foo5() pulumi.StringOutput {
@@ -154,6 +179,12 @@ func (i AcyclicTArgs) ToAcyclicTOutputWithContext(ctx context.Context) AcyclicTO
 	return pulumi.ToOutputWithContext(ctx, i).(AcyclicTOutput)
 }
 
+func (i AcyclicTArgs) ToOutput(ctx context.Context) pulumix.Output[AcyclicT] {
+	return pulumix.Output[AcyclicT]{
+		OutputState: i.ToAcyclicTOutputWithContext(ctx).OutputState,
+	}
+}
+
 type AcyclicTOutput struct{ *pulumi.OutputState }
 
 func (AcyclicTOutput) ElementType() reflect.Type {
@@ -166,6 +197,12 @@ func (o AcyclicTOutput) ToAcyclicTOutput() AcyclicTOutput {
 
 func (o AcyclicTOutput) ToAcyclicTOutputWithContext(ctx context.Context) AcyclicTOutput {
 	return o
+}
+
+func (o AcyclicTOutput) ToOutput(ctx context.Context) pulumix.Output[AcyclicT] {
+	return pulumix.Output[AcyclicT]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o AcyclicTOutput) Foo6() AcyclicSOutput {
@@ -201,6 +238,12 @@ func (i DirectCycleArgs) ToDirectCycleOutput() DirectCycleOutput {
 
 func (i DirectCycleArgs) ToDirectCycleOutputWithContext(ctx context.Context) DirectCycleOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DirectCycleOutput)
+}
+
+func (i DirectCycleArgs) ToOutput(ctx context.Context) pulumix.Output[DirectCycle] {
+	return pulumix.Output[DirectCycle]{
+		OutputState: i.ToDirectCycleOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i DirectCycleArgs) ToDirectCyclePtrOutput() DirectCyclePtrOutput {
@@ -244,6 +287,12 @@ func (i *directCyclePtrType) ToDirectCyclePtrOutputWithContext(ctx context.Conte
 	return pulumi.ToOutputWithContext(ctx, i).(DirectCyclePtrOutput)
 }
 
+func (i *directCyclePtrType) ToOutput(ctx context.Context) pulumix.Output[*DirectCycle] {
+	return pulumix.Output[*DirectCycle]{
+		OutputState: i.ToDirectCyclePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type DirectCycleOutput struct{ *pulumi.OutputState }
 
 func (DirectCycleOutput) ElementType() reflect.Type {
@@ -268,6 +317,12 @@ func (o DirectCycleOutput) ToDirectCyclePtrOutputWithContext(ctx context.Context
 	}).(DirectCyclePtrOutput)
 }
 
+func (o DirectCycleOutput) ToOutput(ctx context.Context) pulumix.Output[DirectCycle] {
+	return pulumix.Output[DirectCycle]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o DirectCycleOutput) Foo() DirectCyclePtrOutput {
 	return o.ApplyT(func(v DirectCycle) *DirectCycle { return v.Foo }).(DirectCyclePtrOutput)
 }
@@ -284,6 +339,12 @@ func (o DirectCyclePtrOutput) ToDirectCyclePtrOutput() DirectCyclePtrOutput {
 
 func (o DirectCyclePtrOutput) ToDirectCyclePtrOutputWithContext(ctx context.Context) DirectCyclePtrOutput {
 	return o
+}
+
+func (o DirectCyclePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*DirectCycle] {
+	return pulumix.Output[*DirectCycle]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DirectCyclePtrOutput) Elem() DirectCycleOutput {
@@ -336,6 +397,12 @@ func (i IndirectCycleSArgs) ToIndirectCycleSOutputWithContext(ctx context.Contex
 	return pulumi.ToOutputWithContext(ctx, i).(IndirectCycleSOutput)
 }
 
+func (i IndirectCycleSArgs) ToOutput(ctx context.Context) pulumix.Output[IndirectCycleS] {
+	return pulumix.Output[IndirectCycleS]{
+		OutputState: i.ToIndirectCycleSOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i IndirectCycleSArgs) ToIndirectCycleSPtrOutput() IndirectCycleSPtrOutput {
 	return i.ToIndirectCycleSPtrOutputWithContext(context.Background())
 }
@@ -377,6 +444,12 @@ func (i *indirectCycleSPtrType) ToIndirectCycleSPtrOutputWithContext(ctx context
 	return pulumi.ToOutputWithContext(ctx, i).(IndirectCycleSPtrOutput)
 }
 
+func (i *indirectCycleSPtrType) ToOutput(ctx context.Context) pulumix.Output[*IndirectCycleS] {
+	return pulumix.Output[*IndirectCycleS]{
+		OutputState: i.ToIndirectCycleSPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type IndirectCycleSOutput struct{ *pulumi.OutputState }
 
 func (IndirectCycleSOutput) ElementType() reflect.Type {
@@ -401,6 +474,12 @@ func (o IndirectCycleSOutput) ToIndirectCycleSPtrOutputWithContext(ctx context.C
 	}).(IndirectCycleSPtrOutput)
 }
 
+func (o IndirectCycleSOutput) ToOutput(ctx context.Context) pulumix.Output[IndirectCycleS] {
+	return pulumix.Output[IndirectCycleS]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o IndirectCycleSOutput) Foo2() IndirectCycleTPtrOutput {
 	return o.ApplyT(func(v IndirectCycleS) *IndirectCycleT { return v.Foo2 }).(IndirectCycleTPtrOutput)
 }
@@ -417,6 +496,12 @@ func (o IndirectCycleSPtrOutput) ToIndirectCycleSPtrOutput() IndirectCycleSPtrOu
 
 func (o IndirectCycleSPtrOutput) ToIndirectCycleSPtrOutputWithContext(ctx context.Context) IndirectCycleSPtrOutput {
 	return o
+}
+
+func (o IndirectCycleSPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*IndirectCycleS] {
+	return pulumix.Output[*IndirectCycleS]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o IndirectCycleSPtrOutput) Elem() IndirectCycleSOutput {
@@ -469,6 +554,12 @@ func (i IndirectCycleTArgs) ToIndirectCycleTOutputWithContext(ctx context.Contex
 	return pulumi.ToOutputWithContext(ctx, i).(IndirectCycleTOutput)
 }
 
+func (i IndirectCycleTArgs) ToOutput(ctx context.Context) pulumix.Output[IndirectCycleT] {
+	return pulumix.Output[IndirectCycleT]{
+		OutputState: i.ToIndirectCycleTOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i IndirectCycleTArgs) ToIndirectCycleTPtrOutput() IndirectCycleTPtrOutput {
 	return i.ToIndirectCycleTPtrOutputWithContext(context.Background())
 }
@@ -510,6 +601,12 @@ func (i *indirectCycleTPtrType) ToIndirectCycleTPtrOutputWithContext(ctx context
 	return pulumi.ToOutputWithContext(ctx, i).(IndirectCycleTPtrOutput)
 }
 
+func (i *indirectCycleTPtrType) ToOutput(ctx context.Context) pulumix.Output[*IndirectCycleT] {
+	return pulumix.Output[*IndirectCycleT]{
+		OutputState: i.ToIndirectCycleTPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type IndirectCycleTOutput struct{ *pulumi.OutputState }
 
 func (IndirectCycleTOutput) ElementType() reflect.Type {
@@ -534,6 +631,12 @@ func (o IndirectCycleTOutput) ToIndirectCycleTPtrOutputWithContext(ctx context.C
 	}).(IndirectCycleTPtrOutput)
 }
 
+func (o IndirectCycleTOutput) ToOutput(ctx context.Context) pulumix.Output[IndirectCycleT] {
+	return pulumix.Output[IndirectCycleT]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o IndirectCycleTOutput) Foo3() IndirectCycleSPtrOutput {
 	return o.ApplyT(func(v IndirectCycleT) *IndirectCycleS { return v.Foo3 }).(IndirectCycleSPtrOutput)
 }
@@ -550,6 +653,12 @@ func (o IndirectCycleTPtrOutput) ToIndirectCycleTPtrOutput() IndirectCycleTPtrOu
 
 func (o IndirectCycleTPtrOutput) ToIndirectCycleTPtrOutputWithContext(ctx context.Context) IndirectCycleTPtrOutput {
 	return o
+}
+
+func (o IndirectCycleTPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*IndirectCycleT] {
+	return pulumix.Output[*IndirectCycleT]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o IndirectCycleTPtrOutput) Elem() IndirectCycleTOutput {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/provider.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"dash-named-schema/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"dash-named-schema/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -42,6 +43,12 @@ func (i TopLevelArgs) ToTopLevelOutput() TopLevelOutput {
 
 func (i TopLevelArgs) ToTopLevelOutputWithContext(ctx context.Context) TopLevelOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TopLevelOutput)
+}
+
+func (i TopLevelArgs) ToOutput(ctx context.Context) pulumix.Output[TopLevel] {
+	return pulumix.Output[TopLevel]{
+		OutputState: i.ToTopLevelOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i TopLevelArgs) ToTopLevelPtrOutput() TopLevelPtrOutput {
@@ -85,6 +92,12 @@ func (i *topLevelPtrType) ToTopLevelPtrOutputWithContext(ctx context.Context) To
 	return pulumi.ToOutputWithContext(ctx, i).(TopLevelPtrOutput)
 }
 
+func (i *topLevelPtrType) ToOutput(ctx context.Context) pulumix.Output[*TopLevel] {
+	return pulumix.Output[*TopLevel]{
+		OutputState: i.ToTopLevelPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TopLevelOutput struct{ *pulumi.OutputState }
 
 func (TopLevelOutput) ElementType() reflect.Type {
@@ -109,6 +122,12 @@ func (o TopLevelOutput) ToTopLevelPtrOutputWithContext(ctx context.Context) TopL
 	}).(TopLevelPtrOutput)
 }
 
+func (o TopLevelOutput) ToOutput(ctx context.Context) pulumix.Output[TopLevel] {
+	return pulumix.Output[TopLevel]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TopLevelOutput) Buzz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v TopLevel) *string { return v.Buzz }).(pulumi.StringPtrOutput)
 }
@@ -125,6 +144,12 @@ func (o TopLevelPtrOutput) ToTopLevelPtrOutput() TopLevelPtrOutput {
 
 func (o TopLevelPtrOutput) ToTopLevelPtrOutputWithContext(ctx context.Context) TopLevelPtrOutput {
 	return o
+}
+
+func (o TopLevelPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*TopLevel] {
+	return pulumix.Output[*TopLevel]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TopLevelPtrOutput) Elem() TopLevelOutput {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/fooencryptedBarClass.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/fooencryptedBarClass.go
@@ -9,6 +9,7 @@ import (
 
 	"dash-named-schema/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type FOOEncryptedBarClass struct {
@@ -84,6 +85,12 @@ func (i *FOOEncryptedBarClass) ToFOOEncryptedBarClassOutputWithContext(ctx conte
 	return pulumi.ToOutputWithContext(ctx, i).(FOOEncryptedBarClassOutput)
 }
 
+func (i *FOOEncryptedBarClass) ToOutput(ctx context.Context) pulumix.Output[*FOOEncryptedBarClass] {
+	return pulumix.Output[*FOOEncryptedBarClass]{
+		OutputState: i.ToFOOEncryptedBarClassOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FOOEncryptedBarClassOutput struct{ *pulumi.OutputState }
 
 func (FOOEncryptedBarClassOutput) ElementType() reflect.Type {
@@ -96,6 +103,12 @@ func (o FOOEncryptedBarClassOutput) ToFOOEncryptedBarClassOutput() FOOEncryptedB
 
 func (o FOOEncryptedBarClassOutput) ToFOOEncryptedBarClassOutputWithContext(ctx context.Context) FOOEncryptedBarClassOutput {
 	return o
+}
+
+func (o FOOEncryptedBarClassOutput) ToOutput(ctx context.Context) pulumix.Output[*FOOEncryptedBarClass] {
+	return pulumix.Output[*FOOEncryptedBarClass]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
@@ -10,6 +10,7 @@ import (
 	"dash-named-schema/foo"
 	"dash-named-schema/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type ModuleResource struct {
@@ -89,6 +90,12 @@ func (i *ModuleResource) ToModuleResourceOutputWithContext(ctx context.Context) 
 	return pulumi.ToOutputWithContext(ctx, i).(ModuleResourceOutput)
 }
 
+func (i *ModuleResource) ToOutput(ctx context.Context) pulumix.Output[*ModuleResource] {
+	return pulumix.Output[*ModuleResource]{
+		OutputState: i.ToModuleResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ModuleResourceOutput struct{ *pulumi.OutputState }
 
 func (ModuleResourceOutput) ElementType() reflect.Type {
@@ -101,6 +108,12 @@ func (o ModuleResourceOutput) ToModuleResourceOutput() ModuleResourceOutput {
 
 func (o ModuleResourceOutput) ToModuleResourceOutputWithContext(ctx context.Context) ModuleResourceOutput {
 	return o
+}
+
+func (o ModuleResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*ModuleResource] {
+	return pulumix.Output[*ModuleResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ModuleResourceOutput) Thing() foo.TopLevelPtrOutput {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/provider.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"dashed-import-schema/plant-provider/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -84,6 +85,12 @@ func (o CloudAuditOptionsLogNameOutput) ToCloudAuditOptionsLogNamePtrOutputWithC
 	}).(CloudAuditOptionsLogNamePtrOutput)
 }
 
+func (o CloudAuditOptionsLogNameOutput) ToOutput(ctx context.Context) pulumix.Output[CloudAuditOptionsLogName] {
+	return pulumix.Output[CloudAuditOptionsLogName]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o CloudAuditOptionsLogNameOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -117,6 +124,12 @@ func (o CloudAuditOptionsLogNamePtrOutput) ToCloudAuditOptionsLogNamePtrOutput()
 
 func (o CloudAuditOptionsLogNamePtrOutput) ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx context.Context) CloudAuditOptionsLogNamePtrOutput {
 	return o
+}
+
+func (o CloudAuditOptionsLogNamePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*CloudAuditOptionsLogName] {
+	return pulumix.Output[*CloudAuditOptionsLogName]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CloudAuditOptionsLogNamePtrOutput) Elem() CloudAuditOptionsLogNameOutput {
@@ -179,6 +192,12 @@ func (in *cloudAuditOptionsLogNamePtr) ToCloudAuditOptionsLogNamePtrOutput() Clo
 
 func (in *cloudAuditOptionsLogNamePtr) ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx context.Context) CloudAuditOptionsLogNamePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(CloudAuditOptionsLogNamePtrOutput)
+}
+
+func (in *cloudAuditOptionsLogNamePtr) ToOutput(ctx context.Context) pulumix.Output[*CloudAuditOptionsLogName] {
+	return pulumix.Output[*CloudAuditOptionsLogName]{
+		OutputState: in.ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type ContainerBrightness float64
@@ -248,6 +267,12 @@ func (o ContainerBrightnessOutput) ToContainerBrightnessPtrOutputWithContext(ctx
 	}).(ContainerBrightnessPtrOutput)
 }
 
+func (o ContainerBrightnessOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerBrightness] {
+	return pulumix.Output[ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerBrightnessOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -281,6 +306,12 @@ func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutput() Container
 
 func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return o
+}
+
+func (o ContainerBrightnessPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerBrightnessPtrOutput) Elem() ContainerBrightnessOutput {
@@ -343,6 +374,12 @@ func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutput() ContainerBrig
 
 func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerBrightnessPtrOutput)
+}
+
+func (in *containerBrightnessPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: in.ToContainerBrightnessPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // plant container colors
@@ -414,6 +451,12 @@ func (o ContainerColorOutput) ToContainerColorPtrOutputWithContext(ctx context.C
 	}).(ContainerColorPtrOutput)
 }
 
+func (o ContainerColorOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerColor] {
+	return pulumix.Output[ContainerColor]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerColorOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -447,6 +490,12 @@ func (o ContainerColorPtrOutput) ToContainerColorPtrOutput() ContainerColorPtrOu
 
 func (o ContainerColorPtrOutput) ToContainerColorPtrOutputWithContext(ctx context.Context) ContainerColorPtrOutput {
 	return o
+}
+
+func (o ContainerColorPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
+	return pulumix.Output[*ContainerColor]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerColorPtrOutput) Elem() ContainerColorOutput {
@@ -509,6 +558,12 @@ func (in *containerColorPtr) ToContainerColorPtrOutput() ContainerColorPtrOutput
 
 func (in *containerColorPtr) ToContainerColorPtrOutputWithContext(ctx context.Context) ContainerColorPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerColorPtrOutput)
+}
+
+func (in *containerColorPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
+	return pulumix.Output[*ContainerColor]{
+		OutputState: in.ToContainerColorPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // plant container sizes
@@ -581,6 +636,12 @@ func (o ContainerSizeOutput) ToContainerSizePtrOutputWithContext(ctx context.Con
 	}).(ContainerSizePtrOutput)
 }
 
+func (o ContainerSizeOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerSize] {
+	return pulumix.Output[ContainerSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerSizeOutput) ToIntOutput() pulumi.IntOutput {
 	return o.ToIntOutputWithContext(context.Background())
 }
@@ -614,6 +675,12 @@ func (o ContainerSizePtrOutput) ToContainerSizePtrOutput() ContainerSizePtrOutpu
 
 func (o ContainerSizePtrOutput) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return o
+}
+
+func (o ContainerSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerSizePtrOutput) Elem() ContainerSizeOutput {
@@ -676,6 +743,12 @@ func (in *containerSizePtr) ToContainerSizePtrOutput() ContainerSizePtrOutput {
 
 func (in *containerSizePtr) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerSizePtrOutput)
+}
+
+func (in *containerSizePtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: in.ToContainerSizePtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"dashed-import-schema/plant-provider/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -74,6 +75,12 @@ func (i ContainerArgs) ToContainerOutputWithContext(ctx context.Context) Contain
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput)
 }
 
+func (i ContainerArgs) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: i.ToContainerOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ContainerArgs) ToContainerPtrOutput() ContainerPtrOutput {
 	return i.ToContainerPtrOutputWithContext(context.Background())
 }
@@ -115,6 +122,12 @@ func (i *containerPtrType) ToContainerPtrOutputWithContext(ctx context.Context) 
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
 }
 
+func (i *containerPtrType) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: i.ToContainerPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ContainerOutput struct{ *pulumi.OutputState }
 
 func (ContainerOutput) ElementType() reflect.Type {
@@ -137,6 +150,12 @@ func (o ContainerOutput) ToContainerPtrOutputWithContext(ctx context.Context) Co
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Container) *Container {
 		return &v
 	}).(ContainerPtrOutput)
+}
+
+func (o ContainerOutput) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerOutput) Brightness() ContainerBrightnessPtrOutput {
@@ -167,6 +186,12 @@ func (o ContainerPtrOutput) ToContainerPtrOutput() ContainerPtrOutput {
 
 func (o ContainerPtrOutput) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
 	return o
+}
+
+func (o ContainerPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerPtrOutput) Elem() ContainerOutput {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
@@ -10,6 +10,7 @@ import (
 	"dashed-import-schema/plant-provider/internal"
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Nursery struct {
@@ -96,6 +97,12 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(NurseryOutput)
 }
 
+func (i *Nursery) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: i.ToNurseryOutputWithContext(ctx).OutputState,
+	}
+}
+
 type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
@@ -108,6 +115,12 @@ func (o NurseryOutput) ToNurseryOutput() NurseryOutput {
 
 func (o NurseryOutput) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput {
 	return o
+}
+
+func (o NurseryOutput) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Diameter float64
@@ -77,6 +78,12 @@ func (o DiameterOutput) ToDiameterPtrOutputWithContext(ctx context.Context) Diam
 	}).(DiameterPtrOutput)
 }
 
+func (o DiameterOutput) ToOutput(ctx context.Context) pulumix.Output[Diameter] {
+	return pulumix.Output[Diameter]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o DiameterOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o DiameterPtrOutput) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (o DiameterPtrOutput) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return o
+}
+
+func (o DiameterPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DiameterPtrOutput) Elem() DiameterOutput {
@@ -172,6 +185,12 @@ func (in *diameterPtr) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (in *diameterPtr) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(DiameterPtrOutput)
+}
+
+func (in *diameterPtr) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: in.ToDiameterPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type Farm string
@@ -241,6 +260,12 @@ func (o FarmOutput) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutpu
 	}).(FarmPtrOutput)
 }
 
+func (o FarmOutput) ToOutput(ctx context.Context) pulumix.Output[Farm] {
+	return pulumix.Output[Farm]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FarmOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -274,6 +299,12 @@ func (o FarmPtrOutput) ToFarmPtrOutput() FarmPtrOutput {
 
 func (o FarmPtrOutput) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return o
+}
+
+func (o FarmPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
+	return pulumix.Output[*Farm]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FarmPtrOutput) Elem() FarmOutput {
@@ -336,6 +367,12 @@ func (in *farmPtr) ToFarmPtrOutput() FarmPtrOutput {
 
 func (in *farmPtr) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(FarmPtrOutput)
+}
+
+func (in *farmPtr) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
+	return pulumix.Output[*Farm]{
+		OutputState: in.ToFarmPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // types of rubber trees
@@ -410,6 +447,12 @@ func (o RubberTreeVarietyOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx con
 	}).(RubberTreeVarietyPtrOutput)
 }
 
+func (o RubberTreeVarietyOutput) ToOutput(ctx context.Context) pulumix.Output[RubberTreeVariety] {
+	return pulumix.Output[RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RubberTreeVarietyOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -443,6 +486,12 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
@@ -507,6 +556,12 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
 }
 
+func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // RubberTreeVarietyArrayInput is an input type that accepts RubberTreeVarietyArray and RubberTreeVarietyArrayOutput values.
 // You can construct a concrete instance of `RubberTreeVarietyArrayInput` via:
 //
@@ -532,6 +587,12 @@ func (i RubberTreeVarietyArray) ToRubberTreeVarietyArrayOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeVarietyArrayOutput)
 }
 
+func (i RubberTreeVarietyArray) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: i.ToRubberTreeVarietyArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeVarietyArrayOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeVarietyArrayOutput) ElementType() reflect.Type {
@@ -544,6 +605,12 @@ func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutput() RubberTre
 
 func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutputWithContext(ctx context.Context) RubberTreeVarietyArrayOutput {
 	return o
+}
+
+func (o RubberTreeVarietyArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyArrayOutput) Index(i pulumi.IntInput) RubberTreeVarietyOutput {
@@ -620,6 +687,12 @@ func (o TreeSizeOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) Tree
 	}).(TreeSizePtrOutput)
 }
 
+func (o TreeSizeOutput) ToOutput(ctx context.Context) pulumix.Output[TreeSize] {
+	return pulumix.Output[TreeSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TreeSizeOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -653,6 +726,12 @@ func (o TreeSizePtrOutput) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (o TreeSizePtrOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return o
+}
+
+func (o TreeSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizePtrOutput) Elem() TreeSizeOutput {
@@ -717,6 +796,12 @@ func (in *treeSizePtr) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeS
 	return pulumi.ToOutputWithContext(ctx, in).(TreeSizePtrOutput)
 }
 
+func (in *treeSizePtr) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: in.ToTreeSizePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // TreeSizeMapInput is an input type that accepts TreeSizeMap and TreeSizeMapOutput values.
 // You can construct a concrete instance of `TreeSizeMapInput` via:
 //
@@ -742,6 +827,12 @@ func (i TreeSizeMap) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSiz
 	return pulumi.ToOutputWithContext(ctx, i).(TreeSizeMapOutput)
 }
 
+func (i TreeSizeMap) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: i.ToTreeSizeMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TreeSizeMapOutput struct{ *pulumi.OutputState }
 
 func (TreeSizeMapOutput) ElementType() reflect.Type {
@@ -754,6 +845,12 @@ func (o TreeSizeMapOutput) ToTreeSizeMapOutput() TreeSizeMapOutput {
 
 func (o TreeSizeMapOutput) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSizeMapOutput {
 	return o
+}
+
+func (o TreeSizeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizeMapOutput) MapIndex(k pulumi.StringInput) TreeSizeOutput {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
@@ -11,6 +11,7 @@ import (
 	"dashed-import-schema/plant-provider/internal"
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type RubberTree struct {
@@ -119,6 +120,12 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeOutput)
 }
 
+func (i *RubberTree) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: i.ToRubberTreeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
@@ -131,6 +138,12 @@ func (o RubberTreeOutput) ToRubberTreeOutput() RubberTreeOutput {
 
 func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) RubberTreeOutput {
 	return o
+}
+
+func (o RubberTreeOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeOutput) Container() plantprovider.ContainerPtrOutput {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/provider.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"different-enum/plant/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -91,6 +92,12 @@ func (o ContainerBrightnessOutput) ToContainerBrightnessPtrOutputWithContext(ctx
 	}).(ContainerBrightnessPtrOutput)
 }
 
+func (o ContainerBrightnessOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerBrightness] {
+	return pulumix.Output[ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerBrightnessOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -124,6 +131,12 @@ func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutput() Container
 
 func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return o
+}
+
+func (o ContainerBrightnessPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerBrightnessPtrOutput) Elem() ContainerBrightnessOutput {
@@ -186,6 +199,12 @@ func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutput() ContainerBrig
 
 func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerBrightnessPtrOutput)
+}
+
+func (in *containerBrightnessPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: in.ToContainerBrightnessPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // plant container colors
@@ -267,6 +286,12 @@ func (o ContainerSizeOutput) ToContainerSizePtrOutputWithContext(ctx context.Con
 	}).(ContainerSizePtrOutput)
 }
 
+func (o ContainerSizeOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerSize] {
+	return pulumix.Output[ContainerSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerSizeOutput) ToIntOutput() pulumi.IntOutput {
 	return o.ToIntOutputWithContext(context.Background())
 }
@@ -300,6 +325,12 @@ func (o ContainerSizePtrOutput) ToContainerSizePtrOutput() ContainerSizePtrOutpu
 
 func (o ContainerSizePtrOutput) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return o
+}
+
+func (o ContainerSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerSizePtrOutput) Elem() ContainerSizeOutput {
@@ -362,6 +393,12 @@ func (in *containerSizePtr) ToContainerSizePtrOutput() ContainerSizePtrOutput {
 
 func (in *containerSizePtr) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerSizePtrOutput)
+}
+
+func (in *containerSizePtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: in.ToContainerSizePtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"different-enum/plant/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -74,6 +75,12 @@ func (i ContainerArgs) ToContainerOutputWithContext(ctx context.Context) Contain
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput)
 }
 
+func (i ContainerArgs) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: i.ToContainerOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ContainerArgs) ToContainerPtrOutput() ContainerPtrOutput {
 	return i.ToContainerPtrOutputWithContext(context.Background())
 }
@@ -115,6 +122,12 @@ func (i *containerPtrType) ToContainerPtrOutputWithContext(ctx context.Context) 
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
 }
 
+func (i *containerPtrType) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: i.ToContainerPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ContainerOutput struct{ *pulumi.OutputState }
 
 func (ContainerOutput) ElementType() reflect.Type {
@@ -137,6 +150,12 @@ func (o ContainerOutput) ToContainerPtrOutputWithContext(ctx context.Context) Co
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Container) *Container {
 		return &v
 	}).(ContainerPtrOutput)
+}
+
+func (o ContainerOutput) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerOutput) Brightness() ContainerBrightnessPtrOutput {
@@ -167,6 +186,12 @@ func (o ContainerPtrOutput) ToContainerPtrOutput() ContainerPtrOutput {
 
 func (o ContainerPtrOutput) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
 	return o
+}
+
+func (o ContainerPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerPtrOutput) Elem() ContainerOutput {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
@@ -10,6 +10,7 @@ import (
 	"different-enum/plant/internal"
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Nursery struct {
@@ -96,6 +97,12 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(NurseryOutput)
 }
 
+func (i *Nursery) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: i.ToNurseryOutputWithContext(ctx).OutputState,
+	}
+}
+
 type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
@@ -108,6 +115,12 @@ func (o NurseryOutput) ToNurseryOutput() NurseryOutput {
 
 func (o NurseryOutput) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput {
 	return o
+}
+
+func (o NurseryOutput) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Diameter float64
@@ -77,6 +78,12 @@ func (o DiameterOutput) ToDiameterPtrOutputWithContext(ctx context.Context) Diam
 	}).(DiameterPtrOutput)
 }
 
+func (o DiameterOutput) ToOutput(ctx context.Context) pulumix.Output[Diameter] {
+	return pulumix.Output[Diameter]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o DiameterOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o DiameterPtrOutput) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (o DiameterPtrOutput) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return o
+}
+
+func (o DiameterPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DiameterPtrOutput) Elem() DiameterOutput {
@@ -172,6 +185,12 @@ func (in *diameterPtr) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (in *diameterPtr) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(DiameterPtrOutput)
+}
+
+func (in *diameterPtr) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: in.ToDiameterPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type Farm string
@@ -253,6 +272,12 @@ func (o RubberTreeVarietyOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx con
 	}).(RubberTreeVarietyPtrOutput)
 }
 
+func (o RubberTreeVarietyOutput) ToOutput(ctx context.Context) pulumix.Output[RubberTreeVariety] {
+	return pulumix.Output[RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RubberTreeVarietyOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -286,6 +311,12 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
@@ -350,6 +381,12 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
 }
 
+func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // RubberTreeVarietyArrayInput is an input type that accepts RubberTreeVarietyArray and RubberTreeVarietyArrayOutput values.
 // You can construct a concrete instance of `RubberTreeVarietyArrayInput` via:
 //
@@ -375,6 +412,12 @@ func (i RubberTreeVarietyArray) ToRubberTreeVarietyArrayOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeVarietyArrayOutput)
 }
 
+func (i RubberTreeVarietyArray) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: i.ToRubberTreeVarietyArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeVarietyArrayOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeVarietyArrayOutput) ElementType() reflect.Type {
@@ -387,6 +430,12 @@ func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutput() RubberTre
 
 func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutputWithContext(ctx context.Context) RubberTreeVarietyArrayOutput {
 	return o
+}
+
+func (o RubberTreeVarietyArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyArrayOutput) Index(i pulumi.IntInput) RubberTreeVarietyOutput {
@@ -463,6 +512,12 @@ func (o TreeSizeOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) Tree
 	}).(TreeSizePtrOutput)
 }
 
+func (o TreeSizeOutput) ToOutput(ctx context.Context) pulumix.Output[TreeSize] {
+	return pulumix.Output[TreeSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TreeSizeOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -496,6 +551,12 @@ func (o TreeSizePtrOutput) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (o TreeSizePtrOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return o
+}
+
+func (o TreeSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizePtrOutput) Elem() TreeSizeOutput {
@@ -560,6 +621,12 @@ func (in *treeSizePtr) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeS
 	return pulumi.ToOutputWithContext(ctx, in).(TreeSizePtrOutput)
 }
 
+func (in *treeSizePtr) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: in.ToTreeSizePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // TreeSizeMapInput is an input type that accepts TreeSizeMap and TreeSizeMapOutput values.
 // You can construct a concrete instance of `TreeSizeMapInput` via:
 //
@@ -585,6 +652,12 @@ func (i TreeSizeMap) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSiz
 	return pulumi.ToOutputWithContext(ctx, i).(TreeSizeMapOutput)
 }
 
+func (i TreeSizeMap) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: i.ToTreeSizeMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TreeSizeMapOutput struct{ *pulumi.OutputState }
 
 func (TreeSizeMapOutput) ElementType() reflect.Type {
@@ -597,6 +670,12 @@ func (o TreeSizeMapOutput) ToTreeSizeMapOutput() TreeSizeMapOutput {
 
 func (o TreeSizeMapOutput) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSizeMapOutput {
 	return o
+}
+
+func (o TreeSizeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizeMapOutput) MapIndex(k pulumi.StringInput) TreeSizeOutput {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
@@ -11,6 +11,7 @@ import (
 	"different-enum/plant/internal"
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type RubberTree struct {
@@ -119,6 +120,12 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeOutput)
 }
 
+func (i *RubberTree) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: i.ToRubberTreeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
@@ -131,6 +138,12 @@ func (o RubberTreeOutput) ToRubberTreeOutput() RubberTreeOutput {
 
 func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) RubberTreeOutput {
 	return o
+}
+
+func (o RubberTreeOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeOutput) Container() plant.ContainerPtrOutput {

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/component.go
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/component.go
@@ -11,6 +11,7 @@ import (
 	"embedded-crd-types/foo/internal"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Component struct {
@@ -70,6 +71,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -82,6 +89,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) EniConfig() v1alpha1.ENIConfigSpecMapOutput {

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/crd.k8s.amazonaws.com/v1alpha1/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/crd.k8s.amazonaws.com/v1alpha1/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"embedded-crd-types/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -52,6 +53,12 @@ func (i ENIConfigSpecArgs) ToENIConfigSpecOutputWithContext(ctx context.Context)
 	return pulumi.ToOutputWithContext(ctx, i).(ENIConfigSpecOutput)
 }
 
+func (i ENIConfigSpecArgs) ToOutput(ctx context.Context) pulumix.Output[ENIConfigSpec] {
+	return pulumix.Output[ENIConfigSpec]{
+		OutputState: i.ToENIConfigSpecOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ENIConfigSpecMapInput is an input type that accepts ENIConfigSpecMap and ENIConfigSpecMapOutput values.
 // You can construct a concrete instance of `ENIConfigSpecMapInput` via:
 //
@@ -77,6 +84,12 @@ func (i ENIConfigSpecMap) ToENIConfigSpecMapOutputWithContext(ctx context.Contex
 	return pulumi.ToOutputWithContext(ctx, i).(ENIConfigSpecMapOutput)
 }
 
+func (i ENIConfigSpecMap) ToOutput(ctx context.Context) pulumix.Output[map[string]ENIConfigSpec] {
+	return pulumix.Output[map[string]ENIConfigSpec]{
+		OutputState: i.ToENIConfigSpecMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ENIConfigSpecOutput struct{ *pulumi.OutputState }
 
 func (ENIConfigSpecOutput) ElementType() reflect.Type {
@@ -89,6 +102,12 @@ func (o ENIConfigSpecOutput) ToENIConfigSpecOutput() ENIConfigSpecOutput {
 
 func (o ENIConfigSpecOutput) ToENIConfigSpecOutputWithContext(ctx context.Context) ENIConfigSpecOutput {
 	return o
+}
+
+func (o ENIConfigSpecOutput) ToOutput(ctx context.Context) pulumix.Output[ENIConfigSpec] {
+	return pulumix.Output[ENIConfigSpec]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ENIConfigSpecOutput) SecurityGroups() pulumi.StringArrayOutput {
@@ -111,6 +130,12 @@ func (o ENIConfigSpecMapOutput) ToENIConfigSpecMapOutput() ENIConfigSpecMapOutpu
 
 func (o ENIConfigSpecMapOutput) ToENIConfigSpecMapOutputWithContext(ctx context.Context) ENIConfigSpecMapOutput {
 	return o
+}
+
+func (o ENIConfigSpecMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]ENIConfigSpec] {
+	return pulumix.Output[map[string]ENIConfigSpec]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ENIConfigSpecMapOutput) MapIndex(k pulumi.StringInput) ENIConfigSpecOutput {

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/provider.go
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/go/foo/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"embedded-crd-types/foo/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/enum-reference/go/example/mymodule/iamResource.go
+++ b/pkg/codegen/testing/test/testdata/enum-reference/go/example/mymodule/iamResource.go
@@ -10,6 +10,7 @@ import (
 	"enum-reference/example/internal"
 	iam "github.com/pulumi/pulumi-google-native/sdk/go/google/iam/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type IamResource struct {
@@ -64,6 +65,12 @@ func (i *IamResource) ToIamResourceOutputWithContext(ctx context.Context) IamRes
 	return pulumi.ToOutputWithContext(ctx, i).(IamResourceOutput)
 }
 
+func (i *IamResource) ToOutput(ctx context.Context) pulumix.Output[*IamResource] {
+	return pulumix.Output[*IamResource]{
+		OutputState: i.ToIamResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type IamResourceOutput struct{ *pulumi.OutputState }
 
 func (IamResourceOutput) ElementType() reflect.Type {
@@ -76,6 +83,12 @@ func (o IamResourceOutput) ToIamResourceOutput() IamResourceOutput {
 
 func (o IamResourceOutput) ToIamResourceOutputWithContext(ctx context.Context) IamResourceOutput {
 	return o
+}
+
+func (o IamResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*IamResource] {
+	return pulumix.Output[*IamResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/enum-reference/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/enum-reference/go/example/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"enum-reference/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/component.go
@@ -11,6 +11,7 @@ import (
 	"external-enum/example/local"
 	accesscontextmanager "github.com/pulumi/pulumi-google-native/sdk/go/google/accesscontextmanager/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Component struct {
@@ -93,6 +94,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ComponentArrayInput is an input type that accepts ComponentArray and ComponentArrayOutput values.
 // You can construct a concrete instance of `ComponentArrayInput` via:
 //
@@ -116,6 +123,12 @@ func (i ComponentArray) ToComponentArrayOutput() ComponentArrayOutput {
 
 func (i ComponentArray) ToComponentArrayOutputWithContext(ctx context.Context) ComponentArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentArrayOutput)
+}
+
+func (i ComponentArray) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: i.ToComponentArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ComponentMapInput is an input type that accepts ComponentMap and ComponentMapOutput values.
@@ -143,6 +156,12 @@ func (i ComponentMap) ToComponentMapOutputWithContext(ctx context.Context) Compo
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentMapOutput)
 }
 
+func (i ComponentMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: i.ToComponentMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -155,6 +174,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) LocalEnum() local.MyEnumPtrOutput {
@@ -181,6 +206,12 @@ func (o ComponentArrayOutput) ToComponentArrayOutputWithContext(ctx context.Cont
 	return o
 }
 
+func (o ComponentArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ComponentArrayOutput) Index(i pulumi.IntInput) ComponentOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Component {
 		return vs[0].([]*Component)[vs[1].(int)]
@@ -199,6 +230,12 @@ func (o ComponentMapOutput) ToComponentMapOutput() ComponentMapOutput {
 
 func (o ComponentMapOutput) ToComponentMapOutputWithContext(ctx context.Context) ComponentMapOutput {
 	return o
+}
+
+func (o ComponentMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentMapOutput) MapIndex(k pulumi.StringInput) ComponentOutput {

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type MyEnum float64
@@ -77,6 +78,12 @@ func (o MyEnumOutput) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPt
 	}).(MyEnumPtrOutput)
 }
 
+func (o MyEnumOutput) ToOutput(ctx context.Context) pulumix.Output[MyEnum] {
+	return pulumix.Output[MyEnum]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o MyEnumOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o MyEnumPtrOutput) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (o MyEnumPtrOutput) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return o
+}
+
+func (o MyEnumPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
+	return pulumix.Output[*MyEnum]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o MyEnumPtrOutput) Elem() MyEnumOutput {
@@ -172,6 +185,12 @@ func (in *myEnumPtr) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (in *myEnumPtr) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(MyEnumPtrOutput)
+}
+
+func (in *myEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
+	return pulumix.Output[*MyEnum]{
+		OutputState: in.ToMyEnumPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"external-enum/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
@@ -15,6 +15,7 @@ import (
 	dns "github.com/pulumi/pulumi-google-native/sdk/go/google/dns/v1"
 	gcpiamv1 "github.com/pulumi/pulumi-google-native/sdk/go/google/iam/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Component struct {
@@ -141,6 +142,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ComponentArrayInput is an input type that accepts ComponentArray and ComponentArrayOutput values.
 // You can construct a concrete instance of `ComponentArrayInput` via:
 //
@@ -164,6 +171,12 @@ func (i ComponentArray) ToComponentArrayOutput() ComponentArrayOutput {
 
 func (i ComponentArray) ToComponentArrayOutputWithContext(ctx context.Context) ComponentArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentArrayOutput)
+}
+
+func (i ComponentArray) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: i.ToComponentArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ComponentMapInput is an input type that accepts ComponentMap and ComponentMapOutput values.
@@ -191,6 +204,12 @@ func (i ComponentMap) ToComponentMapOutputWithContext(ctx context.Context) Compo
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentMapOutput)
 }
 
+func (i ComponentMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: i.ToComponentMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -203,6 +222,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) ResourceLocalAlias() awsec2.InstanceOutput {
@@ -251,6 +276,12 @@ func (o ComponentArrayOutput) ToComponentArrayOutputWithContext(ctx context.Cont
 	return o
 }
 
+func (o ComponentArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ComponentArrayOutput) Index(i pulumi.IntInput) ComponentOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Component {
 		return vs[0].([]*Component)[vs[1].(int)]
@@ -269,6 +300,12 @@ func (o ComponentMapOutput) ToComponentMapOutput() ComponentMapOutput {
 
 func (o ComponentMapOutput) ToComponentMapOutputWithContext(ctx context.Context) ComponentMapOutput {
 	return o
+}
+
+func (o ComponentMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentMapOutput) MapIndex(k pulumi.StringInput) ComponentOutput {

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"external-go-import-aliases/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -63,6 +64,12 @@ func (o ArgFunctionResultOutput) ToArgFunctionResultOutput() ArgFunctionResultOu
 
 func (o ArgFunctionResultOutput) ToArgFunctionResultOutputWithContext(ctx context.Context) ArgFunctionResultOutput {
 	return o
+}
+
+func (o ArgFunctionResultOutput) ToOutput(ctx context.Context) pulumix.Output[ArgFunctionResult] {
+	return pulumix.Output[ArgFunctionResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ArgFunctionResultOutput) Age() pulumi.IntPtrOutput {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -90,6 +91,12 @@ func (i *Cat) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatOutput)
 }
 
+func (i *Cat) ToOutput(ctx context.Context) pulumix.Output[*Cat] {
+	return pulumix.Output[*Cat]{
+		OutputState: i.ToCatOutputWithContext(ctx).OutputState,
+	}
+}
+
 // CatArrayInput is an input type that accepts CatArray and CatArrayOutput values.
 // You can construct a concrete instance of `CatArrayInput` via:
 //
@@ -113,6 +120,12 @@ func (i CatArray) ToCatArrayOutput() CatArrayOutput {
 
 func (i CatArray) ToCatArrayOutputWithContext(ctx context.Context) CatArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatArrayOutput)
+}
+
+func (i CatArray) ToOutput(ctx context.Context) pulumix.Output[[]*Cat] {
+	return pulumix.Output[[]*Cat]{
+		OutputState: i.ToCatArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // CatMapInput is an input type that accepts CatMap and CatMapOutput values.
@@ -140,6 +153,12 @@ func (i CatMap) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatMapOutput)
 }
 
+func (i CatMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Cat] {
+	return pulumix.Output[map[string]*Cat]{
+		OutputState: i.ToCatMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type CatOutput struct{ *pulumi.OutputState }
 
 func (CatOutput) ElementType() reflect.Type {
@@ -152,6 +171,12 @@ func (o CatOutput) ToCatOutput() CatOutput {
 
 func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
+}
+
+func (o CatOutput) ToOutput(ctx context.Context) pulumix.Output[*Cat] {
+	return pulumix.Output[*Cat]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CatOutput) Name() pulumi.StringPtrOutput {
@@ -172,6 +197,12 @@ func (o CatArrayOutput) ToCatArrayOutputWithContext(ctx context.Context) CatArra
 	return o
 }
 
+func (o CatArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Cat] {
+	return pulumix.Output[[]*Cat]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o CatArrayOutput) Index(i pulumi.IntInput) CatOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Cat {
 		return vs[0].([]*Cat)[vs[1].(int)]
@@ -190,6 +221,12 @@ func (o CatMapOutput) ToCatMapOutput() CatMapOutput {
 
 func (o CatMapOutput) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 	return o
+}
+
+func (o CatMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Cat] {
+	return pulumix.Output[map[string]*Cat]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CatMapOutput) MapIndex(k pulumi.StringInput) CatOutput {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
@@ -13,6 +13,7 @@ import (
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
 	storagev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/storage/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -114,6 +115,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ComponentArrayInput is an input type that accepts ComponentArray and ComponentArrayOutput values.
 // You can construct a concrete instance of `ComponentArrayInput` via:
 //
@@ -137,6 +144,12 @@ func (i ComponentArray) ToComponentArrayOutput() ComponentArrayOutput {
 
 func (i ComponentArray) ToComponentArrayOutputWithContext(ctx context.Context) ComponentArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentArrayOutput)
+}
+
+func (i ComponentArray) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: i.ToComponentArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ComponentMapInput is an input type that accepts ComponentMap and ComponentMapOutput values.
@@ -164,6 +177,12 @@ func (i ComponentMap) ToComponentMapOutputWithContext(ctx context.Context) Compo
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentMapOutput)
 }
 
+func (i ComponentMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: i.ToComponentMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -176,6 +195,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) Provider() kubernetes.ProviderOutput {
@@ -204,6 +229,12 @@ func (o ComponentArrayOutput) ToComponentArrayOutputWithContext(ctx context.Cont
 	return o
 }
 
+func (o ComponentArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Component] {
+	return pulumix.Output[[]*Component]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ComponentArrayOutput) Index(i pulumi.IntInput) ComponentOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Component {
 		return vs[0].([]*Component)[vs[1].(int)]
@@ -222,6 +253,12 @@ func (o ComponentMapOutput) ToComponentMapOutput() ComponentMapOutput {
 
 func (o ComponentMapOutput) ToComponentMapOutputWithContext(ctx context.Context) ComponentMapOutput {
 	return o
+}
+
+func (o ComponentMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Component] {
+	return pulumix.Output[map[string]*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentMapOutput) MapIndex(k pulumi.StringInput) ComponentOutput {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -57,6 +58,12 @@ func (i PetArgs) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetOutput)
 }
 
+func (i PetArgs) ToOutput(ctx context.Context) pulumix.Output[Pet] {
+	return pulumix.Output[Pet]{
+		OutputState: i.ToPetOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i PetArgs) ToPetPtrOutput() PetPtrOutput {
 	return i.ToPetPtrOutputWithContext(context.Background())
 }
@@ -98,6 +105,12 @@ func (i *petPtrType) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(PetPtrOutput)
 }
 
+func (i *petPtrType) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: i.ToPetPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
@@ -120,6 +133,12 @@ func (o PetOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Pet) *Pet {
 		return &v
 	}).(PetPtrOutput)
+}
+
+func (o PetOutput) ToOutput(ctx context.Context) pulumix.Output[Pet] {
+	return pulumix.Output[Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetOutput) Age() pulumi.IntPtrOutput {
@@ -162,6 +181,12 @@ func (o PetPtrOutput) ToPetPtrOutput() PetPtrOutput {
 
 func (o PetPtrOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
 	return o
+}
+
+func (o PetPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetPtrOutput) Elem() PetOutput {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/workload.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/workload.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -87,6 +88,12 @@ func (i *Workload) ToWorkloadOutputWithContext(ctx context.Context) WorkloadOutp
 	return pulumi.ToOutputWithContext(ctx, i).(WorkloadOutput)
 }
 
+func (i *Workload) ToOutput(ctx context.Context) pulumix.Output[*Workload] {
+	return pulumix.Output[*Workload]{
+		OutputState: i.ToWorkloadOutputWithContext(ctx).OutputState,
+	}
+}
+
 // WorkloadArrayInput is an input type that accepts WorkloadArray and WorkloadArrayOutput values.
 // You can construct a concrete instance of `WorkloadArrayInput` via:
 //
@@ -110,6 +117,12 @@ func (i WorkloadArray) ToWorkloadArrayOutput() WorkloadArrayOutput {
 
 func (i WorkloadArray) ToWorkloadArrayOutputWithContext(ctx context.Context) WorkloadArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(WorkloadArrayOutput)
+}
+
+func (i WorkloadArray) ToOutput(ctx context.Context) pulumix.Output[[]*Workload] {
+	return pulumix.Output[[]*Workload]{
+		OutputState: i.ToWorkloadArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // WorkloadMapInput is an input type that accepts WorkloadMap and WorkloadMapOutput values.
@@ -137,6 +150,12 @@ func (i WorkloadMap) ToWorkloadMapOutputWithContext(ctx context.Context) Workloa
 	return pulumi.ToOutputWithContext(ctx, i).(WorkloadMapOutput)
 }
 
+func (i WorkloadMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Workload] {
+	return pulumix.Output[map[string]*Workload]{
+		OutputState: i.ToWorkloadMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type WorkloadOutput struct{ *pulumi.OutputState }
 
 func (WorkloadOutput) ElementType() reflect.Type {
@@ -149,6 +168,12 @@ func (o WorkloadOutput) ToWorkloadOutput() WorkloadOutput {
 
 func (o WorkloadOutput) ToWorkloadOutputWithContext(ctx context.Context) WorkloadOutput {
 	return o
+}
+
+func (o WorkloadOutput) ToOutput(ctx context.Context) pulumix.Output[*Workload] {
+	return pulumix.Output[*Workload]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o WorkloadOutput) Pod() *corev1.PodTypeOutput {
@@ -169,6 +194,12 @@ func (o WorkloadArrayOutput) ToWorkloadArrayOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o WorkloadArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Workload] {
+	return pulumix.Output[[]*Workload]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o WorkloadArrayOutput) Index(i pulumi.IntInput) WorkloadOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Workload {
 		return vs[0].([]*Workload)[vs[1].(int)]
@@ -187,6 +218,12 @@ func (o WorkloadMapOutput) ToWorkloadMapOutput() WorkloadMapOutput {
 
 func (o WorkloadMapOutput) ToWorkloadMapOutputWithContext(ctx context.Context) WorkloadMapOutput {
 	return o
+}
+
+func (o WorkloadMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Workload] {
+	return pulumix.Output[map[string]*Workload]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o WorkloadMapOutput) MapIndex(k pulumi.StringInput) WorkloadOutput {

--- a/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/funcWithSecrets.go
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/funcWithSecrets.go
@@ -9,6 +9,7 @@ import (
 
 	"functions-secrets/mypkg/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 func FuncWithSecrets(ctx *pulumi.Context, args *FuncWithSecretsArgs, opts ...pulumi.InvokeOption) (*FuncWithSecretsResult, error) {
@@ -67,6 +68,12 @@ func (o FuncWithSecretsResultOutput) ToFuncWithSecretsResultOutput() FuncWithSec
 
 func (o FuncWithSecretsResultOutput) ToFuncWithSecretsResultOutputWithContext(ctx context.Context) FuncWithSecretsResultOutput {
 	return o
+}
+
+func (o FuncWithSecretsResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithSecretsResult] {
+	return pulumix.Output[FuncWithSecretsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithSecretsResultOutput) Ciphertext() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/provider.go
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"functions-secrets/mypkg/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/elementtype/elementType.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/elementtype/elementType.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *ElementType) ToElementTypeOutputWithContext(ctx context.Context) Elemen
 	return pulumi.ToOutputWithContext(ctx, i).(ElementTypeOutput)
 }
 
+func (i *ElementType) ToOutput(ctx context.Context) pulumix.Output[*ElementType] {
+	return pulumix.Output[*ElementType]{
+		OutputState: i.ToElementTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ElementTypeArrayInput is an input type that accepts ElementTypeArray and ElementTypeArrayOutput values.
 // You can construct a concrete instance of `ElementTypeArrayInput` via:
 //
@@ -109,6 +116,12 @@ func (i ElementTypeArray) ToElementTypeArrayOutput() ElementTypeArrayOutput {
 
 func (i ElementTypeArray) ToElementTypeArrayOutputWithContext(ctx context.Context) ElementTypeArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ElementTypeArrayOutput)
+}
+
+func (i ElementTypeArray) ToOutput(ctx context.Context) pulumix.Output[[]*ElementType] {
+	return pulumix.Output[[]*ElementType]{
+		OutputState: i.ToElementTypeArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ElementTypeMapInput is an input type that accepts ElementTypeMap and ElementTypeMapOutput values.
@@ -136,6 +149,12 @@ func (i ElementTypeMap) ToElementTypeMapOutputWithContext(ctx context.Context) E
 	return pulumi.ToOutputWithContext(ctx, i).(ElementTypeMapOutput)
 }
 
+func (i ElementTypeMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*ElementType] {
+	return pulumix.Output[map[string]*ElementType]{
+		OutputState: i.ToElementTypeMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ElementTypeOutput struct{ *pulumi.OutputState }
 
 func (ElementTypeOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o ElementTypeOutput) ToElementTypeOutput() ElementTypeOutput {
 
 func (o ElementTypeOutput) ToElementTypeOutputWithContext(ctx context.Context) ElementTypeOutput {
 	return o
+}
+
+func (o ElementTypeOutput) ToOutput(ctx context.Context) pulumix.Output[*ElementType] {
+	return pulumix.Output[*ElementType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ElementTypeOutput) GetElementType_() ElementTypeTypePtrOutput {
@@ -168,6 +193,12 @@ func (o ElementTypeArrayOutput) ToElementTypeArrayOutputWithContext(ctx context.
 	return o
 }
 
+func (o ElementTypeArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*ElementType] {
+	return pulumix.Output[[]*ElementType]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ElementTypeArrayOutput) Index(i pulumi.IntInput) ElementTypeOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *ElementType {
 		return vs[0].([]*ElementType)[vs[1].(int)]
@@ -186,6 +217,12 @@ func (o ElementTypeMapOutput) ToElementTypeMapOutput() ElementTypeMapOutput {
 
 func (o ElementTypeMapOutput) ToElementTypeMapOutputWithContext(ctx context.Context) ElementTypeMapOutput {
 	return o
+}
+
+func (o ElementTypeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*ElementType] {
+	return pulumix.Output[map[string]*ElementType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ElementTypeMapOutput) MapIndex(k pulumi.StringInput) ElementTypeOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/elementtype/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/elementtype/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -31,6 +32,12 @@ func (o ElementTypeTypeOutput) ToElementTypeTypeOutputWithContext(ctx context.Co
 	return o
 }
 
+func (o ElementTypeTypeOutput) ToOutput(ctx context.Context) pulumix.Output[ElementTypeType] {
+	return pulumix.Output[ElementTypeType]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ElementTypeTypeOutput) GetElementType_() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ElementTypeType) *string { return v.ElementType_ }).(pulumi.StringPtrOutput)
 }
@@ -47,6 +54,12 @@ func (o ElementTypeTypePtrOutput) ToElementTypeTypePtrOutput() ElementTypeTypePt
 
 func (o ElementTypeTypePtrOutput) ToElementTypeTypePtrOutputWithContext(ctx context.Context) ElementTypeTypePtrOutput {
 	return o
+}
+
+func (o ElementTypeTypePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ElementTypeType] {
+	return pulumix.Output[*ElementTypeType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ElementTypeTypePtrOutput) Elem() ElementTypeTypeOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/foo.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/foo.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.
 // You can construct a concrete instance of `FooArrayInput` via:
 //
@@ -109,6 +116,12 @@ func (i FooArray) ToFooArrayOutput() FooArrayOutput {
 
 func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
+}
+
+func (i FooArray) ToOutput(ctx context.Context) pulumix.Output[[]*Foo] {
+	return pulumix.Output[[]*Foo]{
+		OutputState: i.ToFooArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // FooMapInput is an input type that accepts FooMap and FooMapOutput values.
@@ -136,6 +149,12 @@ func (i FooMap) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooMapOutput)
 }
 
+func (i FooMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Foo] {
+	return pulumix.Output[map[string]*Foo]{
+		OutputState: i.ToFooMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooOutput) ConditionSets() BarArrayArrayArrayOutput {
@@ -168,6 +193,12 @@ func (o FooArrayOutput) ToFooArrayOutputWithContext(ctx context.Context) FooArra
 	return o
 }
 
+func (o FooArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Foo] {
+	return pulumix.Output[[]*Foo]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Foo {
 		return vs[0].([]*Foo)[vs[1].(int)]
@@ -186,6 +217,12 @@ func (o FooMapOutput) ToFooMapOutput() FooMapOutput {
 
 func (o FooMapOutput) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return o
+}
+
+func (o FooMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Foo] {
+	return pulumix.Output[map[string]*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooMapOutput) MapIndex(k pulumi.StringInput) FooOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/consumer.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/consumer.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -88,6 +89,12 @@ func (i *Consumer) ToConsumerOutputWithContext(ctx context.Context) ConsumerOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ConsumerOutput)
 }
 
+func (i *Consumer) ToOutput(ctx context.Context) pulumix.Output[*Consumer] {
+	return pulumix.Output[*Consumer]{
+		OutputState: i.ToConsumerOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConsumerArrayInput is an input type that accepts ConsumerArray and ConsumerArrayOutput values.
 // You can construct a concrete instance of `ConsumerArrayInput` via:
 //
@@ -111,6 +118,12 @@ func (i ConsumerArray) ToConsumerArrayOutput() ConsumerArrayOutput {
 
 func (i ConsumerArray) ToConsumerArrayOutputWithContext(ctx context.Context) ConsumerArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ConsumerArrayOutput)
+}
+
+func (i ConsumerArray) ToOutput(ctx context.Context) pulumix.Output[[]*Consumer] {
+	return pulumix.Output[[]*Consumer]{
+		OutputState: i.ToConsumerArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ConsumerMapInput is an input type that accepts ConsumerMap and ConsumerMapOutput values.
@@ -138,6 +151,12 @@ func (i ConsumerMap) ToConsumerMapOutputWithContext(ctx context.Context) Consume
 	return pulumi.ToOutputWithContext(ctx, i).(ConsumerMapOutput)
 }
 
+func (i ConsumerMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Consumer] {
+	return pulumix.Output[map[string]*Consumer]{
+		OutputState: i.ToConsumerMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConsumerOutput struct{ *pulumi.OutputState }
 
 func (ConsumerOutput) ElementType() reflect.Type {
@@ -152,6 +171,12 @@ func (o ConsumerOutput) ToConsumerOutputWithContext(ctx context.Context) Consume
 	return o
 }
 
+func (o ConsumerOutput) ToOutput(ctx context.Context) pulumix.Output[*Consumer] {
+	return pulumix.Output[*Consumer]{
+		OutputState: o.OutputState,
+	}
+}
+
 type ConsumerArrayOutput struct{ *pulumi.OutputState }
 
 func (ConsumerArrayOutput) ElementType() reflect.Type {
@@ -164,6 +189,12 @@ func (o ConsumerArrayOutput) ToConsumerArrayOutput() ConsumerArrayOutput {
 
 func (o ConsumerArrayOutput) ToConsumerArrayOutputWithContext(ctx context.Context) ConsumerArrayOutput {
 	return o
+}
+
+func (o ConsumerArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Consumer] {
+	return pulumix.Output[[]*Consumer]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConsumerArrayOutput) Index(i pulumi.IntInput) ConsumerOutput {
@@ -184,6 +215,12 @@ func (o ConsumerMapOutput) ToConsumerMapOutput() ConsumerMapOutput {
 
 func (o ConsumerMapOutput) ToConsumerMapOutputWithContext(ctx context.Context) ConsumerMapOutput {
 	return o
+}
+
+func (o ConsumerMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Consumer] {
+	return pulumix.Output[map[string]*Consumer]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConsumerMapOutput) MapIndex(k pulumi.StringInput) ConsumerOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/someType.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/someType.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -84,6 +85,12 @@ func (i *SomeType) ToSomeTypeOutputWithContext(ctx context.Context) SomeTypeOutp
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeOutput)
 }
 
+func (i *SomeType) ToOutput(ctx context.Context) pulumix.Output[*SomeType] {
+	return pulumix.Output[*SomeType]{
+		OutputState: i.ToSomeTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeTypeArrayInput is an input type that accepts SomeTypeArray and SomeTypeArrayOutput values.
 // You can construct a concrete instance of `SomeTypeArrayInput` via:
 //
@@ -107,6 +114,12 @@ func (i SomeTypeArray) ToSomeTypeArrayOutput() SomeTypeArrayOutput {
 
 func (i SomeTypeArray) ToSomeTypeArrayOutputWithContext(ctx context.Context) SomeTypeArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeArrayOutput)
+}
+
+func (i SomeTypeArray) ToOutput(ctx context.Context) pulumix.Output[[]*SomeType] {
+	return pulumix.Output[[]*SomeType]{
+		OutputState: i.ToSomeTypeArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeTypeMapInput is an input type that accepts SomeTypeMap and SomeTypeMapOutput values.
@@ -134,6 +147,12 @@ func (i SomeTypeMap) ToSomeTypeMapOutputWithContext(ctx context.Context) SomeTyp
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeMapOutput)
 }
 
+func (i SomeTypeMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*SomeType] {
+	return pulumix.Output[map[string]*SomeType]{
+		OutputState: i.ToSomeTypeMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type SomeTypeOutput struct{ *pulumi.OutputState }
 
 func (SomeTypeOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o SomeTypeOutput) ToSomeTypeOutputWithContext(ctx context.Context) SomeTyp
 	return o
 }
 
+func (o SomeTypeOutput) ToOutput(ctx context.Context) pulumix.Output[*SomeType] {
+	return pulumix.Output[*SomeType]{
+		OutputState: o.OutputState,
+	}
+}
+
 type SomeTypeArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeTypeArrayOutput) ElementType() reflect.Type {
@@ -160,6 +185,12 @@ func (o SomeTypeArrayOutput) ToSomeTypeArrayOutput() SomeTypeArrayOutput {
 
 func (o SomeTypeArrayOutput) ToSomeTypeArrayOutputWithContext(ctx context.Context) SomeTypeArrayOutput {
 	return o
+}
+
+func (o SomeTypeArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*SomeType] {
+	return pulumix.Output[[]*SomeType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeTypeArrayOutput) Index(i pulumi.IntInput) SomeTypeOutput {
@@ -180,6 +211,12 @@ func (o SomeTypeMapOutput) ToSomeTypeMapOutput() SomeTypeMapOutput {
 
 func (o SomeTypeMapOutput) ToSomeTypeMapOutputWithContext(ctx context.Context) SomeTypeMapOutput {
 	return o
+}
+
+func (o SomeTypeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*SomeType] {
+	return pulumix.Output[map[string]*SomeType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeTypeMapOutput) MapIndex(k pulumi.StringInput) SomeTypeOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/someTypeMap.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/someTypeMap.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -84,6 +85,12 @@ func (i *SomeTypeMapResource) ToSomeTypeMapResourceOutputWithContext(ctx context
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeMapResourceOutput)
 }
 
+func (i *SomeTypeMapResource) ToOutput(ctx context.Context) pulumix.Output[*SomeTypeMapResource] {
+	return pulumix.Output[*SomeTypeMapResource]{
+		OutputState: i.ToSomeTypeMapResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeTypeMapResourceArrayInput is an input type that accepts SomeTypeMapResourceArray and SomeTypeMapResourceArrayOutput values.
 // You can construct a concrete instance of `SomeTypeMapResourceArrayInput` via:
 //
@@ -107,6 +114,12 @@ func (i SomeTypeMapResourceArray) ToSomeTypeMapResourceArrayOutput() SomeTypeMap
 
 func (i SomeTypeMapResourceArray) ToSomeTypeMapResourceArrayOutputWithContext(ctx context.Context) SomeTypeMapResourceArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeMapResourceArrayOutput)
+}
+
+func (i SomeTypeMapResourceArray) ToOutput(ctx context.Context) pulumix.Output[[]*SomeTypeMapResource] {
+	return pulumix.Output[[]*SomeTypeMapResource]{
+		OutputState: i.ToSomeTypeMapResourceArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeTypeMapResourceMapInput is an input type that accepts SomeTypeMapResourceMap and SomeTypeMapResourceMapOutput values.
@@ -134,6 +147,12 @@ func (i SomeTypeMapResourceMap) ToSomeTypeMapResourceMapOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(SomeTypeMapResourceMapOutput)
 }
 
+func (i SomeTypeMapResourceMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*SomeTypeMapResource] {
+	return pulumix.Output[map[string]*SomeTypeMapResource]{
+		OutputState: i.ToSomeTypeMapResourceMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type SomeTypeMapResourceOutput struct{ *pulumi.OutputState }
 
 func (SomeTypeMapResourceOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o SomeTypeMapResourceOutput) ToSomeTypeMapResourceOutputWithContext(ctx co
 	return o
 }
 
+func (o SomeTypeMapResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*SomeTypeMapResource] {
+	return pulumix.Output[*SomeTypeMapResource]{
+		OutputState: o.OutputState,
+	}
+}
+
 type SomeTypeMapResourceArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeTypeMapResourceArrayOutput) ElementType() reflect.Type {
@@ -160,6 +185,12 @@ func (o SomeTypeMapResourceArrayOutput) ToSomeTypeMapResourceArrayOutput() SomeT
 
 func (o SomeTypeMapResourceArrayOutput) ToSomeTypeMapResourceArrayOutputWithContext(ctx context.Context) SomeTypeMapResourceArrayOutput {
 	return o
+}
+
+func (o SomeTypeMapResourceArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*SomeTypeMapResource] {
+	return pulumix.Output[[]*SomeTypeMapResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeTypeMapResourceArrayOutput) Index(i pulumi.IntInput) SomeTypeMapResourceOutput {
@@ -180,6 +211,12 @@ func (o SomeTypeMapResourceMapOutput) ToSomeTypeMapResourceMapOutput() SomeTypeM
 
 func (o SomeTypeMapResourceMapOutput) ToSomeTypeMapResourceMapOutputWithContext(ctx context.Context) SomeTypeMapResourceMapOutput {
 	return o
+}
+
+func (o SomeTypeMapResourceMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*SomeTypeMapResource] {
+	return pulumix.Output[map[string]*SomeTypeMapResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeTypeMapResourceMapOutput) MapIndex(k pulumi.StringInput) SomeTypeMapResourceOutput {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/provider.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-nested-collections/repro/internal"
 )
 
@@ -31,6 +32,12 @@ func (o BarOutput) ToBarOutputWithContext(ctx context.Context) BarOutput {
 	return o
 }
 
+func (o BarOutput) ToOutput(ctx context.Context) pulumix.Output[Bar] {
+	return pulumix.Output[Bar]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o BarOutput) Prop() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Bar) *string { return v.Prop }).(pulumi.StringPtrOutput)
 }
@@ -47,6 +54,12 @@ func (o BarArrayOutput) ToBarArrayOutput() BarArrayOutput {
 
 func (o BarArrayOutput) ToBarArrayOutputWithContext(ctx context.Context) BarArrayOutput {
 	return o
+}
+
+func (o BarArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Bar] {
+	return pulumix.Output[[]Bar]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarArrayOutput) Index(i pulumi.IntInput) BarOutput {
@@ -69,6 +82,12 @@ func (o BarArrayArrayOutput) ToBarArrayArrayOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o BarArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]Bar] {
+	return pulumix.Output[[][]Bar]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o BarArrayArrayOutput) Index(i pulumi.IntInput) BarArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []Bar {
 		return vs[0].([][]Bar)[vs[1].(int)]
@@ -87,6 +106,12 @@ func (o BarArrayArrayArrayOutput) ToBarArrayArrayArrayOutput() BarArrayArrayArra
 
 func (o BarArrayArrayArrayOutput) ToBarArrayArrayArrayOutputWithContext(ctx context.Context) BarArrayArrayArrayOutput {
 	return o
+}
+
+func (o BarArrayArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][][]Bar] {
+	return pulumix.Output[[][][]Bar]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarArrayArrayArrayOutput) Index(i pulumi.IntInput) BarArrayArrayOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/argFunction.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -62,6 +63,12 @@ func (o ArgFunctionResultOutput) ToArgFunctionResultOutput() ArgFunctionResultOu
 
 func (o ArgFunctionResultOutput) ToArgFunctionResultOutputWithContext(ctx context.Context) ArgFunctionResultOutput {
 	return o
+}
+
+func (o ArgFunctionResultOutput) ToOutput(ctx context.Context) pulumix.Output[ArgFunctionResult] {
+	return pulumix.Output[ArgFunctionResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ArgFunctionResultOutput) Result() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/barResource.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/barResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -65,6 +66,12 @@ func (i *BarResource) ToBarResourceOutputWithContext(ctx context.Context) BarRes
 	return pulumi.ToOutputWithContext(ctx, i).(BarResourceOutput)
 }
 
+func (i *BarResource) ToOutput(ctx context.Context) pulumix.Output[*BarResource] {
+	return pulumix.Output[*BarResource]{
+		OutputState: i.ToBarResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type BarResourceOutput struct{ *pulumi.OutputState }
 
 func (BarResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o BarResourceOutput) ToBarResourceOutput() BarResourceOutput {
 
 func (o BarResourceOutput) ToBarResourceOutputWithContext(ctx context.Context) BarResourceOutput {
 	return o
+}
+
+func (o BarResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*BarResource] {
+	return pulumix.Output[*BarResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/fooResource.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/fooResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -65,6 +66,12 @@ func (i *FooResource) ToFooResourceOutputWithContext(ctx context.Context) FooRes
 	return pulumi.ToOutputWithContext(ctx, i).(FooResourceOutput)
 }
 
+func (i *FooResource) ToOutput(ctx context.Context) pulumix.Output[*FooResource] {
+	return pulumix.Output[*FooResource]{
+		OutputState: i.ToFooResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooResourceOutput struct{ *pulumi.OutputState }
 
 func (FooResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o FooResourceOutput) ToFooResourceOutput() FooResourceOutput {
 
 func (o FooResourceOutput) ToFooResourceOutputWithContext(ctx context.Context) FooResourceOutput {
 	return o
+}
+
+func (o FooResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*FooResource] {
+	return pulumix.Output[*FooResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/otherResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -65,6 +66,12 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
+func (i *OtherResource) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: i.ToOtherResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {
 
 func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Context) OtherResourceOutput {
 	return o
+}
+
+func (o OtherResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -44,6 +45,12 @@ func (i ConfigMapArgs) ToConfigMapOutputWithContext(ctx context.Context) ConfigM
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapOutput)
 }
 
+func (i ConfigMapArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: i.ToConfigMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigMapArrayInput is an input type that accepts ConfigMapArray and ConfigMapArrayOutput values.
 // You can construct a concrete instance of `ConfigMapArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i ConfigMapArray) ToConfigMapArrayOutputWithContext(ctx context.Context) C
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapArrayOutput)
 }
 
+func (i ConfigMapArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: i.ToConfigMapArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConfigMapOutput struct{ *pulumi.OutputState }
 
 func (ConfigMapOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o ConfigMapOutput) ToConfigMapOutput() ConfigMapOutput {
 
 func (o ConfigMapOutput) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOutput {
 	return o
+}
+
+func (o ConfigMapOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapOutput) Config() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o ConfigMapArrayOutput) ToConfigMapArrayOutput() ConfigMapArrayOutput {
 
 func (o ConfigMapArrayOutput) ToConfigMapArrayOutputWithContext(ctx context.Context) ConfigMapArrayOutput {
 	return o
+}
+
+func (o ConfigMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapArrayOutput) Index(i pulumi.IntInput) ConfigMapOutput {
@@ -150,6 +175,12 @@ func (i ObjectArgs) ToObjectOutputWithContext(ctx context.Context) ObjectOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectOutput)
 }
 
+func (i ObjectArgs) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: i.ToObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectArgs) ToObjectPtrOutput() ObjectPtrOutput {
 	return i.ToObjectPtrOutputWithContext(context.Background())
 }
@@ -191,6 +222,12 @@ func (i *objectPtrType) ToObjectPtrOutputWithContext(ctx context.Context) Object
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectPtrOutput)
 }
 
+func (i *objectPtrType) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: i.ToObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectOutput struct{ *pulumi.OutputState }
 
 func (ObjectOutput) ElementType() reflect.Type {
@@ -213,6 +250,12 @@ func (o ObjectOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPt
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Object) *Object {
 		return &v
 	}).(ObjectPtrOutput)
+}
+
+func (o ObjectOutput) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
@@ -249,6 +292,12 @@ func (o ObjectPtrOutput) ToObjectPtrOutput() ObjectPtrOutput {
 
 func (o ObjectPtrOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPtrOutput {
 	return o
+}
+
+func (o ObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectPtrOutput) Elem() ObjectOutput {
@@ -341,6 +390,12 @@ func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsOutput)
 }
 
+func (i ObjectWithNodeOptionalInputsArgs) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsPtrOutput() ObjectWithNodeOptionalInputsPtrOutput {
 	return i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(context.Background())
 }
@@ -382,6 +437,12 @@ func (i *objectWithNodeOptionalInputsPtrType) ToObjectWithNodeOptionalInputsPtrO
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (i *objectWithNodeOptionalInputsPtrType) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectWithNodeOptionalInputsOutput struct{ *pulumi.OutputState }
 
 func (ObjectWithNodeOptionalInputsOutput) ElementType() reflect.Type {
@@ -406,6 +467,12 @@ func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOut
 	}).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (o ObjectWithNodeOptionalInputsOutput) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ObjectWithNodeOptionalInputsOutput) Bar() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *int { return v.Bar }).(pulumi.IntPtrOutput)
 }
@@ -426,6 +493,12 @@ func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtr
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx context.Context) ObjectWithNodeOptionalInputsPtrOutput {
 	return o
+}
+
+func (o ObjectWithNodeOptionalInputsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Elem() ObjectWithNodeOptionalInputsOutput {
@@ -487,6 +560,12 @@ func (i OtherResourceOutputTypeArgs) ToOtherResourceOutputTypeOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutputTypeOutput)
 }
 
+func (i OtherResourceOutputTypeArgs) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: i.ToOtherResourceOutputTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutputTypeOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutputTypeOutput) ElementType() reflect.Type {
@@ -499,6 +578,12 @@ func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutput() OtherRe
 
 func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutputWithContext(ctx context.Context) OtherResourceOutputTypeOutput {
 	return o
+}
+
+func (o OtherResourceOutputTypeOutput) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutputTypeOutput) Foo() pulumi.StringPtrOutput {
@@ -534,6 +619,12 @@ func (i SomeOtherObjectArgs) ToSomeOtherObjectOutput() SomeOtherObjectOutput {
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectOutputWithContext(ctx context.Context) SomeOtherObjectOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectOutput)
+}
+
+func (i SomeOtherObjectArgs) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectPtrOutput() SomeOtherObjectPtrOutput {
@@ -577,6 +668,12 @@ func (i *someOtherObjectPtrType) ToSomeOtherObjectPtrOutputWithContext(ctx conte
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectPtrOutput)
 }
 
+func (i *someOtherObjectPtrType) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeOtherObjectArrayInput is an input type that accepts SomeOtherObjectArray and SomeOtherObjectArrayOutput values.
 // You can construct a concrete instance of `SomeOtherObjectArrayInput` via:
 //
@@ -600,6 +697,12 @@ func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutput() SomeOtherObjectArra
 
 func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayOutput)
+}
+
+func (i SomeOtherObjectArray) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 type SomeOtherObjectOutput struct{ *pulumi.OutputState }
@@ -626,6 +729,12 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context
 	}).(SomeOtherObjectPtrOutput)
 }
 
+func (o SomeOtherObjectOutput) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SomeOtherObject) *string { return v.Baz }).(pulumi.StringPtrOutput)
 }
@@ -642,6 +751,12 @@ func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutput() SomeOtherObjectPt
 
 func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context.Context) SomeOtherObjectPtrOutput {
 	return o
+}
+
+func (o SomeOtherObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectPtrOutput) Elem() SomeOtherObjectOutput {
@@ -677,6 +792,12 @@ func (o SomeOtherObjectArrayOutput) ToSomeOtherObjectArrayOutputWithContext(ctx 
 	return o
 }
 
+func (o SomeOtherObjectArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObject {
 		return vs[0].([]SomeOtherObject)[vs[1].(int)]
@@ -695,6 +816,12 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOther
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayArrayOutput)
+}
+
+func (i SomeOtherObjectArrayArray) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayArrayInput is an input type that accepts SomeOtherObjectArrayArray and SomeOtherObjectArrayArrayOutput values.
@@ -722,6 +849,12 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 	return o
 }
 
+func (o SomeOtherObjectArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
 		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
@@ -740,6 +873,12 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObje
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayMapOutput)
+}
+
+func (i SomeOtherObjectArrayMap) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayMapInput is an input type that accepts SomeOtherObjectArrayMap and SomeOtherObjectArrayMapOutput values.
@@ -765,6 +904,12 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOth
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return o
+}
+
+func (o SomeOtherObjectArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -97,6 +98,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -109,6 +116,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/go-overridden-internal-module-name/go/example/typeUses.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-overridden-internal-module-name/example/utilities"
 )
 
@@ -94,6 +95,12 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 	return pulumi.ToOutputWithContext(ctx, i).(TypeUsesOutput)
 }
 
+func (i *TypeUses) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: i.ToTypeUsesOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
@@ -106,6 +113,12 @@ func (o TypeUsesOutput) ToTypeUsesOutput() TypeUsesOutput {
 
 func (o TypeUsesOutput) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutput {
 	return o
+}
+
+func (o TypeUsesOutput) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypeUsesOutput) Bar() SomeOtherObjectPtrOutput {

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/fargateTaskDefinition.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/fargateTaskDefinition.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-plain-ref-repro/repro/internal"
 )
 
@@ -67,6 +68,12 @@ func (i *FargateTaskDefinition) ToFargateTaskDefinitionOutputWithContext(ctx con
 	return pulumi.ToOutputWithContext(ctx, i).(FargateTaskDefinitionOutput)
 }
 
+func (i *FargateTaskDefinition) ToOutput(ctx context.Context) pulumix.Output[*FargateTaskDefinition] {
+	return pulumix.Output[*FargateTaskDefinition]{
+		OutputState: i.ToFargateTaskDefinitionOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FargateTaskDefinitionArrayInput is an input type that accepts FargateTaskDefinitionArray and FargateTaskDefinitionArrayOutput values.
 // You can construct a concrete instance of `FargateTaskDefinitionArrayInput` via:
 //
@@ -90,6 +97,12 @@ func (i FargateTaskDefinitionArray) ToFargateTaskDefinitionArrayOutput() Fargate
 
 func (i FargateTaskDefinitionArray) ToFargateTaskDefinitionArrayOutputWithContext(ctx context.Context) FargateTaskDefinitionArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FargateTaskDefinitionArrayOutput)
+}
+
+func (i FargateTaskDefinitionArray) ToOutput(ctx context.Context) pulumix.Output[[]*FargateTaskDefinition] {
+	return pulumix.Output[[]*FargateTaskDefinition]{
+		OutputState: i.ToFargateTaskDefinitionArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // FargateTaskDefinitionMapInput is an input type that accepts FargateTaskDefinitionMap and FargateTaskDefinitionMapOutput values.
@@ -117,6 +130,12 @@ func (i FargateTaskDefinitionMap) ToFargateTaskDefinitionMapOutputWithContext(ct
 	return pulumi.ToOutputWithContext(ctx, i).(FargateTaskDefinitionMapOutput)
 }
 
+func (i FargateTaskDefinitionMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*FargateTaskDefinition] {
+	return pulumix.Output[map[string]*FargateTaskDefinition]{
+		OutputState: i.ToFargateTaskDefinitionMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FargateTaskDefinitionOutput struct{ *pulumi.OutputState }
 
 func (FargateTaskDefinitionOutput) ElementType() reflect.Type {
@@ -129,6 +148,12 @@ func (o FargateTaskDefinitionOutput) ToFargateTaskDefinitionOutput() FargateTask
 
 func (o FargateTaskDefinitionOutput) ToFargateTaskDefinitionOutputWithContext(ctx context.Context) FargateTaskDefinitionOutput {
 	return o
+}
+
+func (o FargateTaskDefinitionOutput) ToOutput(ctx context.Context) pulumix.Output[*FargateTaskDefinition] {
+	return pulumix.Output[*FargateTaskDefinition]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FargateTaskDefinitionOutput) LoadBalancers() pulumi.StringArrayOutput {
@@ -149,6 +174,12 @@ func (o FargateTaskDefinitionArrayOutput) ToFargateTaskDefinitionArrayOutputWith
 	return o
 }
 
+func (o FargateTaskDefinitionArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*FargateTaskDefinition] {
+	return pulumix.Output[[]*FargateTaskDefinition]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FargateTaskDefinitionArrayOutput) Index(i pulumi.IntInput) FargateTaskDefinitionOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *FargateTaskDefinition {
 		return vs[0].([]*FargateTaskDefinition)[vs[1].(int)]
@@ -167,6 +198,12 @@ func (o FargateTaskDefinitionMapOutput) ToFargateTaskDefinitionMapOutput() Farga
 
 func (o FargateTaskDefinitionMapOutput) ToFargateTaskDefinitionMapOutputWithContext(ctx context.Context) FargateTaskDefinitionMapOutput {
 	return o
+}
+
+func (o FargateTaskDefinitionMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*FargateTaskDefinition] {
+	return pulumix.Output[map[string]*FargateTaskDefinition]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FargateTaskDefinitionMapOutput) MapIndex(k pulumi.StringInput) FargateTaskDefinitionOutput {

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-plain-ref-repro/repro/internal"
 )
 
@@ -44,6 +45,12 @@ func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefiniti
 
 func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionOutput)
+}
+
+func (i TaskDefinitionContainerDefinitionArgs) ToOutput(ctx context.Context) pulumix.Output[TaskDefinitionContainerDefinition] {
+	return pulumix.Output[TaskDefinitionContainerDefinition]{
+		OutputState: i.ToTaskDefinitionContainerDefinitionOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput {
@@ -87,6 +94,12 @@ func (i *taskDefinitionContainerDefinitionPtrType) ToTaskDefinitionContainerDefi
 	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionPtrOutput)
 }
 
+func (i *taskDefinitionContainerDefinitionPtrType) ToOutput(ctx context.Context) pulumix.Output[*TaskDefinitionContainerDefinition] {
+	return pulumix.Output[*TaskDefinitionContainerDefinition]{
+		OutputState: i.ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // TaskDefinitionContainerDefinitionMapInput is an input type that accepts TaskDefinitionContainerDefinitionMap and TaskDefinitionContainerDefinitionMapOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDefinitionMapInput` via:
 //
@@ -110,6 +123,12 @@ func (i TaskDefinitionContainerDefinitionMap) ToTaskDefinitionContainerDefinitio
 
 func (i TaskDefinitionContainerDefinitionMap) ToTaskDefinitionContainerDefinitionMapOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+func (i TaskDefinitionContainerDefinitionMap) ToOutput(ctx context.Context) pulumix.Output[map[string]TaskDefinitionContainerDefinition] {
+	return pulumix.Output[map[string]TaskDefinitionContainerDefinition]{
+		OutputState: i.ToTaskDefinitionContainerDefinitionMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 type TaskDefinitionContainerDefinitionOutput struct{ *pulumi.OutputState }
@@ -136,6 +155,12 @@ func (o TaskDefinitionContainerDefinitionOutput) ToTaskDefinitionContainerDefini
 	}).(TaskDefinitionContainerDefinitionPtrOutput)
 }
 
+func (o TaskDefinitionContainerDefinitionOutput) ToOutput(ctx context.Context) pulumix.Output[TaskDefinitionContainerDefinition] {
+	return pulumix.Output[TaskDefinitionContainerDefinition]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TaskDefinitionContainerDefinitionOutput) Command() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.Command }).(pulumi.StringArrayOutput)
 }
@@ -156,6 +181,12 @@ func (o TaskDefinitionContainerDefinitionPtrOutput) ToTaskDefinitionContainerDef
 
 func (o TaskDefinitionContainerDefinitionPtrOutput) ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionPtrOutput {
 	return o
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*TaskDefinitionContainerDefinition] {
+	return pulumix.Output[*TaskDefinitionContainerDefinition]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TaskDefinitionContainerDefinitionPtrOutput) Elem() TaskDefinitionContainerDefinitionOutput {
@@ -198,6 +229,12 @@ func (o TaskDefinitionContainerDefinitionMapOutput) ToTaskDefinitionContainerDef
 
 func (o TaskDefinitionContainerDefinitionMapOutput) ToTaskDefinitionContainerDefinitionMapOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionMapOutput {
 	return o
+}
+
+func (o TaskDefinitionContainerDefinitionMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]TaskDefinitionContainerDefinition] {
+	return pulumix.Output[map[string]TaskDefinitionContainerDefinition]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TaskDefinitionContainerDefinitionMapOutput) MapIndex(k pulumi.StringInput) TaskDefinitionContainerDefinitionOutput {

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/provider.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"go-plain-ref-repro/repro/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/foo.go
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/foo.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"hyphenated-symbols/repro/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.
 // You can construct a concrete instance of `FooArrayInput` via:
 //
@@ -109,6 +116,12 @@ func (i FooArray) ToFooArrayOutput() FooArrayOutput {
 
 func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
+}
+
+func (i FooArray) ToOutput(ctx context.Context) pulumix.Output[[]*Foo] {
+	return pulumix.Output[[]*Foo]{
+		OutputState: i.ToFooArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // FooMapInput is an input type that accepts FooMap and FooMapOutput values.
@@ -136,6 +149,12 @@ func (i FooMap) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooMapOutput)
 }
 
+func (i FooMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Foo] {
+	return pulumix.Output[map[string]*Foo]{
+		OutputState: i.ToFooMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooOutput) ConditionSets() BarArrayArrayArrayOutput {
@@ -168,6 +193,12 @@ func (o FooArrayOutput) ToFooArrayOutputWithContext(ctx context.Context) FooArra
 	return o
 }
 
+func (o FooArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Foo] {
+	return pulumix.Output[[]*Foo]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Foo {
 		return vs[0].([]*Foo)[vs[1].(int)]
@@ -186,6 +217,12 @@ func (o FooMapOutput) ToFooMapOutput() FooMapOutput {
 
 func (o FooMapOutput) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return o
+}
+
+func (o FooMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Foo] {
+	return pulumix.Output[map[string]*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooMapOutput) MapIndex(k pulumi.StringInput) FooOutput {

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/provider.go
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"hyphenated-symbols/repro/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"hyphenated-symbols/repro/internal"
 )
 
@@ -31,6 +32,12 @@ func (o BarOutput) ToBarOutputWithContext(ctx context.Context) BarOutput {
 	return o
 }
 
+func (o BarOutput) ToOutput(ctx context.Context) pulumix.Output[Bar] {
+	return pulumix.Output[Bar]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o BarOutput) HasAHyphen() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Bar) *string { return v.HasAHyphen }).(pulumi.StringPtrOutput)
 }
@@ -47,6 +54,12 @@ func (o BarArrayOutput) ToBarArrayOutput() BarArrayOutput {
 
 func (o BarArrayOutput) ToBarArrayOutputWithContext(ctx context.Context) BarArrayOutput {
 	return o
+}
+
+func (o BarArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Bar] {
+	return pulumix.Output[[]Bar]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarArrayOutput) Index(i pulumi.IntInput) BarOutput {
@@ -69,6 +82,12 @@ func (o BarArrayArrayOutput) ToBarArrayArrayOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o BarArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]Bar] {
+	return pulumix.Output[[][]Bar]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o BarArrayArrayOutput) Index(i pulumi.IntInput) BarArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []Bar {
 		return vs[0].([][]Bar)[vs[1].(int)]
@@ -87,6 +106,12 @@ func (o BarArrayArrayArrayOutput) ToBarArrayArrayArrayOutput() BarArrayArrayArra
 
 func (o BarArrayArrayArrayOutput) ToBarArrayArrayArrayOutputWithContext(ctx context.Context) BarArrayArrayArrayOutput {
 	return o
+}
+
+func (o BarArrayArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][][]Bar] {
+	return pulumix.Output[[][][]Bar]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarArrayArrayArrayOutput) Index(i pulumi.IntInput) BarArrayArrayOutput {

--- a/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal-dependencies-go/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mainComponent.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mainComponent.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -84,6 +85,12 @@ func (i *MainComponent) ToMainComponentOutputWithContext(ctx context.Context) Ma
 	return pulumi.ToOutputWithContext(ctx, i).(MainComponentOutput)
 }
 
+func (i *MainComponent) ToOutput(ctx context.Context) pulumix.Output[*MainComponent] {
+	return pulumix.Output[*MainComponent]{
+		OutputState: i.ToMainComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type MainComponentOutput struct{ *pulumi.OutputState }
 
 func (MainComponentOutput) ElementType() reflect.Type {
@@ -96,6 +103,12 @@ func (o MainComponentOutput) ToMainComponentOutput() MainComponentOutput {
 
 func (o MainComponentOutput) ToMainComponentOutputWithContext(ctx context.Context) MainComponentOutput {
 	return o
+}
+
+func (o MainComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*MainComponent] {
+	return pulumix.Output[*MainComponent]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example"
 	"naming-collisions/example/internal"
 )
@@ -89,6 +90,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -101,6 +108,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component2.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component2.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -84,6 +85,12 @@ func (i *Component2) ToComponent2OutputWithContext(ctx context.Context) Componen
 	return pulumi.ToOutputWithContext(ctx, i).(Component2Output)
 }
 
+func (i *Component2) ToOutput(ctx context.Context) pulumix.Output[*Component2] {
+	return pulumix.Output[*Component2]{
+		OutputState: i.ToComponent2OutputWithContext(ctx).OutputState,
+	}
+}
+
 type Component2Output struct{ *pulumi.OutputState }
 
 func (Component2Output) ElementType() reflect.Type {
@@ -96,6 +103,12 @@ func (o Component2Output) ToComponent2Output() Component2Output {
 
 func (o Component2Output) ToComponent2OutputWithContext(ctx context.Context) Component2Output {
 	return o
+}
+
+func (o Component2Output) ToOutput(ctx context.Context) pulumix.Output[*Component2] {
+	return pulumix.Output[*Component2]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type ExampleEnum string
@@ -77,6 +78,12 @@ func (o ExampleEnumOutput) ToExampleEnumPtrOutputWithContext(ctx context.Context
 	}).(ExampleEnumPtrOutput)
 }
 
+func (o ExampleEnumOutput) ToOutput(ctx context.Context) pulumix.Output[ExampleEnum] {
+	return pulumix.Output[ExampleEnum]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ExampleEnumOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o ExampleEnumPtrOutput) ToExampleEnumPtrOutput() ExampleEnumPtrOutput {
 
 func (o ExampleEnumPtrOutput) ToExampleEnumPtrOutputWithContext(ctx context.Context) ExampleEnumPtrOutput {
 	return o
+}
+
+func (o ExampleEnumPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnum] {
+	return pulumix.Output[*ExampleEnum]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ExampleEnumPtrOutput) Elem() ExampleEnumOutput {
@@ -172,6 +185,12 @@ func (in *exampleEnumPtr) ToExampleEnumPtrOutput() ExampleEnumPtrOutput {
 
 func (in *exampleEnumPtr) ToExampleEnumPtrOutputWithContext(ctx context.Context) ExampleEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ExampleEnumPtrOutput)
+}
+
+func (in *exampleEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnum] {
+	return pulumix.Output[*ExampleEnum]{
+		OutputState: in.ToExampleEnumPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type ExampleEnumInputEnum string
@@ -241,6 +260,12 @@ func (o ExampleEnumInputEnumOutput) ToExampleEnumInputEnumPtrOutputWithContext(c
 	}).(ExampleEnumInputEnumPtrOutput)
 }
 
+func (o ExampleEnumInputEnumOutput) ToOutput(ctx context.Context) pulumix.Output[ExampleEnumInputEnum] {
+	return pulumix.Output[ExampleEnumInputEnum]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ExampleEnumInputEnumOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -274,6 +299,12 @@ func (o ExampleEnumInputEnumPtrOutput) ToExampleEnumInputEnumPtrOutput() Example
 
 func (o ExampleEnumInputEnumPtrOutput) ToExampleEnumInputEnumPtrOutputWithContext(ctx context.Context) ExampleEnumInputEnumPtrOutput {
 	return o
+}
+
+func (o ExampleEnumInputEnumPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnumInputEnum] {
+	return pulumix.Output[*ExampleEnumInputEnum]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ExampleEnumInputEnumPtrOutput) Elem() ExampleEnumInputEnumOutput {
@@ -336,6 +367,12 @@ func (in *exampleEnumInputEnumPtr) ToExampleEnumInputEnumPtrOutput() ExampleEnum
 
 func (in *exampleEnumInputEnumPtr) ToExampleEnumInputEnumPtrOutputWithContext(ctx context.Context) ExampleEnumInputEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ExampleEnumInputEnumPtrOutput)
+}
+
+func (in *exampleEnumInputEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnumInputEnum] {
+	return pulumix.Output[*ExampleEnumInputEnum]{
+		OutputState: in.ToExampleEnumInputEnumPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type ResourceTypeEnum string
@@ -405,6 +442,12 @@ func (o ResourceTypeEnumOutput) ToResourceTypeEnumPtrOutputWithContext(ctx conte
 	}).(ResourceTypeEnumPtrOutput)
 }
 
+func (o ResourceTypeEnumOutput) ToOutput(ctx context.Context) pulumix.Output[ResourceTypeEnum] {
+	return pulumix.Output[ResourceTypeEnum]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ResourceTypeEnumOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -438,6 +481,12 @@ func (o ResourceTypeEnumPtrOutput) ToResourceTypeEnumPtrOutput() ResourceTypeEnu
 
 func (o ResourceTypeEnumPtrOutput) ToResourceTypeEnumPtrOutputWithContext(ctx context.Context) ResourceTypeEnumPtrOutput {
 	return o
+}
+
+func (o ResourceTypeEnumPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ResourceTypeEnum] {
+	return pulumix.Output[*ResourceTypeEnum]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceTypeEnumPtrOutput) Elem() ResourceTypeEnumOutput {
@@ -500,6 +549,12 @@ func (in *resourceTypeEnumPtr) ToResourceTypeEnumPtrOutput() ResourceTypeEnumPtr
 
 func (in *resourceTypeEnumPtr) ToResourceTypeEnumPtrOutputWithContext(ctx context.Context) ResourceTypeEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ResourceTypeEnumPtrOutput)
+}
+
+func (in *resourceTypeEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ResourceTypeEnum] {
+	return pulumix.Output[*ResourceTypeEnum]{
+		OutputState: in.ToResourceTypeEnumPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ObjectArgs) ToObjectOutputWithContext(ctx context.Context) ObjectOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectOutput)
 }
 
+func (i ObjectArgs) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: i.ToObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectOutput struct{ *pulumi.OutputState }
 
 func (ObjectOutput) ElementType() reflect.Type {
@@ -56,6 +63,12 @@ func (o ObjectOutput) ToObjectOutput() ObjectOutput {
 
 func (o ObjectOutput) ToObjectOutputWithContext(ctx context.Context) ObjectOutput {
 	return o
+}
+
+func (o ObjectOutput) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
@@ -93,6 +106,12 @@ func (i ObjectInputTypeArgs) ToObjectInputTypeOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectInputTypeOutput)
 }
 
+func (i ObjectInputTypeArgs) ToOutput(ctx context.Context) pulumix.Output[ObjectInputType] {
+	return pulumix.Output[ObjectInputType]{
+		OutputState: i.ToObjectInputTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectInputTypeOutput struct{ *pulumi.OutputState }
 
 func (ObjectInputTypeOutput) ElementType() reflect.Type {
@@ -105,6 +124,12 @@ func (o ObjectInputTypeOutput) ToObjectInputTypeOutput() ObjectInputTypeOutput {
 
 func (o ObjectInputTypeOutput) ToObjectInputTypeOutputWithContext(ctx context.Context) ObjectInputTypeOutput {
 	return o
+}
+
+func (o ObjectInputTypeOutput) ToOutput(ctx context.Context) pulumix.Output[ObjectInputType] {
+	return pulumix.Output[ObjectInputType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectInputTypeOutput) Bar() pulumi.StringPtrOutput {
@@ -142,6 +167,12 @@ func (i ResourceTypeArgs) ToResourceTypeOutputWithContext(ctx context.Context) R
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceTypeOutput)
 }
 
+func (i ResourceTypeArgs) ToOutput(ctx context.Context) pulumix.Output[ResourceType] {
+	return pulumix.Output[ResourceType]{
+		OutputState: i.ToResourceTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceTypeOutput struct{ *pulumi.OutputState }
 
 func (ResourceTypeOutput) ElementType() reflect.Type {
@@ -154,6 +185,12 @@ func (o ResourceTypeOutput) ToResourceTypeOutput() ResourceTypeOutput {
 
 func (o ResourceTypeOutput) ToResourceTypeOutputWithContext(ctx context.Context) ResourceTypeOutput {
 	return o
+}
+
+func (o ResourceTypeOutput) ToOutput(ctx context.Context) pulumix.Output[ResourceType] {
+	return pulumix.Output[ResourceType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceTypeOutput) Name() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -98,6 +105,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resourceInput.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resourceInput.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"naming-collisions/example/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *ResourceInputResource) ToResourceInputResourceOutputWithContext(ctx con
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceInputResourceOutput)
 }
 
+func (i *ResourceInputResource) ToOutput(ctx context.Context) pulumix.Output[*ResourceInputResource] {
+	return pulumix.Output[*ResourceInputResource]{
+		OutputState: i.ToResourceInputResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceInputResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceInputResourceOutput) ElementType() reflect.Type {
@@ -98,6 +105,12 @@ func (o ResourceInputResourceOutput) ToResourceInputResourceOutput() ResourceInp
 
 func (o ResourceInputResourceOutput) ToResourceInputResourceOutputWithContext(ctx context.Context) ResourceInputResourceOutput {
 	return o
+}
+
+func (o ResourceInputResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*ResourceInputResource] {
+	return pulumix.Output[*ResourceInputResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceInputResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"nested-module-thirdparty/foo/internal"
 )
 
@@ -95,6 +96,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -107,6 +114,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Baz() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/provider.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"nested-module-thirdparty/foo/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"nested-module/foo/internal"
 )
 
@@ -95,6 +96,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -107,6 +114,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/provider.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"nested-module/foo/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -79,6 +80,12 @@ func (o ListConfigurationsResultOutput) ToListConfigurationsResultOutput() ListC
 
 func (o ListConfigurationsResultOutput) ToListConfigurationsResultOutputWithContext(ctx context.Context) ListConfigurationsResultOutput {
 	return o
+}
+
+func (o ListConfigurationsResultOutput) ToOutput(ctx context.Context) pulumix.Output[ListConfigurationsResult] {
+	return pulumix.Output[ListConfigurationsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Link for the next set of configurations.

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -83,6 +84,12 @@ func (o ListProductFamiliesResultOutput) ToListProductFamiliesResultOutput() Lis
 
 func (o ListProductFamiliesResultOutput) ToListProductFamiliesResultOutputWithContext(ctx context.Context) ListProductFamiliesResultOutput {
 	return o
+}
+
+func (o ListProductFamiliesResultOutput) ToOutput(ctx context.Context) pulumix.Output[ListProductFamiliesResult] {
+	return pulumix.Output[ListProductFamiliesResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Link for the next set of product families.

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/provider.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // Type of product filter.
@@ -80,6 +81,12 @@ func (o SupportedFilterTypesOutput) ToSupportedFilterTypesPtrOutputWithContext(c
 	}).(SupportedFilterTypesPtrOutput)
 }
 
+func (o SupportedFilterTypesOutput) ToOutput(ctx context.Context) pulumix.Output[SupportedFilterTypes] {
+	return pulumix.Output[SupportedFilterTypes]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SupportedFilterTypesOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -113,6 +120,12 @@ func (o SupportedFilterTypesPtrOutput) ToSupportedFilterTypesPtrOutput() Support
 
 func (o SupportedFilterTypesPtrOutput) ToSupportedFilterTypesPtrOutputWithContext(ctx context.Context) SupportedFilterTypesPtrOutput {
 	return o
+}
+
+func (o SupportedFilterTypesPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*SupportedFilterTypes] {
+	return pulumix.Output[*SupportedFilterTypes]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SupportedFilterTypesPtrOutput) Elem() SupportedFilterTypesOutput {
@@ -175,6 +188,12 @@ func (in *supportedFilterTypesPtr) ToSupportedFilterTypesPtrOutput() SupportedFi
 
 func (in *supportedFilterTypesPtr) ToSupportedFilterTypesPtrOutputWithContext(ctx context.Context) SupportedFilterTypesPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(SupportedFilterTypesPtrOutput)
+}
+
+func (in *supportedFilterTypesPtr) ToOutput(ctx context.Context) pulumix.Output[*SupportedFilterTypes] {
+	return pulumix.Output[*SupportedFilterTypes]{
+		OutputState: in.ToSupportedFilterTypesPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -56,6 +57,12 @@ func (i AvailabilityInformationResponseArgs) ToAvailabilityInformationResponseOu
 	return pulumi.ToOutputWithContext(ctx, i).(AvailabilityInformationResponseOutput)
 }
 
+func (i AvailabilityInformationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[AvailabilityInformationResponse] {
+	return pulumix.Output[AvailabilityInformationResponse]{
+		OutputState: i.ToAvailabilityInformationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Availability information of a product system.
 type AvailabilityInformationResponseOutput struct{ *pulumi.OutputState }
 
@@ -69,6 +76,12 @@ func (o AvailabilityInformationResponseOutput) ToAvailabilityInformationResponse
 
 func (o AvailabilityInformationResponseOutput) ToAvailabilityInformationResponseOutputWithContext(ctx context.Context) AvailabilityInformationResponseOutput {
 	return o
+}
+
+func (o AvailabilityInformationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[AvailabilityInformationResponse] {
+	return pulumix.Output[AvailabilityInformationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Current availability stage of the product. Availability stage
@@ -133,6 +146,12 @@ func (i BillingMeterDetailsResponseArgs) ToBillingMeterDetailsResponseOutputWith
 	return pulumi.ToOutputWithContext(ctx, i).(BillingMeterDetailsResponseOutput)
 }
 
+func (i BillingMeterDetailsResponseArgs) ToOutput(ctx context.Context) pulumix.Output[BillingMeterDetailsResponse] {
+	return pulumix.Output[BillingMeterDetailsResponse]{
+		OutputState: i.ToBillingMeterDetailsResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // BillingMeterDetailsResponseArrayInput is an input type that accepts BillingMeterDetailsResponseArray and BillingMeterDetailsResponseArrayOutput values.
 // You can construct a concrete instance of `BillingMeterDetailsResponseArrayInput` via:
 //
@@ -158,6 +177,12 @@ func (i BillingMeterDetailsResponseArray) ToBillingMeterDetailsResponseArrayOutp
 	return pulumi.ToOutputWithContext(ctx, i).(BillingMeterDetailsResponseArrayOutput)
 }
 
+func (i BillingMeterDetailsResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]BillingMeterDetailsResponse] {
+	return pulumix.Output[[]BillingMeterDetailsResponse]{
+		OutputState: i.ToBillingMeterDetailsResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Holds billing meter details for each type of billing
 type BillingMeterDetailsResponseOutput struct{ *pulumi.OutputState }
 
@@ -171,6 +196,12 @@ func (o BillingMeterDetailsResponseOutput) ToBillingMeterDetailsResponseOutput()
 
 func (o BillingMeterDetailsResponseOutput) ToBillingMeterDetailsResponseOutputWithContext(ctx context.Context) BillingMeterDetailsResponseOutput {
 	return o
+}
+
+func (o BillingMeterDetailsResponseOutput) ToOutput(ctx context.Context) pulumix.Output[BillingMeterDetailsResponse] {
+	return pulumix.Output[BillingMeterDetailsResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Frequency of recurrence
@@ -205,6 +236,12 @@ func (o BillingMeterDetailsResponseArrayOutput) ToBillingMeterDetailsResponseArr
 
 func (o BillingMeterDetailsResponseArrayOutput) ToBillingMeterDetailsResponseArrayOutputWithContext(ctx context.Context) BillingMeterDetailsResponseArrayOutput {
 	return o
+}
+
+func (o BillingMeterDetailsResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]BillingMeterDetailsResponse] {
+	return pulumix.Output[[]BillingMeterDetailsResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BillingMeterDetailsResponseArrayOutput) Index(i pulumi.IntInput) BillingMeterDetailsResponseOutput {
@@ -252,6 +289,12 @@ func (i ConfigurationFiltersArgs) ToConfigurationFiltersOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigurationFiltersOutput)
 }
 
+func (i ConfigurationFiltersArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigurationFilters] {
+	return pulumix.Output[ConfigurationFilters]{
+		OutputState: i.ToConfigurationFiltersOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigurationFiltersArrayInput is an input type that accepts ConfigurationFiltersArray and ConfigurationFiltersArrayOutput values.
 // You can construct a concrete instance of `ConfigurationFiltersArrayInput` via:
 //
@@ -277,6 +320,12 @@ func (i ConfigurationFiltersArray) ToConfigurationFiltersArrayOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigurationFiltersArrayOutput)
 }
 
+func (i ConfigurationFiltersArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigurationFilters] {
+	return pulumix.Output[[]ConfigurationFilters]{
+		OutputState: i.ToConfigurationFiltersArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Configuration filters
 type ConfigurationFiltersOutput struct{ *pulumi.OutputState }
 
@@ -290,6 +339,12 @@ func (o ConfigurationFiltersOutput) ToConfigurationFiltersOutput() Configuration
 
 func (o ConfigurationFiltersOutput) ToConfigurationFiltersOutputWithContext(ctx context.Context) ConfigurationFiltersOutput {
 	return o
+}
+
+func (o ConfigurationFiltersOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigurationFilters] {
+	return pulumix.Output[ConfigurationFilters]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Filters specific to product
@@ -314,6 +369,12 @@ func (o ConfigurationFiltersArrayOutput) ToConfigurationFiltersArrayOutput() Con
 
 func (o ConfigurationFiltersArrayOutput) ToConfigurationFiltersArrayOutputWithContext(ctx context.Context) ConfigurationFiltersArrayOutput {
 	return o
+}
+
+func (o ConfigurationFiltersArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigurationFilters] {
+	return pulumix.Output[[]ConfigurationFilters]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigurationFiltersArrayOutput) Index(i pulumi.IntInput) ConfigurationFiltersOutput {
@@ -389,6 +450,12 @@ func (i ConfigurationResponseArgs) ToConfigurationResponseOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigurationResponseOutput)
 }
 
+func (i ConfigurationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigurationResponse] {
+	return pulumix.Output[ConfigurationResponse]{
+		OutputState: i.ToConfigurationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigurationResponseArrayInput is an input type that accepts ConfigurationResponseArray and ConfigurationResponseArrayOutput values.
 // You can construct a concrete instance of `ConfigurationResponseArrayInput` via:
 //
@@ -414,6 +481,12 @@ func (i ConfigurationResponseArray) ToConfigurationResponseArrayOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigurationResponseArrayOutput)
 }
 
+func (i ConfigurationResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigurationResponse] {
+	return pulumix.Output[[]ConfigurationResponse]{
+		OutputState: i.ToConfigurationResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Configuration object.
 type ConfigurationResponseOutput struct{ *pulumi.OutputState }
 
@@ -427,6 +500,12 @@ func (o ConfigurationResponseOutput) ToConfigurationResponseOutput() Configurati
 
 func (o ConfigurationResponseOutput) ToConfigurationResponseOutputWithContext(ctx context.Context) ConfigurationResponseOutput {
 	return o
+}
+
+func (o ConfigurationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigurationResponse] {
+	return pulumix.Output[ConfigurationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Availability information of the product system.
@@ -488,6 +567,12 @@ func (o ConfigurationResponseArrayOutput) ToConfigurationResponseArrayOutputWith
 	return o
 }
 
+func (o ConfigurationResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigurationResponse] {
+	return pulumix.Output[[]ConfigurationResponse]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ConfigurationResponseArrayOutput) Index(i pulumi.IntInput) ConfigurationResponseOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ConfigurationResponse {
 		return vs[0].([]ConfigurationResponse)[vs[1].(int)]
@@ -533,6 +618,12 @@ func (i CostInformationResponseArgs) ToCostInformationResponseOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(CostInformationResponseOutput)
 }
 
+func (i CostInformationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[CostInformationResponse] {
+	return pulumix.Output[CostInformationResponse]{
+		OutputState: i.ToCostInformationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Cost information for the product system
 type CostInformationResponseOutput struct{ *pulumi.OutputState }
 
@@ -546,6 +637,12 @@ func (o CostInformationResponseOutput) ToCostInformationResponseOutput() CostInf
 
 func (o CostInformationResponseOutput) ToCostInformationResponseOutputWithContext(ctx context.Context) CostInformationResponseOutput {
 	return o
+}
+
+func (o CostInformationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[CostInformationResponse] {
+	return pulumix.Output[CostInformationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Default url to display billing information
@@ -601,6 +698,12 @@ func (i CustomerSubscriptionDetailsArgs) ToCustomerSubscriptionDetailsOutputWith
 	return pulumi.ToOutputWithContext(ctx, i).(CustomerSubscriptionDetailsOutput)
 }
 
+func (i CustomerSubscriptionDetailsArgs) ToOutput(ctx context.Context) pulumix.Output[CustomerSubscriptionDetails] {
+	return pulumix.Output[CustomerSubscriptionDetails]{
+		OutputState: i.ToCustomerSubscriptionDetailsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i CustomerSubscriptionDetailsArgs) ToCustomerSubscriptionDetailsPtrOutput() CustomerSubscriptionDetailsPtrOutput {
 	return i.ToCustomerSubscriptionDetailsPtrOutputWithContext(context.Background())
 }
@@ -642,6 +745,12 @@ func (i *customerSubscriptionDetailsPtrType) ToCustomerSubscriptionDetailsPtrOut
 	return pulumi.ToOutputWithContext(ctx, i).(CustomerSubscriptionDetailsPtrOutput)
 }
 
+func (i *customerSubscriptionDetailsPtrType) ToOutput(ctx context.Context) pulumix.Output[*CustomerSubscriptionDetails] {
+	return pulumix.Output[*CustomerSubscriptionDetails]{
+		OutputState: i.ToCustomerSubscriptionDetailsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Holds Customer subscription details. Clients can display available products to unregistered customers by explicitly passing subscription details
 type CustomerSubscriptionDetailsOutput struct{ *pulumi.OutputState }
 
@@ -665,6 +774,12 @@ func (o CustomerSubscriptionDetailsOutput) ToCustomerSubscriptionDetailsPtrOutpu
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v CustomerSubscriptionDetails) *CustomerSubscriptionDetails {
 		return &v
 	}).(CustomerSubscriptionDetailsPtrOutput)
+}
+
+func (o CustomerSubscriptionDetailsOutput) ToOutput(ctx context.Context) pulumix.Output[CustomerSubscriptionDetails] {
+	return pulumix.Output[CustomerSubscriptionDetails]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Location placement Id of a subscription
@@ -696,6 +811,12 @@ func (o CustomerSubscriptionDetailsPtrOutput) ToCustomerSubscriptionDetailsPtrOu
 
 func (o CustomerSubscriptionDetailsPtrOutput) ToCustomerSubscriptionDetailsPtrOutputWithContext(ctx context.Context) CustomerSubscriptionDetailsPtrOutput {
 	return o
+}
+
+func (o CustomerSubscriptionDetailsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*CustomerSubscriptionDetails] {
+	return pulumix.Output[*CustomerSubscriptionDetails]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CustomerSubscriptionDetailsPtrOutput) Elem() CustomerSubscriptionDetailsOutput {
@@ -777,6 +898,12 @@ func (i CustomerSubscriptionRegisteredFeaturesArgs) ToCustomerSubscriptionRegist
 	return pulumi.ToOutputWithContext(ctx, i).(CustomerSubscriptionRegisteredFeaturesOutput)
 }
 
+func (i CustomerSubscriptionRegisteredFeaturesArgs) ToOutput(ctx context.Context) pulumix.Output[CustomerSubscriptionRegisteredFeatures] {
+	return pulumix.Output[CustomerSubscriptionRegisteredFeatures]{
+		OutputState: i.ToCustomerSubscriptionRegisteredFeaturesOutputWithContext(ctx).OutputState,
+	}
+}
+
 // CustomerSubscriptionRegisteredFeaturesArrayInput is an input type that accepts CustomerSubscriptionRegisteredFeaturesArray and CustomerSubscriptionRegisteredFeaturesArrayOutput values.
 // You can construct a concrete instance of `CustomerSubscriptionRegisteredFeaturesArrayInput` via:
 //
@@ -802,6 +929,12 @@ func (i CustomerSubscriptionRegisteredFeaturesArray) ToCustomerSubscriptionRegis
 	return pulumi.ToOutputWithContext(ctx, i).(CustomerSubscriptionRegisteredFeaturesArrayOutput)
 }
 
+func (i CustomerSubscriptionRegisteredFeaturesArray) ToOutput(ctx context.Context) pulumix.Output[[]CustomerSubscriptionRegisteredFeatures] {
+	return pulumix.Output[[]CustomerSubscriptionRegisteredFeatures]{
+		OutputState: i.ToCustomerSubscriptionRegisteredFeaturesArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Represents subscription registered features
 type CustomerSubscriptionRegisteredFeaturesOutput struct{ *pulumi.OutputState }
 
@@ -815,6 +948,12 @@ func (o CustomerSubscriptionRegisteredFeaturesOutput) ToCustomerSubscriptionRegi
 
 func (o CustomerSubscriptionRegisteredFeaturesOutput) ToCustomerSubscriptionRegisteredFeaturesOutputWithContext(ctx context.Context) CustomerSubscriptionRegisteredFeaturesOutput {
 	return o
+}
+
+func (o CustomerSubscriptionRegisteredFeaturesOutput) ToOutput(ctx context.Context) pulumix.Output[CustomerSubscriptionRegisteredFeatures] {
+	return pulumix.Output[CustomerSubscriptionRegisteredFeatures]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Name of subscription registered feature
@@ -839,6 +978,12 @@ func (o CustomerSubscriptionRegisteredFeaturesArrayOutput) ToCustomerSubscriptio
 
 func (o CustomerSubscriptionRegisteredFeaturesArrayOutput) ToCustomerSubscriptionRegisteredFeaturesArrayOutputWithContext(ctx context.Context) CustomerSubscriptionRegisteredFeaturesArrayOutput {
 	return o
+}
+
+func (o CustomerSubscriptionRegisteredFeaturesArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]CustomerSubscriptionRegisteredFeatures] {
+	return pulumix.Output[[]CustomerSubscriptionRegisteredFeatures]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CustomerSubscriptionRegisteredFeaturesArrayOutput) Index(i pulumi.IntInput) CustomerSubscriptionRegisteredFeaturesOutput {
@@ -902,6 +1047,12 @@ func (i DescriptionResponseArgs) ToDescriptionResponseOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(DescriptionResponseOutput)
 }
 
+func (i DescriptionResponseArgs) ToOutput(ctx context.Context) pulumix.Output[DescriptionResponse] {
+	return pulumix.Output[DescriptionResponse]{
+		OutputState: i.ToDescriptionResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Description related properties of a product system.
 type DescriptionResponseOutput struct{ *pulumi.OutputState }
 
@@ -915,6 +1066,12 @@ func (o DescriptionResponseOutput) ToDescriptionResponseOutput() DescriptionResp
 
 func (o DescriptionResponseOutput) ToDescriptionResponseOutputWithContext(ctx context.Context) DescriptionResponseOutput {
 	return o
+}
+
+func (o DescriptionResponseOutput) ToOutput(ctx context.Context) pulumix.Output[DescriptionResponse] {
+	return pulumix.Output[DescriptionResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Attributes for the product system.
@@ -1006,6 +1163,12 @@ func (i DimensionsResponseArgs) ToDimensionsResponseOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(DimensionsResponseOutput)
 }
 
+func (i DimensionsResponseArgs) ToOutput(ctx context.Context) pulumix.Output[DimensionsResponse] {
+	return pulumix.Output[DimensionsResponse]{
+		OutputState: i.ToDimensionsResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Dimensions of a configuration.
 type DimensionsResponseOutput struct{ *pulumi.OutputState }
 
@@ -1019,6 +1182,12 @@ func (o DimensionsResponseOutput) ToDimensionsResponseOutput() DimensionsRespons
 
 func (o DimensionsResponseOutput) ToDimensionsResponseOutputWithContext(ctx context.Context) DimensionsResponseOutput {
 	return o
+}
+
+func (o DimensionsResponseOutput) ToOutput(ctx context.Context) pulumix.Output[DimensionsResponse] {
+	return pulumix.Output[DimensionsResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Depth of the device.
@@ -1095,6 +1264,12 @@ func (i FilterablePropertyArgs) ToFilterablePropertyOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(FilterablePropertyOutput)
 }
 
+func (i FilterablePropertyArgs) ToOutput(ctx context.Context) pulumix.Output[FilterableProperty] {
+	return pulumix.Output[FilterableProperty]{
+		OutputState: i.ToFilterablePropertyOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FilterablePropertyArrayInput is an input type that accepts FilterablePropertyArray and FilterablePropertyArrayOutput values.
 // You can construct a concrete instance of `FilterablePropertyArrayInput` via:
 //
@@ -1120,6 +1295,12 @@ func (i FilterablePropertyArray) ToFilterablePropertyArrayOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, i).(FilterablePropertyArrayOutput)
 }
 
+func (i FilterablePropertyArray) ToOutput(ctx context.Context) pulumix.Output[[]FilterableProperty] {
+	return pulumix.Output[[]FilterableProperty]{
+		OutputState: i.ToFilterablePropertyArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Different types of filters supported and its values.
 type FilterablePropertyOutput struct{ *pulumi.OutputState }
 
@@ -1133,6 +1314,12 @@ func (o FilterablePropertyOutput) ToFilterablePropertyOutput() FilterablePropert
 
 func (o FilterablePropertyOutput) ToFilterablePropertyOutputWithContext(ctx context.Context) FilterablePropertyOutput {
 	return o
+}
+
+func (o FilterablePropertyOutput) ToOutput(ctx context.Context) pulumix.Output[FilterableProperty] {
+	return pulumix.Output[FilterableProperty]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Values to be filtered.
@@ -1157,6 +1344,12 @@ func (o FilterablePropertyArrayOutput) ToFilterablePropertyArrayOutput() Filtera
 
 func (o FilterablePropertyArrayOutput) ToFilterablePropertyArrayOutputWithContext(ctx context.Context) FilterablePropertyArrayOutput {
 	return o
+}
+
+func (o FilterablePropertyArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]FilterableProperty] {
+	return pulumix.Output[[]FilterableProperty]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FilterablePropertyArrayOutput) Index(i pulumi.IntInput) FilterablePropertyOutput {
@@ -1204,6 +1397,12 @@ func (i FilterablePropertyResponseArgs) ToFilterablePropertyResponseOutputWithCo
 	return pulumi.ToOutputWithContext(ctx, i).(FilterablePropertyResponseOutput)
 }
 
+func (i FilterablePropertyResponseArgs) ToOutput(ctx context.Context) pulumix.Output[FilterablePropertyResponse] {
+	return pulumix.Output[FilterablePropertyResponse]{
+		OutputState: i.ToFilterablePropertyResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FilterablePropertyResponseArrayInput is an input type that accepts FilterablePropertyResponseArray and FilterablePropertyResponseArrayOutput values.
 // You can construct a concrete instance of `FilterablePropertyResponseArrayInput` via:
 //
@@ -1229,6 +1428,12 @@ func (i FilterablePropertyResponseArray) ToFilterablePropertyResponseArrayOutput
 	return pulumi.ToOutputWithContext(ctx, i).(FilterablePropertyResponseArrayOutput)
 }
 
+func (i FilterablePropertyResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]FilterablePropertyResponse] {
+	return pulumix.Output[[]FilterablePropertyResponse]{
+		OutputState: i.ToFilterablePropertyResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Different types of filters supported and its values.
 type FilterablePropertyResponseOutput struct{ *pulumi.OutputState }
 
@@ -1242,6 +1447,12 @@ func (o FilterablePropertyResponseOutput) ToFilterablePropertyResponseOutput() F
 
 func (o FilterablePropertyResponseOutput) ToFilterablePropertyResponseOutputWithContext(ctx context.Context) FilterablePropertyResponseOutput {
 	return o
+}
+
+func (o FilterablePropertyResponseOutput) ToOutput(ctx context.Context) pulumix.Output[FilterablePropertyResponse] {
+	return pulumix.Output[FilterablePropertyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Values to be filtered.
@@ -1266,6 +1477,12 @@ func (o FilterablePropertyResponseArrayOutput) ToFilterablePropertyResponseArray
 
 func (o FilterablePropertyResponseArrayOutput) ToFilterablePropertyResponseArrayOutputWithContext(ctx context.Context) FilterablePropertyResponseArrayOutput {
 	return o
+}
+
+func (o FilterablePropertyResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]FilterablePropertyResponse] {
+	return pulumix.Output[[]FilterablePropertyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FilterablePropertyResponseArrayOutput) Index(i pulumi.IntInput) FilterablePropertyResponseOutput {
@@ -1321,6 +1538,12 @@ func (i HierarchyInformationArgs) ToHierarchyInformationOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(HierarchyInformationOutput)
 }
 
+func (i HierarchyInformationArgs) ToOutput(ctx context.Context) pulumix.Output[HierarchyInformation] {
+	return pulumix.Output[HierarchyInformation]{
+		OutputState: i.ToHierarchyInformationOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Holds details about product hierarchy information
 type HierarchyInformationOutput struct{ *pulumi.OutputState }
 
@@ -1334,6 +1557,12 @@ func (o HierarchyInformationOutput) ToHierarchyInformationOutput() HierarchyInfo
 
 func (o HierarchyInformationOutput) ToHierarchyInformationOutputWithContext(ctx context.Context) HierarchyInformationOutput {
 	return o
+}
+
+func (o HierarchyInformationOutput) ToOutput(ctx context.Context) pulumix.Output[HierarchyInformation] {
+	return pulumix.Output[HierarchyInformation]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Represents configuration name that uniquely identifies configuration
@@ -1403,6 +1632,12 @@ func (i HierarchyInformationResponseArgs) ToHierarchyInformationResponseOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(HierarchyInformationResponseOutput)
 }
 
+func (i HierarchyInformationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[HierarchyInformationResponse] {
+	return pulumix.Output[HierarchyInformationResponse]{
+		OutputState: i.ToHierarchyInformationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Holds details about product hierarchy information
 type HierarchyInformationResponseOutput struct{ *pulumi.OutputState }
 
@@ -1416,6 +1651,12 @@ func (o HierarchyInformationResponseOutput) ToHierarchyInformationResponseOutput
 
 func (o HierarchyInformationResponseOutput) ToHierarchyInformationResponseOutputWithContext(ctx context.Context) HierarchyInformationResponseOutput {
 	return o
+}
+
+func (o HierarchyInformationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[HierarchyInformationResponse] {
+	return pulumix.Output[HierarchyInformationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Represents configuration name that uniquely identifies configuration
@@ -1477,6 +1718,12 @@ func (i ImageInformationResponseArgs) ToImageInformationResponseOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(ImageInformationResponseOutput)
 }
 
+func (i ImageInformationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[ImageInformationResponse] {
+	return pulumix.Output[ImageInformationResponse]{
+		OutputState: i.ToImageInformationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ImageInformationResponseArrayInput is an input type that accepts ImageInformationResponseArray and ImageInformationResponseArrayOutput values.
 // You can construct a concrete instance of `ImageInformationResponseArrayInput` via:
 //
@@ -1502,6 +1749,12 @@ func (i ImageInformationResponseArray) ToImageInformationResponseArrayOutputWith
 	return pulumi.ToOutputWithContext(ctx, i).(ImageInformationResponseArrayOutput)
 }
 
+func (i ImageInformationResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]ImageInformationResponse] {
+	return pulumix.Output[[]ImageInformationResponse]{
+		OutputState: i.ToImageInformationResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Image for the product
 type ImageInformationResponseOutput struct{ *pulumi.OutputState }
 
@@ -1515,6 +1768,12 @@ func (o ImageInformationResponseOutput) ToImageInformationResponseOutput() Image
 
 func (o ImageInformationResponseOutput) ToImageInformationResponseOutputWithContext(ctx context.Context) ImageInformationResponseOutput {
 	return o
+}
+
+func (o ImageInformationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[ImageInformationResponse] {
+	return pulumix.Output[ImageInformationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Type of the image
@@ -1539,6 +1798,12 @@ func (o ImageInformationResponseArrayOutput) ToImageInformationResponseArrayOutp
 
 func (o ImageInformationResponseArrayOutput) ToImageInformationResponseArrayOutputWithContext(ctx context.Context) ImageInformationResponseArrayOutput {
 	return o
+}
+
+func (o ImageInformationResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ImageInformationResponse] {
+	return pulumix.Output[[]ImageInformationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ImageInformationResponseArrayOutput) Index(i pulumi.IntInput) ImageInformationResponseOutput {
@@ -1586,6 +1851,12 @@ func (i LinkResponseArgs) ToLinkResponseOutputWithContext(ctx context.Context) L
 	return pulumi.ToOutputWithContext(ctx, i).(LinkResponseOutput)
 }
 
+func (i LinkResponseArgs) ToOutput(ctx context.Context) pulumix.Output[LinkResponse] {
+	return pulumix.Output[LinkResponse]{
+		OutputState: i.ToLinkResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // LinkResponseArrayInput is an input type that accepts LinkResponseArray and LinkResponseArrayOutput values.
 // You can construct a concrete instance of `LinkResponseArrayInput` via:
 //
@@ -1611,6 +1882,12 @@ func (i LinkResponseArray) ToLinkResponseArrayOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(LinkResponseArrayOutput)
 }
 
+func (i LinkResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]LinkResponse] {
+	return pulumix.Output[[]LinkResponse]{
+		OutputState: i.ToLinkResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Returns link related to the product
 type LinkResponseOutput struct{ *pulumi.OutputState }
 
@@ -1624,6 +1901,12 @@ func (o LinkResponseOutput) ToLinkResponseOutput() LinkResponseOutput {
 
 func (o LinkResponseOutput) ToLinkResponseOutputWithContext(ctx context.Context) LinkResponseOutput {
 	return o
+}
+
+func (o LinkResponseOutput) ToOutput(ctx context.Context) pulumix.Output[LinkResponse] {
+	return pulumix.Output[LinkResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Type of link
@@ -1648,6 +1931,12 @@ func (o LinkResponseArrayOutput) ToLinkResponseArrayOutput() LinkResponseArrayOu
 
 func (o LinkResponseArrayOutput) ToLinkResponseArrayOutputWithContext(ctx context.Context) LinkResponseArrayOutput {
 	return o
+}
+
+func (o LinkResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]LinkResponse] {
+	return pulumix.Output[[]LinkResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o LinkResponseArrayOutput) Index(i pulumi.IntInput) LinkResponseOutput {
@@ -1705,6 +1994,12 @@ func (i Pav2MeterDetailsResponseArgs) ToPav2MeterDetailsResponseOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(Pav2MeterDetailsResponseOutput)
 }
 
+func (i Pav2MeterDetailsResponseArgs) ToOutput(ctx context.Context) pulumix.Output[Pav2MeterDetailsResponse] {
+	return pulumix.Output[Pav2MeterDetailsResponse]{
+		OutputState: i.ToPav2MeterDetailsResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Billing type PAV2 meter details
 type Pav2MeterDetailsResponseOutput struct{ *pulumi.OutputState }
 
@@ -1718,6 +2013,12 @@ func (o Pav2MeterDetailsResponseOutput) ToPav2MeterDetailsResponseOutput() Pav2M
 
 func (o Pav2MeterDetailsResponseOutput) ToPav2MeterDetailsResponseOutputWithContext(ctx context.Context) Pav2MeterDetailsResponseOutput {
 	return o
+}
+
+func (o Pav2MeterDetailsResponseOutput) ToOutput(ctx context.Context) pulumix.Output[Pav2MeterDetailsResponse] {
+	return pulumix.Output[Pav2MeterDetailsResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Represents billing type.
@@ -1804,6 +2105,12 @@ func (i ProductFamilyResponseArgs) ToProductFamilyResponseOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, i).(ProductFamilyResponseOutput)
 }
 
+func (i ProductFamilyResponseArgs) ToOutput(ctx context.Context) pulumix.Output[ProductFamilyResponse] {
+	return pulumix.Output[ProductFamilyResponse]{
+		OutputState: i.ToProductFamilyResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ProductFamilyResponseArrayInput is an input type that accepts ProductFamilyResponseArray and ProductFamilyResponseArrayOutput values.
 // You can construct a concrete instance of `ProductFamilyResponseArrayInput` via:
 //
@@ -1829,6 +2136,12 @@ func (i ProductFamilyResponseArray) ToProductFamilyResponseArrayOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(ProductFamilyResponseArrayOutput)
 }
 
+func (i ProductFamilyResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]ProductFamilyResponse] {
+	return pulumix.Output[[]ProductFamilyResponse]{
+		OutputState: i.ToProductFamilyResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Product Family
 type ProductFamilyResponseOutput struct{ *pulumi.OutputState }
 
@@ -1842,6 +2155,12 @@ func (o ProductFamilyResponseOutput) ToProductFamilyResponseOutput() ProductFami
 
 func (o ProductFamilyResponseOutput) ToProductFamilyResponseOutputWithContext(ctx context.Context) ProductFamilyResponseOutput {
 	return o
+}
+
+func (o ProductFamilyResponseOutput) ToOutput(ctx context.Context) pulumix.Output[ProductFamilyResponse] {
+	return pulumix.Output[ProductFamilyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Availability information of the product system.
@@ -1896,6 +2215,12 @@ func (o ProductFamilyResponseArrayOutput) ToProductFamilyResponseArrayOutput() P
 
 func (o ProductFamilyResponseArrayOutput) ToProductFamilyResponseArrayOutputWithContext(ctx context.Context) ProductFamilyResponseArrayOutput {
 	return o
+}
+
+func (o ProductFamilyResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ProductFamilyResponse] {
+	return pulumix.Output[[]ProductFamilyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ProductFamilyResponseArrayOutput) Index(i pulumi.IntInput) ProductFamilyResponseOutput {
@@ -1967,6 +2292,12 @@ func (i ProductLineResponseArgs) ToProductLineResponseOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(ProductLineResponseOutput)
 }
 
+func (i ProductLineResponseArgs) ToOutput(ctx context.Context) pulumix.Output[ProductLineResponse] {
+	return pulumix.Output[ProductLineResponse]{
+		OutputState: i.ToProductLineResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ProductLineResponseArrayInput is an input type that accepts ProductLineResponseArray and ProductLineResponseArrayOutput values.
 // You can construct a concrete instance of `ProductLineResponseArrayInput` via:
 //
@@ -1992,6 +2323,12 @@ func (i ProductLineResponseArray) ToProductLineResponseArrayOutputWithContext(ct
 	return pulumi.ToOutputWithContext(ctx, i).(ProductLineResponseArrayOutput)
 }
 
+func (i ProductLineResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]ProductLineResponse] {
+	return pulumix.Output[[]ProductLineResponse]{
+		OutputState: i.ToProductLineResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Product line
 type ProductLineResponseOutput struct{ *pulumi.OutputState }
 
@@ -2005,6 +2342,12 @@ func (o ProductLineResponseOutput) ToProductLineResponseOutput() ProductLineResp
 
 func (o ProductLineResponseOutput) ToProductLineResponseOutputWithContext(ctx context.Context) ProductLineResponseOutput {
 	return o
+}
+
+func (o ProductLineResponseOutput) ToOutput(ctx context.Context) pulumix.Output[ProductLineResponse] {
+	return pulumix.Output[ProductLineResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Availability information of the product system.
@@ -2059,6 +2402,12 @@ func (o ProductLineResponseArrayOutput) ToProductLineResponseArrayOutput() Produ
 
 func (o ProductLineResponseArrayOutput) ToProductLineResponseArrayOutputWithContext(ctx context.Context) ProductLineResponseArrayOutput {
 	return o
+}
+
+func (o ProductLineResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ProductLineResponse] {
+	return pulumix.Output[[]ProductLineResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ProductLineResponseArrayOutput) Index(i pulumi.IntInput) ProductLineResponseOutput {
@@ -2130,6 +2479,12 @@ func (i ProductResponseArgs) ToProductResponseOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(ProductResponseOutput)
 }
 
+func (i ProductResponseArgs) ToOutput(ctx context.Context) pulumix.Output[ProductResponse] {
+	return pulumix.Output[ProductResponse]{
+		OutputState: i.ToProductResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ProductResponseArrayInput is an input type that accepts ProductResponseArray and ProductResponseArrayOutput values.
 // You can construct a concrete instance of `ProductResponseArrayInput` via:
 //
@@ -2155,6 +2510,12 @@ func (i ProductResponseArray) ToProductResponseArrayOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(ProductResponseArrayOutput)
 }
 
+func (i ProductResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]ProductResponse] {
+	return pulumix.Output[[]ProductResponse]{
+		OutputState: i.ToProductResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // List of Products
 type ProductResponseOutput struct{ *pulumi.OutputState }
 
@@ -2168,6 +2529,12 @@ func (o ProductResponseOutput) ToProductResponseOutput() ProductResponseOutput {
 
 func (o ProductResponseOutput) ToProductResponseOutputWithContext(ctx context.Context) ProductResponseOutput {
 	return o
+}
+
+func (o ProductResponseOutput) ToOutput(ctx context.Context) pulumix.Output[ProductResponse] {
+	return pulumix.Output[ProductResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Availability information of the product system.
@@ -2222,6 +2589,12 @@ func (o ProductResponseArrayOutput) ToProductResponseArrayOutput() ProductRespon
 
 func (o ProductResponseArrayOutput) ToProductResponseArrayOutputWithContext(ctx context.Context) ProductResponseArrayOutput {
 	return o
+}
+
+func (o ProductResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ProductResponse] {
+	return pulumix.Output[[]ProductResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ProductResponseArrayOutput) Index(i pulumi.IntInput) ProductResponseOutput {
@@ -2287,6 +2660,12 @@ func (i PurchaseMeterDetailsResponseArgs) ToPurchaseMeterDetailsResponseOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(PurchaseMeterDetailsResponseOutput)
 }
 
+func (i PurchaseMeterDetailsResponseArgs) ToOutput(ctx context.Context) pulumix.Output[PurchaseMeterDetailsResponse] {
+	return pulumix.Output[PurchaseMeterDetailsResponse]{
+		OutputState: i.ToPurchaseMeterDetailsResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Billing type Purchase meter details
 type PurchaseMeterDetailsResponseOutput struct{ *pulumi.OutputState }
 
@@ -2300,6 +2679,12 @@ func (o PurchaseMeterDetailsResponseOutput) ToPurchaseMeterDetailsResponseOutput
 
 func (o PurchaseMeterDetailsResponseOutput) ToPurchaseMeterDetailsResponseOutputWithContext(ctx context.Context) PurchaseMeterDetailsResponseOutput {
 	return o
+}
+
+func (o PurchaseMeterDetailsResponseOutput) ToOutput(ctx context.Context) pulumix.Output[PurchaseMeterDetailsResponse] {
+	return pulumix.Output[PurchaseMeterDetailsResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Represents billing type.
@@ -2372,6 +2757,12 @@ func (i SpecificationResponseArgs) ToSpecificationResponseOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, i).(SpecificationResponseOutput)
 }
 
+func (i SpecificationResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SpecificationResponse] {
+	return pulumix.Output[SpecificationResponse]{
+		OutputState: i.ToSpecificationResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SpecificationResponseArrayInput is an input type that accepts SpecificationResponseArray and SpecificationResponseArrayOutput values.
 // You can construct a concrete instance of `SpecificationResponseArrayInput` via:
 //
@@ -2397,6 +2788,12 @@ func (i SpecificationResponseArray) ToSpecificationResponseArrayOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(SpecificationResponseArrayOutput)
 }
 
+func (i SpecificationResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]SpecificationResponse] {
+	return pulumix.Output[[]SpecificationResponse]{
+		OutputState: i.ToSpecificationResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Specifications of the configurations
 type SpecificationResponseOutput struct{ *pulumi.OutputState }
 
@@ -2410,6 +2807,12 @@ func (o SpecificationResponseOutput) ToSpecificationResponseOutput() Specificati
 
 func (o SpecificationResponseOutput) ToSpecificationResponseOutputWithContext(ctx context.Context) SpecificationResponseOutput {
 	return o
+}
+
+func (o SpecificationResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SpecificationResponse] {
+	return pulumix.Output[SpecificationResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Name of the specification
@@ -2436,6 +2839,12 @@ func (o SpecificationResponseArrayOutput) ToSpecificationResponseArrayOutputWith
 	return o
 }
 
+func (o SpecificationResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SpecificationResponse] {
+	return pulumix.Output[[]SpecificationResponse]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SpecificationResponseArrayOutput) Index(i pulumi.IntInput) SpecificationResponseOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SpecificationResponse {
 		return vs[0].([]SpecificationResponse)[vs[1].(int)]
@@ -2454,6 +2863,12 @@ func (i FilterablePropertyArrayMap) ToFilterablePropertyArrayMapOutput() Filtera
 
 func (i FilterablePropertyArrayMap) ToFilterablePropertyArrayMapOutputWithContext(ctx context.Context) FilterablePropertyArrayMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FilterablePropertyArrayMapOutput)
+}
+
+func (i FilterablePropertyArrayMap) ToOutput(ctx context.Context) pulumix.Output[map[string][]FilterableProperty] {
+	return pulumix.Output[map[string][]FilterableProperty]{
+		OutputState: i.ToFilterablePropertyArrayMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 // FilterablePropertyArrayMapInput is an input type that accepts FilterablePropertyArrayMap and FilterablePropertyArrayMapOutput values.
@@ -2479,6 +2894,12 @@ func (o FilterablePropertyArrayMapOutput) ToFilterablePropertyArrayMapOutput() F
 
 func (o FilterablePropertyArrayMapOutput) ToFilterablePropertyArrayMapOutputWithContext(ctx context.Context) FilterablePropertyArrayMapOutput {
 	return o
+}
+
+func (o FilterablePropertyArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]FilterableProperty] {
+	return pulumix.Output[map[string][]FilterableProperty]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FilterablePropertyArrayMapOutput) MapIndex(k pulumi.StringInput) FilterablePropertyArrayOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs-tfbridge20/mypkg/internal"
 )
 
@@ -108,6 +109,12 @@ func (o GetAmiIdsResultOutput) ToGetAmiIdsResultOutput() GetAmiIdsResultOutput {
 
 func (o GetAmiIdsResultOutput) ToGetAmiIdsResultOutputWithContext(ctx context.Context) GetAmiIdsResultOutput {
 	return o
+}
+
+func (o GetAmiIdsResultOutput) ToOutput(ctx context.Context) pulumix.Output[GetAmiIdsResult] {
+	return pulumix.Output[GetAmiIdsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GetAmiIdsResultOutput) ExecutableUsers() pulumi.StringArrayOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs-tfbridge20/mypkg/internal"
 )
 
@@ -77,6 +78,12 @@ func (o ListStorageAccountKeysResultOutput) ToListStorageAccountKeysResultOutput
 
 func (o ListStorageAccountKeysResultOutput) ToListStorageAccountKeysResultOutputWithContext(ctx context.Context) ListStorageAccountKeysResultOutput {
 	return o
+}
+
+func (o ListStorageAccountKeysResultOutput) ToOutput(ctx context.Context) pulumix.Output[ListStorageAccountKeysResult] {
+	return pulumix.Output[ListStorageAccountKeysResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Gets the list of storage account keys and their properties for the specified storage account.

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/provider.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs-tfbridge20/mypkg/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs-tfbridge20/mypkg/internal"
 )
 
@@ -60,6 +61,12 @@ func (i StorageAccountKeyResponseArgs) ToStorageAccountKeyResponseOutputWithCont
 	return pulumi.ToOutputWithContext(ctx, i).(StorageAccountKeyResponseOutput)
 }
 
+func (i StorageAccountKeyResponseArgs) ToOutput(ctx context.Context) pulumix.Output[StorageAccountKeyResponse] {
+	return pulumix.Output[StorageAccountKeyResponse]{
+		OutputState: i.ToStorageAccountKeyResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // StorageAccountKeyResponseArrayInput is an input type that accepts StorageAccountKeyResponseArray and StorageAccountKeyResponseArrayOutput values.
 // You can construct a concrete instance of `StorageAccountKeyResponseArrayInput` via:
 //
@@ -85,6 +92,12 @@ func (i StorageAccountKeyResponseArray) ToStorageAccountKeyResponseArrayOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(StorageAccountKeyResponseArrayOutput)
 }
 
+func (i StorageAccountKeyResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]StorageAccountKeyResponse] {
+	return pulumix.Output[[]StorageAccountKeyResponse]{
+		OutputState: i.ToStorageAccountKeyResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // An access key for the storage account.
 type StorageAccountKeyResponseOutput struct{ *pulumi.OutputState }
 
@@ -98,6 +111,12 @@ func (o StorageAccountKeyResponseOutput) ToStorageAccountKeyResponseOutput() Sto
 
 func (o StorageAccountKeyResponseOutput) ToStorageAccountKeyResponseOutputWithContext(ctx context.Context) StorageAccountKeyResponseOutput {
 	return o
+}
+
+func (o StorageAccountKeyResponseOutput) ToOutput(ctx context.Context) pulumix.Output[StorageAccountKeyResponse] {
+	return pulumix.Output[StorageAccountKeyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Creation time of the key, in round trip date format.
@@ -132,6 +151,12 @@ func (o StorageAccountKeyResponseArrayOutput) ToStorageAccountKeyResponseArrayOu
 
 func (o StorageAccountKeyResponseArrayOutput) ToStorageAccountKeyResponseArrayOutputWithContext(ctx context.Context) StorageAccountKeyResponseArrayOutput {
 	return o
+}
+
+func (o StorageAccountKeyResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]StorageAccountKeyResponse] {
+	return pulumix.Output[[]StorageAccountKeyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o StorageAccountKeyResponseArrayOutput) Index(i pulumi.IntInput) StorageAccountKeyResponseOutput {
@@ -173,6 +198,12 @@ func (i GetAmiIdsFilterArgs) ToGetAmiIdsFilterOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(GetAmiIdsFilterOutput)
 }
 
+func (i GetAmiIdsFilterArgs) ToOutput(ctx context.Context) pulumix.Output[GetAmiIdsFilter] {
+	return pulumix.Output[GetAmiIdsFilter]{
+		OutputState: i.ToGetAmiIdsFilterOutputWithContext(ctx).OutputState,
+	}
+}
+
 // GetAmiIdsFilterArrayInput is an input type that accepts GetAmiIdsFilterArray and GetAmiIdsFilterArrayOutput values.
 // You can construct a concrete instance of `GetAmiIdsFilterArrayInput` via:
 //
@@ -198,6 +229,12 @@ func (i GetAmiIdsFilterArray) ToGetAmiIdsFilterArrayOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(GetAmiIdsFilterArrayOutput)
 }
 
+func (i GetAmiIdsFilterArray) ToOutput(ctx context.Context) pulumix.Output[[]GetAmiIdsFilter] {
+	return pulumix.Output[[]GetAmiIdsFilter]{
+		OutputState: i.ToGetAmiIdsFilterArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type GetAmiIdsFilterOutput struct{ *pulumi.OutputState }
 
 func (GetAmiIdsFilterOutput) ElementType() reflect.Type {
@@ -210,6 +247,12 @@ func (o GetAmiIdsFilterOutput) ToGetAmiIdsFilterOutput() GetAmiIdsFilterOutput {
 
 func (o GetAmiIdsFilterOutput) ToGetAmiIdsFilterOutputWithContext(ctx context.Context) GetAmiIdsFilterOutput {
 	return o
+}
+
+func (o GetAmiIdsFilterOutput) ToOutput(ctx context.Context) pulumix.Output[GetAmiIdsFilter] {
+	return pulumix.Output[GetAmiIdsFilter]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GetAmiIdsFilterOutput) Name() pulumi.StringOutput {
@@ -232,6 +275,12 @@ func (o GetAmiIdsFilterArrayOutput) ToGetAmiIdsFilterArrayOutput() GetAmiIdsFilt
 
 func (o GetAmiIdsFilterArrayOutput) ToGetAmiIdsFilterArrayOutputWithContext(ctx context.Context) GetAmiIdsFilterArrayOutput {
 	return o
+}
+
+func (o GetAmiIdsFilterArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]GetAmiIdsFilter] {
+	return pulumix.Output[[]GetAmiIdsFilter]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GetAmiIdsFilterArrayOutput) Index(i pulumi.IntInput) GetAmiIdsFilterOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -69,6 +70,12 @@ func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResult
 
 func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResultOutputWithContext(ctx context.Context) FuncWithAllOptionalInputsResultOutput {
 	return o
+}
+
+func (o FuncWithAllOptionalInputsResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithAllOptionalInputsResult] {
+	return pulumix.Output[FuncWithAllOptionalInputsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithAllOptionalInputsResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -78,6 +79,12 @@ func (o FuncWithDefaultValueResultOutput) ToFuncWithDefaultValueResultOutput() F
 
 func (o FuncWithDefaultValueResultOutput) ToFuncWithDefaultValueResultOutputWithContext(ctx context.Context) FuncWithDefaultValueResultOutput {
 	return o
+}
+
+func (o FuncWithDefaultValueResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithDefaultValueResult] {
+	return pulumix.Output[FuncWithDefaultValueResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithDefaultValueResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -65,6 +66,12 @@ func (o FuncWithDictParamResultOutput) ToFuncWithDictParamResultOutput() FuncWit
 
 func (o FuncWithDictParamResultOutput) ToFuncWithDictParamResultOutputWithContext(ctx context.Context) FuncWithDictParamResultOutput {
 	return o
+}
+
+func (o FuncWithDictParamResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithDictParamResult] {
+	return pulumix.Output[FuncWithDictParamResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithDictParamResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -65,6 +66,12 @@ func (o FuncWithListParamResultOutput) ToFuncWithListParamResultOutput() FuncWit
 
 func (o FuncWithListParamResultOutput) ToFuncWithListParamResultOutputWithContext(ctx context.Context) FuncWithListParamResultOutput {
 	return o
+}
+
+func (o FuncWithListParamResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithListParamResult] {
+	return pulumix.Output[FuncWithListParamResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithListParamResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -77,6 +78,12 @@ func (o GetBastionShareableLinkResultOutput) ToGetBastionShareableLinkResultOutp
 
 func (o GetBastionShareableLinkResultOutput) ToGetBastionShareableLinkResultOutputWithContext(ctx context.Context) GetBastionShareableLinkResultOutput {
 	return o
+}
+
+func (o GetBastionShareableLinkResultOutput) ToOutput(ctx context.Context) pulumix.Output[GetBastionShareableLinkResult] {
+	return pulumix.Output[GetBastionShareableLinkResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The URL to get the next set of results.

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -83,6 +84,12 @@ func (o GetIntegrationRuntimeObjectMetadatumResultOutput) ToGetIntegrationRuntim
 
 func (o GetIntegrationRuntimeObjectMetadatumResultOutput) ToGetIntegrationRuntimeObjectMetadatumResultOutputWithContext(ctx context.Context) GetIntegrationRuntimeObjectMetadatumResultOutput {
 	return o
+}
+
+func (o GetIntegrationRuntimeObjectMetadatumResultOutput) ToOutput(ctx context.Context) pulumix.Output[GetIntegrationRuntimeObjectMetadatumResult] {
+	return pulumix.Output[GetIntegrationRuntimeObjectMetadatumResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The link to the next page of results, if any remaining results exist.

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -77,6 +78,12 @@ func (o ListStorageAccountKeysResultOutput) ToListStorageAccountKeysResultOutput
 
 func (o ListStorageAccountKeysResultOutput) ToListStorageAccountKeysResultOutputWithContext(ctx context.Context) ListStorageAccountKeysResultOutput {
 	return o
+}
+
+func (o ListStorageAccountKeysResultOutput) ToOutput(ctx context.Context) pulumix.Output[ListStorageAccountKeysResult] {
+	return pulumix.Output[ListStorageAccountKeysResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Gets the list of storage account keys and their properties for the specified storage account.

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/provider.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -48,6 +49,12 @@ func (i BastionShareableLinkArgs) ToBastionShareableLinkOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(BastionShareableLinkOutput)
 }
 
+func (i BastionShareableLinkArgs) ToOutput(ctx context.Context) pulumix.Output[BastionShareableLink] {
+	return pulumix.Output[BastionShareableLink]{
+		OutputState: i.ToBastionShareableLinkOutputWithContext(ctx).OutputState,
+	}
+}
+
 // BastionShareableLinkArrayInput is an input type that accepts BastionShareableLinkArray and BastionShareableLinkArrayOutput values.
 // You can construct a concrete instance of `BastionShareableLinkArrayInput` via:
 //
@@ -73,6 +80,12 @@ func (i BastionShareableLinkArray) ToBastionShareableLinkArrayOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(BastionShareableLinkArrayOutput)
 }
 
+func (i BastionShareableLinkArray) ToOutput(ctx context.Context) pulumix.Output[[]BastionShareableLink] {
+	return pulumix.Output[[]BastionShareableLink]{
+		OutputState: i.ToBastionShareableLinkArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Bastion Shareable Link.
 type BastionShareableLinkOutput struct{ *pulumi.OutputState }
 
@@ -86,6 +99,12 @@ func (o BastionShareableLinkOutput) ToBastionShareableLinkOutput() BastionSharea
 
 func (o BastionShareableLinkOutput) ToBastionShareableLinkOutputWithContext(ctx context.Context) BastionShareableLinkOutput {
 	return o
+}
+
+func (o BastionShareableLinkOutput) ToOutput(ctx context.Context) pulumix.Output[BastionShareableLink] {
+	return pulumix.Output[BastionShareableLink]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Reference of the virtual machine resource.
@@ -105,6 +124,12 @@ func (o BastionShareableLinkArrayOutput) ToBastionShareableLinkArrayOutput() Bas
 
 func (o BastionShareableLinkArrayOutput) ToBastionShareableLinkArrayOutputWithContext(ctx context.Context) BastionShareableLinkArrayOutput {
 	return o
+}
+
+func (o BastionShareableLinkArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]BastionShareableLink] {
+	return pulumix.Output[[]BastionShareableLink]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BastionShareableLinkArrayOutput) Index(i pulumi.IntInput) BastionShareableLinkOutput {
@@ -160,6 +185,12 @@ func (i SsisEnvironmentReferenceResponseArgs) ToSsisEnvironmentReferenceResponse
 	return pulumi.ToOutputWithContext(ctx, i).(SsisEnvironmentReferenceResponseOutput)
 }
 
+func (i SsisEnvironmentReferenceResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisEnvironmentReferenceResponse] {
+	return pulumix.Output[SsisEnvironmentReferenceResponse]{
+		OutputState: i.ToSsisEnvironmentReferenceResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SsisEnvironmentReferenceResponseArrayInput is an input type that accepts SsisEnvironmentReferenceResponseArray and SsisEnvironmentReferenceResponseArrayOutput values.
 // You can construct a concrete instance of `SsisEnvironmentReferenceResponseArrayInput` via:
 //
@@ -185,6 +216,12 @@ func (i SsisEnvironmentReferenceResponseArray) ToSsisEnvironmentReferenceRespons
 	return pulumi.ToOutputWithContext(ctx, i).(SsisEnvironmentReferenceResponseArrayOutput)
 }
 
+func (i SsisEnvironmentReferenceResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]SsisEnvironmentReferenceResponse] {
+	return pulumix.Output[[]SsisEnvironmentReferenceResponse]{
+		OutputState: i.ToSsisEnvironmentReferenceResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis environment reference.
 type SsisEnvironmentReferenceResponseOutput struct{ *pulumi.OutputState }
 
@@ -198,6 +235,12 @@ func (o SsisEnvironmentReferenceResponseOutput) ToSsisEnvironmentReferenceRespon
 
 func (o SsisEnvironmentReferenceResponseOutput) ToSsisEnvironmentReferenceResponseOutputWithContext(ctx context.Context) SsisEnvironmentReferenceResponseOutput {
 	return o
+}
+
+func (o SsisEnvironmentReferenceResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisEnvironmentReferenceResponse] {
+	return pulumix.Output[SsisEnvironmentReferenceResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Environment folder name.
@@ -232,6 +275,12 @@ func (o SsisEnvironmentReferenceResponseArrayOutput) ToSsisEnvironmentReferenceR
 
 func (o SsisEnvironmentReferenceResponseArrayOutput) ToSsisEnvironmentReferenceResponseArrayOutputWithContext(ctx context.Context) SsisEnvironmentReferenceResponseArrayOutput {
 	return o
+}
+
+func (o SsisEnvironmentReferenceResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SsisEnvironmentReferenceResponse] {
+	return pulumix.Output[[]SsisEnvironmentReferenceResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SsisEnvironmentReferenceResponseArrayOutput) Index(i pulumi.IntInput) SsisEnvironmentReferenceResponseOutput {
@@ -297,6 +346,12 @@ func (i SsisEnvironmentResponseArgs) ToSsisEnvironmentResponseOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(SsisEnvironmentResponseOutput)
 }
 
+func (i SsisEnvironmentResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisEnvironmentResponse] {
+	return pulumix.Output[SsisEnvironmentResponse]{
+		OutputState: i.ToSsisEnvironmentResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis environment.
 type SsisEnvironmentResponseOutput struct{ *pulumi.OutputState }
 
@@ -310,6 +365,12 @@ func (o SsisEnvironmentResponseOutput) ToSsisEnvironmentResponseOutput() SsisEnv
 
 func (o SsisEnvironmentResponseOutput) ToSsisEnvironmentResponseOutputWithContext(ctx context.Context) SsisEnvironmentResponseOutput {
 	return o
+}
+
+func (o SsisEnvironmentResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisEnvironmentResponse] {
+	return pulumix.Output[SsisEnvironmentResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Metadata description.
@@ -392,6 +453,12 @@ func (i SsisFolderResponseArgs) ToSsisFolderResponseOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(SsisFolderResponseOutput)
 }
 
+func (i SsisFolderResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisFolderResponse] {
+	return pulumix.Output[SsisFolderResponse]{
+		OutputState: i.ToSsisFolderResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis folder.
 type SsisFolderResponseOutput struct{ *pulumi.OutputState }
 
@@ -405,6 +472,12 @@ func (o SsisFolderResponseOutput) ToSsisFolderResponseOutput() SsisFolderRespons
 
 func (o SsisFolderResponseOutput) ToSsisFolderResponseOutputWithContext(ctx context.Context) SsisFolderResponseOutput {
 	return o
+}
+
+func (o SsisFolderResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisFolderResponse] {
+	return pulumix.Output[SsisFolderResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Metadata description.
@@ -493,6 +566,12 @@ func (i SsisPackageResponseArgs) ToSsisPackageResponseOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(SsisPackageResponseOutput)
 }
 
+func (i SsisPackageResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisPackageResponse] {
+	return pulumix.Output[SsisPackageResponse]{
+		OutputState: i.ToSsisPackageResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis Package.
 type SsisPackageResponseOutput struct{ *pulumi.OutputState }
 
@@ -506,6 +585,12 @@ func (o SsisPackageResponseOutput) ToSsisPackageResponseOutput() SsisPackageResp
 
 func (o SsisPackageResponseOutput) ToSsisPackageResponseOutputWithContext(ctx context.Context) SsisPackageResponseOutput {
 	return o
+}
+
+func (o SsisPackageResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisPackageResponse] {
+	return pulumix.Output[SsisPackageResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Metadata description.
@@ -628,6 +713,12 @@ func (i SsisParameterResponseArgs) ToSsisParameterResponseOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, i).(SsisParameterResponseOutput)
 }
 
+func (i SsisParameterResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisParameterResponse] {
+	return pulumix.Output[SsisParameterResponse]{
+		OutputState: i.ToSsisParameterResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SsisParameterResponseArrayInput is an input type that accepts SsisParameterResponseArray and SsisParameterResponseArrayOutput values.
 // You can construct a concrete instance of `SsisParameterResponseArrayInput` via:
 //
@@ -653,6 +744,12 @@ func (i SsisParameterResponseArray) ToSsisParameterResponseArrayOutputWithContex
 	return pulumi.ToOutputWithContext(ctx, i).(SsisParameterResponseArrayOutput)
 }
 
+func (i SsisParameterResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]SsisParameterResponse] {
+	return pulumix.Output[[]SsisParameterResponse]{
+		OutputState: i.ToSsisParameterResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis parameter.
 type SsisParameterResponseOutput struct{ *pulumi.OutputState }
 
@@ -666,6 +763,12 @@ func (o SsisParameterResponseOutput) ToSsisParameterResponseOutput() SsisParamet
 
 func (o SsisParameterResponseOutput) ToSsisParameterResponseOutputWithContext(ctx context.Context) SsisParameterResponseOutput {
 	return o
+}
+
+func (o SsisParameterResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisParameterResponse] {
+	return pulumix.Output[SsisParameterResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Parameter type.
@@ -742,6 +845,12 @@ func (o SsisParameterResponseArrayOutput) ToSsisParameterResponseArrayOutputWith
 	return o
 }
 
+func (o SsisParameterResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SsisParameterResponse] {
+	return pulumix.Output[[]SsisParameterResponse]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SsisParameterResponseArrayOutput) Index(i pulumi.IntInput) SsisParameterResponseOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SsisParameterResponse {
 		return vs[0].([]SsisParameterResponse)[vs[1].(int)]
@@ -813,6 +922,12 @@ func (i SsisProjectResponseArgs) ToSsisProjectResponseOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(SsisProjectResponseOutput)
 }
 
+func (i SsisProjectResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisProjectResponse] {
+	return pulumix.Output[SsisProjectResponse]{
+		OutputState: i.ToSsisProjectResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis project.
 type SsisProjectResponseOutput struct{ *pulumi.OutputState }
 
@@ -826,6 +941,12 @@ func (o SsisProjectResponseOutput) ToSsisProjectResponseOutput() SsisProjectResp
 
 func (o SsisProjectResponseOutput) ToSsisProjectResponseOutputWithContext(ctx context.Context) SsisProjectResponseOutput {
 	return o
+}
+
+func (o SsisProjectResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisProjectResponse] {
+	return pulumix.Output[SsisProjectResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Metadata description.
@@ -928,6 +1049,12 @@ func (i SsisVariableResponseArgs) ToSsisVariableResponseOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(SsisVariableResponseOutput)
 }
 
+func (i SsisVariableResponseArgs) ToOutput(ctx context.Context) pulumix.Output[SsisVariableResponse] {
+	return pulumix.Output[SsisVariableResponse]{
+		OutputState: i.ToSsisVariableResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SsisVariableResponseArrayInput is an input type that accepts SsisVariableResponseArray and SsisVariableResponseArrayOutput values.
 // You can construct a concrete instance of `SsisVariableResponseArrayInput` via:
 //
@@ -953,6 +1080,12 @@ func (i SsisVariableResponseArray) ToSsisVariableResponseArrayOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(SsisVariableResponseArrayOutput)
 }
 
+func (i SsisVariableResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]SsisVariableResponse] {
+	return pulumix.Output[[]SsisVariableResponse]{
+		OutputState: i.ToSsisVariableResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Ssis variable.
 type SsisVariableResponseOutput struct{ *pulumi.OutputState }
 
@@ -966,6 +1099,12 @@ func (o SsisVariableResponseOutput) ToSsisVariableResponseOutput() SsisVariableR
 
 func (o SsisVariableResponseOutput) ToSsisVariableResponseOutputWithContext(ctx context.Context) SsisVariableResponseOutput {
 	return o
+}
+
+func (o SsisVariableResponseOutput) ToOutput(ctx context.Context) pulumix.Output[SsisVariableResponse] {
+	return pulumix.Output[SsisVariableResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Variable type.
@@ -1015,6 +1154,12 @@ func (o SsisVariableResponseArrayOutput) ToSsisVariableResponseArrayOutput() Ssi
 
 func (o SsisVariableResponseArrayOutput) ToSsisVariableResponseArrayOutputWithContext(ctx context.Context) SsisVariableResponseArrayOutput {
 	return o
+}
+
+func (o SsisVariableResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SsisVariableResponse] {
+	return pulumix.Output[[]SsisVariableResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SsisVariableResponseArrayOutput) Index(i pulumi.IntInput) SsisVariableResponseOutput {
@@ -1070,6 +1215,12 @@ func (i StorageAccountKeyResponseArgs) ToStorageAccountKeyResponseOutputWithCont
 	return pulumi.ToOutputWithContext(ctx, i).(StorageAccountKeyResponseOutput)
 }
 
+func (i StorageAccountKeyResponseArgs) ToOutput(ctx context.Context) pulumix.Output[StorageAccountKeyResponse] {
+	return pulumix.Output[StorageAccountKeyResponse]{
+		OutputState: i.ToStorageAccountKeyResponseOutputWithContext(ctx).OutputState,
+	}
+}
+
 // StorageAccountKeyResponseArrayInput is an input type that accepts StorageAccountKeyResponseArray and StorageAccountKeyResponseArrayOutput values.
 // You can construct a concrete instance of `StorageAccountKeyResponseArrayInput` via:
 //
@@ -1095,6 +1246,12 @@ func (i StorageAccountKeyResponseArray) ToStorageAccountKeyResponseArrayOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(StorageAccountKeyResponseArrayOutput)
 }
 
+func (i StorageAccountKeyResponseArray) ToOutput(ctx context.Context) pulumix.Output[[]StorageAccountKeyResponse] {
+	return pulumix.Output[[]StorageAccountKeyResponse]{
+		OutputState: i.ToStorageAccountKeyResponseArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 // An access key for the storage account.
 type StorageAccountKeyResponseOutput struct{ *pulumi.OutputState }
 
@@ -1108,6 +1265,12 @@ func (o StorageAccountKeyResponseOutput) ToStorageAccountKeyResponseOutput() Sto
 
 func (o StorageAccountKeyResponseOutput) ToStorageAccountKeyResponseOutputWithContext(ctx context.Context) StorageAccountKeyResponseOutput {
 	return o
+}
+
+func (o StorageAccountKeyResponseOutput) ToOutput(ctx context.Context) pulumix.Output[StorageAccountKeyResponse] {
+	return pulumix.Output[StorageAccountKeyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Creation time of the key, in round trip date format.
@@ -1142,6 +1305,12 @@ func (o StorageAccountKeyResponseArrayOutput) ToStorageAccountKeyResponseArrayOu
 
 func (o StorageAccountKeyResponseArrayOutput) ToStorageAccountKeyResponseArrayOutputWithContext(ctx context.Context) StorageAccountKeyResponseArrayOutput {
 	return o
+}
+
+func (o StorageAccountKeyResponseArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]StorageAccountKeyResponse] {
+	return pulumix.Output[[]StorageAccountKeyResponse]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o StorageAccountKeyResponseArrayOutput) Index(i pulumi.IntInput) StorageAccountKeyResponseOutput {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-and-default/foo/internal"
 )
 
@@ -170,6 +171,12 @@ func (i *ModuleResource) ToModuleResourceOutputWithContext(ctx context.Context) 
 	return pulumi.ToOutputWithContext(ctx, i).(ModuleResourceOutput)
 }
 
+func (i *ModuleResource) ToOutput(ctx context.Context) pulumix.Output[*ModuleResource] {
+	return pulumix.Output[*ModuleResource]{
+		OutputState: i.ToModuleResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ModuleResourceOutput struct{ *pulumi.OutputState }
 
 func (ModuleResourceOutput) ElementType() reflect.Type {
@@ -182,6 +189,12 @@ func (o ModuleResourceOutput) ToModuleResourceOutput() ModuleResourceOutput {
 
 func (o ModuleResourceOutput) ToModuleResourceOutputWithContext(ctx context.Context) ModuleResourceOutput {
 	return o
+}
+
+func (o ModuleResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*ModuleResource] {
+	return pulumix.Output[*ModuleResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ModuleResourceOutput) Optional_bool() pulumi.BoolPtrOutput {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-and-default/foo/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type EnumThing int
@@ -78,6 +79,12 @@ func (o EnumThingOutput) ToEnumThingPtrOutputWithContext(ctx context.Context) En
 	}).(EnumThingPtrOutput)
 }
 
+func (o EnumThingOutput) ToOutput(ctx context.Context) pulumix.Output[EnumThing] {
+	return pulumix.Output[EnumThing]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o EnumThingOutput) ToIntOutput() pulumi.IntOutput {
 	return o.ToIntOutputWithContext(context.Background())
 }
@@ -111,6 +118,12 @@ func (o EnumThingPtrOutput) ToEnumThingPtrOutput() EnumThingPtrOutput {
 
 func (o EnumThingPtrOutput) ToEnumThingPtrOutputWithContext(ctx context.Context) EnumThingPtrOutput {
 	return o
+}
+
+func (o EnumThingPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*EnumThing] {
+	return pulumix.Output[*EnumThing]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o EnumThingPtrOutput) Elem() EnumThingOutput {
@@ -173,6 +186,12 @@ func (in *enumThingPtr) ToEnumThingPtrOutput() EnumThingPtrOutput {
 
 func (in *enumThingPtr) ToEnumThingPtrOutputWithContext(ctx context.Context) EnumThingPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(EnumThingPtrOutput)
+}
+
+func (in *enumThingPtr) ToOutput(ctx context.Context) pulumix.Output[*EnumThing] {
+	return pulumix.Output[*EnumThing]{
+		OutputState: in.ToEnumThingPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 )
 
@@ -113,6 +114,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -125,6 +132,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 // A test for plain types

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 )
 
@@ -84,6 +85,12 @@ func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResult
 
 func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResultOutputWithContext(ctx context.Context) FuncWithAllOptionalInputsResultOutput {
 	return o
+}
+
+func (o FuncWithAllOptionalInputsResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithAllOptionalInputsResult] {
+	return pulumix.Output[FuncWithAllOptionalInputsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithAllOptionalInputsResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod1/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod1/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 )
 
@@ -74,6 +75,12 @@ func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
 }
 
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
 	return i.ToTypPtrOutputWithContext(context.Background())
 }
@@ -115,6 +122,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod 1)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -140,6 +153,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	}).(TypPtrOutput)
 }
 
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TypOutput) Val() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Typ) *string { return v.Val }).(pulumi.StringPtrOutput)
 }
@@ -156,6 +175,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod2/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod2/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 	"plain-object-defaults/example/mod1"
 )
@@ -76,6 +77,12 @@ func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
 }
 
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
 	return i.ToTypPtrOutputWithContext(context.Background())
 }
@@ -117,6 +124,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod 2)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -142,6 +155,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	}).(TypPtrOutput)
 }
 
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TypOutput) Mod1() mod1.TypPtrOutput {
 	return o.ApplyT(func(v Typ) *mod1.Typ { return v.Mod1 }).(mod1.TypPtrOutput)
 }
@@ -162,6 +181,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/moduleTest.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/moduleTest.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 	"plain-object-defaults/example/mod1"
 )
@@ -95,6 +96,12 @@ func (i *ModuleTest) ToModuleTestOutputWithContext(ctx context.Context) ModuleTe
 	return pulumi.ToOutputWithContext(ctx, i).(ModuleTestOutput)
 }
 
+func (i *ModuleTest) ToOutput(ctx context.Context) pulumix.Output[*ModuleTest] {
+	return pulumix.Output[*ModuleTest]{
+		OutputState: i.ToModuleTestOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ModuleTestOutput struct{ *pulumi.OutputState }
 
 func (ModuleTestOutput) ElementType() reflect.Type {
@@ -107,6 +114,12 @@ func (o ModuleTestOutput) ToModuleTestOutput() ModuleTestOutput {
 
 func (o ModuleTestOutput) ToModuleTestOutputWithContext(ctx context.Context) ModuleTestOutput {
 	return o
+}
+
+func (o ModuleTestOutput) ToOutput(ctx context.Context) pulumix.Output[*ModuleTest] {
+	return pulumix.Output[*ModuleTest]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 )
 
@@ -69,6 +70,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -81,6 +88,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-defaults/example/internal"
 	"plain-object-defaults/example/mod1"
 	"plain-object-defaults/example/mod2"
@@ -97,6 +98,12 @@ func (i HelmReleaseSettingsArgs) ToHelmReleaseSettingsOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(HelmReleaseSettingsOutput)
 }
 
+func (i HelmReleaseSettingsArgs) ToOutput(ctx context.Context) pulumix.Output[HelmReleaseSettings] {
+	return pulumix.Output[HelmReleaseSettings]{
+		OutputState: i.ToHelmReleaseSettingsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i HelmReleaseSettingsArgs) ToHelmReleaseSettingsPtrOutput() HelmReleaseSettingsPtrOutput {
 	return i.ToHelmReleaseSettingsPtrOutputWithContext(context.Background())
 }
@@ -138,6 +145,12 @@ func (i *helmReleaseSettingsPtrType) ToHelmReleaseSettingsPtrOutputWithContext(c
 	return pulumi.ToOutputWithContext(ctx, i).(HelmReleaseSettingsPtrOutput)
 }
 
+func (i *helmReleaseSettingsPtrType) ToOutput(ctx context.Context) pulumix.Output[*HelmReleaseSettings] {
+	return pulumix.Output[*HelmReleaseSettings]{
+		OutputState: i.ToHelmReleaseSettingsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // BETA FEATURE - Options to configure the Helm Release resource.
 type HelmReleaseSettingsOutput struct{ *pulumi.OutputState }
 
@@ -161,6 +174,12 @@ func (o HelmReleaseSettingsOutput) ToHelmReleaseSettingsPtrOutputWithContext(ctx
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v HelmReleaseSettings) *HelmReleaseSettings {
 		return &v
 	}).(HelmReleaseSettingsPtrOutput)
+}
+
+func (o HelmReleaseSettingsOutput) ToOutput(ctx context.Context) pulumix.Output[HelmReleaseSettings] {
+	return pulumix.Output[HelmReleaseSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
@@ -190,6 +209,12 @@ func (o HelmReleaseSettingsPtrOutput) ToHelmReleaseSettingsPtrOutput() HelmRelea
 
 func (o HelmReleaseSettingsPtrOutput) ToHelmReleaseSettingsPtrOutputWithContext(ctx context.Context) HelmReleaseSettingsPtrOutput {
 	return o
+}
+
+func (o HelmReleaseSettingsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*HelmReleaseSettings] {
+	return pulumix.Output[*HelmReleaseSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o HelmReleaseSettingsPtrOutput) Elem() HelmReleaseSettingsOutput {
@@ -315,6 +340,12 @@ func (i KubeClientSettingsArgs) ToKubeClientSettingsOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(KubeClientSettingsOutput)
 }
 
+func (i KubeClientSettingsArgs) ToOutput(ctx context.Context) pulumix.Output[KubeClientSettings] {
+	return pulumix.Output[KubeClientSettings]{
+		OutputState: i.ToKubeClientSettingsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i KubeClientSettingsArgs) ToKubeClientSettingsPtrOutput() KubeClientSettingsPtrOutput {
 	return i.ToKubeClientSettingsPtrOutputWithContext(context.Background())
 }
@@ -356,6 +387,12 @@ func (i *kubeClientSettingsPtrType) ToKubeClientSettingsPtrOutputWithContext(ctx
 	return pulumi.ToOutputWithContext(ctx, i).(KubeClientSettingsPtrOutput)
 }
 
+func (i *kubeClientSettingsPtrType) ToOutput(ctx context.Context) pulumix.Output[*KubeClientSettings] {
+	return pulumix.Output[*KubeClientSettings]{
+		OutputState: i.ToKubeClientSettingsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Options for tuning the Kubernetes client used by a Provider.
 type KubeClientSettingsOutput struct{ *pulumi.OutputState }
 
@@ -379,6 +416,12 @@ func (o KubeClientSettingsOutput) ToKubeClientSettingsPtrOutputWithContext(ctx c
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v KubeClientSettings) *KubeClientSettings {
 		return &v
 	}).(KubeClientSettingsPtrOutput)
+}
+
+func (o KubeClientSettingsOutput) ToOutput(ctx context.Context) pulumix.Output[KubeClientSettings] {
+	return pulumix.Output[KubeClientSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Maximum burst for throttle. Default value is 10.
@@ -407,6 +450,12 @@ func (o KubeClientSettingsPtrOutput) ToKubeClientSettingsPtrOutput() KubeClientS
 
 func (o KubeClientSettingsPtrOutput) ToKubeClientSettingsPtrOutputWithContext(ctx context.Context) KubeClientSettingsPtrOutput {
 	return o
+}
+
+func (o KubeClientSettingsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*KubeClientSettings] {
+	return pulumix.Output[*KubeClientSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o KubeClientSettingsPtrOutput) Elem() KubeClientSettingsOutput {
@@ -550,6 +599,12 @@ func (i LayeredTypeArgs) ToLayeredTypeOutputWithContext(ctx context.Context) Lay
 	return pulumi.ToOutputWithContext(ctx, i).(LayeredTypeOutput)
 }
 
+func (i LayeredTypeArgs) ToOutput(ctx context.Context) pulumix.Output[LayeredType] {
+	return pulumix.Output[LayeredType]{
+		OutputState: i.ToLayeredTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i LayeredTypeArgs) ToLayeredTypePtrOutput() LayeredTypePtrOutput {
 	return i.ToLayeredTypePtrOutputWithContext(context.Background())
 }
@@ -591,6 +646,12 @@ func (i *layeredTypePtrType) ToLayeredTypePtrOutputWithContext(ctx context.Conte
 	return pulumi.ToOutputWithContext(ctx, i).(LayeredTypePtrOutput)
 }
 
+func (i *layeredTypePtrType) ToOutput(ctx context.Context) pulumix.Output[*LayeredType] {
+	return pulumix.Output[*LayeredType]{
+		OutputState: i.ToLayeredTypePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Make sure that defaults propagate through types
 type LayeredTypeOutput struct{ *pulumi.OutputState }
 
@@ -614,6 +675,12 @@ func (o LayeredTypeOutput) ToLayeredTypePtrOutputWithContext(ctx context.Context
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v LayeredType) *LayeredType {
 		return &v
 	}).(LayeredTypePtrOutput)
+}
+
+func (o LayeredTypeOutput) ToOutput(ctx context.Context) pulumix.Output[LayeredType] {
+	return pulumix.Output[LayeredType]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The answer to the question
@@ -656,6 +723,12 @@ func (o LayeredTypePtrOutput) ToLayeredTypePtrOutput() LayeredTypePtrOutput {
 
 func (o LayeredTypePtrOutput) ToLayeredTypePtrOutputWithContext(ctx context.Context) LayeredTypePtrOutput {
 	return o
+}
+
+func (o LayeredTypePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*LayeredType] {
+	return pulumix.Output[*LayeredType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o LayeredTypePtrOutput) Elem() LayeredTypeOutput {
@@ -792,6 +865,12 @@ func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
 }
 
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
 	return i.ToTypPtrOutputWithContext(context.Background())
 }
@@ -833,6 +912,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod main)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -856,6 +941,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Typ) *Typ {
 		return &v
 	}).(TypPtrOutput)
+}
+
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypOutput) Mod1() mod1.TypPtrOutput {
@@ -882,6 +973,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 )
 
@@ -106,6 +107,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -118,6 +125,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 // A test for plain types

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 )
 
@@ -69,6 +70,12 @@ func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResult
 
 func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResultOutputWithContext(ctx context.Context) FuncWithAllOptionalInputsResultOutput {
 	return o
+}
+
+func (o FuncWithAllOptionalInputsResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithAllOptionalInputsResult] {
+	return pulumix.Output[FuncWithAllOptionalInputsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithAllOptionalInputsResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod1/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod1/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i TypArgs) ToTypOutput() TypOutput {
 
 func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
+}
+
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
@@ -87,6 +94,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod 1)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -112,6 +125,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	}).(TypPtrOutput)
 }
 
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TypOutput) Val() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Typ) *string { return v.Val }).(pulumi.StringPtrOutput)
 }
@@ -128,6 +147,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod2/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod2/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 	"plain-object-disable-defaults/example/mod1"
 )
@@ -47,6 +48,12 @@ func (i TypArgs) ToTypOutput() TypOutput {
 
 func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
+}
+
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
@@ -90,6 +97,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod 2)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -115,6 +128,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	}).(TypPtrOutput)
 }
 
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TypOutput) Mod1() mod1.TypPtrOutput {
 	return o.ApplyT(func(v Typ) *mod1.Typ { return v.Mod1 }).(mod1.TypPtrOutput)
 }
@@ -135,6 +154,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/moduleTest.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/moduleTest.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 	"plain-object-disable-defaults/example/mod1"
 )
@@ -89,6 +90,12 @@ func (i *ModuleTest) ToModuleTestOutputWithContext(ctx context.Context) ModuleTe
 	return pulumi.ToOutputWithContext(ctx, i).(ModuleTestOutput)
 }
 
+func (i *ModuleTest) ToOutput(ctx context.Context) pulumix.Output[*ModuleTest] {
+	return pulumix.Output[*ModuleTest]{
+		OutputState: i.ToModuleTestOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ModuleTestOutput struct{ *pulumi.OutputState }
 
 func (ModuleTestOutput) ElementType() reflect.Type {
@@ -101,6 +108,12 @@ func (o ModuleTestOutput) ToModuleTestOutput() ModuleTestOutput {
 
 func (o ModuleTestOutput) ToModuleTestOutputWithContext(ctx context.Context) ModuleTestOutput {
 	return o
+}
+
+func (o ModuleTestOutput) ToOutput(ctx context.Context) pulumix.Output[*ModuleTest] {
+	return pulumix.Output[*ModuleTest]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 )
 
@@ -66,6 +67,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -78,6 +85,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-object-disable-defaults/example/internal"
 	"plain-object-disable-defaults/example/mod1"
 	"plain-object-disable-defaults/example/mod2"
@@ -58,6 +59,12 @@ func (i HelmReleaseSettingsArgs) ToHelmReleaseSettingsOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, i).(HelmReleaseSettingsOutput)
 }
 
+func (i HelmReleaseSettingsArgs) ToOutput(ctx context.Context) pulumix.Output[HelmReleaseSettings] {
+	return pulumix.Output[HelmReleaseSettings]{
+		OutputState: i.ToHelmReleaseSettingsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i HelmReleaseSettingsArgs) ToHelmReleaseSettingsPtrOutput() HelmReleaseSettingsPtrOutput {
 	return i.ToHelmReleaseSettingsPtrOutputWithContext(context.Background())
 }
@@ -99,6 +106,12 @@ func (i *helmReleaseSettingsPtrType) ToHelmReleaseSettingsPtrOutputWithContext(c
 	return pulumi.ToOutputWithContext(ctx, i).(HelmReleaseSettingsPtrOutput)
 }
 
+func (i *helmReleaseSettingsPtrType) ToOutput(ctx context.Context) pulumix.Output[*HelmReleaseSettings] {
+	return pulumix.Output[*HelmReleaseSettings]{
+		OutputState: i.ToHelmReleaseSettingsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // BETA FEATURE - Options to configure the Helm Release resource.
 type HelmReleaseSettingsOutput struct{ *pulumi.OutputState }
 
@@ -122,6 +135,12 @@ func (o HelmReleaseSettingsOutput) ToHelmReleaseSettingsPtrOutputWithContext(ctx
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v HelmReleaseSettings) *HelmReleaseSettings {
 		return &v
 	}).(HelmReleaseSettingsPtrOutput)
+}
+
+func (o HelmReleaseSettingsOutput) ToOutput(ctx context.Context) pulumix.Output[HelmReleaseSettings] {
+	return pulumix.Output[HelmReleaseSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
@@ -151,6 +170,12 @@ func (o HelmReleaseSettingsPtrOutput) ToHelmReleaseSettingsPtrOutput() HelmRelea
 
 func (o HelmReleaseSettingsPtrOutput) ToHelmReleaseSettingsPtrOutputWithContext(ctx context.Context) HelmReleaseSettingsPtrOutput {
 	return o
+}
+
+func (o HelmReleaseSettingsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*HelmReleaseSettings] {
+	return pulumix.Output[*HelmReleaseSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o HelmReleaseSettingsPtrOutput) Elem() HelmReleaseSettingsOutput {
@@ -234,6 +259,12 @@ func (i KubeClientSettingsArgs) ToKubeClientSettingsOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(KubeClientSettingsOutput)
 }
 
+func (i KubeClientSettingsArgs) ToOutput(ctx context.Context) pulumix.Output[KubeClientSettings] {
+	return pulumix.Output[KubeClientSettings]{
+		OutputState: i.ToKubeClientSettingsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i KubeClientSettingsArgs) ToKubeClientSettingsPtrOutput() KubeClientSettingsPtrOutput {
 	return i.ToKubeClientSettingsPtrOutputWithContext(context.Background())
 }
@@ -275,6 +306,12 @@ func (i *kubeClientSettingsPtrType) ToKubeClientSettingsPtrOutputWithContext(ctx
 	return pulumi.ToOutputWithContext(ctx, i).(KubeClientSettingsPtrOutput)
 }
 
+func (i *kubeClientSettingsPtrType) ToOutput(ctx context.Context) pulumix.Output[*KubeClientSettings] {
+	return pulumix.Output[*KubeClientSettings]{
+		OutputState: i.ToKubeClientSettingsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Options for tuning the Kubernetes client used by a Provider.
 type KubeClientSettingsOutput struct{ *pulumi.OutputState }
 
@@ -298,6 +335,12 @@ func (o KubeClientSettingsOutput) ToKubeClientSettingsPtrOutputWithContext(ctx c
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v KubeClientSettings) *KubeClientSettings {
 		return &v
 	}).(KubeClientSettingsPtrOutput)
+}
+
+func (o KubeClientSettingsOutput) ToOutput(ctx context.Context) pulumix.Output[KubeClientSettings] {
+	return pulumix.Output[KubeClientSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 // Maximum burst for throttle. Default value is 10.
@@ -326,6 +369,12 @@ func (o KubeClientSettingsPtrOutput) ToKubeClientSettingsPtrOutput() KubeClientS
 
 func (o KubeClientSettingsPtrOutput) ToKubeClientSettingsPtrOutputWithContext(ctx context.Context) KubeClientSettingsPtrOutput {
 	return o
+}
+
+func (o KubeClientSettingsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*KubeClientSettings] {
+	return pulumix.Output[*KubeClientSettings]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o KubeClientSettingsPtrOutput) Elem() KubeClientSettingsOutput {
@@ -418,6 +467,12 @@ func (i LayeredTypeArgs) ToLayeredTypeOutputWithContext(ctx context.Context) Lay
 	return pulumi.ToOutputWithContext(ctx, i).(LayeredTypeOutput)
 }
 
+func (i LayeredTypeArgs) ToOutput(ctx context.Context) pulumix.Output[LayeredType] {
+	return pulumix.Output[LayeredType]{
+		OutputState: i.ToLayeredTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i LayeredTypeArgs) ToLayeredTypePtrOutput() LayeredTypePtrOutput {
 	return i.ToLayeredTypePtrOutputWithContext(context.Background())
 }
@@ -459,6 +514,12 @@ func (i *layeredTypePtrType) ToLayeredTypePtrOutputWithContext(ctx context.Conte
 	return pulumi.ToOutputWithContext(ctx, i).(LayeredTypePtrOutput)
 }
 
+func (i *layeredTypePtrType) ToOutput(ctx context.Context) pulumix.Output[*LayeredType] {
+	return pulumix.Output[*LayeredType]{
+		OutputState: i.ToLayeredTypePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // Make sure that defaults propagate through types
 type LayeredTypeOutput struct{ *pulumi.OutputState }
 
@@ -482,6 +543,12 @@ func (o LayeredTypeOutput) ToLayeredTypePtrOutputWithContext(ctx context.Context
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v LayeredType) *LayeredType {
 		return &v
 	}).(LayeredTypePtrOutput)
+}
+
+func (o LayeredTypeOutput) ToOutput(ctx context.Context) pulumix.Output[LayeredType] {
+	return pulumix.Output[LayeredType]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The answer to the question
@@ -524,6 +591,12 @@ func (o LayeredTypePtrOutput) ToLayeredTypePtrOutput() LayeredTypePtrOutput {
 
 func (o LayeredTypePtrOutput) ToLayeredTypePtrOutputWithContext(ctx context.Context) LayeredTypePtrOutput {
 	return o
+}
+
+func (o LayeredTypePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*LayeredType] {
+	return pulumix.Output[*LayeredType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o LayeredTypePtrOutput) Elem() LayeredTypeOutput {
@@ -631,6 +704,12 @@ func (i TypArgs) ToTypOutputWithContext(ctx context.Context) TypOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(TypOutput)
 }
 
+func (i TypArgs) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: i.ToTypOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i TypArgs) ToTypPtrOutput() TypPtrOutput {
 	return i.ToTypPtrOutputWithContext(context.Background())
 }
@@ -672,6 +751,12 @@ func (i *typPtrType) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(TypPtrOutput)
 }
 
+func (i *typPtrType) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: i.ToTypPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A test for namespaces (mod main)
 type TypOutput struct{ *pulumi.OutputState }
 
@@ -695,6 +780,12 @@ func (o TypOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Typ) *Typ {
 		return &v
 	}).(TypPtrOutput)
+}
+
+func (o TypOutput) ToOutput(ctx context.Context) pulumix.Output[Typ] {
+	return pulumix.Output[Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypOutput) Mod1() mod1.TypPtrOutput {
@@ -721,6 +812,12 @@ func (o TypPtrOutput) ToTypPtrOutput() TypPtrOutput {
 
 func (o TypPtrOutput) ToTypPtrOutputWithContext(ctx context.Context) TypPtrOutput {
 	return o
+}
+
+func (o TypPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Typ] {
+	return pulumix.Output[*Typ]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypPtrOutput) Elem() TypOutput {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-schema-gh6957/xyz/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-schema-gh6957/xyz/internal"
 )
 
@@ -42,6 +43,12 @@ func (i FooArgs) ToFooOutput() FooOutput {
 
 func (i FooArgs) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
+}
+
+func (i FooArgs) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i FooArgs) ToFooPtrOutput() FooPtrOutput {
@@ -85,6 +92,12 @@ func (i *fooPtrType) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(FooPtrOutput)
 }
 
+func (i *fooPtrType) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -109,6 +122,12 @@ func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	}).(FooPtrOutput)
 }
 
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FooOutput) A() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v Foo) *bool { return v.A }).(pulumi.BoolPtrOutput)
 }
@@ -125,6 +144,12 @@ func (o FooPtrOutput) ToFooPtrOutput() FooPtrOutput {
 
 func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	return o
+}
+
+func (o FooPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooPtrOutput) Elem() FooOutput {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"plain-schema-gh6957/xyz/internal"
 )
 
@@ -77,6 +78,12 @@ func (i *StaticPage) ToStaticPageOutputWithContext(ctx context.Context) StaticPa
 	return pulumi.ToOutputWithContext(ctx, i).(StaticPageOutput)
 }
 
+func (i *StaticPage) ToOutput(ctx context.Context) pulumix.Output[*StaticPage] {
+	return pulumix.Output[*StaticPage]{
+		OutputState: i.ToStaticPageOutputWithContext(ctx).OutputState,
+	}
+}
+
 // StaticPageArrayInput is an input type that accepts StaticPageArray and StaticPageArrayOutput values.
 // You can construct a concrete instance of `StaticPageArrayInput` via:
 //
@@ -100,6 +107,12 @@ func (i StaticPageArray) ToStaticPageArrayOutput() StaticPageArrayOutput {
 
 func (i StaticPageArray) ToStaticPageArrayOutputWithContext(ctx context.Context) StaticPageArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(StaticPageArrayOutput)
+}
+
+func (i StaticPageArray) ToOutput(ctx context.Context) pulumix.Output[[]*StaticPage] {
+	return pulumix.Output[[]*StaticPage]{
+		OutputState: i.ToStaticPageArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // StaticPageMapInput is an input type that accepts StaticPageMap and StaticPageMapOutput values.
@@ -127,6 +140,12 @@ func (i StaticPageMap) ToStaticPageMapOutputWithContext(ctx context.Context) Sta
 	return pulumi.ToOutputWithContext(ctx, i).(StaticPageMapOutput)
 }
 
+func (i StaticPageMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*StaticPage] {
+	return pulumix.Output[map[string]*StaticPage]{
+		OutputState: i.ToStaticPageMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type StaticPageOutput struct{ *pulumi.OutputState }
 
 func (StaticPageOutput) ElementType() reflect.Type {
@@ -139,6 +158,12 @@ func (o StaticPageOutput) ToStaticPageOutput() StaticPageOutput {
 
 func (o StaticPageOutput) ToStaticPageOutputWithContext(ctx context.Context) StaticPageOutput {
 	return o
+}
+
+func (o StaticPageOutput) ToOutput(ctx context.Context) pulumix.Output[*StaticPage] {
+	return pulumix.Output[*StaticPage]{
+		OutputState: o.OutputState,
+	}
 }
 
 // The bucket resource.
@@ -165,6 +190,12 @@ func (o StaticPageArrayOutput) ToStaticPageArrayOutputWithContext(ctx context.Co
 	return o
 }
 
+func (o StaticPageArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*StaticPage] {
+	return pulumix.Output[[]*StaticPage]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o StaticPageArrayOutput) Index(i pulumi.IntInput) StaticPageOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *StaticPage {
 		return vs[0].([]*StaticPage)[vs[1].(int)]
@@ -183,6 +214,12 @@ func (o StaticPageMapOutput) ToStaticPageMapOutput() StaticPageMapOutput {
 
 func (o StaticPageMapOutput) ToStaticPageMapOutputWithContext(ctx context.Context) StaticPageMapOutput {
 	return o
+}
+
+func (o StaticPageMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*StaticPage] {
+	return pulumix.Output[map[string]*StaticPage]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o StaticPageMapOutput) MapIndex(k pulumi.StringInput) StaticPageOutput {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/config/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/config/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -46,6 +47,12 @@ func (i SandwichArgs) ToSandwichOutputWithContext(ctx context.Context) SandwichO
 	return pulumi.ToOutputWithContext(ctx, i).(SandwichOutput)
 }
 
+func (i SandwichArgs) ToOutput(ctx context.Context) pulumix.Output[Sandwich] {
+	return pulumix.Output[Sandwich]{
+		OutputState: i.ToSandwichOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SandwichArrayInput is an input type that accepts SandwichArray and SandwichArrayOutput values.
 // You can construct a concrete instance of `SandwichArrayInput` via:
 //
@@ -71,6 +78,12 @@ func (i SandwichArray) ToSandwichArrayOutputWithContext(ctx context.Context) San
 	return pulumi.ToOutputWithContext(ctx, i).(SandwichArrayOutput)
 }
 
+func (i SandwichArray) ToOutput(ctx context.Context) pulumix.Output[[]Sandwich] {
+	return pulumix.Output[[]Sandwich]{
+		OutputState: i.ToSandwichArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type SandwichOutput struct{ *pulumi.OutputState }
 
 func (SandwichOutput) ElementType() reflect.Type {
@@ -83,6 +96,12 @@ func (o SandwichOutput) ToSandwichOutput() SandwichOutput {
 
 func (o SandwichOutput) ToSandwichOutputWithContext(ctx context.Context) SandwichOutput {
 	return o
+}
+
+func (o SandwichOutput) ToOutput(ctx context.Context) pulumix.Output[Sandwich] {
+	return pulumix.Output[Sandwich]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SandwichOutput) Bread() pulumi.StringPtrOutput {
@@ -105,6 +124,12 @@ func (o SandwichArrayOutput) ToSandwichArrayOutput() SandwichArrayOutput {
 
 func (o SandwichArrayOutput) ToSandwichArrayOutputWithContext(ctx context.Context) SandwichArrayOutput {
 	return o
+}
+
+func (o SandwichArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Sandwich] {
+	return pulumix.Output[[]Sandwich]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SandwichArrayOutput) Index(i pulumi.IntInput) SandwichOutput {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -69,6 +70,12 @@ func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResult
 
 func (o FuncWithAllOptionalInputsResultOutput) ToFuncWithAllOptionalInputsResultOutputWithContext(ctx context.Context) FuncWithAllOptionalInputsResultOutput {
 	return o
+}
+
+func (o FuncWithAllOptionalInputsResultOutput) ToOutput(ctx context.Context) pulumix.Output[FuncWithAllOptionalInputsResult] {
+	return pulumix.Output[FuncWithAllOptionalInputsResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FuncWithAllOptionalInputsResultOutput) R() pulumi.StringOutput {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"config"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -78,6 +79,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -90,6 +97,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Color string
@@ -77,6 +78,12 @@ func (o ColorOutput) ToColorPtrOutputWithContext(ctx context.Context) ColorPtrOu
 	}).(ColorPtrOutput)
 }
 
+func (o ColorOutput) ToOutput(ctx context.Context) pulumix.Output[Color] {
+	return pulumix.Output[Color]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ColorOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o ColorPtrOutput) ToColorPtrOutput() ColorPtrOutput {
 
 func (o ColorPtrOutput) ToColorPtrOutputWithContext(ctx context.Context) ColorPtrOutput {
 	return o
+}
+
+func (o ColorPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Color] {
+	return pulumix.Output[*Color]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ColorPtrOutput) Elem() ColorOutput {
@@ -172,6 +185,12 @@ func (in *colorPtr) ToColorPtrOutput() ColorPtrOutput {
 
 func (in *colorPtr) ToColorPtrOutputWithContext(ctx context.Context) ColorPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ColorPtrOutput)
+}
+
+func (in *colorPtr) ToOutput(ctx context.Context) pulumix.Output[*Color] {
+	return pulumix.Output[*Color]{
+		OutputState: in.ToColorPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"internal"
 )
 
@@ -46,6 +47,12 @@ func (i ChildArgs) ToChildOutputWithContext(ctx context.Context) ChildOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ChildOutput)
 }
 
+func (i ChildArgs) ToOutput(ctx context.Context) pulumix.Output[Child] {
+	return pulumix.Output[Child]{
+		OutputState: i.ToChildOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ChildOutput struct{ *pulumi.OutputState }
 
 func (ChildOutput) ElementType() reflect.Type {
@@ -58,6 +65,12 @@ func (o ChildOutput) ToChildOutput() ChildOutput {
 
 func (o ChildOutput) ToChildOutputWithContext(ctx context.Context) ChildOutput {
 	return o
+}
+
+func (o ChildOutput) ToOutput(ctx context.Context) pulumix.Output[Child] {
+	return pulumix.Output[Child]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ChildOutput) Age() pulumi.IntPtrOutput {

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"provider-type-schema/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/go/example/submod/provider.go
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/go/example/submod/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"provider-type-schema/example/internal"
 )
 
@@ -88,6 +89,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -100,6 +107,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ProviderOutput) A() pulumi.BoolPtrOutput {

--- a/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/provider.go
+++ b/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-8403/mongodbatlas/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-8403/mongodbatlas/internal"
 )
 
@@ -40,6 +41,12 @@ func (i GetCustomDbRolesResultArgs) ToGetCustomDbRolesResultOutput() GetCustomDb
 
 func (i GetCustomDbRolesResultArgs) ToGetCustomDbRolesResultOutputWithContext(ctx context.Context) GetCustomDbRolesResultOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(GetCustomDbRolesResultOutput)
+}
+
+func (i GetCustomDbRolesResultArgs) ToOutput(ctx context.Context) pulumix.Output[GetCustomDbRolesResult] {
+	return pulumix.Output[GetCustomDbRolesResult]{
+		OutputState: i.ToGetCustomDbRolesResultOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i GetCustomDbRolesResultArgs) ToGetCustomDbRolesResultPtrOutput() GetCustomDbRolesResultPtrOutput {
@@ -83,6 +90,12 @@ func (i *getCustomDbRolesResultPtrType) ToGetCustomDbRolesResultPtrOutputWithCon
 	return pulumi.ToOutputWithContext(ctx, i).(GetCustomDbRolesResultPtrOutput)
 }
 
+func (i *getCustomDbRolesResultPtrType) ToOutput(ctx context.Context) pulumix.Output[*GetCustomDbRolesResult] {
+	return pulumix.Output[*GetCustomDbRolesResult]{
+		OutputState: i.ToGetCustomDbRolesResultPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type GetCustomDbRolesResultOutput struct{ *pulumi.OutputState }
 
 func (GetCustomDbRolesResultOutput) ElementType() reflect.Type {
@@ -107,6 +120,12 @@ func (o GetCustomDbRolesResultOutput) ToGetCustomDbRolesResultPtrOutputWithConte
 	}).(GetCustomDbRolesResultPtrOutput)
 }
 
+func (o GetCustomDbRolesResultOutput) ToOutput(ctx context.Context) pulumix.Output[GetCustomDbRolesResult] {
+	return pulumix.Output[GetCustomDbRolesResult]{
+		OutputState: o.OutputState,
+	}
+}
+
 type GetCustomDbRolesResultPtrOutput struct{ *pulumi.OutputState }
 
 func (GetCustomDbRolesResultPtrOutput) ElementType() reflect.Type {
@@ -119,6 +138,12 @@ func (o GetCustomDbRolesResultPtrOutput) ToGetCustomDbRolesResultPtrOutput() Get
 
 func (o GetCustomDbRolesResultPtrOutput) ToGetCustomDbRolesResultPtrOutputWithContext(ctx context.Context) GetCustomDbRolesResultPtrOutput {
 	return o
+}
+
+func (o GetCustomDbRolesResultPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*GetCustomDbRolesResult] {
+	return pulumix.Output[*GetCustomDbRolesResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GetCustomDbRolesResultPtrOutput) Elem() GetCustomDbRolesResultOutput {

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/provider.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-10527/world/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-10527/world/internal"
 )
 
@@ -44,6 +45,12 @@ func (i WorldArgs) ToWorldOutputWithContext(ctx context.Context) WorldOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(WorldOutput)
 }
 
+func (i WorldArgs) ToOutput(ctx context.Context) pulumix.Output[World] {
+	return pulumix.Output[World]{
+		OutputState: i.ToWorldOutputWithContext(ctx).OutputState,
+	}
+}
+
 type WorldOutput struct{ *pulumi.OutputState }
 
 func (WorldOutput) ElementType() reflect.Type {
@@ -56,6 +63,12 @@ func (o WorldOutput) ToWorldOutput() WorldOutput {
 
 func (o WorldOutput) ToWorldOutputWithContext(ctx context.Context) WorldOutput {
 	return o
+}
+
+func (o WorldOutput) ToOutput(ctx context.Context) pulumix.Output[World] {
+	return pulumix.Output[World]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o WorldOutput) Name() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/universe.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/universe.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-10527/world/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *Universe) ToUniverseOutputWithContext(ctx context.Context) UniverseOutp
 	return pulumi.ToOutputWithContext(ctx, i).(UniverseOutput)
 }
 
+func (i *Universe) ToOutput(ctx context.Context) pulumix.Output[*Universe] {
+	return pulumix.Output[*Universe]{
+		OutputState: i.ToUniverseOutputWithContext(ctx).OutputState,
+	}
+}
+
 type UniverseOutput struct{ *pulumi.OutputState }
 
 func (UniverseOutput) ElementType() reflect.Type {
@@ -98,6 +105,12 @@ func (o UniverseOutput) ToUniverseOutput() UniverseOutput {
 
 func (o UniverseOutput) ToUniverseOutputWithContext(ctx context.Context) UniverseOutput {
 	return o
+}
+
+func (o UniverseOutput) ToOutput(ctx context.Context) pulumix.Output[*Universe] {
+	return pulumix.Output[*Universe]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/worldMap.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/worldMap.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-10527/world/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *WorldMap) ToWorldMapOutputWithContext(ctx context.Context) WorldMapOutp
 	return pulumi.ToOutputWithContext(ctx, i).(WorldMapOutput)
 }
 
+func (i *WorldMap) ToOutput(ctx context.Context) pulumix.Output[*WorldMap] {
+	return pulumix.Output[*WorldMap]{
+		OutputState: i.ToWorldMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type WorldMapOutput struct{ *pulumi.OutputState }
 
 func (WorldMapOutput) ElementType() reflect.Type {
@@ -98,6 +105,12 @@ func (o WorldMapOutput) ToWorldMapOutput() WorldMapOutput {
 
 func (o WorldMapOutput) ToWorldMapOutputWithContext(ctx context.Context) WorldMapOutput {
 	return o
+}
+
+func (o WorldMapOutput) ToOutput(ctx context.Context) pulumix.Output[*WorldMap] {
+	return pulumix.Output[*WorldMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o WorldMapOutput) Name() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/regress-go-12971/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-12971/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-12971/example/internal"
 )
 
@@ -82,6 +83,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -94,6 +101,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-go-12971/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-12971/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-12971/example/internal"
 )
 
@@ -98,6 +99,12 @@ func (i WorldArgs) ToWorldOutputWithContext(ctx context.Context) WorldOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(WorldOutput)
 }
 
+func (i WorldArgs) ToOutput(ctx context.Context) pulumix.Output[World] {
+	return pulumix.Output[World]{
+		OutputState: i.ToWorldOutputWithContext(ctx).OutputState,
+	}
+}
+
 type WorldOutput struct{ *pulumi.OutputState }
 
 func (WorldOutput) ElementType() reflect.Type {
@@ -110,6 +117,12 @@ func (o WorldOutput) ToWorldOutput() WorldOutput {
 
 func (o WorldOutput) ToWorldOutputWithContext(ctx context.Context) WorldOutput {
 	return o
+}
+
+func (o WorldOutput) ToOutput(ctx context.Context) pulumix.Output[World] {
+	return pulumix.Output[World]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o WorldOutput) Name() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/conditionalAccessPolicy.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/conditionalAccessPolicy.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-8664/example/internal"
 )
 
@@ -94,6 +95,12 @@ func (i *ConditionalAccessPolicy) ToConditionalAccessPolicyOutputWithContext(ctx
 	return pulumi.ToOutputWithContext(ctx, i).(ConditionalAccessPolicyOutput)
 }
 
+func (i *ConditionalAccessPolicy) ToOutput(ctx context.Context) pulumix.Output[*ConditionalAccessPolicy] {
+	return pulumix.Output[*ConditionalAccessPolicy]{
+		OutputState: i.ToConditionalAccessPolicyOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConditionalAccessPolicyOutput struct{ *pulumi.OutputState }
 
 func (ConditionalAccessPolicyOutput) ElementType() reflect.Type {
@@ -106,6 +113,12 @@ func (o ConditionalAccessPolicyOutput) ToConditionalAccessPolicyOutput() Conditi
 
 func (o ConditionalAccessPolicyOutput) ToConditionalAccessPolicyOutputWithContext(ctx context.Context) ConditionalAccessPolicyOutput {
 	return o
+}
+
+func (o ConditionalAccessPolicyOutput) ToOutput(ctx context.Context) pulumix.Output[*ConditionalAccessPolicy] {
+	return pulumix.Output[*ConditionalAccessPolicy]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConditionalAccessPolicyOutput) Conditions() ConditionalAccessPolicyConditionsOutput {

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-8664/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-go-8664/example/internal"
 )
 
@@ -42,6 +43,12 @@ func (i ConditionalAccessPolicyConditionsArgs) ToConditionalAccessPolicyConditio
 
 func (i ConditionalAccessPolicyConditionsArgs) ToConditionalAccessPolicyConditionsOutputWithContext(ctx context.Context) ConditionalAccessPolicyConditionsOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ConditionalAccessPolicyConditionsOutput)
+}
+
+func (i ConditionalAccessPolicyConditionsArgs) ToOutput(ctx context.Context) pulumix.Output[ConditionalAccessPolicyConditions] {
+	return pulumix.Output[ConditionalAccessPolicyConditions]{
+		OutputState: i.ToConditionalAccessPolicyConditionsOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i ConditionalAccessPolicyConditionsArgs) ToConditionalAccessPolicyConditionsPtrOutput() ConditionalAccessPolicyConditionsPtrOutput {
@@ -85,6 +92,12 @@ func (i *conditionalAccessPolicyConditionsPtrType) ToConditionalAccessPolicyCond
 	return pulumi.ToOutputWithContext(ctx, i).(ConditionalAccessPolicyConditionsPtrOutput)
 }
 
+func (i *conditionalAccessPolicyConditionsPtrType) ToOutput(ctx context.Context) pulumix.Output[*ConditionalAccessPolicyConditions] {
+	return pulumix.Output[*ConditionalAccessPolicyConditions]{
+		OutputState: i.ToConditionalAccessPolicyConditionsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConditionalAccessPolicyConditionsOutput struct{ *pulumi.OutputState }
 
 func (ConditionalAccessPolicyConditionsOutput) ElementType() reflect.Type {
@@ -109,6 +122,12 @@ func (o ConditionalAccessPolicyConditionsOutput) ToConditionalAccessPolicyCondit
 	}).(ConditionalAccessPolicyConditionsPtrOutput)
 }
 
+func (o ConditionalAccessPolicyConditionsOutput) ToOutput(ctx context.Context) pulumix.Output[ConditionalAccessPolicyConditions] {
+	return pulumix.Output[ConditionalAccessPolicyConditions]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ConditionalAccessPolicyConditionsOutput) ClientAppTypes() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v ConditionalAccessPolicyConditions) []string { return v.ClientAppTypes }).(pulumi.StringArrayOutput)
 }
@@ -125,6 +144,12 @@ func (o ConditionalAccessPolicyConditionsPtrOutput) ToConditionalAccessPolicyCon
 
 func (o ConditionalAccessPolicyConditionsPtrOutput) ToConditionalAccessPolicyConditionsPtrOutputWithContext(ctx context.Context) ConditionalAccessPolicyConditionsPtrOutput {
 	return o
+}
+
+func (o ConditionalAccessPolicyConditionsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ConditionalAccessPolicyConditions] {
+	return pulumix.Output[*ConditionalAccessPolicyConditions]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConditionalAccessPolicyConditionsPtrOutput) Elem() ConditionalAccessPolicyConditionsOutput {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/provider.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-node-8110/my8110/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type MyEnum string
@@ -77,6 +78,12 @@ func (o MyEnumOutput) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPt
 	}).(MyEnumPtrOutput)
 }
 
+func (o MyEnumOutput) ToOutput(ctx context.Context) pulumix.Output[MyEnum] {
+	return pulumix.Output[MyEnum]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o MyEnumOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o MyEnumPtrOutput) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (o MyEnumPtrOutput) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return o
+}
+
+func (o MyEnumPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
+	return pulumix.Output[*MyEnum]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o MyEnumPtrOutput) Elem() MyEnumOutput {
@@ -172,6 +185,12 @@ func (in *myEnumPtr) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (in *myEnumPtr) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(MyEnumPtrOutput)
+}
+
+func (in *myEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
+	return pulumix.Output[*MyEnum]{
+		OutputState: in.ToMyEnumPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-node-8110/my8110/internal"
 )
 
@@ -44,6 +45,12 @@ func (i MyObjArgs) ToMyObjOutputWithContext(ctx context.Context) MyObjOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(MyObjOutput)
 }
 
+func (i MyObjArgs) ToOutput(ctx context.Context) pulumix.Output[MyObj] {
+	return pulumix.Output[MyObj]{
+		OutputState: i.ToMyObjOutputWithContext(ctx).OutputState,
+	}
+}
+
 type MyObjOutput struct{ *pulumi.OutputState }
 
 func (MyObjOutput) ElementType() reflect.Type {
@@ -56,6 +63,12 @@ func (o MyObjOutput) ToMyObjOutput() MyObjOutput {
 
 func (o MyObjOutput) ToMyObjOutputWithContext(ctx context.Context) MyObjOutput {
 	return o
+}
+
+func (o MyObjOutput) ToOutput(ctx context.Context) pulumix.Output[MyObj] {
+	return pulumix.Output[MyObj]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o MyObjOutput) A() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -103,6 +104,12 @@ func (i *Cat) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatOutput)
 }
 
+func (i *Cat) ToOutput(ctx context.Context) pulumix.Output[*Cat] {
+	return pulumix.Output[*Cat]{
+		OutputState: i.ToCatOutputWithContext(ctx).OutputState,
+	}
+}
+
 // CatArrayInput is an input type that accepts CatArray and CatArrayOutput values.
 // You can construct a concrete instance of `CatArrayInput` via:
 //
@@ -126,6 +133,12 @@ func (i CatArray) ToCatArrayOutput() CatArrayOutput {
 
 func (i CatArray) ToCatArrayOutputWithContext(ctx context.Context) CatArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatArrayOutput)
+}
+
+func (i CatArray) ToOutput(ctx context.Context) pulumix.Output[[]*Cat] {
+	return pulumix.Output[[]*Cat]{
+		OutputState: i.ToCatArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // CatMapInput is an input type that accepts CatMap and CatMapOutput values.
@@ -153,6 +166,12 @@ func (i CatMap) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatMapOutput)
 }
 
+func (i CatMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Cat] {
+	return pulumix.Output[map[string]*Cat]{
+		OutputState: i.ToCatMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type CatOutput struct{ *pulumi.OutputState }
 
 func (CatOutput) ElementType() reflect.Type {
@@ -165,6 +184,12 @@ func (o CatOutput) ToCatOutput() CatOutput {
 
 func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
+}
+
+func (o CatOutput) ToOutput(ctx context.Context) pulumix.Output[*Cat] {
+	return pulumix.Output[*Cat]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CatOutput) Foes() ToyMapOutput {
@@ -201,6 +226,12 @@ func (o CatArrayOutput) ToCatArrayOutputWithContext(ctx context.Context) CatArra
 	return o
 }
 
+func (o CatArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Cat] {
+	return pulumix.Output[[]*Cat]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o CatArrayOutput) Index(i pulumi.IntInput) CatOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Cat {
 		return vs[0].([]*Cat)[vs[1].(int)]
@@ -219,6 +250,12 @@ func (o CatMapOutput) ToCatMapOutput() CatMapOutput {
 
 func (o CatMapOutput) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 	return o
+}
+
+func (o CatMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Cat] {
+	return pulumix.Output[map[string]*Cat]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CatMapOutput) MapIndex(k pulumi.StringInput) CatOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/dog.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/dog.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -90,6 +91,12 @@ func (i *Dog) ToDogOutputWithContext(ctx context.Context) DogOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DogOutput)
 }
 
+func (i *Dog) ToOutput(ctx context.Context) pulumix.Output[*Dog] {
+	return pulumix.Output[*Dog]{
+		OutputState: i.ToDogOutputWithContext(ctx).OutputState,
+	}
+}
+
 // DogArrayInput is an input type that accepts DogArray and DogArrayOutput values.
 // You can construct a concrete instance of `DogArrayInput` via:
 //
@@ -113,6 +120,12 @@ func (i DogArray) ToDogArrayOutput() DogArrayOutput {
 
 func (i DogArray) ToDogArrayOutputWithContext(ctx context.Context) DogArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DogArrayOutput)
+}
+
+func (i DogArray) ToOutput(ctx context.Context) pulumix.Output[[]*Dog] {
+	return pulumix.Output[[]*Dog]{
+		OutputState: i.ToDogArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // DogMapInput is an input type that accepts DogMap and DogMapOutput values.
@@ -140,6 +153,12 @@ func (i DogMap) ToDogMapOutputWithContext(ctx context.Context) DogMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DogMapOutput)
 }
 
+func (i DogMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Dog] {
+	return pulumix.Output[map[string]*Dog]{
+		OutputState: i.ToDogMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type DogOutput struct{ *pulumi.OutputState }
 
 func (DogOutput) ElementType() reflect.Type {
@@ -152,6 +171,12 @@ func (o DogOutput) ToDogOutput() DogOutput {
 
 func (o DogOutput) ToDogOutputWithContext(ctx context.Context) DogOutput {
 	return o
+}
+
+func (o DogOutput) ToOutput(ctx context.Context) pulumix.Output[*Dog] {
+	return pulumix.Output[*Dog]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DogOutput) Bone() pulumi.StringPtrOutput {
@@ -172,6 +197,12 @@ func (o DogArrayOutput) ToDogArrayOutputWithContext(ctx context.Context) DogArra
 	return o
 }
 
+func (o DogArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Dog] {
+	return pulumix.Output[[]*Dog]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o DogArrayOutput) Index(i pulumi.IntInput) DogOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Dog {
 		return vs[0].([]*Dog)[vs[1].(int)]
@@ -190,6 +221,12 @@ func (o DogMapOutput) ToDogMapOutput() DogMapOutput {
 
 func (o DogMapOutput) ToDogMapOutputWithContext(ctx context.Context) DogMapOutput {
 	return o
+}
+
+func (o DogMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Dog] {
+	return pulumix.Output[map[string]*Dog]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DogMapOutput) MapIndex(k pulumi.StringInput) DogOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/god.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/god.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *God) ToGodOutputWithContext(ctx context.Context) GodOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(GodOutput)
 }
 
+func (i *God) ToOutput(ctx context.Context) pulumix.Output[*God] {
+	return pulumix.Output[*God]{
+		OutputState: i.ToGodOutputWithContext(ctx).OutputState,
+	}
+}
+
 // GodArrayInput is an input type that accepts GodArray and GodArrayOutput values.
 // You can construct a concrete instance of `GodArrayInput` via:
 //
@@ -109,6 +116,12 @@ func (i GodArray) ToGodArrayOutput() GodArrayOutput {
 
 func (i GodArray) ToGodArrayOutputWithContext(ctx context.Context) GodArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(GodArrayOutput)
+}
+
+func (i GodArray) ToOutput(ctx context.Context) pulumix.Output[[]*God] {
+	return pulumix.Output[[]*God]{
+		OutputState: i.ToGodArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // GodMapInput is an input type that accepts GodMap and GodMapOutput values.
@@ -136,6 +149,12 @@ func (i GodMap) ToGodMapOutputWithContext(ctx context.Context) GodMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(GodMapOutput)
 }
 
+func (i GodMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*God] {
+	return pulumix.Output[map[string]*God]{
+		OutputState: i.ToGodMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type GodOutput struct{ *pulumi.OutputState }
 
 func (GodOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o GodOutput) ToGodOutput() GodOutput {
 
 func (o GodOutput) ToGodOutputWithContext(ctx context.Context) GodOutput {
 	return o
+}
+
+func (o GodOutput) ToOutput(ctx context.Context) pulumix.Output[*God] {
+	return pulumix.Output[*God]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GodOutput) Backwards() DogOutput {
@@ -168,6 +193,12 @@ func (o GodArrayOutput) ToGodArrayOutputWithContext(ctx context.Context) GodArra
 	return o
 }
 
+func (o GodArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*God] {
+	return pulumix.Output[[]*God]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o GodArrayOutput) Index(i pulumi.IntInput) GodOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *God {
 		return vs[0].([]*God)[vs[1].(int)]
@@ -186,6 +217,12 @@ func (o GodMapOutput) ToGodMapOutput() GodMapOutput {
 
 func (o GodMapOutput) ToGodMapOutputWithContext(ctx context.Context) GodMapOutput {
 	return o
+}
+
+func (o GodMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*God] {
+	return pulumix.Output[map[string]*God]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o GodMapOutput) MapIndex(k pulumi.StringInput) GodOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/noRecursive.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/noRecursive.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -91,6 +92,12 @@ func (i *NoRecursive) ToNoRecursiveOutputWithContext(ctx context.Context) NoRecu
 	return pulumi.ToOutputWithContext(ctx, i).(NoRecursiveOutput)
 }
 
+func (i *NoRecursive) ToOutput(ctx context.Context) pulumix.Output[*NoRecursive] {
+	return pulumix.Output[*NoRecursive]{
+		OutputState: i.ToNoRecursiveOutputWithContext(ctx).OutputState,
+	}
+}
+
 // NoRecursiveArrayInput is an input type that accepts NoRecursiveArray and NoRecursiveArrayOutput values.
 // You can construct a concrete instance of `NoRecursiveArrayInput` via:
 //
@@ -114,6 +121,12 @@ func (i NoRecursiveArray) ToNoRecursiveArrayOutput() NoRecursiveArrayOutput {
 
 func (i NoRecursiveArray) ToNoRecursiveArrayOutputWithContext(ctx context.Context) NoRecursiveArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(NoRecursiveArrayOutput)
+}
+
+func (i NoRecursiveArray) ToOutput(ctx context.Context) pulumix.Output[[]*NoRecursive] {
+	return pulumix.Output[[]*NoRecursive]{
+		OutputState: i.ToNoRecursiveArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // NoRecursiveMapInput is an input type that accepts NoRecursiveMap and NoRecursiveMapOutput values.
@@ -141,6 +154,12 @@ func (i NoRecursiveMap) ToNoRecursiveMapOutputWithContext(ctx context.Context) N
 	return pulumi.ToOutputWithContext(ctx, i).(NoRecursiveMapOutput)
 }
 
+func (i NoRecursiveMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*NoRecursive] {
+	return pulumix.Output[map[string]*NoRecursive]{
+		OutputState: i.ToNoRecursiveMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type NoRecursiveOutput struct{ *pulumi.OutputState }
 
 func (NoRecursiveOutput) ElementType() reflect.Type {
@@ -153,6 +172,12 @@ func (o NoRecursiveOutput) ToNoRecursiveOutput() NoRecursiveOutput {
 
 func (o NoRecursiveOutput) ToNoRecursiveOutputWithContext(ctx context.Context) NoRecursiveOutput {
 	return o
+}
+
+func (o NoRecursiveOutput) ToOutput(ctx context.Context) pulumix.Output[*NoRecursive] {
+	return pulumix.Output[*NoRecursive]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o NoRecursiveOutput) Rec() RecPtrOutput {
@@ -177,6 +202,12 @@ func (o NoRecursiveArrayOutput) ToNoRecursiveArrayOutputWithContext(ctx context.
 	return o
 }
 
+func (o NoRecursiveArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*NoRecursive] {
+	return pulumix.Output[[]*NoRecursive]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o NoRecursiveArrayOutput) Index(i pulumi.IntInput) NoRecursiveOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *NoRecursive {
 		return vs[0].([]*NoRecursive)[vs[1].(int)]
@@ -195,6 +226,12 @@ func (o NoRecursiveMapOutput) ToNoRecursiveMapOutput() NoRecursiveMapOutput {
 
 func (o NoRecursiveMapOutput) ToNoRecursiveMapOutputWithContext(ctx context.Context) NoRecursiveMapOutput {
 	return o
+}
+
+func (o NoRecursiveMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*NoRecursive] {
+	return pulumix.Output[map[string]*NoRecursive]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o NoRecursiveMapOutput) MapIndex(k pulumi.StringInput) NoRecursiveOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ChewArgs) ToChewOutput() ChewOutput {
 
 func (i ChewArgs) ToChewOutputWithContext(ctx context.Context) ChewOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ChewOutput)
+}
+
+func (i ChewArgs) ToOutput(ctx context.Context) pulumix.Output[Chew] {
+	return pulumix.Output[Chew]{
+		OutputState: i.ToChewOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i ChewArgs) ToChewPtrOutput() ChewPtrOutput {
@@ -87,6 +94,12 @@ func (i *chewPtrType) ToChewPtrOutputWithContext(ctx context.Context) ChewPtrOut
 	return pulumi.ToOutputWithContext(ctx, i).(ChewPtrOutput)
 }
 
+func (i *chewPtrType) ToOutput(ctx context.Context) pulumix.Output[*Chew] {
+	return pulumix.Output[*Chew]{
+		OutputState: i.ToChewPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A toy for a dog
 type ChewOutput struct{ *pulumi.OutputState }
 
@@ -112,6 +125,12 @@ func (o ChewOutput) ToChewPtrOutputWithContext(ctx context.Context) ChewPtrOutpu
 	}).(ChewPtrOutput)
 }
 
+func (o ChewOutput) ToOutput(ctx context.Context) pulumix.Output[Chew] {
+	return pulumix.Output[Chew]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ChewOutput) Owner() DogOutput {
 	return o.ApplyT(func(v Chew) *Dog { return v.Owner }).(DogOutput)
 }
@@ -128,6 +147,12 @@ func (o ChewPtrOutput) ToChewPtrOutput() ChewPtrOutput {
 
 func (o ChewPtrOutput) ToChewPtrOutputWithContext(ctx context.Context) ChewPtrOutput {
 	return o
+}
+
+func (o ChewPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Chew] {
+	return pulumix.Output[*Chew]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ChewPtrOutput) Elem() ChewOutput {
@@ -186,6 +211,12 @@ func (i LaserArgs) ToLaserOutputWithContext(ctx context.Context) LaserOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(LaserOutput)
 }
 
+func (i LaserArgs) ToOutput(ctx context.Context) pulumix.Output[Laser] {
+	return pulumix.Output[Laser]{
+		OutputState: i.ToLaserOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i LaserArgs) ToLaserPtrOutput() LaserPtrOutput {
 	return i.ToLaserPtrOutputWithContext(context.Background())
 }
@@ -227,6 +258,12 @@ func (i *laserPtrType) ToLaserPtrOutputWithContext(ctx context.Context) LaserPtr
 	return pulumi.ToOutputWithContext(ctx, i).(LaserPtrOutput)
 }
 
+func (i *laserPtrType) ToOutput(ctx context.Context) pulumix.Output[*Laser] {
+	return pulumix.Output[*Laser]{
+		OutputState: i.ToLaserPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // A Toy for a cat
 type LaserOutput struct{ *pulumi.OutputState }
 
@@ -250,6 +287,12 @@ func (o LaserOutput) ToLaserPtrOutputWithContext(ctx context.Context) LaserPtrOu
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Laser) *Laser {
 		return &v
 	}).(LaserPtrOutput)
+}
+
+func (o LaserOutput) ToOutput(ctx context.Context) pulumix.Output[Laser] {
+	return pulumix.Output[Laser]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o LaserOutput) Animal() CatOutput {
@@ -276,6 +319,12 @@ func (o LaserPtrOutput) ToLaserPtrOutput() LaserPtrOutput {
 
 func (o LaserPtrOutput) ToLaserPtrOutputWithContext(ctx context.Context) LaserPtrOutput {
 	return o
+}
+
+func (o LaserPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Laser] {
+	return pulumix.Output[*Laser]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o LaserPtrOutput) Elem() LaserOutput {
@@ -346,6 +395,12 @@ func (i RecArgs) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RecOutput)
 }
 
+func (i RecArgs) ToOutput(ctx context.Context) pulumix.Output[Rec] {
+	return pulumix.Output[Rec]{
+		OutputState: i.ToRecOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i RecArgs) ToRecPtrOutput() RecPtrOutput {
 	return i.ToRecPtrOutputWithContext(context.Background())
 }
@@ -387,6 +442,12 @@ func (i *recPtrType) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(RecPtrOutput)
 }
 
+func (i *recPtrType) ToOutput(ctx context.Context) pulumix.Output[*Rec] {
+	return pulumix.Output[*Rec]{
+		OutputState: i.ToRecPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RecOutput struct{ *pulumi.OutputState }
 
 func (RecOutput) ElementType() reflect.Type {
@@ -411,6 +472,12 @@ func (o RecOutput) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
 	}).(RecPtrOutput)
 }
 
+func (o RecOutput) ToOutput(ctx context.Context) pulumix.Output[Rec] {
+	return pulumix.Output[Rec]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RecOutput) Rec1() RecPtrOutput {
 	return o.ApplyT(func(v Rec) *Rec { return v.Rec1 }).(RecPtrOutput)
 }
@@ -427,6 +494,12 @@ func (o RecPtrOutput) ToRecPtrOutput() RecPtrOutput {
 
 func (o RecPtrOutput) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
 	return o
+}
+
+func (o RecPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Rec] {
+	return pulumix.Output[*Rec]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RecPtrOutput) Elem() RecOutput {
@@ -485,6 +558,12 @@ func (i ToyArgs) ToToyOutputWithContext(ctx context.Context) ToyOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ToyOutput)
 }
 
+func (i ToyArgs) ToOutput(ctx context.Context) pulumix.Output[Toy] {
+	return pulumix.Output[Toy]{
+		OutputState: i.ToToyOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ToyArgs) ToToyPtrOutput() ToyPtrOutput {
 	return i.ToToyPtrOutputWithContext(context.Background())
 }
@@ -526,6 +605,12 @@ func (i *toyPtrType) ToToyPtrOutputWithContext(ctx context.Context) ToyPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(ToyPtrOutput)
 }
 
+func (i *toyPtrType) ToOutput(ctx context.Context) pulumix.Output[*Toy] {
+	return pulumix.Output[*Toy]{
+		OutputState: i.ToToyPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ToyArrayInput is an input type that accepts ToyArray and ToyArrayOutput values.
 // You can construct a concrete instance of `ToyArrayInput` via:
 //
@@ -549,6 +634,12 @@ func (i ToyArray) ToToyArrayOutput() ToyArrayOutput {
 
 func (i ToyArray) ToToyArrayOutputWithContext(ctx context.Context) ToyArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ToyArrayOutput)
+}
+
+func (i ToyArray) ToOutput(ctx context.Context) pulumix.Output[[]Toy] {
+	return pulumix.Output[[]Toy]{
+		OutputState: i.ToToyArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ToyMapInput is an input type that accepts ToyMap and ToyMapOutput values.
@@ -576,6 +667,12 @@ func (i ToyMap) ToToyMapOutputWithContext(ctx context.Context) ToyMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ToyMapOutput)
 }
 
+func (i ToyMap) ToOutput(ctx context.Context) pulumix.Output[map[string]Toy] {
+	return pulumix.Output[map[string]Toy]{
+		OutputState: i.ToToyMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 // This is a toy
 type ToyOutput struct{ *pulumi.OutputState }
 
@@ -599,6 +696,12 @@ func (o ToyOutput) ToToyPtrOutputWithContext(ctx context.Context) ToyPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Toy) *Toy {
 		return &v
 	}).(ToyPtrOutput)
+}
+
+func (o ToyOutput) ToOutput(ctx context.Context) pulumix.Output[Toy] {
+	return pulumix.Output[Toy]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ToyOutput) Associated() ToyPtrOutput {
@@ -625,6 +728,12 @@ func (o ToyPtrOutput) ToToyPtrOutput() ToyPtrOutput {
 
 func (o ToyPtrOutput) ToToyPtrOutputWithContext(ctx context.Context) ToyPtrOutput {
 	return o
+}
+
+func (o ToyPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Toy] {
+	return pulumix.Output[*Toy]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ToyPtrOutput) Elem() ToyOutput {
@@ -678,6 +787,12 @@ func (o ToyArrayOutput) ToToyArrayOutputWithContext(ctx context.Context) ToyArra
 	return o
 }
 
+func (o ToyArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Toy] {
+	return pulumix.Output[[]Toy]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ToyArrayOutput) Index(i pulumi.IntInput) ToyOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Toy {
 		return vs[0].([]Toy)[vs[1].(int)]
@@ -696,6 +811,12 @@ func (o ToyMapOutput) ToToyMapOutput() ToyMapOutput {
 
 func (o ToyMapOutput) ToToyMapOutputWithContext(ctx context.Context) ToyMapOutput {
 	return o
+}
+
+func (o ToyMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]Toy] {
+	return pulumix.Output[map[string]Toy]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ToyMapOutput) MapIndex(k pulumi.StringInput) ToyOutput {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/toyStore.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/toyStore.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"replace-on-change/example/internal"
 )
 
@@ -97,6 +98,12 @@ func (i *ToyStore) ToToyStoreOutputWithContext(ctx context.Context) ToyStoreOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ToyStoreOutput)
 }
 
+func (i *ToyStore) ToOutput(ctx context.Context) pulumix.Output[*ToyStore] {
+	return pulumix.Output[*ToyStore]{
+		OutputState: i.ToToyStoreOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ToyStoreArrayInput is an input type that accepts ToyStoreArray and ToyStoreArrayOutput values.
 // You can construct a concrete instance of `ToyStoreArrayInput` via:
 //
@@ -120,6 +127,12 @@ func (i ToyStoreArray) ToToyStoreArrayOutput() ToyStoreArrayOutput {
 
 func (i ToyStoreArray) ToToyStoreArrayOutputWithContext(ctx context.Context) ToyStoreArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ToyStoreArrayOutput)
+}
+
+func (i ToyStoreArray) ToOutput(ctx context.Context) pulumix.Output[[]*ToyStore] {
+	return pulumix.Output[[]*ToyStore]{
+		OutputState: i.ToToyStoreArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ToyStoreMapInput is an input type that accepts ToyStoreMap and ToyStoreMapOutput values.
@@ -147,6 +160,12 @@ func (i ToyStoreMap) ToToyStoreMapOutputWithContext(ctx context.Context) ToyStor
 	return pulumi.ToOutputWithContext(ctx, i).(ToyStoreMapOutput)
 }
 
+func (i ToyStoreMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*ToyStore] {
+	return pulumix.Output[map[string]*ToyStore]{
+		OutputState: i.ToToyStoreMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ToyStoreOutput struct{ *pulumi.OutputState }
 
 func (ToyStoreOutput) ElementType() reflect.Type {
@@ -159,6 +178,12 @@ func (o ToyStoreOutput) ToToyStoreOutput() ToyStoreOutput {
 
 func (o ToyStoreOutput) ToToyStoreOutputWithContext(ctx context.Context) ToyStoreOutput {
 	return o
+}
+
+func (o ToyStoreOutput) ToOutput(ctx context.Context) pulumix.Output[*ToyStore] {
+	return pulumix.Output[*ToyStore]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ToyStoreOutput) Chew() ChewPtrOutput {
@@ -191,6 +216,12 @@ func (o ToyStoreArrayOutput) ToToyStoreArrayOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o ToyStoreArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*ToyStore] {
+	return pulumix.Output[[]*ToyStore]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ToyStoreArrayOutput) Index(i pulumi.IntInput) ToyStoreOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *ToyStore {
 		return vs[0].([]*ToyStore)[vs[1].(int)]
@@ -209,6 +240,12 @@ func (o ToyStoreMapOutput) ToToyStoreMapOutput() ToyStoreMapOutput {
 
 func (o ToyStoreMapOutput) ToToyStoreMapOutputWithContext(ctx context.Context) ToyStoreMapOutput {
 	return o
+}
+
+func (o ToyStoreMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*ToyStore] {
+	return pulumix.Output[map[string]*ToyStore]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ToyStoreMapOutput) MapIndex(k pulumi.StringInput) ToyStoreOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python-case-insensitive/example/internal"
 )
 
@@ -91,6 +92,12 @@ func (i *Person) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonOutput)
 }
 
+func (i *Person) ToOutput(ctx context.Context) pulumix.Output[*Person] {
+	return pulumix.Output[*Person]{
+		OutputState: i.ToPersonOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PersonArrayInput is an input type that accepts PersonArray and PersonArrayOutput values.
 // You can construct a concrete instance of `PersonArrayInput` via:
 //
@@ -114,6 +121,12 @@ func (i PersonArray) ToPersonArrayOutput() PersonArrayOutput {
 
 func (i PersonArray) ToPersonArrayOutputWithContext(ctx context.Context) PersonArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonArrayOutput)
+}
+
+func (i PersonArray) ToOutput(ctx context.Context) pulumix.Output[[]*Person] {
+	return pulumix.Output[[]*Person]{
+		OutputState: i.ToPersonArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // PersonMapInput is an input type that accepts PersonMap and PersonMapOutput values.
@@ -141,6 +154,12 @@ func (i PersonMap) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOu
 	return pulumi.ToOutputWithContext(ctx, i).(PersonMapOutput)
 }
 
+func (i PersonMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Person] {
+	return pulumix.Output[map[string]*Person]{
+		OutputState: i.ToPersonMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PersonOutput struct{ *pulumi.OutputState }
 
 func (PersonOutput) ElementType() reflect.Type {
@@ -153,6 +172,12 @@ func (o PersonOutput) ToPersonOutput() PersonOutput {
 
 func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return o
+}
+
+func (o PersonOutput) ToOutput(ctx context.Context) pulumix.Output[*Person] {
+	return pulumix.Output[*Person]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PersonOutput) Name() pulumi.StringPtrOutput {
@@ -177,6 +202,12 @@ func (o PersonArrayOutput) ToPersonArrayOutputWithContext(ctx context.Context) P
 	return o
 }
 
+func (o PersonArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Person] {
+	return pulumix.Output[[]*Person]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o PersonArrayOutput) Index(i pulumi.IntInput) PersonOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Person {
 		return vs[0].([]*Person)[vs[1].(int)]
@@ -195,6 +226,12 @@ func (o PersonMapOutput) ToPersonMapOutput() PersonMapOutput {
 
 func (o PersonMapOutput) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOutput {
 	return o
+}
+
+func (o PersonMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Person] {
+	return pulumix.Output[map[string]*Person]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PersonMapOutput) MapIndex(k pulumi.StringInput) PersonOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python-case-insensitive/example/internal"
 )
 
@@ -88,6 +89,12 @@ func (i *Pet) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetOutput)
 }
 
+func (i *Pet) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: i.ToPetOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PetArrayInput is an input type that accepts PetArray and PetArrayOutput values.
 // You can construct a concrete instance of `PetArrayInput` via:
 //
@@ -111,6 +118,12 @@ func (i PetArray) ToPetArrayOutput() PetArrayOutput {
 
 func (i PetArray) ToPetArrayOutputWithContext(ctx context.Context) PetArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetArrayOutput)
+}
+
+func (i PetArray) ToOutput(ctx context.Context) pulumix.Output[[]*Pet] {
+	return pulumix.Output[[]*Pet]{
+		OutputState: i.ToPetArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // PetMapInput is an input type that accepts PetMap and PetMapOutput values.
@@ -138,6 +151,12 @@ func (i PetMap) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetMapOutput)
 }
 
+func (i PetMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Pet] {
+	return pulumix.Output[map[string]*Pet]{
+		OutputState: i.ToPetMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
@@ -150,6 +169,12 @@ func (o PetOutput) ToPetOutput() PetOutput {
 
 func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
+}
+
+func (o PetOutput) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetOutput) Name() pulumi.StringPtrOutput {
@@ -170,6 +195,12 @@ func (o PetArrayOutput) ToPetArrayOutputWithContext(ctx context.Context) PetArra
 	return o
 }
 
+func (o PetArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Pet] {
+	return pulumix.Output[[]*Pet]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o PetArrayOutput) Index(i pulumi.IntInput) PetOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Pet {
 		return vs[0].([]*Pet)[vs[1].(int)]
@@ -188,6 +219,12 @@ func (o PetMapOutput) ToPetMapOutput() PetMapOutput {
 
 func (o PetMapOutput) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 	return o
+}
+
+func (o PetMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Pet] {
+	return pulumix.Output[map[string]*Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetMapOutput) MapIndex(k pulumi.StringInput) PetOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python-case-insensitive/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python-case-insensitive/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i PetTypeArgs) ToPetTypeOutputWithContext(ctx context.Context) PetTypeOutp
 	return pulumi.ToOutputWithContext(ctx, i).(PetTypeOutput)
 }
 
+func (i PetTypeArgs) ToOutput(ctx context.Context) pulumix.Output[PetType] {
+	return pulumix.Output[PetType]{
+		OutputState: i.ToPetTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PetTypeArrayInput is an input type that accepts PetTypeArray and PetTypeArrayOutput values.
 // You can construct a concrete instance of `PetTypeArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i PetTypeArray) ToPetTypeArrayOutputWithContext(ctx context.Context) PetTy
 	return pulumi.ToOutputWithContext(ctx, i).(PetTypeArrayOutput)
 }
 
+func (i PetTypeArray) ToOutput(ctx context.Context) pulumix.Output[[]PetType] {
+	return pulumix.Output[[]PetType]{
+		OutputState: i.ToPetTypeArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PetTypeOutput struct{ *pulumi.OutputState }
 
 func (PetTypeOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o PetTypeOutput) ToPetTypeOutput() PetTypeOutput {
 
 func (o PetTypeOutput) ToPetTypeOutputWithContext(ctx context.Context) PetTypeOutput {
 	return o
+}
+
+func (o PetTypeOutput) ToOutput(ctx context.Context) pulumix.Output[PetType] {
+	return pulumix.Output[PetType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetTypeOutput) Name() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o PetTypeArrayOutput) ToPetTypeArrayOutput() PetTypeArrayOutput {
 
 func (o PetTypeArrayOutput) ToPetTypeArrayOutputWithContext(ctx context.Context) PetTypeArrayOutput {
 	return o
+}
+
+func (o PetTypeArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]PetType] {
+	return pulumix.Output[[]PetType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetTypeArrayOutput) Index(i pulumi.IntInput) PetTypeOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python/example/internal"
 )
 
@@ -91,6 +92,12 @@ func (i *Person) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonOutput)
 }
 
+func (i *Person) ToOutput(ctx context.Context) pulumix.Output[*Person] {
+	return pulumix.Output[*Person]{
+		OutputState: i.ToPersonOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PersonArrayInput is an input type that accepts PersonArray and PersonArrayOutput values.
 // You can construct a concrete instance of `PersonArrayInput` via:
 //
@@ -114,6 +121,12 @@ func (i PersonArray) ToPersonArrayOutput() PersonArrayOutput {
 
 func (i PersonArray) ToPersonArrayOutputWithContext(ctx context.Context) PersonArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonArrayOutput)
+}
+
+func (i PersonArray) ToOutput(ctx context.Context) pulumix.Output[[]*Person] {
+	return pulumix.Output[[]*Person]{
+		OutputState: i.ToPersonArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // PersonMapInput is an input type that accepts PersonMap and PersonMapOutput values.
@@ -141,6 +154,12 @@ func (i PersonMap) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOu
 	return pulumi.ToOutputWithContext(ctx, i).(PersonMapOutput)
 }
 
+func (i PersonMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Person] {
+	return pulumix.Output[map[string]*Person]{
+		OutputState: i.ToPersonMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PersonOutput struct{ *pulumi.OutputState }
 
 func (PersonOutput) ElementType() reflect.Type {
@@ -153,6 +172,12 @@ func (o PersonOutput) ToPersonOutput() PersonOutput {
 
 func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return o
+}
+
+func (o PersonOutput) ToOutput(ctx context.Context) pulumix.Output[*Person] {
+	return pulumix.Output[*Person]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PersonOutput) Name() pulumi.StringPtrOutput {
@@ -177,6 +202,12 @@ func (o PersonArrayOutput) ToPersonArrayOutputWithContext(ctx context.Context) P
 	return o
 }
 
+func (o PersonArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Person] {
+	return pulumix.Output[[]*Person]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o PersonArrayOutput) Index(i pulumi.IntInput) PersonOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Person {
 		return vs[0].([]*Person)[vs[1].(int)]
@@ -195,6 +226,12 @@ func (o PersonMapOutput) ToPersonMapOutput() PersonMapOutput {
 
 func (o PersonMapOutput) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOutput {
 	return o
+}
+
+func (o PersonMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Person] {
+	return pulumix.Output[map[string]*Person]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PersonMapOutput) MapIndex(k pulumi.StringInput) PersonOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python/example/internal"
 )
 
@@ -88,6 +89,12 @@ func (i *Pet) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetOutput)
 }
 
+func (i *Pet) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: i.ToPetOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PetArrayInput is an input type that accepts PetArray and PetArrayOutput values.
 // You can construct a concrete instance of `PetArrayInput` via:
 //
@@ -111,6 +118,12 @@ func (i PetArray) ToPetArrayOutput() PetArrayOutput {
 
 func (i PetArray) ToPetArrayOutputWithContext(ctx context.Context) PetArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetArrayOutput)
+}
+
+func (i PetArray) ToOutput(ctx context.Context) pulumix.Output[[]*Pet] {
+	return pulumix.Output[[]*Pet]{
+		OutputState: i.ToPetArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // PetMapInput is an input type that accepts PetMap and PetMapOutput values.
@@ -138,6 +151,12 @@ func (i PetMap) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetMapOutput)
 }
 
+func (i PetMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Pet] {
+	return pulumix.Output[map[string]*Pet]{
+		OutputState: i.ToPetMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
@@ -150,6 +169,12 @@ func (o PetOutput) ToPetOutput() PetOutput {
 
 func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
+}
+
+func (o PetOutput) ToOutput(ctx context.Context) pulumix.Output[*Pet] {
+	return pulumix.Output[*Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetOutput) Name() pulumi.StringPtrOutput {
@@ -170,6 +195,12 @@ func (o PetArrayOutput) ToPetArrayOutputWithContext(ctx context.Context) PetArra
 	return o
 }
 
+func (o PetArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Pet] {
+	return pulumix.Output[[]*Pet]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o PetArrayOutput) Index(i pulumi.IntInput) PetOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Pet {
 		return vs[0].([]*Pet)[vs[1].(int)]
@@ -188,6 +219,12 @@ func (o PetMapOutput) ToPetMapOutput() PetMapOutput {
 
 func (o PetMapOutput) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 	return o
+}
+
+func (o PetMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Pet] {
+	return pulumix.Output[map[string]*Pet]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetMapOutput) MapIndex(k pulumi.StringInput) PetOutput {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-args-python/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i PetTypeArgs) ToPetTypeOutputWithContext(ctx context.Context) PetTypeOutp
 	return pulumi.ToOutputWithContext(ctx, i).(PetTypeOutput)
 }
 
+func (i PetTypeArgs) ToOutput(ctx context.Context) pulumix.Output[PetType] {
+	return pulumix.Output[PetType]{
+		OutputState: i.ToPetTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 // PetTypeArrayInput is an input type that accepts PetTypeArray and PetTypeArrayOutput values.
 // You can construct a concrete instance of `PetTypeArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i PetTypeArray) ToPetTypeArrayOutputWithContext(ctx context.Context) PetTy
 	return pulumi.ToOutputWithContext(ctx, i).(PetTypeArrayOutput)
 }
 
+func (i PetTypeArray) ToOutput(ctx context.Context) pulumix.Output[[]PetType] {
+	return pulumix.Output[[]PetType]{
+		OutputState: i.ToPetTypeArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type PetTypeOutput struct{ *pulumi.OutputState }
 
 func (PetTypeOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o PetTypeOutput) ToPetTypeOutput() PetTypeOutput {
 
 func (o PetTypeOutput) ToPetTypeOutputWithContext(ctx context.Context) PetTypeOutput {
 	return o
+}
+
+func (o PetTypeOutput) ToOutput(ctx context.Context) pulumix.Output[PetType] {
+	return pulumix.Output[PetType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetTypeOutput) Name() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o PetTypeArrayOutput) ToPetTypeArrayOutput() PetTypeArrayOutput {
 
 func (o PetTypeArrayOutput) ToPetTypeArrayOutputWithContext(ctx context.Context) PetTypeArrayOutput {
 	return o
+}
+
+func (o PetTypeArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]PetType] {
+	return pulumix.Output[[]PetType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o PetTypeArrayOutput) Index(i pulumi.IntInput) PetTypeOutput {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-property-overlap/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/rec.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/rec.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"resource-property-overlap/example/internal"
 )
 
@@ -86,6 +87,12 @@ func (i *Rec) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RecOutput)
 }
 
+func (i *Rec) ToOutput(ctx context.Context) pulumix.Output[*Rec] {
+	return pulumix.Output[*Rec]{
+		OutputState: i.ToRecOutputWithContext(ctx).OutputState,
+	}
+}
+
 // RecArrayInput is an input type that accepts RecArray and RecArrayOutput values.
 // You can construct a concrete instance of `RecArrayInput` via:
 //
@@ -109,6 +116,12 @@ func (i RecArray) ToRecArrayOutput() RecArrayOutput {
 
 func (i RecArray) ToRecArrayOutputWithContext(ctx context.Context) RecArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RecArrayOutput)
+}
+
+func (i RecArray) ToOutput(ctx context.Context) pulumix.Output[[]*Rec] {
+	return pulumix.Output[[]*Rec]{
+		OutputState: i.ToRecArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // RecMapInput is an input type that accepts RecMap and RecMapOutput values.
@@ -136,6 +149,12 @@ func (i RecMap) ToRecMapOutputWithContext(ctx context.Context) RecMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RecMapOutput)
 }
 
+func (i RecMap) ToOutput(ctx context.Context) pulumix.Output[map[string]*Rec] {
+	return pulumix.Output[map[string]*Rec]{
+		OutputState: i.ToRecMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RecOutput struct{ *pulumi.OutputState }
 
 func (RecOutput) ElementType() reflect.Type {
@@ -148,6 +167,12 @@ func (o RecOutput) ToRecOutput() RecOutput {
 
 func (o RecOutput) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return o
+}
+
+func (o RecOutput) ToOutput(ctx context.Context) pulumix.Output[*Rec] {
+	return pulumix.Output[*Rec]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RecOutput) Rec() RecOutput {
@@ -168,6 +193,12 @@ func (o RecArrayOutput) ToRecArrayOutputWithContext(ctx context.Context) RecArra
 	return o
 }
 
+func (o RecArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]*Rec] {
+	return pulumix.Output[[]*Rec]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RecArrayOutput) Index(i pulumi.IntInput) RecOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Rec {
 		return vs[0].([]*Rec)[vs[1].(int)]
@@ -186,6 +217,12 @@ func (o RecMapOutput) ToRecMapOutput() RecMapOutput {
 
 func (o RecMapOutput) ToRecMapOutputWithContext(ctx context.Context) RecMapOutput {
 	return o
+}
+
+func (o RecMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]*Rec] {
+	return pulumix.Output[map[string]*Rec]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RecMapOutput) MapIndex(k pulumi.StringInput) RecOutput {

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/provider.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"secrets/mypkg/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"secrets/mypkg/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ConfigArgs) ToConfigOutputWithContext(ctx context.Context) ConfigOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigOutput)
 }
 
+func (i ConfigArgs) ToOutput(ctx context.Context) pulumix.Output[Config] {
+	return pulumix.Output[Config]{
+		OutputState: i.ToConfigOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigArrayInput is an input type that accepts ConfigArray and ConfigArrayOutput values.
 // You can construct a concrete instance of `ConfigArrayInput` via:
 //
@@ -67,6 +74,12 @@ func (i ConfigArray) ToConfigArrayOutput() ConfigArrayOutput {
 
 func (i ConfigArray) ToConfigArrayOutputWithContext(ctx context.Context) ConfigArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigArrayOutput)
+}
+
+func (i ConfigArray) ToOutput(ctx context.Context) pulumix.Output[[]Config] {
+	return pulumix.Output[[]Config]{
+		OutputState: i.ToConfigArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // ConfigMapInput is an input type that accepts ConfigMap and ConfigMapOutput values.
@@ -94,6 +107,12 @@ func (i ConfigMap) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOu
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapOutput)
 }
 
+func (i ConfigMap) ToOutput(ctx context.Context) pulumix.Output[map[string]Config] {
+	return pulumix.Output[map[string]Config]{
+		OutputState: i.ToConfigMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConfigOutput struct{ *pulumi.OutputState }
 
 func (ConfigOutput) ElementType() reflect.Type {
@@ -106,6 +125,12 @@ func (o ConfigOutput) ToConfigOutput() ConfigOutput {
 
 func (o ConfigOutput) ToConfigOutputWithContext(ctx context.Context) ConfigOutput {
 	return o
+}
+
+func (o ConfigOutput) ToOutput(ctx context.Context) pulumix.Output[Config] {
+	return pulumix.Output[Config]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigOutput) Foo() pulumi.StringPtrOutput {
@@ -126,6 +151,12 @@ func (o ConfigArrayOutput) ToConfigArrayOutputWithContext(ctx context.Context) C
 	return o
 }
 
+func (o ConfigArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Config] {
+	return pulumix.Output[[]Config]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ConfigArrayOutput) Index(i pulumi.IntInput) ConfigOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Config {
 		return vs[0].([]Config)[vs[1].(int)]
@@ -144,6 +175,12 @@ func (o ConfigMapOutput) ToConfigMapOutput() ConfigMapOutput {
 
 func (o ConfigMapOutput) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOutput {
 	return o
+}
+
+func (o ConfigMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]Config] {
+	return pulumix.Output[map[string]Config]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapOutput) MapIndex(k pulumi.StringInput) ConfigOutput {

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"secrets/mypkg/internal"
 )
 
@@ -149,6 +150,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -161,6 +168,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Config() ConfigOutput {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-enum-schema/plant/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -85,6 +86,12 @@ func (o CloudAuditOptionsLogNameOutput) ToCloudAuditOptionsLogNamePtrOutputWithC
 	}).(CloudAuditOptionsLogNamePtrOutput)
 }
 
+func (o CloudAuditOptionsLogNameOutput) ToOutput(ctx context.Context) pulumix.Output[CloudAuditOptionsLogName] {
+	return pulumix.Output[CloudAuditOptionsLogName]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o CloudAuditOptionsLogNameOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -118,6 +125,12 @@ func (o CloudAuditOptionsLogNamePtrOutput) ToCloudAuditOptionsLogNamePtrOutput()
 
 func (o CloudAuditOptionsLogNamePtrOutput) ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx context.Context) CloudAuditOptionsLogNamePtrOutput {
 	return o
+}
+
+func (o CloudAuditOptionsLogNamePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*CloudAuditOptionsLogName] {
+	return pulumix.Output[*CloudAuditOptionsLogName]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o CloudAuditOptionsLogNamePtrOutput) Elem() CloudAuditOptionsLogNameOutput {
@@ -180,6 +193,12 @@ func (in *cloudAuditOptionsLogNamePtr) ToCloudAuditOptionsLogNamePtrOutput() Clo
 
 func (in *cloudAuditOptionsLogNamePtr) ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx context.Context) CloudAuditOptionsLogNamePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(CloudAuditOptionsLogNamePtrOutput)
+}
+
+func (in *cloudAuditOptionsLogNamePtr) ToOutput(ctx context.Context) pulumix.Output[*CloudAuditOptionsLogName] {
+	return pulumix.Output[*CloudAuditOptionsLogName]{
+		OutputState: in.ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type ContainerBrightness float64
@@ -249,6 +268,12 @@ func (o ContainerBrightnessOutput) ToContainerBrightnessPtrOutputWithContext(ctx
 	}).(ContainerBrightnessPtrOutput)
 }
 
+func (o ContainerBrightnessOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerBrightness] {
+	return pulumix.Output[ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerBrightnessOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -282,6 +307,12 @@ func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutput() Container
 
 func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return o
+}
+
+func (o ContainerBrightnessPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerBrightnessPtrOutput) Elem() ContainerBrightnessOutput {
@@ -344,6 +375,12 @@ func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutput() ContainerBrig
 
 func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerBrightnessPtrOutput)
+}
+
+func (in *containerBrightnessPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
+	return pulumix.Output[*ContainerBrightness]{
+		OutputState: in.ToContainerBrightnessPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // plant container colors
@@ -415,6 +452,12 @@ func (o ContainerColorOutput) ToContainerColorPtrOutputWithContext(ctx context.C
 	}).(ContainerColorPtrOutput)
 }
 
+func (o ContainerColorOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerColor] {
+	return pulumix.Output[ContainerColor]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerColorOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -448,6 +491,12 @@ func (o ContainerColorPtrOutput) ToContainerColorPtrOutput() ContainerColorPtrOu
 
 func (o ContainerColorPtrOutput) ToContainerColorPtrOutputWithContext(ctx context.Context) ContainerColorPtrOutput {
 	return o
+}
+
+func (o ContainerColorPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
+	return pulumix.Output[*ContainerColor]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerColorPtrOutput) Elem() ContainerColorOutput {
@@ -510,6 +559,12 @@ func (in *containerColorPtr) ToContainerColorPtrOutput() ContainerColorPtrOutput
 
 func (in *containerColorPtr) ToContainerColorPtrOutputWithContext(ctx context.Context) ContainerColorPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerColorPtrOutput)
+}
+
+func (in *containerColorPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
+	return pulumix.Output[*ContainerColor]{
+		OutputState: in.ToContainerColorPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // plant container sizes
@@ -582,6 +637,12 @@ func (o ContainerSizeOutput) ToContainerSizePtrOutputWithContext(ctx context.Con
 	}).(ContainerSizePtrOutput)
 }
 
+func (o ContainerSizeOutput) ToOutput(ctx context.Context) pulumix.Output[ContainerSize] {
+	return pulumix.Output[ContainerSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ContainerSizeOutput) ToIntOutput() pulumi.IntOutput {
 	return o.ToIntOutputWithContext(context.Background())
 }
@@ -615,6 +676,12 @@ func (o ContainerSizePtrOutput) ToContainerSizePtrOutput() ContainerSizePtrOutpu
 
 func (o ContainerSizePtrOutput) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return o
+}
+
+func (o ContainerSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerSizePtrOutput) Elem() ContainerSizeOutput {
@@ -677,6 +744,12 @@ func (in *containerSizePtr) ToContainerSizePtrOutput() ContainerSizePtrOutput {
 
 func (in *containerSizePtr) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerSizePtrOutput)
+}
+
+func (in *containerSizePtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
+	return pulumix.Output[*ContainerSize]{
+		OutputState: in.ToContainerSizePtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-enum-schema/plant/internal"
 )
 
@@ -74,6 +75,12 @@ func (i ContainerArgs) ToContainerOutputWithContext(ctx context.Context) Contain
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput)
 }
 
+func (i ContainerArgs) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: i.ToContainerOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ContainerArgs) ToContainerPtrOutput() ContainerPtrOutput {
 	return i.ToContainerPtrOutputWithContext(context.Background())
 }
@@ -115,6 +122,12 @@ func (i *containerPtrType) ToContainerPtrOutputWithContext(ctx context.Context) 
 	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
 }
 
+func (i *containerPtrType) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: i.ToContainerPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ContainerOutput struct{ *pulumi.OutputState }
 
 func (ContainerOutput) ElementType() reflect.Type {
@@ -137,6 +150,12 @@ func (o ContainerOutput) ToContainerPtrOutputWithContext(ctx context.Context) Co
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Container) *Container {
 		return &v
 	}).(ContainerPtrOutput)
+}
+
+func (o ContainerOutput) ToOutput(ctx context.Context) pulumix.Output[Container] {
+	return pulumix.Output[Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerOutput) Brightness() ContainerBrightnessPtrOutput {
@@ -167,6 +186,12 @@ func (o ContainerPtrOutput) ToContainerPtrOutput() ContainerPtrOutput {
 
 func (o ContainerPtrOutput) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
 	return o
+}
+
+func (o ContainerPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Container] {
+	return pulumix.Output[*Container]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ContainerPtrOutput) Elem() ContainerOutput {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-enum-schema/plant/internal"
 )
 
@@ -96,6 +97,12 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(NurseryOutput)
 }
 
+func (i *Nursery) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: i.ToNurseryOutputWithContext(ctx).OutputState,
+	}
+}
+
 type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
@@ -108,6 +115,12 @@ func (o NurseryOutput) ToNurseryOutput() NurseryOutput {
 
 func (o NurseryOutput) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput {
 	return o
+}
+
+func (o NurseryOutput) ToOutput(ctx context.Context) pulumix.Output[*Nursery] {
+	return pulumix.Output[*Nursery]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Diameter float64
@@ -77,6 +78,12 @@ func (o DiameterOutput) ToDiameterPtrOutputWithContext(ctx context.Context) Diam
 	}).(DiameterPtrOutput)
 }
 
+func (o DiameterOutput) ToOutput(ctx context.Context) pulumix.Output[Diameter] {
+	return pulumix.Output[Diameter]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o DiameterOutput) ToFloat64Output() pulumi.Float64Output {
 	return o.ToFloat64OutputWithContext(context.Background())
 }
@@ -110,6 +117,12 @@ func (o DiameterPtrOutput) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (o DiameterPtrOutput) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return o
+}
+
+func (o DiameterPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o DiameterPtrOutput) Elem() DiameterOutput {
@@ -172,6 +185,12 @@ func (in *diameterPtr) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (in *diameterPtr) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(DiameterPtrOutput)
+}
+
+func (in *diameterPtr) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
+	return pulumix.Output[*Diameter]{
+		OutputState: in.ToDiameterPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 type Farm string
@@ -241,6 +260,12 @@ func (o FarmOutput) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutpu
 	}).(FarmPtrOutput)
 }
 
+func (o FarmOutput) ToOutput(ctx context.Context) pulumix.Output[Farm] {
+	return pulumix.Output[Farm]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FarmOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -274,6 +299,12 @@ func (o FarmPtrOutput) ToFarmPtrOutput() FarmPtrOutput {
 
 func (o FarmPtrOutput) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return o
+}
+
+func (o FarmPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
+	return pulumix.Output[*Farm]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FarmPtrOutput) Elem() FarmOutput {
@@ -336,6 +367,12 @@ func (in *farmPtr) ToFarmPtrOutput() FarmPtrOutput {
 
 func (in *farmPtr) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(FarmPtrOutput)
+}
+
+func (in *farmPtr) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
+	return pulumix.Output[*Farm]{
+		OutputState: in.ToFarmPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 // types of rubber trees
@@ -410,6 +447,12 @@ func (o RubberTreeVarietyOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx con
 	}).(RubberTreeVarietyPtrOutput)
 }
 
+func (o RubberTreeVarietyOutput) ToOutput(ctx context.Context) pulumix.Output[RubberTreeVariety] {
+	return pulumix.Output[RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RubberTreeVarietyOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -443,6 +486,12 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
@@ -507,6 +556,12 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx cont
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
 }
 
+func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // RubberTreeVarietyArrayInput is an input type that accepts RubberTreeVarietyArray and RubberTreeVarietyArrayOutput values.
 // You can construct a concrete instance of `RubberTreeVarietyArrayInput` via:
 //
@@ -532,6 +587,12 @@ func (i RubberTreeVarietyArray) ToRubberTreeVarietyArrayOutputWithContext(ctx co
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeVarietyArrayOutput)
 }
 
+func (i RubberTreeVarietyArray) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: i.ToRubberTreeVarietyArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeVarietyArrayOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeVarietyArrayOutput) ElementType() reflect.Type {
@@ -544,6 +605,12 @@ func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutput() RubberTre
 
 func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutputWithContext(ctx context.Context) RubberTreeVarietyArrayOutput {
 	return o
+}
+
+func (o RubberTreeVarietyArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]RubberTreeVariety] {
+	return pulumix.Output[[]RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyArrayOutput) Index(i pulumi.IntInput) RubberTreeVarietyOutput {
@@ -620,6 +687,12 @@ func (o TreeSizeOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) Tree
 	}).(TreeSizePtrOutput)
 }
 
+func (o TreeSizeOutput) ToOutput(ctx context.Context) pulumix.Output[TreeSize] {
+	return pulumix.Output[TreeSize]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o TreeSizeOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -653,6 +726,12 @@ func (o TreeSizePtrOutput) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (o TreeSizePtrOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return o
+}
+
+func (o TreeSizePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizePtrOutput) Elem() TreeSizeOutput {
@@ -717,6 +796,12 @@ func (in *treeSizePtr) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeS
 	return pulumi.ToOutputWithContext(ctx, in).(TreeSizePtrOutput)
 }
 
+func (in *treeSizePtr) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
+	return pulumix.Output[*TreeSize]{
+		OutputState: in.ToTreeSizePtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // TreeSizeMapInput is an input type that accepts TreeSizeMap and TreeSizeMapOutput values.
 // You can construct a concrete instance of `TreeSizeMapInput` via:
 //
@@ -742,6 +827,12 @@ func (i TreeSizeMap) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSiz
 	return pulumi.ToOutputWithContext(ctx, i).(TreeSizeMapOutput)
 }
 
+func (i TreeSizeMap) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: i.ToTreeSizeMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TreeSizeMapOutput struct{ *pulumi.OutputState }
 
 func (TreeSizeMapOutput) ElementType() reflect.Type {
@@ -754,6 +845,12 @@ func (o TreeSizeMapOutput) ToTreeSizeMapOutput() TreeSizeMapOutput {
 
 func (o TreeSizeMapOutput) ToTreeSizeMapOutputWithContext(ctx context.Context) TreeSizeMapOutput {
 	return o
+}
+
+func (o TreeSizeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]TreeSize] {
+	return pulumix.Output[map[string]TreeSize]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TreeSizeMapOutput) MapIndex(k pulumi.StringInput) TreeSizeOutput {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-enum-schema/plant"
 	"simple-enum-schema/plant/internal"
 )
@@ -119,6 +120,12 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeOutput)
 }
 
+func (i *RubberTree) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: i.ToRubberTreeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
@@ -131,6 +138,12 @@ func (o RubberTreeOutput) ToRubberTreeOutput() RubberTreeOutput {
 
 func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) RubberTreeOutput {
 	return o
+}
+
+func (o RubberTreeOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTree] {
+	return pulumix.Output[*RubberTree]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeOutput) Container() plant.ContainerPtrOutput {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-methods-schema-single-value-returns/example/internal"
 )
 
@@ -98,6 +99,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -110,6 +117,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-methods-schema-single-value-returns/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test/testdata/simple-methods-schema/go/example/internal"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test/testdata/simple-methods-schema/go/example/nested"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Foo struct {
@@ -162,6 +163,12 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i *Foo) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -174,6 +181,12 @@ func (o FooOutput) ToFooOutput() FooOutput {
 
 func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/nested/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/nested/pulumiTypes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test/testdata/simple-methods-schema/go/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 var _ = internal.GetEnvOrDefault
@@ -44,6 +45,12 @@ func (i BazArgs) ToBazOutput() BazOutput {
 
 func (i BazArgs) ToBazOutputWithContext(ctx context.Context) BazOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(BazOutput)
+}
+
+func (i BazArgs) ToOutput(ctx context.Context) pulumix.Output[Baz] {
+	return pulumix.Output[Baz]{
+		OutputState: i.ToBazOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i BazArgs) ToBazPtrOutput() BazPtrOutput {
@@ -87,6 +94,12 @@ func (i *bazPtrType) ToBazPtrOutputWithContext(ctx context.Context) BazPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(BazPtrOutput)
 }
 
+func (i *bazPtrType) ToOutput(ctx context.Context) pulumix.Output[*Baz] {
+	return pulumix.Output[*Baz]{
+		OutputState: i.ToBazPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type BazOutput struct{ *pulumi.OutputState }
 
 func (BazOutput) ElementType() reflect.Type {
@@ -111,6 +124,12 @@ func (o BazOutput) ToBazPtrOutputWithContext(ctx context.Context) BazPtrOutput {
 	}).(BazPtrOutput)
 }
 
+func (o BazOutput) ToOutput(ctx context.Context) pulumix.Output[Baz] {
+	return pulumix.Output[Baz]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o BazOutput) Hello() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Baz) *string { return v.Hello }).(pulumi.StringPtrOutput)
 }
@@ -131,6 +150,12 @@ func (o BazPtrOutput) ToBazPtrOutput() BazPtrOutput {
 
 func (o BazPtrOutput) ToBazPtrOutputWithContext(ctx context.Context) BazPtrOutput {
 	return o
+}
+
+func (o BazPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Baz] {
+	return pulumix.Output[*Baz]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BazPtrOutput) Elem() BazOutput {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test/testdata/simple-methods-schema/go/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Provider struct {
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema-with-root-package/internal"
 )
 
@@ -90,6 +91,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -102,6 +109,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) A() pulumi.BoolOutput {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema-with-root-package/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema-with-root-package/internal"
 )
 
@@ -54,6 +55,12 @@ func (i FooArgs) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i FooArgs) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i FooArgs) ToFooPtrOutput() FooPtrOutput {
 	return i.ToFooPtrOutputWithContext(context.Background())
 }
@@ -95,6 +102,12 @@ func (i *fooPtrType) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(FooPtrOutput)
 }
 
+func (i *fooPtrType) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.
 // You can construct a concrete instance of `FooArrayInput` via:
 //
@@ -120,6 +133,12 @@ func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutpu
 	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
 }
 
+func (i FooArray) ToOutput(ctx context.Context) pulumix.Output[[]Foo] {
+	return pulumix.Output[[]Foo]{
+		OutputState: i.ToFooArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -142,6 +161,12 @@ func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Foo) *Foo {
 		return &v
 	}).(FooPtrOutput)
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooOutput) A() pulumi.BoolOutput {
@@ -180,6 +205,12 @@ func (o FooPtrOutput) ToFooPtrOutput() FooPtrOutput {
 
 func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	return o
+}
+
+func (o FooPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooPtrOutput) Elem() FooOutput {
@@ -258,6 +289,12 @@ func (o FooArrayOutput) ToFooArrayOutput() FooArrayOutput {
 
 func (o FooArrayOutput) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
 	return o
+}
+
+func (o FooArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Foo] {
+	return pulumix.Output[[]Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema/example/internal"
 )
 
@@ -92,6 +93,12 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
+func (i *Component) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: i.ToComponentOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
@@ -104,6 +111,12 @@ func (o ComponentOutput) ToComponentOutput() ComponentOutput {
 
 func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return o
+}
+
+func (o ComponentOutput) ToOutput(ctx context.Context) pulumix.Output[*Component] {
+	return pulumix.Output[*Component]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ComponentOutput) A() pulumi.BoolOutput {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-plain-schema/example/internal"
 )
 
@@ -54,6 +55,12 @@ func (i FooArgs) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
+func (i FooArgs) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: i.ToFooOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i FooArgs) ToFooPtrOutput() FooPtrOutput {
 	return i.ToFooPtrOutputWithContext(context.Background())
 }
@@ -95,6 +102,12 @@ func (i *fooPtrType) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(FooPtrOutput)
 }
 
+func (i *fooPtrType) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: i.ToFooPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.
 // You can construct a concrete instance of `FooArrayInput` via:
 //
@@ -118,6 +131,12 @@ func (i FooArray) ToFooArrayOutput() FooArrayOutput {
 
 func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
+}
+
+func (i FooArray) ToOutput(ctx context.Context) pulumix.Output[[]Foo] {
+	return pulumix.Output[[]Foo]{
+		OutputState: i.ToFooArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // FooMapInput is an input type that accepts FooMap and FooMapOutput values.
@@ -145,6 +164,12 @@ func (i FooMap) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooMapOutput)
 }
 
+func (i FooMap) ToOutput(ctx context.Context) pulumix.Output[map[string]Foo] {
+	return pulumix.Output[map[string]Foo]{
+		OutputState: i.ToFooMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -167,6 +192,12 @@ func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Foo) *Foo {
 		return &v
 	}).(FooPtrOutput)
+}
+
+func (o FooOutput) ToOutput(ctx context.Context) pulumix.Output[Foo] {
+	return pulumix.Output[Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooOutput) A() pulumi.BoolOutput {
@@ -205,6 +236,12 @@ func (o FooPtrOutput) ToFooPtrOutput() FooPtrOutput {
 
 func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
 	return o
+}
+
+func (o FooPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Foo] {
+	return pulumix.Output[*Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooPtrOutput) Elem() FooOutput {
@@ -285,6 +322,12 @@ func (o FooArrayOutput) ToFooArrayOutputWithContext(ctx context.Context) FooArra
 	return o
 }
 
+func (o FooArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Foo] {
+	return pulumix.Output[[]Foo]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Foo {
 		return vs[0].([]Foo)[vs[1].(int)]
@@ -303,6 +346,12 @@ func (o FooMapOutput) ToFooMapOutput() FooMapOutput {
 
 func (o FooMapOutput) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
 	return o
+}
+
+func (o FooMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]Foo] {
+	return pulumix.Output[map[string]Foo]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooMapOutput) MapIndex(k pulumi.StringInput) FooOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema-custom-pypackage-name/example/internal"
 )
 
@@ -62,6 +63,12 @@ func (o ArgFunctionResultOutput) ToArgFunctionResultOutput() ArgFunctionResultOu
 
 func (o ArgFunctionResultOutput) ToArgFunctionResultOutputWithContext(ctx context.Context) ArgFunctionResultOutput {
 	return o
+}
+
+func (o ArgFunctionResultOutput) ToOutput(ctx context.Context) pulumix.Output[ArgFunctionResult] {
+	return pulumix.Output[ArgFunctionResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ArgFunctionResultOutput) Result() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema-custom-pypackage-name/example/internal"
 )
 
@@ -65,6 +66,12 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
+func (i *OtherResource) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: i.ToOtherResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {
 
 func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Context) OtherResourceOutput {
 	return o
+}
+
+func (o OtherResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema-custom-pypackage-name/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema-custom-pypackage-name/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ConfigMapArgs) ToConfigMapOutputWithContext(ctx context.Context) ConfigM
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapOutput)
 }
 
+func (i ConfigMapArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: i.ToConfigMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigMapArrayInput is an input type that accepts ConfigMapArray and ConfigMapArrayOutput values.
 // You can construct a concrete instance of `ConfigMapArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i ConfigMapArray) ToConfigMapArrayOutputWithContext(ctx context.Context) C
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapArrayOutput)
 }
 
+func (i ConfigMapArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: i.ToConfigMapArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConfigMapOutput struct{ *pulumi.OutputState }
 
 func (ConfigMapOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o ConfigMapOutput) ToConfigMapOutput() ConfigMapOutput {
 
 func (o ConfigMapOutput) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOutput {
 	return o
+}
+
+func (o ConfigMapOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapOutput) Config() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o ConfigMapArrayOutput) ToConfigMapArrayOutput() ConfigMapArrayOutput {
 
 func (o ConfigMapArrayOutput) ToConfigMapArrayOutputWithContext(ctx context.Context) ConfigMapArrayOutput {
 	return o
+}
+
+func (o ConfigMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapArrayOutput) Index(i pulumi.IntInput) ConfigMapOutput {
@@ -150,6 +175,12 @@ func (i ObjectArgs) ToObjectOutputWithContext(ctx context.Context) ObjectOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectOutput)
 }
 
+func (i ObjectArgs) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: i.ToObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectOutput struct{ *pulumi.OutputState }
 
 func (ObjectOutput) ElementType() reflect.Type {
@@ -162,6 +193,12 @@ func (o ObjectOutput) ToObjectOutput() ObjectOutput {
 
 func (o ObjectOutput) ToObjectOutputWithContext(ctx context.Context) ObjectOutput {
 	return o
+}
+
+func (o ObjectOutput) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
@@ -217,6 +254,12 @@ func (i OtherResourceOutputTypeArgs) ToOtherResourceOutputTypeOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutputTypeOutput)
 }
 
+func (i OtherResourceOutputTypeArgs) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: i.ToOtherResourceOutputTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutputTypeOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutputTypeOutput) ElementType() reflect.Type {
@@ -229,6 +272,12 @@ func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutput() OtherRe
 
 func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutputWithContext(ctx context.Context) OtherResourceOutputTypeOutput {
 	return o
+}
+
+func (o OtherResourceOutputTypeOutput) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutputTypeOutput) Foo() pulumi.StringPtrOutput {
@@ -266,6 +315,12 @@ func (i SomeOtherObjectArgs) ToSomeOtherObjectOutputWithContext(ctx context.Cont
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectOutput)
 }
 
+func (i SomeOtherObjectArgs) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeOtherObjectArrayInput is an input type that accepts SomeOtherObjectArray and SomeOtherObjectArrayOutput values.
 // You can construct a concrete instance of `SomeOtherObjectArrayInput` via:
 //
@@ -291,6 +346,12 @@ func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutputWithContext(ctx contex
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayOutput)
 }
 
+func (i SomeOtherObjectArray) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type SomeOtherObjectOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectOutput) ElementType() reflect.Type {
@@ -303,6 +364,12 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectOutput() SomeOtherObjectOutput {
 
 func (o SomeOtherObjectOutput) ToSomeOtherObjectOutputWithContext(ctx context.Context) SomeOtherObjectOutput {
 	return o
+}
+
+func (o SomeOtherObjectOutput) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
@@ -323,6 +390,12 @@ func (o SomeOtherObjectArrayOutput) ToSomeOtherObjectArrayOutputWithContext(ctx 
 	return o
 }
 
+func (o SomeOtherObjectArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObject {
 		return vs[0].([]SomeOtherObject)[vs[1].(int)]
@@ -341,6 +414,12 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOther
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayArrayOutput)
+}
+
+func (i SomeOtherObjectArrayArray) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayArrayInput is an input type that accepts SomeOtherObjectArrayArray and SomeOtherObjectArrayArrayOutput values.
@@ -368,6 +447,12 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 	return o
 }
 
+func (o SomeOtherObjectArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
 		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
@@ -386,6 +471,12 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObje
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayMapOutput)
+}
+
+func (i SomeOtherObjectArrayMap) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayMapInput is an input type that accepts SomeOtherObjectArrayMap and SomeOtherObjectArrayMapOutput values.
@@ -411,6 +502,12 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOth
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return o
+}
+
+func (o SomeOtherObjectArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema-custom-pypackage-name/example/internal"
 )
 
@@ -88,6 +89,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -100,6 +107,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -62,6 +63,12 @@ func (o ArgFunctionResultOutput) ToArgFunctionResultOutput() ArgFunctionResultOu
 
 func (o ArgFunctionResultOutput) ToArgFunctionResultOutputWithContext(ctx context.Context) ArgFunctionResultOutput {
 	return o
+}
+
+func (o ArgFunctionResultOutput) ToOutput(ctx context.Context) pulumix.Output[ArgFunctionResult] {
+	return pulumix.Output[ArgFunctionResult]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ArgFunctionResultOutput) Result() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -65,6 +66,12 @@ func (i *BarResource) ToBarResourceOutputWithContext(ctx context.Context) BarRes
 	return pulumi.ToOutputWithContext(ctx, i).(BarResourceOutput)
 }
 
+func (i *BarResource) ToOutput(ctx context.Context) pulumix.Output[*BarResource] {
+	return pulumix.Output[*BarResource]{
+		OutputState: i.ToBarResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type BarResourceOutput struct{ *pulumi.OutputState }
 
 func (BarResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o BarResourceOutput) ToBarResourceOutput() BarResourceOutput {
 
 func (o BarResourceOutput) ToBarResourceOutputWithContext(ctx context.Context) BarResourceOutput {
 	return o
+}
+
+func (o BarResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*BarResource] {
+	return pulumix.Output[*BarResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o BarResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -65,6 +66,12 @@ func (i *FooResource) ToFooResourceOutputWithContext(ctx context.Context) FooRes
 	return pulumi.ToOutputWithContext(ctx, i).(FooResourceOutput)
 }
 
+func (i *FooResource) ToOutput(ctx context.Context) pulumix.Output[*FooResource] {
+	return pulumix.Output[*FooResource]{
+		OutputState: i.ToFooResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type FooResourceOutput struct{ *pulumi.OutputState }
 
 func (FooResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o FooResourceOutput) ToFooResourceOutput() FooResourceOutput {
 
 func (o FooResourceOutput) ToFooResourceOutputWithContext(ctx context.Context) FooResourceOutput {
 	return o
+}
+
+func (o FooResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*FooResource] {
+	return pulumix.Output[*FooResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o FooResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -65,6 +66,12 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
+func (i *OtherResource) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: i.ToOtherResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
@@ -77,6 +84,12 @@ func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {
 
 func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Context) OtherResourceOutput {
 	return o
+}
+
+func (o OtherResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ConfigMapArgs) ToConfigMapOutputWithContext(ctx context.Context) ConfigM
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapOutput)
 }
 
+func (i ConfigMapArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: i.ToConfigMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigMapArrayInput is an input type that accepts ConfigMapArray and ConfigMapArrayOutput values.
 // You can construct a concrete instance of `ConfigMapArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i ConfigMapArray) ToConfigMapArrayOutputWithContext(ctx context.Context) C
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapArrayOutput)
 }
 
+func (i ConfigMapArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: i.ToConfigMapArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConfigMapOutput struct{ *pulumi.OutputState }
 
 func (ConfigMapOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o ConfigMapOutput) ToConfigMapOutput() ConfigMapOutput {
 
 func (o ConfigMapOutput) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOutput {
 	return o
+}
+
+func (o ConfigMapOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapOutput) Config() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o ConfigMapArrayOutput) ToConfigMapArrayOutput() ConfigMapArrayOutput {
 
 func (o ConfigMapArrayOutput) ToConfigMapArrayOutputWithContext(ctx context.Context) ConfigMapArrayOutput {
 	return o
+}
+
+func (o ConfigMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapArrayOutput) Index(i pulumi.IntInput) ConfigMapOutput {
@@ -150,6 +175,12 @@ func (i ObjectArgs) ToObjectOutputWithContext(ctx context.Context) ObjectOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectOutput)
 }
 
+func (i ObjectArgs) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: i.ToObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectArgs) ToObjectPtrOutput() ObjectPtrOutput {
 	return i.ToObjectPtrOutputWithContext(context.Background())
 }
@@ -191,6 +222,12 @@ func (i *objectPtrType) ToObjectPtrOutputWithContext(ctx context.Context) Object
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectPtrOutput)
 }
 
+func (i *objectPtrType) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: i.ToObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectOutput struct{ *pulumi.OutputState }
 
 func (ObjectOutput) ElementType() reflect.Type {
@@ -213,6 +250,12 @@ func (o ObjectOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPt
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Object) *Object {
 		return &v
 	}).(ObjectPtrOutput)
+}
+
+func (o ObjectOutput) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
@@ -249,6 +292,12 @@ func (o ObjectPtrOutput) ToObjectPtrOutput() ObjectPtrOutput {
 
 func (o ObjectPtrOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPtrOutput {
 	return o
+}
+
+func (o ObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectPtrOutput) Elem() ObjectOutput {
@@ -341,6 +390,12 @@ func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsOutput)
 }
 
+func (i ObjectWithNodeOptionalInputsArgs) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsPtrOutput() ObjectWithNodeOptionalInputsPtrOutput {
 	return i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(context.Background())
 }
@@ -382,6 +437,12 @@ func (i *objectWithNodeOptionalInputsPtrType) ToObjectWithNodeOptionalInputsPtrO
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (i *objectWithNodeOptionalInputsPtrType) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectWithNodeOptionalInputsOutput struct{ *pulumi.OutputState }
 
 func (ObjectWithNodeOptionalInputsOutput) ElementType() reflect.Type {
@@ -406,6 +467,12 @@ func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOut
 	}).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (o ObjectWithNodeOptionalInputsOutput) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ObjectWithNodeOptionalInputsOutput) Bar() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *int { return v.Bar }).(pulumi.IntPtrOutput)
 }
@@ -426,6 +493,12 @@ func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtr
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx context.Context) ObjectWithNodeOptionalInputsPtrOutput {
 	return o
+}
+
+func (o ObjectWithNodeOptionalInputsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Elem() ObjectWithNodeOptionalInputsOutput {
@@ -487,6 +560,12 @@ func (i OtherResourceOutputTypeArgs) ToOtherResourceOutputTypeOutputWithContext(
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutputTypeOutput)
 }
 
+func (i OtherResourceOutputTypeArgs) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: i.ToOtherResourceOutputTypeOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutputTypeOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutputTypeOutput) ElementType() reflect.Type {
@@ -499,6 +578,12 @@ func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutput() OtherRe
 
 func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutputWithContext(ctx context.Context) OtherResourceOutputTypeOutput {
 	return o
+}
+
+func (o OtherResourceOutputTypeOutput) ToOutput(ctx context.Context) pulumix.Output[OtherResourceOutputType] {
+	return pulumix.Output[OtherResourceOutputType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutputTypeOutput) Foo() pulumi.StringPtrOutput {
@@ -534,6 +619,12 @@ func (i SomeOtherObjectArgs) ToSomeOtherObjectOutput() SomeOtherObjectOutput {
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectOutputWithContext(ctx context.Context) SomeOtherObjectOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectOutput)
+}
+
+func (i SomeOtherObjectArgs) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectPtrOutput() SomeOtherObjectPtrOutput {
@@ -577,6 +668,12 @@ func (i *someOtherObjectPtrType) ToSomeOtherObjectPtrOutputWithContext(ctx conte
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectPtrOutput)
 }
 
+func (i *someOtherObjectPtrType) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeOtherObjectArrayInput is an input type that accepts SomeOtherObjectArray and SomeOtherObjectArrayOutput values.
 // You can construct a concrete instance of `SomeOtherObjectArrayInput` via:
 //
@@ -600,6 +697,12 @@ func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutput() SomeOtherObjectArra
 
 func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayOutput)
+}
+
+func (i SomeOtherObjectArray) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 type SomeOtherObjectOutput struct{ *pulumi.OutputState }
@@ -626,6 +729,12 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context
 	}).(SomeOtherObjectPtrOutput)
 }
 
+func (o SomeOtherObjectOutput) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SomeOtherObject) *string { return v.Baz }).(pulumi.StringPtrOutput)
 }
@@ -642,6 +751,12 @@ func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutput() SomeOtherObjectPt
 
 func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context.Context) SomeOtherObjectPtrOutput {
 	return o
+}
+
+func (o SomeOtherObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectPtrOutput) Elem() SomeOtherObjectOutput {
@@ -677,6 +792,12 @@ func (o SomeOtherObjectArrayOutput) ToSomeOtherObjectArrayOutputWithContext(ctx 
 	return o
 }
 
+func (o SomeOtherObjectArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObject {
 		return vs[0].([]SomeOtherObject)[vs[1].(int)]
@@ -695,6 +816,12 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOther
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayArrayOutput)
+}
+
+func (i SomeOtherObjectArrayArray) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayArrayInput is an input type that accepts SomeOtherObjectArrayArray and SomeOtherObjectArrayArrayOutput values.
@@ -722,6 +849,12 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 	return o
 }
 
+func (o SomeOtherObjectArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
 		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
@@ -740,6 +873,12 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObje
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayMapOutput)
+}
+
+func (i SomeOtherObjectArrayMap) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayMapInput is an input type that accepts SomeOtherObjectArrayMap and SomeOtherObjectArrayMapOutput values.
@@ -765,6 +904,12 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOth
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return o
+}
+
+func (o SomeOtherObjectArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -97,6 +98,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -109,6 +116,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-resource-schema/example/internal"
 )
 
@@ -94,6 +95,12 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 	return pulumi.ToOutputWithContext(ctx, i).(TypeUsesOutput)
 }
 
+func (i *TypeUses) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: i.ToTypeUsesOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
@@ -106,6 +113,12 @@ func (o TypeUsesOutput) ToTypeUsesOutput() TypeUsesOutput {
 
 func (o TypeUsesOutput) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutput {
 	return o
+}
+
+func (o TypeUsesOutput) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypeUsesOutput) Bar() SomeOtherObjectPtrOutput {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -67,6 +68,12 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
+func (i *OtherResource) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: i.ToOtherResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
@@ -79,6 +86,12 @@ func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {
 
 func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Context) OtherResourceOutput {
 	return o
+}
+
+func (o OtherResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*OtherResource] {
+	return pulumix.Output[*OtherResource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OtherResourceOutput) Foo() ResourceOutput {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/provider.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -61,6 +62,12 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: i.ToProviderOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
@@ -73,6 +80,12 @@ func (o ProviderOutput) ToProviderOutput() ProviderOutput {
 
 func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) ProviderOutput {
 	return o
+}
+
+func (o ProviderOutput) ToOutput(ctx context.Context) pulumix.Output[*Provider] {
+	return pulumix.Output[*Provider]{
+		OutputState: o.OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type OutputOnlyEnumType string
@@ -39,6 +40,12 @@ func (o OutputOnlyEnumTypeOutput) ToOutputOnlyEnumTypePtrOutputWithContext(ctx c
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v OutputOnlyEnumType) *OutputOnlyEnumType {
 		return &v
 	}).(OutputOnlyEnumTypePtrOutput)
+}
+
+func (o OutputOnlyEnumTypeOutput) ToOutput(ctx context.Context) pulumix.Output[OutputOnlyEnumType] {
+	return pulumix.Output[OutputOnlyEnumType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OutputOnlyEnumTypeOutput) ToStringOutput() pulumi.StringOutput {
@@ -74,6 +81,12 @@ func (o OutputOnlyEnumTypePtrOutput) ToOutputOnlyEnumTypePtrOutput() OutputOnlyE
 
 func (o OutputOnlyEnumTypePtrOutput) ToOutputOnlyEnumTypePtrOutputWithContext(ctx context.Context) OutputOnlyEnumTypePtrOutput {
 	return o
+}
+
+func (o OutputOnlyEnumTypePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*OutputOnlyEnumType] {
+	return pulumix.Output[*OutputOnlyEnumType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OutputOnlyEnumTypePtrOutput) Elem() OutputOnlyEnumTypeOutput {
@@ -112,6 +125,12 @@ func (o OutputOnlyEnumTypeMapOutput) ToOutputOnlyEnumTypeMapOutput() OutputOnlyE
 
 func (o OutputOnlyEnumTypeMapOutput) ToOutputOnlyEnumTypeMapOutputWithContext(ctx context.Context) OutputOnlyEnumTypeMapOutput {
 	return o
+}
+
+func (o OutputOnlyEnumTypeMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]OutputOnlyEnumType] {
+	return pulumix.Output[map[string]OutputOnlyEnumType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OutputOnlyEnumTypeMapOutput) MapIndex(k pulumi.StringInput) OutputOnlyEnumTypeOutput {
@@ -192,6 +211,12 @@ func (o RubberTreeVarietyOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx con
 	}).(RubberTreeVarietyPtrOutput)
 }
 
+func (o RubberTreeVarietyOutput) ToOutput(ctx context.Context) pulumix.Output[RubberTreeVariety] {
+	return pulumix.Output[RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o RubberTreeVarietyOutput) ToStringOutput() pulumi.StringOutput {
 	return o.ToStringOutputWithContext(context.Background())
 }
@@ -225,6 +250,12 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
@@ -287,6 +318,12 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutput() RubberTreeVariety
 
 func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
+}
+
+func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
+	return pulumix.Output[*RubberTreeVariety]{
+		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
+	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -44,6 +45,12 @@ func (i ConfigMapArgs) ToConfigMapOutputWithContext(ctx context.Context) ConfigM
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapOutput)
 }
 
+func (i ConfigMapArgs) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: i.ToConfigMapOutputWithContext(ctx).OutputState,
+	}
+}
+
 // ConfigMapArrayInput is an input type that accepts ConfigMapArray and ConfigMapArrayOutput values.
 // You can construct a concrete instance of `ConfigMapArrayInput` via:
 //
@@ -69,6 +76,12 @@ func (i ConfigMapArray) ToConfigMapArrayOutputWithContext(ctx context.Context) C
 	return pulumi.ToOutputWithContext(ctx, i).(ConfigMapArrayOutput)
 }
 
+func (i ConfigMapArray) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: i.ToConfigMapArrayOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ConfigMapOutput struct{ *pulumi.OutputState }
 
 func (ConfigMapOutput) ElementType() reflect.Type {
@@ -81,6 +94,12 @@ func (o ConfigMapOutput) ToConfigMapOutput() ConfigMapOutput {
 
 func (o ConfigMapOutput) ToConfigMapOutputWithContext(ctx context.Context) ConfigMapOutput {
 	return o
+}
+
+func (o ConfigMapOutput) ToOutput(ctx context.Context) pulumix.Output[ConfigMap] {
+	return pulumix.Output[ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapOutput) Config() pulumi.StringPtrOutput {
@@ -99,6 +118,12 @@ func (o ConfigMapArrayOutput) ToConfigMapArrayOutput() ConfigMapArrayOutput {
 
 func (o ConfigMapArrayOutput) ToConfigMapArrayOutputWithContext(ctx context.Context) ConfigMapArrayOutput {
 	return o
+}
+
+func (o ConfigMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ConfigMap] {
+	return pulumix.Output[[]ConfigMap]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ConfigMapArrayOutput) Index(i pulumi.IntInput) ConfigMapOutput {
@@ -150,6 +175,12 @@ func (i ObjectArgs) ToObjectOutputWithContext(ctx context.Context) ObjectOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectOutput)
 }
 
+func (i ObjectArgs) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: i.ToObjectOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectArgs) ToObjectPtrOutput() ObjectPtrOutput {
 	return i.ToObjectPtrOutputWithContext(context.Background())
 }
@@ -191,6 +222,12 @@ func (i *objectPtrType) ToObjectPtrOutputWithContext(ctx context.Context) Object
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectPtrOutput)
 }
 
+func (i *objectPtrType) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: i.ToObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectOutput struct{ *pulumi.OutputState }
 
 func (ObjectOutput) ElementType() reflect.Type {
@@ -213,6 +250,12 @@ func (o ObjectOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPt
 	return o.ApplyTWithContext(ctx, func(_ context.Context, v Object) *Object {
 		return &v
 	}).(ObjectPtrOutput)
+}
+
+func (o ObjectOutput) ToOutput(ctx context.Context) pulumix.Output[Object] {
+	return pulumix.Output[Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
@@ -249,6 +292,12 @@ func (o ObjectPtrOutput) ToObjectPtrOutput() ObjectPtrOutput {
 
 func (o ObjectPtrOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPtrOutput {
 	return o
+}
+
+func (o ObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*Object] {
+	return pulumix.Output[*Object]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectPtrOutput) Elem() ObjectOutput {
@@ -341,6 +390,12 @@ func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsOutputWi
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsOutput)
 }
 
+func (i ObjectWithNodeOptionalInputsArgs) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsOutputWithContext(ctx).OutputState,
+	}
+}
+
 func (i ObjectWithNodeOptionalInputsArgs) ToObjectWithNodeOptionalInputsPtrOutput() ObjectWithNodeOptionalInputsPtrOutput {
 	return i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(context.Background())
 }
@@ -382,6 +437,12 @@ func (i *objectWithNodeOptionalInputsPtrType) ToObjectWithNodeOptionalInputsPtrO
 	return pulumi.ToOutputWithContext(ctx, i).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (i *objectWithNodeOptionalInputsPtrType) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: i.ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ObjectWithNodeOptionalInputsOutput struct{ *pulumi.OutputState }
 
 func (ObjectWithNodeOptionalInputsOutput) ElementType() reflect.Type {
@@ -406,6 +467,12 @@ func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOut
 	}).(ObjectWithNodeOptionalInputsPtrOutput)
 }
 
+func (o ObjectWithNodeOptionalInputsOutput) ToOutput(ctx context.Context) pulumix.Output[ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o ObjectWithNodeOptionalInputsOutput) Bar() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *int { return v.Bar }).(pulumi.IntPtrOutput)
 }
@@ -426,6 +493,12 @@ func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtr
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx context.Context) ObjectWithNodeOptionalInputsPtrOutput {
 	return o
+}
+
+func (o ObjectWithNodeOptionalInputsPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ObjectWithNodeOptionalInputs] {
+	return pulumix.Output[*ObjectWithNodeOptionalInputs]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Elem() ObjectWithNodeOptionalInputsOutput {
@@ -478,6 +551,12 @@ func (o OutputOnlyObjectTypeOutput) ToOutputOnlyObjectTypeOutputWithContext(ctx 
 	return o
 }
 
+func (o OutputOnlyObjectTypeOutput) ToOutput(ctx context.Context) pulumix.Output[OutputOnlyObjectType] {
+	return pulumix.Output[OutputOnlyObjectType]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o OutputOnlyObjectTypeOutput) Foo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v OutputOnlyObjectType) *string { return v.Foo }).(pulumi.StringPtrOutput)
 }
@@ -494,6 +573,12 @@ func (o OutputOnlyObjectTypePtrOutput) ToOutputOnlyObjectTypePtrOutput() OutputO
 
 func (o OutputOnlyObjectTypePtrOutput) ToOutputOnlyObjectTypePtrOutputWithContext(ctx context.Context) OutputOnlyObjectTypePtrOutput {
 	return o
+}
+
+func (o OutputOnlyObjectTypePtrOutput) ToOutput(ctx context.Context) pulumix.Output[*OutputOnlyObjectType] {
+	return pulumix.Output[*OutputOnlyObjectType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OutputOnlyObjectTypePtrOutput) Elem() OutputOnlyObjectTypeOutput {
@@ -527,6 +612,12 @@ func (o OutputOnlyObjectTypeArrayOutput) ToOutputOnlyObjectTypeArrayOutput() Out
 
 func (o OutputOnlyObjectTypeArrayOutput) ToOutputOnlyObjectTypeArrayOutputWithContext(ctx context.Context) OutputOnlyObjectTypeArrayOutput {
 	return o
+}
+
+func (o OutputOnlyObjectTypeArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]OutputOnlyObjectType] {
+	return pulumix.Output[[]OutputOnlyObjectType]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o OutputOnlyObjectTypeArrayOutput) Index(i pulumi.IntInput) OutputOnlyObjectTypeOutput {
@@ -564,6 +655,12 @@ func (i SomeOtherObjectArgs) ToSomeOtherObjectOutput() SomeOtherObjectOutput {
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectOutputWithContext(ctx context.Context) SomeOtherObjectOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectOutput)
+}
+
+func (i SomeOtherObjectArgs) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectOutputWithContext(ctx).OutputState,
+	}
 }
 
 func (i SomeOtherObjectArgs) ToSomeOtherObjectPtrOutput() SomeOtherObjectPtrOutput {
@@ -607,6 +704,12 @@ func (i *someOtherObjectPtrType) ToSomeOtherObjectPtrOutputWithContext(ctx conte
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectPtrOutput)
 }
 
+func (i *someOtherObjectPtrType) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectPtrOutputWithContext(ctx).OutputState,
+	}
+}
+
 // SomeOtherObjectArrayInput is an input type that accepts SomeOtherObjectArray and SomeOtherObjectArrayOutput values.
 // You can construct a concrete instance of `SomeOtherObjectArrayInput` via:
 //
@@ -630,6 +733,12 @@ func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutput() SomeOtherObjectArra
 
 func (i SomeOtherObjectArray) ToSomeOtherObjectArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayOutput)
+}
+
+func (i SomeOtherObjectArray) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 type SomeOtherObjectOutput struct{ *pulumi.OutputState }
@@ -656,6 +765,12 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context
 	}).(SomeOtherObjectPtrOutput)
 }
 
+func (o SomeOtherObjectOutput) ToOutput(ctx context.Context) pulumix.Output[SomeOtherObject] {
+	return pulumix.Output[SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SomeOtherObject) *string { return v.Baz }).(pulumi.StringPtrOutput)
 }
@@ -672,6 +787,12 @@ func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutput() SomeOtherObjectPt
 
 func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context.Context) SomeOtherObjectPtrOutput {
 	return o
+}
+
+func (o SomeOtherObjectPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*SomeOtherObject] {
+	return pulumix.Output[*SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectPtrOutput) Elem() SomeOtherObjectOutput {
@@ -707,6 +828,12 @@ func (o SomeOtherObjectArrayOutput) ToSomeOtherObjectArrayOutputWithContext(ctx 
 	return o
 }
 
+func (o SomeOtherObjectArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]SomeOtherObject] {
+	return pulumix.Output[[]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObject {
 		return vs[0].([]SomeOtherObject)[vs[1].(int)]
@@ -725,6 +852,12 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOther
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(ctx context.Context) SomeOtherObjectArrayArrayOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayArrayOutput)
+}
+
+func (i SomeOtherObjectArrayArray) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayArrayOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayArrayInput is an input type that accepts SomeOtherObjectArrayArray and SomeOtherObjectArrayArrayOutput values.
@@ -752,6 +885,12 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 	return o
 }
 
+func (o SomeOtherObjectArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]SomeOtherObject] {
+	return pulumix.Output[[][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
+}
+
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
 		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
@@ -770,6 +909,12 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObje
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(SomeOtherObjectArrayMapOutput)
+}
+
+func (i SomeOtherObjectArrayMap) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: i.ToSomeOtherObjectArrayMapOutputWithContext(ctx).OutputState,
+	}
 }
 
 // SomeOtherObjectArrayMapInput is an input type that accepts SomeOtherObjectArrayMap and SomeOtherObjectArrayMapOutput values.
@@ -795,6 +940,12 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOth
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContext(ctx context.Context) SomeOtherObjectArrayMapOutput {
 	return o
+}
+
+func (o SomeOtherObjectArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]SomeOtherObject] {
+	return pulumix.Output[map[string][]SomeOtherObject]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -95,6 +96,12 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: i.ToResourceOutputWithContext(ctx).OutputState,
+	}
+}
+
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
@@ -107,6 +114,12 @@ func (o ResourceOutput) ToResourceOutput() ResourceOutput {
 
 func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) ResourceOutput {
 	return o
+}
+
+func (o ResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Resource] {
+	return pulumix.Output[*Resource]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o ResourceOutput) Bar() pulumi.StringPtrOutput {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -101,6 +102,12 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 	return pulumi.ToOutputWithContext(ctx, i).(TypeUsesOutput)
 }
 
+func (i *TypeUses) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: i.ToTypeUsesOutputWithContext(ctx).OutputState,
+	}
+}
+
 type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
@@ -113,6 +120,12 @@ func (o TypeUsesOutput) ToTypeUsesOutput() TypeUsesOutput {
 
 func (o TypeUsesOutput) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutput {
 	return o
+}
+
+func (o TypeUsesOutput) ToOutput(ctx context.Context) pulumix.Output[*TypeUses] {
+	return pulumix.Output[*TypeUses]{
+		OutputState: o.OutputState,
+	}
 }
 
 func (o TypeUsesOutput) Alpha() OutputOnlyEnumTypePtrOutput {


### PR DESCRIPTION
For generated types that impleemnt `pulumi.Output`,
or those that implement `pulumi.Input` with a means of converting
themselves to a `pulumi.Output`,
also generate `ToOutput(context.Context) pux.Output[..]`
to satisfy the `pux.Input[T]` interface.

This allows all these generated types to be used with `pux.Apply`
and other type-safe generic APIs per #13057.

Resolves #13587