### PR TITLE
[nodejs/program-gen] Fixes parseProxyApply to handle nested outputs within index expressions

### DIFF
--- a/changelog/pending/20230730--programgen-nodejs--fixes-parseproxyapply-to-handle-nested-outputs-within-index-expressions.yaml
+++ b/changelog/pending/20230730--programgen-nodejs--fixes-parseproxyapply-to-handle-nested-outputs-within-index-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fixes parseProxyApply to handle nested outputs within index expressions

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -80,7 +80,8 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	switch then := then.(type) {
 	case *model.IndexExpression:
 		t := arg.Type()
-		if !isParameterReference(parameters, then.Collection) || model.IsOptionalType(t) || isPromiseType(t) {
+		skipType := model.IsOptionalType(t) || isPromiseType(t) || isOutputType(t)
+		if !isParameterReference(parameters, then.Collection) || skipType {
 			return nil, false
 		}
 		then.Collection = arg

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -362,6 +362,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs").Except("python"),
 	},
 	{
+		Directory:   "regress-node-12507",
+		Description: "Regression test for https://github.com/pulumi/pulumi/issues/12507",
+		Skip:        allProgLanguages.Except("nodejs"),
+		BindOptions: []pcl.BindOption{pcl.PreferOutputVersionedInvokes},
+	},
+	{
 		Directory:   "csharp-plain-lists",
 		Description: "Tests that plain lists are supported in C#",
 		Skip:        allProgLanguages.Except("dotnet"),

--- a/pkg/codegen/testing/test/testdata/regress-node-12507-pp/nodejs/regress-node-12507.ts
+++ b/pkg/codegen/testing/test/testdata/regress-node-12507-pp/nodejs/regress-node-12507.ts
@@ -1,0 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+const localGatewayVirtualInterfaceGroupId = config.require("localGatewayVirtualInterfaceGroupId");
+const rts = aws.ec2.getLocalGatewayRouteTablesOutput({
+    filters: [{
+        name: "tag:kubernetes.io/kops/role",
+        values: ["private*"],
+    }],
+});
+const routes: aws.ec2.LocalGatewayRoute[] = [];
+rts.ids.length.apply(rangeBody => {
+    for (const range = {value: 0}; range.value < rangeBody; range.value++) {
+        routes.push(new aws.ec2.LocalGatewayRoute(`routes-${range.value}`, {
+            destinationCidrBlock: "10.0.1.0/22",
+            localGatewayRouteTableId: rts.apply(rts => rts.ids[range.value]),
+            localGatewayVirtualInterfaceGroupId: localGatewayVirtualInterfaceGroupId,
+        }));
+    }
+});

--- a/pkg/codegen/testing/test/testdata/regress-node-12507-pp/regress-node-12507.pp
+++ b/pkg/codegen/testing/test/testdata/regress-node-12507-pp/regress-node-12507.pp
@@ -1,0 +1,18 @@
+config "localGatewayVirtualInterfaceGroupId" "string" {
+}
+
+rts = invoke("aws:ec2/getLocalGatewayRouteTables:getLocalGatewayRouteTables", {
+  filters = [{
+    name   = "tag:kubernetes.io/kops/role"
+    values = ["private*"]
+  }]
+})
+
+resource "routes" "aws:ec2/localGatewayRoute:LocalGatewayRoute" {
+  options {
+    range = length(rts.ids)
+  }
+  destinationCidrBlock                = "10.0.1.0/22"
+  localGatewayRouteTableId            = rts.ids[range.value]
+  localGatewayVirtualInterfaceGroupId = localGatewayVirtualInterfaceGroupId
+}


### PR DESCRIPTION
# Description

This PR fixes an issue with `parseProxyApply` which is supposed to simplify traversals in TypeScript but fails when the body of the apply is an index expression where the collection of that expression is another apply. 

Give this PCL (and using `pcl.PreferOutputVersionedInvokes`):
```
rts = invoke("aws:ec2/getLocalGatewayRouteTables:getLocalGatewayRouteTables", {
  filters = [{
    name   = "tag:kubernetes.io/kops/role"
    values = ["private*"]
  }]
})
```
Then `rts.ids[range.value]` generates just `rts` in TypeScript. 

This PR fixes this such that the expression compiles to `rts.apply(rts => rts.ids[range.value])` (see full test example)

Fixes #12507

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
