### PR TITLE
test(codegen): Disable regress-11176

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -257,11 +257,13 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "multiline-string",
 		Description: "Multiline string literals",
 	},
-	{
-		Directory:   "regress-11176",
-		Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
-		Skip:        allProgLanguages.Except("go"),
-	},
+	// TODO: TEMPORARILY DISABLED
+	// https://github.com/pulumi/pulumi/issues/13644
+	// {
+	// 	Directory:   "regress-11176",
+	// 	Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
+	// 	Skip:        allProgLanguages.Except("go"),
+	// },
 	{
 		Directory:   "throw-not-implemented",
 		Description: "Function notImplemented is compiled to a runtime error at call-site",


### PR DESCRIPTION
regress-11176 is currently broken because it imports awsx which,
without https://github.com/pulumi/pulumi-awsx/pull/1066 released
pulls in an old version of google.golang.org/genproto,
and that conflicts with the newer version.

Details in https://github.com/pulumi/pulumi/issues/13644#issuecomment-1664711242

This change disables the test so that tests on master aren't red.

Refs #13644
