### PR TITLE
Fix ReplaceOnChanges being dropped in schema marshalling

### DIFF
--- a/changelog/pending/20230718--sdkgen-go-nodejs--fix-replaceonchanges-being-dropped-in-go-and-nodejs-codegen.yaml
+++ b/changelog/pending/20230718--sdkgen-go-nodejs--fix-replaceonchanges-being-dropped-in-go-and-nodejs-codegen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go,nodejs
+  description: Fix ReplaceOnChanges being dropped in Go and NodeJS codegen.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1234,14 +1234,16 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 		}
 
 		specs[p.Name] = PropertySpec{
-			TypeSpec:           pkg.marshalType(typ, plain),
-			Description:        p.Comment,
-			Const:              p.ConstValue,
-			Default:            defaultValue,
-			DefaultInfo:        defaultSpec,
-			DeprecationMessage: p.DeprecationMessage,
-			Language:           lang,
-			Secret:             p.Secret,
+			TypeSpec:             pkg.marshalType(typ, plain),
+			Description:          p.Comment,
+			Const:                p.ConstValue,
+			Default:              defaultValue,
+			DefaultInfo:          defaultSpec,
+			DeprecationMessage:   p.DeprecationMessage,
+			Language:             lang,
+			Secret:               p.Secret,
+			ReplaceOnChanges:     p.ReplaceOnChanges,
+			WillReplaceOnChanges: p.WillReplaceOnChanges,
 		}
 	}
 	return required, specs, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13492.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - No, we'll cover this with https://github.com/pulumi/pulumi/issues/13080, but that's a large amount of work. This is a quick fix in now to unblock providers.

<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
