### PR TITLE
Fix panic if colorizer is `""`

### DIFF
--- a/changelog/pending/20230802--cli-state--fix-panic-in-pulumi-state-edit-when-no-stack-is-selected.yaml
+++ b/changelog/pending/20230802--cli-state--fix-panic-in-pulumi-state-edit-when-no-stack-is-selected.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix panic in `pulumi state edit` when no stack is selected.

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -56,6 +56,7 @@ a preview showing a diff of the altered state.`,
 				return result.Error("pulumi state edit must be run in interactive mode")
 			}
 			s, err := requireStack(commandContext(), stackName, stackLoadOnly, display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})
 			if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13637

`display.Options` has a `Colors` field where the default zero value (`""`) causes a panic. This was not specified in `pulumi state edit`'s `display.Options` and a panic occurs when no stack is selected. Fixed by providing a valid value.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ (Was advised that a regression test for this is unnecessary)
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
