### PR TITLE
Fix using backend in new when --generate-only is set

### DIFF
--- a/changelog/pending/20230719--cli-new--fix-the-use-of-uninitalized-backend-when-running-new-with-generate-only-when-generate-only-is-set-new-will-skip-all-checks-that-require-the-backend.yaml
+++ b/changelog/pending/20230719--cli-new--fix-the-use-of-uninitalized-backend-when-running-new-with-generate-only-when-generate-only-is-set-new-will-skip-all-checks-that-require-the-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix the use of uninitalized backend when running `new` with --generate-only. When --generate-only is set `new` will skip all checks that require the backend.

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -118,17 +118,18 @@ func runNew(ctx context.Context, args newArgs) error {
 	// If we're going to be creating a stack, get the current backend, which
 	// will kick off the login flow (if not already logged-in).
 	var b backend.Backend
-	if !args.generateOnly || (args.stack != "" && strings.Count(args.stack, "/") == 2) {
+	if !args.generateOnly {
 		// There is no current project at this point to pass into currentBackend
 		b, err = currentBackend(ctx, nil, opts)
 		if err != nil {
 			return err
 		}
-	}
 
-	// Check project name and stack reference project name are the same.
-	if err := compareStackProjectName(b, args.stack, args.name); err != nil {
-		return err
+		// Check project name and stack reference project name are the same, we skip this check if
+		// --generate-only is set because we're not going to actually use the --stack argument given.
+		if err := compareStackProjectName(b, args.stack, args.name); err != nil {
+			return err
+		}
 	}
 
 	// Retrieve the template repo.
@@ -177,7 +178,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	// created via the web app.
 	var s backend.Stack
 	var orgName string
-	if args.stack != "" && strings.Count(args.stack, "/") == 2 {
+	if !args.generateOnly && args.stack != "" && strings.Count(args.stack, "/") == 2 {
 		parts := strings.SplitN(args.stack, "/", 3)
 
 		// Set the org name for future use.


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13527.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
