### PR TITLE
[sdkgen/python] SDKgen on external enums

### DIFF
--- a/changelog/pending/20230725--sdkgen-python--fixes-python-external-enum-types-missing-the-import-reference-to-the-external-package.yaml
+++ b/changelog/pending/20230725--sdkgen-python--fixes-python-external-enum-types-missing-the-import-reference-to-the-external-package.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fixes python external enum types missing the import reference to the external package.

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">local_enum</span><span class="p">:</span> <span class="nx">Optional[_local.MyEnum]</span> = None<span class="p">,</span>
-              <span class="nx">remote_enum</span><span class="p">:</span> <span class="nx">Optional[_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem]</span> = None<span class="p">)</span>
+              <span class="nx">local_enum</span><span class="p">:</span> <span class="nx">Optional[local.MyEnum]</span> = None<span class="p">,</span>
+              <span class="nx">remote_enum</span><span class="p">:</span> <span class="nx">Optional[pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ComponentArgs]</a></span> = None<span class="p">,</span>

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
@@ -16,8 +16,8 @@ __all__ = ['ComponentArgs', 'Component']
 @pulumi.input_type
 class ComponentArgs:
     def __init__(__self__, *,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None):
+                 local_enum: Optional[pulumi.Input['local.MyEnum']] = None,
+                 remote_enum: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -28,20 +28,20 @@ class ComponentArgs:
 
     @property
     @pulumi.getter(name="localEnum")
-    def local_enum(self) -> Optional[pulumi.Input['_local.MyEnum']]:
+    def local_enum(self) -> Optional[pulumi.Input['local.MyEnum']]:
         return pulumi.get(self, "local_enum")
 
     @local_enum.setter
-    def local_enum(self, value: Optional[pulumi.Input['_local.MyEnum']]):
+    def local_enum(self, value: Optional[pulumi.Input['local.MyEnum']]):
         pulumi.set(self, "local_enum", value)
 
     @property
     @pulumi.getter(name="remoteEnum")
-    def remote_enum(self) -> Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
+    def remote_enum(self) -> Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
         return pulumi.get(self, "remote_enum")
 
     @remote_enum.setter
-    def remote_enum(self, value: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]):
+    def remote_enum(self, value: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]):
         pulumi.set(self, "remote_enum", value)
 
 
@@ -50,8 +50,8 @@ class Component(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
+                 local_enum: Optional[pulumi.Input['local.MyEnum']] = None,
+                 remote_enum: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Component(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
+                 local_enum: Optional[pulumi.Input['local.MyEnum']] = None,
+                 remote_enum: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -122,11 +122,11 @@ class Component(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="localEnum")
-    def local_enum(self) -> pulumi.Output[Optional['_local.MyEnum']]:
+    def local_enum(self) -> pulumi.Output[Optional['local.MyEnum']]:
         return pulumi.get(self, "local_enum")
 
     @property
     @pulumi.getter(name="remoteEnum")
-    def remote_enum(self) -> pulumi.Output[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
+    def remote_enum(self) -> pulumi.Output[Optional['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
         return pulumi.get(self, "remote_enum")
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12695

Python SDKGen was not correctly referencing external enum types which needed an import alias.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
