### PR TITLE
[dotnet/program-gen] Fixes code generation of ForExpressions

### DIFF
--- a/changelog/pending/20230728--programgen-dotnet--fixes-code-generation-of-forexpressions-both-when-creating-a-list-or-a-dictionary.yaml
+++ b/changelog/pending/20230728--programgen-dotnet--fixes-code-generation-of-forexpressions-both-when-creating-a-list-or-a-dictionary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Fixes code generation of ForExpressions, both when creating a list or a dictionary 

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -263,3 +263,19 @@ func UnwrapOption(exprType model.Type) model.Type {
 		return exprType
 	}
 }
+
+// VariableAccessed returns whether the given variable name is accessed in the given expression.
+func VariableAccessed(variableName string, expr model.Expression) bool {
+	accessed := false
+	visitor := func(subExpr model.Expression) (model.Expression, hcl.Diagnostics) {
+		if traversal, ok := subExpr.(*model.ScopeTraversalExpression); ok {
+			if traversal.RootName == variableName {
+				accessed = true
+			}
+		}
+		return subExpr, nil
+	}
+
+	model.VisitExpression(expr, model.IdentityVisitor, visitor)
+	return accessed
+}

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -21,6 +21,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
@@ -276,6 +278,7 @@ func VariableAccessed(variableName string, expr model.Expression) bool {
 		return subExpr, nil
 	}
 
-	model.VisitExpression(expr, model.IdentityVisitor, visitor)
+	_, diags := model.VisitExpression(expr, model.IdentityVisitor, visitor)
+	contract.Assertf(len(diags) == 0, "expected no diagnostics from VisitExpression")
 	return accessed
 }

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -53,6 +53,17 @@ func ProgramTestBatch(k, n int) []ProgramTest {
 	return PulumiPulumiProgramTests[start:end]
 }
 
+// Useful when debugging a single test case.
+func SingleTestCase(directoryName string) []ProgramTest {
+	output := make([]ProgramTest, 0)
+	for _, t := range PulumiPulumiProgramTests {
+		if t.Directory == directoryName {
+			output = append(output, t)
+		}
+	}
+	return output
+}
+
 var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "assets-archives",
@@ -349,6 +360,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "interpolated-string-keys",
 		Description: "Tests that interpolated string keys are supported in maps. ",
 		Skip:        allProgLanguages.Except("nodejs").Except("python"),
+	},
+	{
+		Directory:   "csharp-typed-for-expressions",
+		Description: "Testing for expressions with typed target expressions in csharp",
+		Skip:        allProgLanguages.Except("dotnet"),
 	},
 }
 

--- a/pkg/codegen/testing/test/testdata/csharp-typed-for-expressions-pp/csharp-typed-for-expressions.pp
+++ b/pkg/codegen/testing/test/testdata/csharp-typed-for-expressions-pp/csharp-typed-for-expressions.pp
@@ -1,0 +1,24 @@
+config egress "list(object({FromPort=int, ToPort=int}))" {
+
+}
+
+config tags "map(string)" {
+    default = {}
+}
+
+defaultVpc = invoke("aws:ec2:getVpc", {
+	default = true
+})
+
+// Create a security group that permits HTTP ingress and unrestricted egress.
+resource webSecurityGroup "aws:ec2:SecurityGroup" {
+	vpcId = defaultVpc.id
+	egress = [for entry in entries(egress): {
+		protocol = "-1"
+		fromPort = entry.value.FromPort
+		toPort = entry.value.ToPort
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+
+	tags = { for k, v in tags: k => v }
+}

--- a/pkg/codegen/testing/test/testdata/csharp-typed-for-expressions-pp/dotnet/csharp-typed-for-expressions.cs
+++ b/pkg/codegen/testing/test/testdata/csharp-typed-for-expressions-pp/dotnet/csharp-typed-for-expressions.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var config = new Config();
+    var egress = config.RequireObject<Egress[]>("egress");
+    var tags = config.GetObject<Dictionary<string, string>>("tags") ?? null;
+    var defaultVpc = Aws.Ec2.GetVpc.Invoke(new()
+    {
+        Default = true,
+    });
+
+    // Create a security group that permits HTTP ingress and unrestricted egress.
+    var webSecurityGroup = new Aws.Ec2.SecurityGroup("webSecurityGroup", new()
+    {
+        VpcId = defaultVpc.Apply(getVpcResult => getVpcResult.Id),
+        Egress = egress.Select((v, k) => new { Key = k, Value = v }).Select(entry => 
+        {
+            return new Aws.Ec2.Inputs.SecurityGroupEgressArgs
+            {
+                Protocol = "-1",
+                FromPort = entry.Value.FromPort,
+                ToPort = entry.Value.ToPort,
+                CidrBlocks = new[]
+                {
+                    "0.0.0.0/0",
+                },
+            };
+        }).ToList(),
+        Tags = tags.Select(pair => new { pair.Key, pair.Value }).ToDictionary(item => {
+            var k = item.Key;
+            return k;
+        }, item => {
+            var v = item.Value;
+            return v;
+        }),
+    });
+
+});
+
+public class Egress
+{
+    public int FromPort { get; set; }
+    public int ToPort { get; set; }
+}
+

