### PR TITLE
test(regress-13301): Avoid accidental tidying

### DIFF
--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -2,32 +2,7 @@
 
 set -euo pipefail
 
-# Array of paths to exclude from go mod tidy.
-# Files that are intentionally malformed should be added here
-# with an explanation of why they are excluded.
-EXCLUDE=(
-    # This issue occurs only if a package referenced in the go.mod
-    # is not actually imported by the accompanying Go code.
-    #
-    # 'go mod tidy' will remove the unused dependency,
-    # but we want to keep it in the go.mod file.
-    tests/integration/go/regress-13301 \
-)
-
-# Reads from stdin and filters out any paths that are in the EXCLUDE array.
-filter_excludes() {
-    # Explanation:
-    #  -v: Invert the match, i.e. print lines that don't match
-    #  -F: Treat each line as an exact string, not a regex
-    #  -f: Read patterns from the file
-    #  <(..): Treat the output of the command inside the (..) as a file
-    #  printf: Print each element of the array on a separate line
-    #
-    # Ref: https://askubuntu.com/a/1446204
-    grep -vFf <(printf '%s\n' "${EXCLUDE[@]}")
-}
-
-for f in $(git ls-files | grep go.mod | filter_excludes)
+for f in $(git ls-files | grep go.mod)
 do
     (cd "$(dirname "${f}")" && go mod tidy -compat=1.18)
 done

--- a/tests/integration/go/regress-13301/go.mod.bad
+++ b/tests/integration/go/regress-13301/go.mod.bad
@@ -1,3 +1,6 @@
+// This file is named 'go.mod.bad' to prevent it from being picked up by
+// the Go toolchain and tools searching for 'go.mod' files.
+
 module repro-plugin-install
 
 go 1.20

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -961,6 +961,13 @@ func TestAutomation_externalPluginDownload_issue13301(t *testing.T) {
 		}
 	}()
 	e.ImportDirectory(filepath.Join("go", "regress-13301"))
+
+	// Rename go.mod.bad to go.mod so that the Go toolchain uses it.
+	require.NoError(t, os.Rename(
+		filepath.Join(e.CWD, "go.mod.bad"),
+		filepath.Join(e.CWD, "go.mod"),
+	))
+
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 
 	// Plugins are installed globally in PULUMI_HOME.


### PR DESCRIPTION
The regression test for #13301 needs an intentionally bad go.mod file.
This file was excluded from `make tidy`, allowing it to remain invalid,
but this doesn't protect it from bulk commands like the following
used in #13593

```bash
find . -name go.mod -exec dirname '{}' ';' | while read R; do
  (cd "$R" && ... && go mod tidy)
done
```

In fact, #13593 accidentally tidied this go.mod file
(removing the extraneous dependencies critical to the regression test)
and failed in CI.

To prevent issues like this, rename the go.mod to go.mod.bad,
and rename it back to go.mod in the test environment at test time.

This also lets us revert the `make tidy` exclusion support in tidy.sh.
