### PR TITLE
ci(go): Don't run with -race on Windows

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -108,8 +108,11 @@ jobs:
       - name: Reduce Windows test parallelism
         if: ${{ runner.os == 'Windows' }}
         run: |
-          echo "GO_TEST_PARALLELISM=4" >> "$GITHUB_ENV"
-          echo "GO_TEST_PKG_PARALLELISM=1" >> "$GITHUB_ENV"
+          {
+            echo "GO_TEST_PARALLELISM=4"
+            echo "GO_TEST_PKG_PARALLELISM=1"
+            echo "GO_TEST_RACE=false"
+          } >> "$GITHUB_ENV"
           # For debugging:
           ps aux
       - name: "macOS use coreutils"


### PR DESCRIPTION
For tests on Windows, don't run with data race detection.
This should reduce the time and memory it takes to run these tests,
hopefully reducing the runner disconnects we've been seeing.

Relates to #13238
