### PR TITLE
Fix lookup of side-by-side binaries when PULUMI_IGNORE_AMBIENT_PLUGINS is set

### DIFF
--- a/changelog/pending/20230718--cli-plugin--fix-lookup-of-side-by-side-binaries-when-pulumi_ignore_ambient_plugins-is-set.yaml
+++ b/changelog/pending/20230718--cli-plugin--fix-lookup-of-side-by-side-binaries-when-pulumi_ignore_ambient_plugins-is-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix lookup of side-by-side binaries when PULUMI_IGNORE_AMBIENT_PLUGINS is set.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1714,7 +1714,7 @@ func getPluginInfoAndPath(
 	kind PluginKind, name string, version *semver.Version, skipMetadata bool,
 	projectPlugins []ProjectPlugin,
 ) (*PluginInfo, string, error) {
-	var filename string
+	filename := (&PluginSpec{Kind: kind, Name: name}).File()
 
 	for i, p1 := range projectPlugins {
 		for j, p2 := range projectPlugins {
@@ -1767,7 +1767,6 @@ func getPluginInfoAndPath(
 	// This supports development scenarios.
 	includeAmbient := !(env.IgnoreAmbientPlugins.Value())
 	if includeAmbient {
-		filename = (&PluginSpec{Kind: kind, Name: name}).File()
 		if path, err := exec.LookPath(filename); err == nil {
 			logging.V(6).Infof("GetPluginPath(%s, %s, %v): found on $PATH %s", kind, name, version, path)
 			return &PluginInfo{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

If PULUMI_IGNORE_AMBIENT_PLUGINS was set then the `filename` variable was never initialized, This regressed in https://github.com/pulumi/pulumi/pull/13086.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
