### PR TITLE
[dotnet/program-gen] Fix typing for optional and complex config variables in main program

### DIFF
--- a/changelog/pending/20230726--programgen-dotnet--fix-typing-for-optional-and-complex-config-variables-in-main-program.yaml
+++ b/changelog/pending/20230726--programgen-dotnet--fix-typing-for-optional-and-complex-config-variables-in-main-program.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet
+  description: Fix typing for optional and complex config variables in main program

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -337,8 +337,8 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "optional-complex-config",
 		Description: "Tests generating code for optional and complex config values",
-		Skip:        allProgLanguages.Except("nodejs"),
-		SkipCompile: allProgLanguages.Except("nodejs"),
+		Skip:        allProgLanguages.Except("nodejs").Except("dotnet"),
+		SkipCompile: allProgLanguages.Except("nodejs").Except("dotnet"),
 	},
 	{
 		Directory:   "interpolated-string-keys",

--- a/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/dotnet/invoke-inside-conditional-range.cs
+++ b/pkg/codegen/testing/test/testdata/invoke-inside-conditional-range-pp/dotnet/invoke-inside-conditional-range.cs
@@ -9,9 +9,9 @@ return await Deployment.RunAsync(async() =>
 {
     var config = new Config();
     // A list of availability zones names or ids in the region
-    var azs = config.GetObject<dynamic>("azs") ?? new[] {};
+    var azs = config.GetObject<string[]>("azs") ?? new[] {};
     // Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list
-    var publicSubnetIpv6Prefixes = config.GetObject<dynamic>("publicSubnetIpv6Prefixes") ?? new[] {};
+    var publicSubnetIpv6Prefixes = config.GetObject<string[]>("publicSubnetIpv6Prefixes") ?? new[] {};
     // Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`
     var oneNatGatewayPerAz = config.GetBoolean("oneNatGatewayPerAz") ?? false;
     // Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block

--- a/pkg/codegen/testing/test/testdata/optional-complex-config-pp/dotnet/optional-complex-config.cs
+++ b/pkg/codegen/testing/test/testdata/optional-complex-config-pp/dotnet/optional-complex-config.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var config = new Config();
+    // The tag of the VPC
+    var vpcTag = config.Get("vpcTag");
+    // The id of a VPC to use instead of creating a new one
+    var vpcId = config.Get("vpcId");
+    // The list of subnets to use
+    var subnets = config.GetObject<string[]>("subnets");
+    // Additional tags to add to the VPC
+    var moreTags = config.GetObject<Dictionary<string, string>>("moreTags");
+    // The userdata to use for the instances
+    var userdata = config.GetObject<Userdata>("userdata");
+    // A complex object
+    var complexUserdata = config.GetObject<ComplexUserdata[]>("complexUserdata");
+    var main = new Aws.Ec2.Vpc("main", new()
+    {
+        CidrBlock = "10.100.0.0/16",
+        Tags = 
+        {
+            { "Name", vpcTag },
+        },
+    });
+
+});
+
+public class ComplexUserdata
+{
+    public string content { get; set; }
+    public string path { get; set; }
+}
+
+public class Userdata
+{
+    public string content { get; set; }
+    public string path { get; set; }
+}
+


### PR DESCRIPTION
# Description

This PR adds support in dotnet program-gen for  optional and complex config variables. For Object-typed config variables, it will generate a class with the shape of the type, then later on during `config.GetObject<T>` it will use a reference to that type `T`

Similarly to complex types in component config variables, this does not implemented _nested_ objects yet but handles the most common cases. 

Fixes #13569

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
