### PR TITLE
Add docs JSON to `pulumi package gen sdk`

### DIFF
--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -24,6 +24,7 @@ import (
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/docs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -58,7 +59,7 @@ func newGenSdkCommand() *cobra.Command {
 			}
 
 			if language == "all" {
-				for _, lang := range []string{"dotnet", "go", "java", "nodejs", "python"} {
+				for _, lang := range []string{"dotnet", "go", "java", "nodejs", "python", "docs"} {
 					err := genSDK(lang, out, pkg, overlays)
 					if err != nil {
 						return err
@@ -120,6 +121,9 @@ func genSDK(language, out string, pkg *schema.Package, overlays string) error {
 		generatePackage = writeWrapper(python.GeneratePackage)
 	case "java":
 		generatePackage = writeWrapper(javagen.GeneratePackage)
+	case "docs":
+		docs.Initialize("pulumi", pkg)
+		generatePackage = writeWrapper(docs.GeneratePackageJson)
 	default:
 		generatePackage = func(directory string, pkg *schema.Package, extraFiles map[string][]byte) error {
 			// Ensure the target directory is clean, but created.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Concept: Pre-render all metadata required for docs at the point of provider release.

Instead of generating all the docs from the source schemas at the point of rendering the docs site, generate docs metadata in same process as SDK generation and save as an asset. 
- The docs generation can then just fetch the pre-generated JSON which will make the static rendering of the docs site much faster. 
- Gives the option for the docs site to be dynamically rendered.
- Makes it possible to include a range of older versions of each provider.

TODO:
- [ ] Restructure JSON to be more descriptive.
- [ ] Remove nested HTML embedded in some fields.
- [ ] Fix actual generation process - some context is not initialized correctly.

Out of scope:
- Design how to store the JSON as an asset which can be accessed by the docs site.

Related to https://github.com/pulumi/home/issues/2706

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
