### PR TITLE
Don't unwrap clases in TypeScript

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -488,7 +488,7 @@ function outputRec(val: any): any {
         const promisedArray = Promise.all(allValues.map((v) => getAwaitableValue(v)));
         const [syncResources, isKnown, isSecret, allResources] = getResourcesAndDetails(allValues);
         return new Output(syncResources, promisedArray, isKnown, isSecret, allResources);
-    } else {
+    } else if (Object.getPrototypeOf(val) === Object.prototype) {
         const promisedValues: { key: string; value: any }[] = [];
         let hasOutputs = false;
         for (const k of Object.keys(val)) {
@@ -515,6 +515,9 @@ function outputRec(val: any): any {
             promisedValues.map((kvp) => kvp.value),
         );
         return new Output(syncResources, promisedObject, isKnown, isSecret, allResources);
+    } else {
+        // This is some complex object, just return it as is we can't deeply unwrap outputs within it.
+        return val;
     }
 }
 

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -1033,6 +1033,31 @@ describe("output", () => {
         });
     });
 
+    describe("output", () => {
+        it("deeply unwraps arrays", async () => {
+            const o = output([output(0), output(1)]);
+            const result = await o.promise();
+            assert.deepStrictEqual(result, [0, 1]);
+        });
+
+        it("deeply unwraps objects", async () => {
+            const o = output({ a: output(0), b: output(1) });
+            const result = await o.promise();
+            assert.deepStrictEqual(result, { a: 0, b: 1 });
+        });
+
+        it("does not unwrap classes", async () => {
+            // Regression test for https://github.com/pulumi/pulumi/issues/13561
+            const o = output(new URL("https://example.com"));
+            const host = o.apply(url => {
+                return url.host;
+            });
+            assert.strictEqual(await host.isKnown, true);
+            const result = await host.promise();
+            assert.strictEqual(result, "example.com");
+        });
+    });
+
     describe("concat", () => {
         it("handles no args", async () => {
             const result = concat();


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13561.

This changes the TypeScript unwrap behaviour to not unwrap outputs through non-trivial objects. This keeps classes like `URL` as just `URL`.
## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
