### PR TITLE
[typescript/program-gen] Fix interpolated strings used as keys of maps

### DIFF
--- a/changelog/pending/20230717--programgen-nodejs--fix-interpolated-strings-used-as-keys-of-maps.yaml
+++ b/changelog/pending/20230717--programgen-nodejs--fix-interpolated-strings-used-as-keys-of-maps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix interpolated strings used as keys of maps

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -584,9 +584,8 @@ func (g *generator) literalKey(x model.Expression) (string, bool) {
 				break
 			}
 		}
-		var buf bytes.Buffer
-		g.GenTemplateExpression(&buf, x)
-		return buf.String(), true
+
+		return "", false
 	default:
 		return "", false
 	}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -340,6 +340,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs"),
 		SkipCompile: allProgLanguages.Except("nodejs"),
 	},
+	{
+		Directory:   "interpolated-string-keys",
+		Description: "Tests that interpolated string keys are supported in maps. ",
+		Skip:        allProgLanguages.Except("nodejs").Except("python"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/interpolated-string-keys.pp
+++ b/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/interpolated-string-keys.pp
@@ -1,0 +1,7 @@
+config value "string" {}
+
+config tags "map(string)" {
+    default = {
+        "interpolated/${value}" = "value"
+    }
+}

--- a/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/nodejs/interpolated-string-keys.ts
+++ b/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/nodejs/interpolated-string-keys.ts
@@ -2,6 +2,6 @@ import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 const value = config.require("value");
-const tags = config.getObject("tags") || {
+const tags = config.getObject<Record<string, string>>("tags") || {
     [`interpolated/${value}`]: "value",
 };

--- a/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/nodejs/interpolated-string-keys.ts
+++ b/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/nodejs/interpolated-string-keys.ts
@@ -1,0 +1,7 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const value = config.require("value");
+const tags = config.getObject("tags") || {
+    [`interpolated/${value}`]: "value",
+};

--- a/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/python/interpolated-string-keys.py
+++ b/pkg/codegen/testing/test/testdata/interpolated-string-keys-pp/python/interpolated-string-keys.py
@@ -1,0 +1,9 @@
+import pulumi
+
+config = pulumi.Config()
+value = config.require("value")
+tags = config.get_object("tags")
+if tags is None:
+    tags = {
+        f"interpolated/{value}": "value",
+    }


### PR DESCRIPTION
# Description

Fixes #13513

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
