### PR TITLE
A few fixes for `pulumi logs`

### DIFF
--- a/changelog/pending/20230727--cli--fixes-for-pulumi-import.yaml
+++ b/changelog/pending/20230727--cli--fixes-for-pulumi-import.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli
-  description: Several fixes for `pulumi import` including support for first-class providers, support for ambient credentials and improved error reporting.
+  description: Several fixes for `pulumi logs` including support for first-class providers, support for ambient credentials and improved error reporting.

--- a/changelog/pending/20230727--cli--fixes-for-pulumi-import.yaml
+++ b/changelog/pending/20230727--cli--fixes-for-pulumi-import.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Several fixes for `pulumi import` including support for first-class providers, support for ambient credentials and improved error reporting.

--- a/pkg/operations/operations_aws.go
+++ b/pkg/operations/operations_aws.go
@@ -120,7 +120,7 @@ func (ops *awsOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	switch state.Type {
 	case awsFunctionType:
 		functionName := state.Outputs["name"].StringValue()
-		logResult, err := ops.awsConnection.getLogsForLogGroupsConcurrently(
+		logResult := ops.awsConnection.getLogsForLogGroupsConcurrently(
 			[]string{functionName},
 			[]string{"/aws/lambda/" + functionName},
 			query.StartTime,
@@ -128,10 +128,10 @@ func (ops *awsOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 		)
 		sort.SliceStable(logResult, func(i, j int) bool { return logResult[i].Timestamp < logResult[j].Timestamp })
 		logging.V(5).Infof("GetLogs[%v] return %d logs", state.URN, len(logResult))
-		return &logResult, err
+		return &logResult, nil
 	case awsLogGroupType:
 		name := state.Outputs["name"].StringValue()
-		logResult, err := ops.awsConnection.getLogsForLogGroupsConcurrently(
+		logResult := ops.awsConnection.getLogsForLogGroupsConcurrently(
 			[]string{name},
 			[]string{name},
 			query.StartTime,
@@ -139,7 +139,7 @@ func (ops *awsOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 		)
 		sort.SliceStable(logResult, func(i, j int) bool { return logResult[i].Timestamp < logResult[j].Timestamp })
 		logging.V(5).Infof("GetLogs[%v] return %d logs", state.URN, len(logResult))
-		return &logResult, err
+		return &logResult, nil
 	default:
 		// Else this resource kind does not produce any logs.
 		logging.V(6).Infof("GetLogs[%v] does not produce logs", state.URN)
@@ -199,7 +199,7 @@ func (p *awsConnection) getLogsForLogGroupsConcurrently(
 	logGroups []string,
 	startTime *time.Time,
 	endTime *time.Time,
-) ([]LogEntry, error) {
+) []LogEntry {
 	// Create a channel for collecting log event outputs
 	ch := make(chan []*cloudwatchlogs.FilteredLogEvent, len(logGroups))
 
@@ -247,5 +247,5 @@ func (p *awsConnection) getLogsForLogGroupsConcurrently(
 		}
 	}
 
-	return logs, nil
+	return logs
 }

--- a/pkg/operations/operations_aws_test.go
+++ b/pkg/operations/operations_aws_test.go
@@ -24,13 +24,13 @@ func TestSessionCache(t *testing.T) {
 	t.Parallel()
 
 	// Create a default session in us-west-2.
-	sess1, err := getAWSSession("us-west-2", "", "", "")
+	sess1, err := getAWSSession("us-west-2", "", "", "", "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, sess1)
 	assert.Equal(t, "us-west-2", *sess1.Config.Region)
 
 	// Create a session with explicit credentials and ensure they're set.
-	sess2, err := getAWSSession("us-west-2", "AKIA123", "456", "xyz")
+	sess2, err := getAWSSession("us-west-2", "AKIA123", "456", "xyz", "", false)
 	assert.NoError(t, err)
 
 	creds, err := sess2.Config.Credentials.Get()
@@ -40,7 +40,7 @@ func TestSessionCache(t *testing.T) {
 	assert.Equal(t, "xyz", creds.SessionToken)
 
 	// Create a session with different creds and make sure they're different.
-	sess3, err := getAWSSession("us-west-2", "AKIA123", "456", "hij")
+	sess3, err := getAWSSession("us-west-2", "AKIA123", "456", "hij", "", false)
 	assert.NoError(t, err)
 
 	creds, err = sess3.Config.Credentials.Get()

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -201,7 +201,8 @@ var (
 )
 
 // extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping Lambda-specific
-// metadata.  In particular, only the second and third line below is extracted, and it is extracted with the recorded timestamp.
+// metadata.  In particular, only the second and third line below is extracted, and it is extracted with the
+// recorded timestamp.
 //
 // ```
 //

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -191,16 +191,23 @@ var (
 	// Used prior to pulumi-terraform@1307256eeeefdd87ffd76581cd3ab73c3d7cfd4a
 	oldFunctionNameFromLogGroupNameRegExp = regexp.MustCompile(`^/aws/lambda/(.*)[0-9A-Fa-f]{8}$`)
 	// Extract Lambda log parts from Lambda log format
-	logRegexp = regexp.MustCompile("^(.{23}Z)\t[a-g0-9\\-]{36}\t((?s).*)\n")
+	// * Starts with a timestamp
+	// * Then a tab
+	// * Then either (a) `undefined` or (b) a UUID like `25e0d1e0-cbd6-11e7-9808-c7085dfe5723`
+	// * Then a tab
+	// * Then the message
+	// * Finally a newline
+	logRegexp = regexp.MustCompile("^(.{23}Z)\t[a-z0-9\\-]+\t((?s).*)\n")
 )
 
 // extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping Lambda-specific
-// metadata.  In particular, only the second line below is extracter, and it is extracted with the recorded timestamp.
+// metadata.  In particular, only the second and third line below is extracted, and it is extracted with the recorded timestamp.
 //
 // ```
 //
 //	START RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723 Version: $LATEST
 //	2017-11-17T20:30:27.736Z	25e0d1e0-cbd6-11e7-9808-c7085dfe5723	GET /todo
+//	2017-11-17T20:31:52.126Z	undefined	ERROR	Uncaught Exception 	{}
 //	END RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723
 //	REPORT RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723	Duration: 222.92 ms	Billed Duration: 300 ms 	<snip>
 //

--- a/pkg/operations/operations_cloud_aws_test.go
+++ b/pkg/operations/operations_cloud_aws_test.go
@@ -25,9 +25,15 @@ func Test_extractLambdaLogMessage(t *testing.T) {
 
 	res := extractLambdaLogMessage("START RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723 Version: $LATEST\n", "foo")
 	assert.Nil(t, res)
+
 	res = extractLambdaLogMessage("2017-11-17T20:30:27.736Z	25e0d1e0-cbd6-11e7-9808-c7085dfe5723	GET /todo\n", "foo")
 	assert.NotNil(t, res)
 	assert.Equal(t, "GET /todo", res.Message)
+
+	res = extractLambdaLogMessage("2017-11-17T20:31:52.126Z	undefined	ERROR	Uncaught Exception 	{}\n", "foo")
+	assert.NotNil(t, res)
+	assert.Equal(t, "ERROR	Uncaught Exception 	{}", res.Message)
+
 	res = extractLambdaLogMessage("END RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723\n", "foo")
 	assert.Nil(t, res)
 }


### PR DESCRIPTION
While many of the most fundamental limitations of `pulumi logs` are still dependent on moving this code out of pulumi/pulumi and into pulumi/pulumi-aws and other resource providers (https://github.com/pulumi/pulumi/issues/608), this PR implements a few more tactical fixes which improve some common scenarios.

Unfortunately, this whole area of the code is largely untested, in part because we didn't want to add a dependency on AWS in this layer (yet another reason we really want to do https://github.com/pulumi/pulumi/issues/608).  We could choose to further violate this layering and add tests here that use `pulumi-aws` to deploy Pulumi resources and then test them against this AWS operations provider.

In the meantime, I have manually validated fixes for the following issues.
    
Fixes #2665.
Fixes #1926.
Fixes #3947.
Fixes #1828.