--- a/pkg/codegen/testing/test/testdata/entries-function-pp/dotnet/entries-function.cs
+++ b/pkg/codegen/testing/test/testdata/entries-function-pp/dotnet/entries-function.cs
@@ -11,12 +11,12 @@ return await Deployment.RunAsync(() =>
         3,
     }.Select((v, k) => new { Key = k, Value = v }).Select(entry => 
     {
-        return new Dictionary<string, object?>  
+        return 
         {
             { "usingKey", entry.Key },
             { "usingValue", entry.Value },
         };
-    });
+    }).ToList();
 
 });
 


### PR DESCRIPTION
# Description

When using ForExpressions from PCL, the resulting expression is either a list or a dictionary. Right now the generate code only emits `IEnumerable` and only works for input lists. This PR updates dotnet program-gen to fully support `ForExpressions` when creating a list, in which case the previous expression would use a suffix `.ToList()`. When creating maps/dictionaries, the generated code will use `ToDictionary(item => <keyExpr>, item => <valueExpr>)` 

<details>
<summary>Example PCL</summary>

```
config egress "list(object({FromPort=int, ToPort=int}))" {

}

config tags "map(string)" {
    default = {}
}

defaultVpc = invoke("aws:ec2:getVpc", {
	default = true
})

// Create a security group that permits HTTP ingress and unrestricted egress.
resource webSecurityGroup "aws:ec2:SecurityGroup" {
	vpcId = defaultVpc.id
	egress = [for entry in entries(egress): {
		protocol = "-1"
		fromPort = entry.value.FromPort
		toPort = entry.value.ToPort
		cidrBlocks = ["0.0.0.0/0"]
	}]

	tags = { for k, v in tags: k => v }
}
```

</details>

<details>
<summary>Generated C# which compiles</summary>

```csharp
using System.Collections.Generic;
using System.Linq;
using Pulumi;
using Aws = Pulumi.Aws;

return await Deployment.RunAsync(() => 
{
    var config = new Config();
    var egress = config.RequireObject<Egress[]>("egress");
    var tags = config.GetObject<Dictionary<string, string>>("tags") ?? null;
    var defaultVpc = Aws.Ec2.GetVpc.Invoke(new()
    {
        Default = true,
    });

    // Create a security group that permits HTTP ingress and unrestricted egress.
    var webSecurityGroup = new Aws.Ec2.SecurityGroup("webSecurityGroup", new()
    {
        VpcId = defaultVpc.Apply(getVpcResult => getVpcResult.Id),
        Egress = egress.Select((v, k) => new { Key = k, Value = v }).Select(entry => 
        {
            return new Aws.Ec2.Inputs.SecurityGroupEgressArgs
            {
                Protocol = "-1",
                FromPort = entry.Value.FromPort,
                ToPort = entry.Value.ToPort,
                CidrBlocks = new[]
                {
                    "0.0.0.0/0",
                },
            };
        }).ToList(),
        Tags = tags.Select(pair => new { pair.Key, pair.Value }).ToDictionary(item => {
            var k = item.Key;
            return k;
        }, item => {
            var v = item.Value;
            return v;
        }),
    });

});

public class Egress
{
    public int FromPort { get; set; }
    public int ToPort { get; set; }
}


```

</details>

Fixes #13613

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
