### PR TITLE
[program-gen] Normalize the declaration name of generated resource components

### DIFF
--- a/changelog/pending/20230727--programgen-dotnet-go-nodejs-python--normalize-the-declaration-name-of-generated-resource-components.yaml
+++ b/changelog/pending/20230727--programgen-dotnet-go-nodejs-python--normalize-the-declaration-name-of-generated-resource-components.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet,go,nodejs,python
+  description: Normalize the declaration name of generated resource components

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -152,8 +151,8 @@ func GenerateProgramWithOptions(
 		"Program.cs": index.Bytes(),
 	}
 
-	for componentDir, component := range program.CollectComponents() {
-		componentName := Title(filepath.Base(componentDir))
+	for _, component := range program.CollectComponents() {
+		componentName := component.DeclarationName()
 		componentNodes := pcl.Linearize(component.Program)
 
 		componentGenerator := &generator{
@@ -524,7 +523,7 @@ func annotateObjectTypedConfig(componentName string, typeName string, objectType
 func collectObjectTypedConfigVariables(component *pcl.Component) map[string]*model.ObjectType {
 	objectTypes := map[string]*model.ObjectType{}
 	for _, config := range component.Program.ConfigVariables() {
-		componentName := Title(component.Name())
+		componentName := component.DeclarationName()
 		typeName := configObjectTypeName(config.Name())
 		switch configType := config.Type().(type) {
 		case *model.ObjectType:
@@ -1070,7 +1069,7 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions, resourceOption
 }
 
 func AnnotateComponentInputs(component *pcl.Component) {
-	componentName := Title(component.Name())
+	componentName := component.DeclarationName()
 	configVars := component.Program.ConfigVariables()
 
 	for index := range component.Inputs {
@@ -1225,7 +1224,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
 // genComponent handles the generation of instantiations of non-builtin resources.
 func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
-	componentName := Title(filepath.Base(r.DirPath()))
+	componentName := r.DeclarationName()
 	qualifiedMemberName := fmt.Sprintf("Components.%s", componentName)
 
 	name := r.LogicalName()

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -422,7 +422,8 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 	for componentDir, component := range program.CollectComponents() {
 		g.importer.Reset()
 
-		componentName := filepath.Base(componentDir)
+		componentFilename := filepath.Base(componentDir)
+		componentName := component.DeclarationName()
 		componentGenerator, err := newGenerator(component.Program, opts)
 		componentGenerator.isComponent = true
 		componentHelperse := componentGenerator.collectImports(component.Program)
@@ -447,12 +448,12 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 			// add a warning diagnostic when there is a formatting error
 			componentGenerator.diagnostics = componentGenerator.diagnostics.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
-				Subject:  &hcl.Range{Filename: componentName + ".go"},
+				Subject:  &hcl.Range{Filename: componentFilename + ".go"},
 				Summary:  "could not format go code",
 				Detail:   err.Error(),
 			})
 		}
-		files[componentName+".go"] = componentContent
+		files[componentFilename+".go"] = componentContent
 	}
 	return files, g.diagnostics, nil
 }
@@ -1180,7 +1181,7 @@ func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
 		}
 	}
 
-	componentName := Title(filepath.Base(r.DirPath()))
+	componentName := r.DeclarationName()
 
 	instantiate := func(varName, resourceName string, w io.Writer) {
 		if g.scopeTraversalRoots.Has(varName) || strings.HasPrefix(varName, "__") {

--- a/pkg/codegen/pcl/component.go
+++ b/pkg/codegen/pcl/component.go
@@ -15,11 +15,12 @@
 package pcl
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
-	"path/filepath"
-	"strings"
 )
 
 // Component represents a component reference in a program.

--- a/pkg/codegen/pcl/component.go
+++ b/pkg/codegen/pcl/component.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"path/filepath"
+	"strings"
 )
 
 // Component represents a component reference in a program.
@@ -75,6 +77,24 @@ func (c *Component) LogicalName() string {
 
 func (c *Component) DirPath() string {
 	return c.dirPath
+}
+
+// DeclarationName returns the name of the component to use in the generated program's declaration.
+// It is the name of the component's directory, with invalid characters replaced with underscores.
+func (c *Component) DeclarationName() string {
+	baseDirName := filepath.Base(c.DirPath())
+	invalidChars := []string{"-", ".", " "}
+	for _, invalidChar := range invalidChars {
+		baseDirName = strings.ReplaceAll(baseDirName, invalidChar, "_")
+	}
+
+	componentName := ""
+	componentNameParts := strings.Split(baseDirName, "_")
+	for _, part := range componentNameParts {
+		componentName += titleCase(part)
+	}
+
+	return componentName
 }
 
 func (c *Component) Type() model.Type {

--- a/pkg/codegen/testing/test/testdata/components-pp/another-component/main.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/another-component/main.pp
@@ -1,0 +1,4 @@
+resource firstPassword "random:index/randomPassword:RandomPassword" {
+  length = 16
+  special = true
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/components.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/components.pp
@@ -1,5 +1,7 @@
 component simpleComponent "./simpleComponent" {}
 
+component anotherComponent "./another-component" {}
+
 component exampleComponent "./exampleComponent" {
     input = "doggo"
     ipAddress = [127, 0, 0, 1]

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/AnotherComponent.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/AnotherComponent.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Random = Pulumi.Random;
+
+namespace Components
+{
+    public class AnotherComponent : global::Pulumi.ComponentResource
+    {
+        public AnotherComponent(string name, ComponentResourceOptions? opts = null)
+            : base("components:index:AnotherComponent", name, ResourceArgs.Empty, opts)
+        {
+            var firstPassword = new Random.RandomPassword($"{name}-firstPassword", new()
+            {
+                Length = 16,
+                Special = true,
+            }, new CustomResourceOptions
+            {
+                Parent = this,
+            });
+
+            this.RegisterOutputs();
+        }
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -6,6 +6,8 @@ return await Deployment.RunAsync(() =>
 {
     var simpleComponent = new Components.SimpleComponent("simpleComponent");
 
+    var anotherComponent = new Components.AnotherComponent("anotherComponent");
+
     var exampleComponent = new Components.ExampleComponent("exampleComponent", new()
     {
         Input = "doggo",

--- a/pkg/codegen/testing/test/testdata/components-pp/go/another-component.go
+++ b/pkg/codegen/testing/test/testdata/components-pp/go/another-component.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type AnotherComponentArgs struct {
+}
+
+type AnotherComponent struct {
+	pulumi.ResourceState
+}
+
+func NewAnotherComponent(
+	ctx *pulumi.Context,
+	name string,
+	args *AnotherComponentArgs,
+	opts ...pulumi.ResourceOption,
+) (*AnotherComponent, error) {
+	var componentResource AnotherComponent
+	err := ctx.RegisterComponentResource("components:index:AnotherComponent", name, &componentResource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	_, err = random.NewRandomPassword(ctx, fmt.Sprintf("%s-firstPassword", name), &random.RandomPasswordArgs{
+		Length:  pulumi.Int(16),
+		Special: pulumi.Bool(true),
+	}, pulumi.Parent(&componentResource))
+	if err != nil {
+		return nil, err
+	}
+	err = ctx.RegisterResourceOutputs(&componentResource, pulumi.Map{})
+	if err != nil {
+		return nil, err
+	}
+	return &componentResource, nil
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/go/components.go
+++ b/pkg/codegen/testing/test/testdata/components-pp/go/components.go
@@ -10,6 +10,10 @@ func main() {
 		if err != nil {
 			return err
 		}
+		_, err = NewAnotherComponent(ctx, "anotherComponent", nil)
+		if err != nil {
+			return err
+		}
 		exampleComponent, err := NewExampleComponent(ctx, "exampleComponent", &ExampleComponentArgs{
 			Input: "doggo",
 			IpAddress: []int{

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/another-component.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/another-component.ts
@@ -1,0 +1,16 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+export class AnotherComponent extends pulumi.ComponentResource {
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:AnotherComponent", name, {}, opts);
+        const firstPassword = new random.RandomPassword(`${name}-firstPassword`, {
+            length: 16,
+            special: true,
+        }, {
+            parent: this,
+        });
+
+        this.registerOutputs();
+    }
+}

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -1,8 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
+import { AnotherComponent } from "./another-component";
 import { ExampleComponent } from "./exampleComponent";
 import { SimpleComponent } from "./simpleComponent";
 
 const simpleComponent = new SimpleComponent("simpleComponent");
+const anotherComponent = new AnotherComponent("anotherComponent");
 const exampleComponent = new ExampleComponent("exampleComponent", {
     input: "doggo",
     ipAddress: [

--- a/pkg/codegen/testing/test/testdata/components-pp/python/another_component.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/another_component.py
@@ -1,0 +1,15 @@
+import pulumi
+from pulumi import Input
+from typing import Optional, Dict, TypedDict, Any
+import pulumi_random as random
+
+class AnotherComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("components:index:AnotherComponent", name, {}, opts)
+
+        first_password = random.RandomPassword(f"{name}-firstPassword",
+            length=16,
+            special=True,
+            opts=pulumi.ResourceOptions(parent=self))
+
+        self.register_outputs()

--- a/pkg/codegen/testing/test/testdata/components-pp/python/components.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/components.py
@@ -1,8 +1,10 @@
 import pulumi
+from .another_component import AnotherComponent
 from .exampleComponent import ExampleComponent
 from .simpleComponent import SimpleComponent
 
 simple_component = SimpleComponent("simpleComponent")
+another_component = AnotherComponent("anotherComponent")
 example_component = ExampleComponent("exampleComponent", {
     'input': "doggo", 
     'ipAddress': [


### PR DESCRIPTION
This PR adds a new function `DeclarationName()` to PCL components which is then used as the name of the component inside of the code, distinguishing it from the file name where it lives. The function returns a valid and idiomatic name to be used and references in the generated code for all of the language generators. 

For example if you have a component of which its source code files live `./some-component` then the declaration name for that component would be `SomeComponent` etc. 

Fixes #13151

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
