### PR TITLE
[dotnet/program-gen] Fixes list initializer for plain lists in resource properties

### DIFF
--- a/changelog/pending/20230731--programgen-dotnet--fixes-list-initializer-for-plain-lists-in-resource-properties.yaml
+++ b/changelog/pending/20230731--programgen-dotnet--fixes-list-initializer-for-plain-lists-in-resource-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Fixes list initializer for plain lists in resource properties

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -1032,14 +1032,14 @@ func (g *generator) isListOfDifferentTypes(expr *model.TupleConsExpression) bool
 func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExpression) {
 	switch len(expr.Expressions) {
 	case 0:
-		g.Fgen(w, "new[] {}")
+		g.Fgenf(w, "%s {}", g.listInitializer)
 	default:
 		if !g.isListOfDifferentTypes(expr) {
-			// only generate this when we don't have a list of union types
-			// list of a union is mapped to InputList<object>
+			// only generate a list initializer when we don't have a list of union types
+			// because list of a union is mapped to InputList<object>
 			// which means new[] will not work because type-inference won't
-			// know the type of the array before hand
-			g.Fgen(w, "new[]")
+			// know the type of the array beforehand
+			g.Fgenf(w, "%s", g.listInitializer)
 		}
 
 		g.Fgenf(w, "\n%s{", g.Indent)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -362,6 +362,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Skip:        allProgLanguages.Except("nodejs").Except("python"),
 	},
 	{
+		Directory:   "csharp-plain-lists",
+		Description: "Tests that plain lists are supported in C#",
+		Skip:        allProgLanguages.Except("dotnet"),
+	},
+	{
 		Directory:   "csharp-typed-for-expressions",
 		Description: "Testing for expressions with typed target expressions in csharp",
 		Skip:        allProgLanguages.Except("dotnet"),

--- a/pkg/codegen/testing/test/testdata/csharp-plain-lists-pp/csharp-plain-lists.pp
+++ b/pkg/codegen/testing/test/testdata/csharp-plain-lists-pp/csharp-plain-lists.pp
@@ -1,0 +1,6 @@
+resource vpc "awsx:ec2:Vpc" {
+    subnetSpecs = [
+        { type = "Public", cidrMask = 22 },
+        { type = "Private", cidrMask = 20 }
+    ]
+}

--- a/pkg/codegen/testing/test/testdata/csharp-plain-lists-pp/dotnet/csharp-plain-lists.cs
+++ b/pkg/codegen/testing/test/testdata/csharp-plain-lists-pp/dotnet/csharp-plain-lists.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Awsx = Pulumi.Awsx;
+
+return await Deployment.RunAsync(() => 
+{
+    var vpc = new Awsx.Ec2.Vpc("vpc", new()
+    {
+        SubnetSpecs = new()
+        {
+            new Awsx.Ec2.Inputs.SubnetSpecArgs
+            {
+                Type = Awsx.Ec2.SubnetType.Public,
+                CidrMask = 22,
+            },
+            new Awsx.Ec2.Inputs.SubnetSpecArgs
+            {
+                Type = Awsx.Ec2.SubnetType.Private,
+                CidrMask = 20,
+            },
+        },
+    });
+
+});
+


### PR DESCRIPTION
# Description

Some resources, especially custom resources like those in `awsx` have properties which are _plain_ lists. This means that the generated dotnet SDK for them uses `List<T>` rather than `InputList<T>`. In case of the former, when initializing the list, we cannot use `new[]` (this works for `InputList<T>` because of an implicit conversion from arrays). Instead we have to use `new()` which initializes an instance of the `List<T>` class. 

This PR implements a fix such that the code generator knows when the current resource property is plain or not and subsequently emitting `new()` instead of `new[]`

Fixes https://github.com/pulumi/pulumi-dotnet/issues/21

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
