### PR TITLE
Fix node programgen enum to use package identifier.

### DIFF
--- a/changelog/pending/20230724--programgen-nodejs--fixes-issue-with-javascript-program-generation-where-enums-would-incorrectly-reference-the-package-rather-than-the-import-alias.yaml
+++ b/changelog/pending/20230724--programgen-nodejs--fixes-issue-with-javascript-program-generation-where-enums-would-incorrectly-reference-the-package-rather-than-the-import-alias.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fixes issue with javascript program generation where enums would incorrectly reference the package rather than the import alias.

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateProgramVersionSelection(t *testing.T) {
@@ -46,4 +48,23 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 			ExpectedVersion: expectedVersion,
 			DependencyFile:  "package.json",
 		})
+}
+
+func TestEnumReferencesCorrectIdentifier(t *testing.T) {
+	t.Parallel()
+	s := &schema.Package{
+		Name: "pulumiservice",
+		Language: map[string]interface{}{
+			"nodejs": NodePackageInfo{
+				PackageName: "@pulumi/bar",
+			},
+		},
+	}
+	result, err := enumNameWithPackage("pulumiservice:index:WebhookFilters", s.Reference())
+	assert.NoError(t, err)
+	assert.Equal(t, "pulumiservice.WebhookFilters", result)
+
+	// These are redundant, but serve to clarify our expectations around package alias names.
+	assert.NotEqual(t, "bar.WebhookFilters", result)
+	assert.NotEqual(t, "@pulumi/bar.WebhookFilters", result)
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12986 

Fixes issue with javascript program generation where enums would incorrectly reference the package rather than the import alias.

There are changes being made to codegen testing (adding matrix testing) which is why a more extensive test is not being added.

Context:

NodeJS package aliases are generated using the following code
https://github.com/pulumi/pulumi/blob/917b2afdfcb9d797f5d756f6e9084717d2c57da6/pkg/codegen/nodejs/gen_program.go#L333

When a provider schema supplies a language specific package name for nodejs like

```json
{
  "name": "pulumiservice",
  "language": {
    ...
    "nodejs": {
      "packageName": "@pulumi/bar",
      ...
    },
    ...
  },
  ...
}
```

programgen would use `@pulumi/bar` rather than `pulumiservice`. for enums

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as pulumiservice from "@pulumi/bar";

const my_webhook = new pulumiservice.Webhook("my_webhook", {
    active: true,
    displayName: "kyle-repro",
    filters: [@pulumi/bar.WebhookFilters.DeploymentSucceeded],
    format: @pulumi/bar.WebhookFormat.Raw,
    organizationName: "pulumi",
    payloadUrl: "https://example.com",
    projectName: "awstypescript",
    stackName: "dev",
}, {
    protect: true,
});
```

this PR fixes it to correctly show as follows:

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as pulumiservice from "@pulumi/bar";

const my_webhook = new pulumiservice.Webhook("my_webhook", {
    active: true,
    displayName: "kyle-repro",
    filters: [pulumiservice.WebhookFilters.DeploymentSucceeded],
    format: pulumiservice.WebhookFormat.Raw,
    organizationName: "pulumi",
    payloadUrl: "https://example.com",
    projectName: "awstypescript",
    stackName: "dev",
}, {
    protect: true,
});
```

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
