### PR TITLE
Make `Output.from_input` recurse into tuples.

### DIFF
--- a/changelog/pending/20230727--sdk-python--output-from_input-now-recurses-into-tuples.yaml
+++ b/changelog/pending/20230727--sdk-python--output-from_input-now-recurses-into-tuples.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: `Output.from_input` now recurses into tuples.

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -305,7 +305,7 @@ class Output(Generic[T_co]):
             )
             return cast(Output[T_co], o_typ)
 
-        # Is a (non-empty) dict or list? Recurse into the values within them.
+        # Is a (non-empty) dict, list, or tuple? Recurse into the values within them.
         if val and isinstance(val, dict):
             # The keys themselves might be outputs, so we can't just pass `**val` to all.
 
@@ -324,7 +324,13 @@ class Output(Generic[T_co]):
             o_list: Output[list] = Output.all(*val)
             return cast(Output[T_co], o_list)
 
-        # If it's not an output, list, or dict, it must be known and not secret
+        if val and isinstance(val, tuple):
+            # We can splat a tuple into all, but we'll always get back a list...
+            o_list = Output.all(*val)
+            # ...so we need to convert back to a tuple.
+            return cast(Output[T_co], o_list.apply(tuple))
+
+        # If it's not an output, tuple, list, or dict, it must be known and not secret
         is_known_fut: asyncio.Future[bool] = asyncio.Future()
         is_secret_fut: asyncio.Future[bool] = asyncio.Future()
         is_known_fut.set_result(True)

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -124,6 +124,24 @@ class OutputFromInputTests(unittest.TestCase):
         x_val = await x.future()
         self.assertEqual(x_val, o2)
 
+    @pulumi_test
+    async def test_unwrap_empty_tuple(self):
+        x = Output.from_input(())
+        x_val = await x.future()
+        self.assertEqual(x_val, ())
+
+    @pulumi_test
+    async def test_unwrap_tuple(self):
+        x = Output.from_input(("hello", Output.from_input("world")))
+        x_val = await x.future()
+        self.assertEqual(x_val, ("hello", "world"))
+
+    @pulumi_test
+    async def test_unwrap_tuple_tuple(self):
+        x = Output.from_input(("hello", ("foo", Output.from_input("bar"))))
+        x_val = await x.future()
+        self.assertEqual(x_val, ("hello", ("foo", "bar")))
+
     @pulumi.input_type
     class FooArgs:
         def __init__(self, *,


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/6635.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
