### PR TITLE
Add missing map lock for Registry.RegisterAlias

### DIFF
--- a/changelog/pending/20230719--engine--add-a-missing-lock-that-could-cause-a-concurrent-map-read-write-panic.yaml
+++ b/changelog/pending/20230719--engine--add-a-missing-lock-that-could-cause-a-concurrent-map-read-write-panic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Add a missing lock that could cause a concurrent map read/write panic.

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -292,6 +292,9 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 // RegisterAliases informs the registry that the new provider object with the given URN is aliased to the given list
 // of URNs.
 func (r *Registry) RegisterAlias(providerURN, alias resource.URN) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
 	if providerURN != alias {
 		r.aliases[providerURN] = alias
 	}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13491.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
