### PR TITLE
Revert "test(codegen): Disable regress-11176"

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -257,13 +257,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "multiline-string",
 		Description: "Multiline string literals",
 	},
-	// TODO: TEMPORARILY DISABLED
-	// https://github.com/pulumi/pulumi/issues/13644
-	// {
-	// 	Directory:   "regress-11176",
-	// 	Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
-	// 	Skip:        allProgLanguages.Except("go"),
-	// },
+	{
+		Directory:   "regress-11176",
+		Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
+		Skip:        allProgLanguages.Except("go"),
+	},
 	{
 		Directory:   "throw-not-implemented",
 		Description: "Function notImplemented is compiled to a runtime error at call-site",


### PR DESCRIPTION
Revert the test disabled in #13649 to unblock master builds
now that pulumi-awsx has been released with
https://github.com/pulumi/pulumi-awsx/pull/1066.

This reverts commit e270756ca75c2984413a0bb32cc1b3206e9661cb.

Resolves #13644
