### PR TITLE
Remove 'pluginVersion' and 'pluginName' from nodejs schema options.

### DIFF
--- a/changelog/pending/20230803--sdkgen-nodejs--remove-the-pluginversion-option-from-nodejs-schema-options.yaml
+++ b/changelog/pending/20230803--sdkgen-nodejs--remove-the-pluginversion-option-from-nodejs-schema-options.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen/nodejs
+  description: Remove the pluginVersion and pluginName options from nodejs schema options.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2353,26 +2353,10 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 	devDependencies["@types/node"] = MinimumNodeTypesVersion
 
 	version := "${VERSION}"
-	versionSet := pkg.Version != nil && info.RespectSchemaVersion
-	if versionSet {
+	pluginVersion := ""
+	if pkg.Version != nil && info.RespectSchemaVersion {
 		version = pkg.Version.String()
-	}
-
-	pluginVersion := info.PluginVersion
-	if versionSet && pluginVersion == "" {
 		pluginVersion = version
-	}
-
-	scriptVersion := "${VERSION}"
-	if pluginVersion != "" {
-		scriptVersion = pluginVersion
-	}
-
-	pluginName := info.PluginName
-	// Default to the pulumi package name if PluginName isn't set by the user. This is different to the npm
-	// package name, e.g. the npm package "@pulumiverse/sentry" has a pulumi package name of just "sentry".
-	if pluginName == "" {
-		pluginName = pkg.Name
 	}
 
 	// Create info that will get serialized into an NPM package.json.
@@ -2386,13 +2370,13 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		License:     pkg.License,
 		Scripts: map[string]string{
 			"build":   "tsc",
-			"install": fmt.Sprintf("node scripts/install-pulumi-plugin.js resource %s %s", pkg.Name, scriptVersion),
+			"install": fmt.Sprintf("node scripts/install-pulumi-plugin.js resource %s %s", pkg.Name, version),
 		},
 		DevDependencies: devDependencies,
 		Pulumi: plugin.PulumiPluginJSON{
 			Resource: true,
 			Server:   pkg.PluginDownloadURL,
-			Name:     pluginName,
+			Name:     pkg.Name,
 			Version:  pluginVersion,
 		},
 	}

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -54,10 +54,6 @@ type NodePackageInfo struct {
 	ContainsEnums bool `json:"containsEnums,omitempty"`
 	// A map allowing you to map the name of a provider to the name of the module encapsulating the provider.
 	ProviderNameToModuleName map[string]string `json:"providerNameToModuleName,omitempty"`
-	// The name of the plugin, which might be different from the package name.
-	PluginName string `json:"pluginName,omitempty"`
-	// The version of the plugin, which might be different from the version of the package..
-	PluginVersion string `json:"pluginVersion,omitempty"`
 	// Additional files to include in TypeScript compilation.
 	// These paths are added to the `files` section of the
 	// generated `tsconfig.json`. A typical use case for this is

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/schema.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/schema.json
@@ -62,8 +62,7 @@
             "devDependencies": {
                 "typescript": "^3.7.0",
                 "@types/node": "ts3.7"
-            },
-            "pluginVersion": "3.2.1"
+            }
         },
         "go": {
             "importBasePath": "enum-reference/example",

--- a/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
@@ -3,7 +3,7 @@
     "version": "${VERSION}",
     "scripts": {
         "build": "tsc",
-        "install": "node scripts/install-pulumi-plugin.js resource example 3.2.1"
+        "install": "node scripts/install-pulumi-plugin.js resource example ${VERSION}"
     },
     "dependencies": {
         "@pulumi/google-native": "^0.20.0",
@@ -15,7 +15,6 @@
     },
     "pulumi": {
         "resource": true,
-        "name": "example",
-        "version": "3.2.1"
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/enum-reference/schema.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference/schema.json
@@ -31,8 +31,7 @@
             "devDependencies": {
                 "typescript": "^3.7.0",
                 "@types/node": "ts3.7"
-            },
-            "pluginVersion": "3.2.1"
+            }
         },
         "go": {
             "importBasePath": "enum-reference/example",

--- a/pkg/codegen/testing/test/testdata/external-enum/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/external-enum/nodejs/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "scripts": {
         "build": "tsc",
-        "install": "node scripts/install-pulumi-plugin.js resource example 3.2.1"
+        "install": "node scripts/install-pulumi-plugin.js resource example 0.0.1"
     },
     "dependencies": {
         "@pulumi/google-native": "^0.20.0",
@@ -16,6 +16,6 @@
     "pulumi": {
         "resource": true,
         "name": "example",
-        "version": "3.2.1"
+        "version": "0.0.1"
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-enum/schema.json
+++ b/pkg/codegen/testing/test/testdata/external-enum/schema.json
@@ -49,8 +49,7 @@
         "typescript": "^3.7.0",
         "@types/node": "ts3.7"
       },
-      "respectSchemaVersion": true,
-      "pluginVersion": "3.2.1"
+      "respectSchemaVersion": true
     },
     "python": {
       "requires": {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
@@ -3,7 +3,7 @@
     "version": "1.2.3",
     "scripts": {
         "build": "tsc",
-        "install": "node scripts/install-pulumi-plugin.js resource example 3.2.1"
+        "install": "node scripts/install-pulumi-plugin.js resource example 1.2.3"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.42.0"
@@ -18,7 +18,7 @@
     "pulumi": {
         "resource": true,
         "name": "example",
-        "version": "3.2.1",
+        "version": "1.2.3",
         "server": "example.com/download"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
@@ -269,8 +269,7 @@
       "extraTypeScriptFiles": [
         "tests/codegen.spec.ts"
       ],
-      "respectSchemaVersion": true,
-      "pluginVersion": "3.2.1"
+      "respectSchemaVersion": true
     },
     "python": {
       "respectSchemaVersion": true


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

These options should be unused, and it appears the only use case we have of them is a couple of tests.
Given that these options were only exposed to NodeJS there was no sensible way for users to make use of them, as all the other SDKs would still have used the top level plugin name and version declared by the schema.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
