### PR TITLE
WIP experiment with ProviderResourceReference

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -958,7 +958,7 @@ export interface ProviderResourceReference {
 }
 
 export function referenceProviderResource(pkg: string, pri: Input<ProviderResource>): ProviderResourceReference {
-    let pro = output(pri);
+    let pro = ensureKnown(output(pri), "Unknown provider resource references are not supported");
     return {
         __registrationId: undefined,
         urn: pro.apply(pr => {
@@ -980,6 +980,15 @@ export function referenceProviderResource(pkg: string, pri: Input<ProviderResour
         }),
         getPackage: () => pkg,
     }
+}
+
+function ensureKnown<T>(o: Output<T>, error: string): Output<T> {
+    return output(o.isKnown).apply(isKnown => {
+        if (!isKnown) {
+            throw new Error(error);
+        }
+        return o;
+    });
 }
 
 /**

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -30,6 +30,7 @@ import {
     expandProviders,
     ID,
     ProviderResource,
+    ProviderResourceReference,
     Resource,
     ResourceOptions,
     URN,
@@ -743,14 +744,14 @@ export async function prepareResource(
                 if (componentOpts.providers === undefined) {
                     // We still want to do the promotion, so we define providers
                     componentOpts.providers = [componentOpts.provider];
-                } else if ((<ProviderResource[]>componentOpts.providers)?.indexOf(componentOpts.provider) !== -1) {
+                } else if ((<ProviderResourceReference[]>componentOpts.providers)?.indexOf(componentOpts.provider) !== -1) {
                     const pkg = componentOpts.provider.getPackage();
                     const message = `There is a conflit between the 'provider' field (${pkg}) and a member of the 'providers' map'. `;
                     const deprecationd =
                         "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details";
                     log.warn(message + deprecationd);
                 } else {
-                    (<ProviderResource[]>componentOpts.providers).push(componentOpts.provider);
+                    (<ProviderResourceReference[]>componentOpts.providers).push(componentOpts.provider);
                 }
             }
             if (componentOpts.providers) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Another take on enabling `Output<ProviderResource>` to be passed as a resource option in Node. This weakens the requirement from ProviderResource to a ProviderResourceReference interface.

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
