### PR TITLE
Test Construct on providers configured with unknown values

### DIFF
--- a/changelog/pending/20230725--engine--fix-a-panic-when-trying-to-construct-a-remote-component-with-an-explicit-provider-configured-with-unknown-values-during-preview.yaml
+++ b/changelog/pending/20230725--engine--fix-a-panic-when-trying-to-construct-a-remote-component-with-an-explicit-provider-configured-with-unknown-values-during-preview.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic when trying to construct a remote component with an explicit provider configured with unknown values during preview.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1291,8 +1291,12 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QN
 		return ConstructResult{}, err
 	}
 
-	// We should only be calling Construct if the provider is fully configured.
-	contract.Assertf(pcfg.known, "Construct cannot be called if the configuration is unknown")
+	// If the provider is not fully configured, we need to error. We can't support unknown URNs but if the
+	// provider isn't configured we can't call into it to get the URN.
+	if !pcfg.known {
+		return ConstructResult{}, fmt.Errorf(
+			"cannot construct components if the provider is configured with unknown values")
+	}
 
 	if !pcfg.acceptSecrets {
 		return ConstructResult{}, fmt.Errorf("plugins that can construct components must support secrets")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a test to check that we don't try to call Construct on providers when we haven't yet configured them (because config values were unknown).

This flagged that it was possible for a user program to trigger an assert in the engine Construct code, I've changed that to an error.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
