### PR TITLE
Make MapperAddress consistent everywhere by calling it MapperTarget

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -371,7 +371,7 @@ func runConvert(
 		resp, err := converter.ConvertProgram(pCtx.Request(), &plugin.ConvertProgramRequest{
 			SourceDirectory: cwd,
 			TargetDirectory: pclDirectory,
-			MapperAddress:   grpcServer.Addr(),
+			MapperTarget:    grpcServer.Addr(),
 		})
 		if err != nil {
 			return result.FromError(err)

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -531,7 +531,7 @@ func newImportCmd() *cobra.Command {
 				}
 
 				resp, err := converter.ConvertState(ctx, &plugin.ConvertStateRequest{
-					MapperAddress: grpcServer.Addr(),
+					MapperTarget: grpcServer.Addr(),
 				})
 				if err != nil {
 					return result.FromError(err)

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -11,7 +11,7 @@
 1949619858 9233 proto/pulumi/analyzer.proto
 2452746699 3822 proto/pulumi/codegen/hcl.proto
 3592920431 1785 proto/pulumi/codegen/mapper.proto
-2349987281 2509 proto/pulumi/converter.proto
+264855818 2507 proto/pulumi/converter.proto
 2889436496 3240 proto/pulumi/engine.proto
 3421371250 793 proto/pulumi/errors.proto
 2284604767 7368 proto/pulumi/language.proto

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -34,7 +34,7 @@ service Converter {
 }
 
 message ConvertStateRequest {
-    // the gRPC address of the mapper service.
+    // the gRPC target of the mapper service.
     string mapper_target = 1;
 }
 
@@ -63,7 +63,7 @@ message ConvertProgramRequest {
     string source_directory = 1;
     // a target directory to write the resulting PCL code and project file to.
     string target_directory = 2;
-    // the gRPC address of the mapper service.
+    // the gRPC target of the mapper service.
     string mapper_target = 3;
 }
 

--- a/sdk/go/common/resource/plugin/converter.go
+++ b/sdk/go/common/resource/plugin/converter.go
@@ -31,7 +31,7 @@ type ResourceImport struct {
 }
 
 type ConvertStateRequest struct {
-	MapperAddress string
+	MapperTarget string
 }
 
 type ConvertStateResponse struct {
@@ -41,7 +41,7 @@ type ConvertStateResponse struct {
 type ConvertProgramRequest struct {
 	SourceDirectory string
 	TargetDirectory string
-	MapperAddress   string
+	MapperTarget    string
 }
 
 type ConvertProgramResponse struct {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -109,7 +109,7 @@ func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) 
 	logging.V(7).Infof("%s executing", label)
 
 	resp, err := c.clientRaw.ConvertState(ctx, &pulumirpc.ConvertStateRequest{
-		MapperTarget: req.MapperAddress,
+		MapperTarget: req.MapperTarget,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
@@ -139,7 +139,7 @@ func (c *converter) ConvertProgram(ctx context.Context, req *ConvertProgramReque
 	resp, err := c.clientRaw.ConvertProgram(ctx, &pulumirpc.ConvertProgramRequest{
 		SourceDirectory: req.SourceDirectory,
 		TargetDirectory: req.TargetDirectory,
-		MapperTarget:    req.MapperAddress,
+		MapperTarget:    req.MapperTarget,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)

--- a/sdk/go/common/resource/plugin/converter_plugin_test.go
+++ b/sdk/go/common/resource/plugin/converter_plugin_test.go
@@ -78,7 +78,7 @@ func TestConverterPlugin_State(t *testing.T) {
 	}
 
 	resp, err := plugin.ConvertState(context.Background(), &ConvertStateRequest{
-		MapperAddress: "localhost:1234",
+		MapperTarget: "localhost:1234",
 	})
 
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestConverterPlugin_Program(t *testing.T) {
 	}
 
 	resp, err := plugin.ConvertProgram(context.Background(), &ConvertProgramRequest{
-		MapperAddress:   "localhost:1234",
+		MapperTarget:    "localhost:1234",
 		SourceDirectory: "src",
 		TargetDirectory: "dst",
 	})
@@ -136,7 +136,7 @@ func TestConverterPlugin_Program_EmptyDiagnosticsIsNil(t *testing.T) {
 	}
 
 	resp, err := plugin.ConvertProgram(context.Background(), &ConvertProgramRequest{
-		MapperAddress:   "localhost:1234",
+		MapperTarget:    "localhost:1234",
 		SourceDirectory: "src",
 		TargetDirectory: "dst",
 	})

--- a/sdk/go/common/resource/plugin/converter_server.go
+++ b/sdk/go/common/resource/plugin/converter_server.go
@@ -36,7 +36,7 @@ func (c *converterServer) ConvertState(ctx context.Context,
 	req *pulumirpc.ConvertStateRequest,
 ) (*pulumirpc.ConvertStateResponse, error) {
 	resp, err := c.converter.ConvertState(ctx, &ConvertStateRequest{
-		MapperAddress: req.MapperTarget,
+		MapperTarget: req.MapperTarget,
 	})
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (c *converterServer) ConvertProgram(ctx context.Context,
 	resp, err := c.converter.ConvertProgram(ctx, &ConvertProgramRequest{
 		SourceDirectory: req.SourceDirectory,
 		TargetDirectory: req.TargetDirectory,
-		MapperAddress:   req.MapperTarget,
+		MapperTarget:    req.MapperTarget,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/converter_server_test.go
+++ b/sdk/go/common/resource/plugin/converter_server_test.go
@@ -35,8 +35,8 @@ func (c *testConverter) Close() error {
 func (c *testConverter) ConvertState(
 	ctx context.Context, req *ConvertStateRequest,
 ) (*ConvertStateResponse, error) {
-	if req.MapperAddress != "localhost:1234" {
-		return nil, fmt.Errorf("unexpected MapperAddress: %s", req.MapperAddress)
+	if req.MapperTarget != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperTarget: %s", req.MapperTarget)
 	}
 
 	return &ConvertStateResponse{
@@ -55,8 +55,8 @@ func (c *testConverter) ConvertState(
 func (c *testConverter) ConvertProgram(
 	ctx context.Context, req *ConvertProgramRequest,
 ) (*ConvertProgramResponse, error) {
-	if req.MapperAddress != "localhost:1234" {
-		return nil, fmt.Errorf("unexpected MapperAddress: %s", req.MapperAddress)
+	if req.MapperTarget != "localhost:1234" {
+		return nil, fmt.Errorf("unexpected MapperTarget: %s", req.MapperTarget)
 	}
 	if req.SourceDirectory != "src" {
 		return nil, fmt.Errorf("unexpected SourceDirectory: %s", req.SourceDirectory)

--- a/sdk/proto/go/converter.pb.go
+++ b/sdk/proto/go/converter.pb.go
@@ -42,7 +42,7 @@ type ConvertStateRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// the gRPC address of the mapper service.
+	// the gRPC target of the mapper service.
 	MapperTarget string `protobuf:"bytes,1,opt,name=mapper_target,json=mapperTarget,proto3" json:"mapper_target,omitempty"`
 }
 
@@ -227,7 +227,7 @@ type ConvertProgramRequest struct {
 	SourceDirectory string `protobuf:"bytes,1,opt,name=source_directory,json=sourceDirectory,proto3" json:"source_directory,omitempty"`
 	// a target directory to write the resulting PCL code and project file to.
 	TargetDirectory string `protobuf:"bytes,2,opt,name=target_directory,json=targetDirectory,proto3" json:"target_directory,omitempty"`
-	// the gRPC address of the mapper service.
+	// the gRPC target of the mapper service.
 	MapperTarget string `protobuf:"bytes,3,opt,name=mapper_target,json=mapperTarget,proto3" json:"mapper_target,omitempty"`
 }
 

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
@@ -36,7 +36,7 @@ class ConvertStateRequest(google.protobuf.message.Message):
 
     MAPPER_TARGET_FIELD_NUMBER: builtins.int
     mapper_target: builtins.str
-    """the gRPC address of the mapper service."""
+    """the gRPC target of the mapper service."""
     def __init__(
         self,
         *,
@@ -109,7 +109,7 @@ class ConvertProgramRequest(google.protobuf.message.Message):
     target_directory: builtins.str
     """a target directory to write the resulting PCL code and project file to."""
     mapper_target: builtins.str
-    """the gRPC address of the mapper service."""
+    """the gRPC target of the mapper service."""
     def __init__(
         self,
         *,


### PR DESCRIPTION
We called this Address in one part of the code, and Target in another. This just makes it consistent by calling it Target everywhere.