### PR TITLE
Test and fix --target-dependents

### DIFF
--- a/changelog/pending/20230722--engine--fix-target-dependents-from-targeting-all-resources-with-default-providers.yaml
+++ b/changelog/pending/20230722--engine--fix-target-dependents-from-targeting-all-resources-with-default-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix --target-dependents from targeting all resources with default providers.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -81,9 +81,13 @@ func (sg *stepGenerator) isTargetedForUpdate(res *resource.State) bool {
 	}
 
 	if ref := res.Provider; ref != "" {
-		res, err := providers.ParseReference(ref)
+		proivderRef, err := providers.ParseReference(ref)
 		contract.AssertNoErrorf(err, "failed to parse provider reference: %v", ref)
-		if sg.opts.Targets.Contains(res.URN()) {
+		providerURN := proivderRef.URN()
+		// We don't follow default provider dependents, as default providers are internally managed and are
+		// always targeted. See https://github.com/pulumi/pulumi/issues/13557 for context of what happens if
+		// we do follow these.
+		if !providers.IsDefaultProvider(providerURN) && sg.opts.Targets.Contains(providerURN) {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13557.

A while ago we changed default providers to always count as targeted. Unfortunately that resulted in every resource being manged by a default provider being targeted when --target-dependents was set, which was not expected.

This change changes --target-dependents to not treat resources as targeted just because their default provider is targeted. Explicit providers which are targeted will cause all their managed resources to become targets.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
