### PR TITLE
[codegen] Fix bug in provider schema where default int properties could not be int

### DIFF
--- a/changelog/pending/20230726--sdkgen--fix-bug-binding-provider-schema-where-type-default-int-values-could-not-take-integers.yaml
+++ b/changelog/pending/20230726--sdkgen--fix-bug-binding-provider-schema-where-type-default-int-values-could-not-take-integers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: Fix bug binding provider schema where type default int values could not take integers.

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -18,6 +18,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -955,5 +956,23 @@ func TestPackageIdentity(t *testing.T) {
 				assert.False(t, pkgA.Equals(pkgB))
 			}
 		})
+	}
+}
+
+func TestBindDefaultInt(t *testing.T) {
+	t.Parallel()
+	dv, diag := bindDefaultValue("fake-path", int(32), nil, IntType)
+	if diag.HasErrors() {
+		t.Fail()
+	}
+	assert.Equal(t, int32(32), dv.Value)
+
+	// Check that we error on overflow/underflow when casting int to int32.
+	if _, diag := bindDefaultValue("fake-path", int(math.MaxInt64), nil, IntType); !diag.HasErrors() {
+		assert.Fail(t, "did not catch oveflow")
+		t.Fail()
+	}
+	if _, diag := bindDefaultValue("fake-path", int(math.MinInt64), nil, IntType); !diag.HasErrors() {
+		assert.Fail(t, "did not catch underflow")
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6469

From the issue:

The following type definition

```json
"myprovider:index:ResourceSignal": {
            "properties": {
                "Count": {
                    "type": "integer",
                    "default": 1
                },
                "Timeout": {
                    "type": "string",
                    "default": "PT5M"
                }
            },
            "type": "object"
        }
```

causes an error during schema import

```
panic: error importing schema: binding types: failed to bind type myprovider:index:ResourceSignal:
error binding default value for property "Count": invalid default of type int for integer property
```

Apparently, we only allow floats as defaults here. Changing to `1.0` makes the error go away.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
