### PR TITLE
Fix a working directory issue in language-nodejs

### DIFF
--- a/changelog/pending/20230803--sdk-nodejs--fix-finding-the-pulumi-package-when-the-runtime-wasnt-started-in-the-project-directory.yaml
+++ b/changelog/pending/20230803--sdk-nodejs--fix-finding-the-pulumi-package-when-the-runtime-wasnt-started-in-the-project-directory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix finding the pulumi package when the runtime wasn't started in the project directory.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -151,7 +151,7 @@ func main() {
 }
 
 // locateModule resolves a node module name to a file path that can be loaded
-func locateModule(ctx context.Context, mod string, nodeBin string) (string, error) {
+func locateModule(ctx context.Context, mod, programDir, nodeBin string) (string, error) {
 	args := []string{"-e", fmt.Sprintf("console.log(require.resolve('%s'));", mod)}
 
 	tracingSpan, _ := opentracing.StartSpanFromContext(ctx,
@@ -164,6 +164,7 @@ func locateModule(ctx context.Context, mod string, nodeBin string) (string, erro
 	defer tracingSpan.Finish()
 
 	cmd := exec.Command(nodeBin, args...)
+	cmd.Dir = programDir
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -554,7 +555,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		runPath = defaultRunPath
 	}
 
-	runPath, err = locateModule(ctx, runPath, nodeBin)
+	runPath, err = locateModule(ctx, runPath, req.Pwd, nodeBin)
 	if err != nil {
 		cmdutil.ExitError(
 			"It looks like the Pulumi SDK has not been installed. Have you run npm install or yarn install?")

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1992,15 +1992,19 @@ async function createMockEngineAsync(
 function serveLanguageHostProcess(engineAddr: string): { proc: childProcess.ChildProcess; addr: Promise<string> } {
     // A quick note about this:
     //
-    // Normally, `pulumi-language-nodejs` launches `./node-modules/@pulumi/pulumi/cmd/run` which is responsible
-    // for setting up some state and then running the actual user program.  However, in this case, we don't
-    // have a folder structure like the above because we are seting the package as we've built it, not it installed
-    // in another application.
+    // Normally, `pulumi-language-nodejs` launches `./node-modules/@pulumi/pulumi/cmd/run` which is
+    // responsible for setting up some state and then running the actual user program.  However, in this case,
+    // we don't have a folder structure like the above because we are setting the package as we've built it,
+    // not it installed in another application.
     //
-    // `pulumi-language-nodejs` allows us to set `PULUMI_LANGUAGE_NODEJS_RUN_PATH` in the environment, and when
-    // set, it will use that path instead of the default value. For our tests here, we set it and point at the
-    // just built version of run.
-    process.env.PULUMI_LANGUAGE_NODEJS_RUN_PATH = "./bin/cmd/run";
+    // `pulumi-language-nodejs` allows us to set `PULUMI_LANGUAGE_NODEJS_RUN_PATH` in the environment, and
+    // when set, it will use that path instead of the default value. For our tests here, we set it and point
+    // at the just built version of run.
+    //
+    // We set this to an absolute path because the runtime will search for the module from the programs
+    // directory which is changed by by the pwd option.
+
+    process.env.PULUMI_LANGUAGE_NODEJS_RUN_PATH = path.normalize(path.join(__dirname, "..", "..", "..", "cmd", "run"));
     const proc = childProcess.spawn("pulumi-language-nodejs", [engineAddr]);
 
     // Hook the first line so we can parse the address.  Then we hook the rest to print for debugging purposes, and


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Found this while working on matrix testing which runs the language host in a totally different directory to where the projects are.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - This will be tested as part of matrix testing, current use cases should be covered by existing tests.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - This should have no noticeable effect for current usage.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
