### PR TITLE
Pulumi no longer falls back on old configuration by default.

### DIFF
--- a/changelog/pending/20230717--cli-config--pulumi-no-longer-falls-back-on-old-config-when-config-resolution-fails-except-for-pulumi-destroy-stack-stack-name-where-the-config-may-be-unavailable.yaml
+++ b/changelog/pending/20230717--cli-config--pulumi-no-longer-falls-back-on-old-config-when-config-resolution-fails-except-for-pulumi-destroy-stack-stack-name-where-the-config-may-be-unavailable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Pulumi no longer falls back on old config when config resolution fails (except for `pulumi destroy --stack <stack-name>` where the config may be unavailable).

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -201,7 +201,13 @@ func newDestroyCmd() *cobra.Command {
 				defaultSecretsManager = snap.SecretsManager
 			}
 
-			cfg, sm, err := getStackConfiguration(ctx, s, proj, defaultSecretsManager)
+			getConfig := getStackConfiguration
+			if stackName != "" {
+				// `pulumi destroy --stack <stack>` can be run outside of the project directory.
+				// The config may be missing, fallback on the latest configuration in the backend.
+				getConfig = getStackConfigurationOrLatest
+			}
+			cfg, sm, err := getConfig(ctx, s, proj, defaultSecretsManager)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Pulumi no longer falls back on prior configuration on error getting configuration except for `pulumi destroy --stack <stack-name>` where a user may run `pulumi destroy` and the configuration may not be available.

Fixes #13487

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
