### PR TITLE
Prompt returning methods

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1994,8 +1994,8 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 	methodName := Title(method.Name)
 	f := method.Function
 
-	// Either resourceReturnType is set, or objectReturnType, not both.
-	resourceReturnType, retPlainRes := f.ReturnsPlainResource()
+	// Either returnPlainType is set, or objectReturnType, not both.
+	returnPlainType, doReturnPlainType := f.ReturnsPlainType()
 	var objectReturnType *schema.ObjectType
 	if f.ReturnType != nil {
 		if objectType, ok := f.ReturnType.(*schema.ObjectType); ok && objectType != nil {
@@ -2021,8 +2021,8 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 		argsig = fmt.Sprintf("%s, args *%s%sArgs", argsig, name, methodName)
 	}
 	var retty string
-	if retPlainRes {
-		t := pkg.typeString(codegen.ResolvedType(resourceReturnType))
+	if doReturnPlainType {
+		t := pkg.typeString(codegen.ResolvedType(returnPlainType))
 		retty = fmt.Sprintf("(o %s, e error)", t)
 	} else if objectReturnType == nil {
 		retty = "error"
@@ -2048,7 +2048,7 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 
 	// Now simply invoke the runtime function with the arguments.
 	outputsType := "pulumi.AnyOutput"
-	if objectReturnType != nil || retPlainRes {
+	if objectReturnType != nil || doReturnPlainType {
 		if liftReturn {
 			outputsType = fmt.Sprintf("%s%sResultOutput", cgstrings.Camel(name), methodName)
 		} else {
@@ -2056,11 +2056,11 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 		}
 	}
 
-	if !retPlainRes {
+	if !doReturnPlainType {
 		fmt.Fprintf(w, "\t%s, err := ctx.Call(%q, %s, %s{}, r)\n", resultVar, f.Token, inputsVar, outputsType)
 	}
 
-	if retPlainRes {
+	if doReturnPlainType {
 		fmt.Fprintf(w, "\tctx.CallReturnPlainResource(%q, %s, %s{}, r, reflect.ValueOf(&o), &e)\n",
 			f.Token, inputsVar, outputsType)
 		fmt.Fprintf(w, "\treturn\n")
@@ -2108,16 +2108,16 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 		fmt.Fprintf(w, "\treturn reflect.TypeOf((*%s%sArgs)(nil)).Elem()\n", cgstrings.Camel(name), methodName)
 		fmt.Fprintf(w, "}\n\n")
 	}
-	if objectReturnType != nil || retPlainRes {
+	if objectReturnType != nil || doReturnPlainType {
 		outputStructName := name
 
 		var comment string
 		var properties []*schema.Property
-		if retPlainRes {
+		if doReturnPlainType {
 			properties = []*schema.Property{
 				{
 					Name:  "resource",
-					Type:  resourceReturnType,
+					Type:  returnPlainType,
 					Plain: true,
 				},
 			}
@@ -2908,7 +2908,7 @@ func (pkg *pkgContext) getImports(member interface{}, importsAndAliases map[stri
 						pkg.getTypeImports(p.Type, false, importsAndAliases, seen)
 					}
 				}
-				if t, ok := method.Function.ReturnsPlainResource(); ok {
+				if t, ok := method.Function.ReturnsPlainType(); ok {
 					pkg.getTypeImports(t, false, importsAndAliases, seen)
 				}
 			}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2116,7 +2116,7 @@ func (pkg *pkgContext) genMethod(resourceName string, method *schema.Method, w i
 		if doReturnPlainType {
 			properties = []*schema.Property{
 				{
-					Name:  "resource",
+					Name:  "res",
 					Type:  returnPlainType,
 					Plain: true,
 				},

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1038,7 +1038,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		fmt.Fprintf(w, "        }, this")
 
 		if doReturnPlainType {
-			prop := camel("resource")
+			prop := camel("res")
 			fmt.Fprintf(w, ", {plainResourceField: %q}", prop)
 		}
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1555,7 +1555,7 @@ func (mod *modContext) genMethodReturnType(w io.Writer, method *schema.Method) s
 		comment = ""
 		properties = []*schema.Property{
 			{
-				Name:  "resource",
+				Name:  "res",
 				Type:  t,
 				Plain: true,
 			},

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1714,7 +1714,7 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 
 		if doReturnPlainType {
 			fmt.Fprintf(w, "        return pulumi.runtime.call('%s', __args__, res=__self__%s, plainResourceField='%s')\n",
-				fun.Token, typ, PyName("resource"))
+				fun.Token, typ, PyName("res"))
 		} else if returnType == nil {
 			fmt.Fprintf(w, "        pulumi.runtime.call('%s', __args__, res=__self__%s)\n", fun.Token, typ)
 		} else if shouldLiftReturn {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -535,7 +535,7 @@ type Function struct {
 	Outputs *ObjectType
 	// The return type of the function, if any.
 	ReturnType Type
-	// The return type is plain and not wrapped in an Output. This is only supported for resources.
+	// The return type is plain and not wrapped in an Output.
 	ReturnTypePlain bool
 	// When InlineObjectAsReturnType is true, it means that the return type definition is defined inline
 	// as an object type that should be generated as a separate type and it is not
@@ -552,10 +552,10 @@ type Function struct {
 	IsOverlay bool
 }
 
-// Detects if a function returns a single plain value and that value is a Resource or a Provider type.
-func (fun *Function) ReturnsPlainResource() (*ResourceType, bool) {
-	if resTy, ok := fun.ReturnType.(*ResourceType); ok && fun.ReturnTypePlain {
-		return resTy, true
+// Detects if a function returns a single plain value and that is not wrapped in an Output.
+func (fun *Function) ReturnsPlainType() (Type, bool) {
+	if fun.ReturnType != nil && fun.ReturnTypePlain {
+		return fun.ReturnType, true
 	}
 	return nil, false
 }

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/docs/configurer/_index.md
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/docs/configurer/_index.md
@@ -348,6 +348,49 @@ All [input](#inputs) properties are implicitly available as output properties. A
 ## Configurer Resource Methods {#methods}
 
 
+### MeaningOfLife Method {#method_MeaningOfLife}
+
+
+
+#### Using MeaningOfLife
+
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="javascript,typescript">
+<div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript">meaningOfLife<span class="p">(</span><span class="p">): Output&lt;<span class="nx"><a href="#method_MeaningOfLife_result">number</a></span>&gt;</span></code></pre></div>
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>meaning_of_life(</span><span class="p">) -&gt;</span> Output[<span class="nx"><a href="#method_MeaningOfLife_result">Configurer.Meaning_of_lifeResult</a></span>]</code></pre></div>
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+<div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func</span> <span class="p">(r *Configurer)</span> MeaningOfLife<span class="p">(</span><span class="p">) (<span class="nx"><a href="#method_MeaningOfLife_result">ConfigurerMeaningOfLifeResultOutput</a></span>, error)</span></code></pre></div>
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public </span>Output&lt;<span class="nx"><a href="#method_MeaningOfLife_result">int</a></span>&gt; <span class="nx">MeaningOfLife</span><span class="p">()</span></code></pre></div>
+</pulumi-choosable>
+</div>
+
+
+
+
+
+
 ### TlsProvider Method {#method_TlsProvider}
 
 

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/go/metaprovider/configurer.go
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/go/metaprovider/configurer.go
@@ -45,13 +45,32 @@ func (ConfigurerArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*configurerArgs)(nil)).Elem()
 }
 
+func (r *Configurer) MeaningOfLife(ctx *pulumi.Context) (o int, e error) {
+	ctx.CallReturnPlainResource("metaprovider:index:Configurer/meaningOfLife", nil, ConfigurerMeaningOfLifeResultOutput{}, r, reflect.ValueOf(&o), &e)
+	return
+}
+
+type ConfigurerMeaningOfLifeResult struct {
+	Res int `pulumi:"res"`
+}
+
+type ConfigurerMeaningOfLifeResultOutput struct{ *pulumi.OutputState }
+
+func (ConfigurerMeaningOfLifeResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ConfigurerMeaningOfLifeResult)(nil)).Elem()
+}
+
+func (o ConfigurerMeaningOfLifeResultOutput) Res() pulumi.IntOutput {
+	return o.ApplyT(func(v ConfigurerMeaningOfLifeResult) int { return v.Res }).(pulumi.IntOutput)
+}
+
 func (r *Configurer) TlsProvider(ctx *pulumi.Context) (o *tls.Provider, e error) {
 	ctx.CallReturnPlainResource("metaprovider:index:Configurer/tlsProvider", nil, ConfigurerTlsProviderResultOutput{}, r, reflect.ValueOf(&o), &e)
 	return
 }
 
 type ConfigurerTlsProviderResult struct {
-	Resource *tls.Provider `pulumi:"resource"`
+	Res *tls.Provider `pulumi:"res"`
 }
 
 type ConfigurerTlsProviderResultOutput struct{ *pulumi.OutputState }
@@ -60,8 +79,8 @@ func (ConfigurerTlsProviderResultOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*ConfigurerTlsProviderResult)(nil)).Elem()
 }
 
-func (o ConfigurerTlsProviderResultOutput) Resource() tls.ProviderOutput {
-	return o.ApplyT(func(v ConfigurerTlsProviderResult) *tls.Provider { return v.Resource }).(tls.ProviderOutput)
+func (o ConfigurerTlsProviderResultOutput) Res() tls.ProviderOutput {
+	return o.ApplyT(func(v ConfigurerTlsProviderResult) *tls.Provider { return v.Res }).(tls.ProviderOutput)
 }
 
 type ConfigurerInput interface {

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/nodejs/configurer.ts
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/nodejs/configurer.ts
@@ -40,10 +40,16 @@ export class Configurer extends pulumi.ComponentResource {
         super(Configurer.__pulumiType, name, resourceInputs, opts, true /*remote*/);
     }
 
+    meaningOfLife(): Promise<number> {
+        return pulumi.runtime.callAsync("metaprovider:index:Configurer/meaningOfLife", {
+            "__self__": this,
+        }, this, {plainResourceField: "res"});
+    }
+
     tlsProvider(): Promise<pulumiTls.Provider> {
         return pulumi.runtime.callAsync("metaprovider:index:Configurer/tlsProvider", {
             "__self__": this,
-        }, this, {plainResourceField: "resource"});
+        }, this, {plainResourceField: "res"});
     }
 }
 
@@ -55,6 +61,13 @@ export interface ConfigurerArgs {
 }
 
 export namespace Configurer {
+    /**
+     * The results of the Configurer.meaningOfLife method.
+     */
+    export interface MeaningOfLifeResult {
+        readonly resource: number;
+    }
+
     /**
      * The results of the Configurer.tlsProvider method.
      */

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
@@ -88,6 +88,23 @@ class Configurer(pulumi.ComponentResource):
             remote=True)
 
     @pulumi.output_type
+    class MeaningOfLifeResult:
+        def __init__(__self__, resource=None):
+            if resource and not isinstance(resource, int):
+                raise TypeError("Expected argument 'resource' to be a int")
+            pulumi.set(__self__, "resource", resource)
+
+        @property
+        @pulumi.getter
+        def resource(self) -> int:
+            return pulumi.get(self, "resource")
+
+    def meaning_of_life(__self__) -> int:
+        __args__ = dict()
+        __args__['__self__'] = __self__
+        return pulumi.runtime.call('metaprovider:index:Configurer/meaningOfLife', __args__, res=__self__, typ=Configurer.MeaningOfLifeResult, plainResourceField='res')
+
+    @pulumi.output_type
     class TlsProviderResult:
         def __init__(__self__, resource=None):
             if resource and not isinstance(resource, pulumi_tls.Provider):
@@ -102,5 +119,5 @@ class Configurer(pulumi.ComponentResource):
     def tls_provider(__self__) -> pulumi_tls.Provider:
         __args__ = dict()
         __args__['__self__'] = __self__
-        return pulumi.runtime.call('metaprovider:index:Configurer/tlsProvider', __args__, res=__self__, typ=Configurer.TlsProviderResult, plainResourceField='resource')
+        return pulumi.runtime.call('metaprovider:index:Configurer/tlsProvider', __args__, res=__self__, typ=Configurer.TlsProviderResult, plainResourceField='res')
 

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/configurer.py
@@ -89,15 +89,15 @@ class Configurer(pulumi.ComponentResource):
 
     @pulumi.output_type
     class MeaningOfLifeResult:
-        def __init__(__self__, resource=None):
-            if resource and not isinstance(resource, int):
-                raise TypeError("Expected argument 'resource' to be a int")
-            pulumi.set(__self__, "resource", resource)
+        def __init__(__self__, res=None):
+            if res and not isinstance(res, int):
+                raise TypeError("Expected argument 'res' to be a int")
+            pulumi.set(__self__, "res", res)
 
         @property
         @pulumi.getter
-        def resource(self) -> int:
-            return pulumi.get(self, "resource")
+        def res(self) -> int:
+            return pulumi.get(self, "res")
 
     def meaning_of_life(__self__) -> int:
         __args__ = dict()
@@ -106,15 +106,15 @@ class Configurer(pulumi.ComponentResource):
 
     @pulumi.output_type
     class TlsProviderResult:
-        def __init__(__self__, resource=None):
-            if resource and not isinstance(resource, pulumi_tls.Provider):
-                raise TypeError("Expected argument 'resource' to be a pulumi_tls.Provider")
-            pulumi.set(__self__, "resource", resource)
+        def __init__(__self__, res=None):
+            if res and not isinstance(res, pulumi_tls.Provider):
+                raise TypeError("Expected argument 'res' to be a pulumi_tls.Provider")
+            pulumi.set(__self__, "res", res)
 
         @property
         @pulumi.getter
-        def resource(self) -> 'pulumi_tls.Provider':
-            return pulumi.get(self, "resource")
+        def res(self) -> 'pulumi_tls.Provider':
+            return pulumi.get(self, "res")
 
     def tls_provider(__self__) -> pulumi_tls.Provider:
         __args__ = dict()

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/schema.json
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/schema.json
@@ -10,7 +10,8 @@
         }
       },
       "methods": {
-        "tlsProvider": "metaprovider:index:Configurer/tlsProvider"
+        "tlsProvider": "metaprovider:index:Configurer/tlsProvider",
+        "meaningOfLife":   "metaprovider:index:Configurer/meaningOfLife"
       }
     }
   },
@@ -25,6 +26,19 @@
       },
       "outputs": {
          "$ref": "/tls/v4.10.0/schema.json#/provider",
+         "plain": true
+      }
+    },
+    "metaprovider:index:Configurer/meaningOfLife": {
+      "inputs": {
+        "properties": {
+          "__self__": {
+            "$ref": "#/resources/metaprovider:index:Configurer"
+          }
+        }
+      },
+      "outputs": {
+         "type": "integer",
          "plain": true
       }
     }

--- a/tests/integration/construct_component_configure_provider/go/main.go
+++ b/tests/integration/construct_component_configure_provider/go/main.go
@@ -46,6 +46,13 @@ func main() {
 			return err
 		}
 
+		var n int
+		n, err = configurer.MeaningOfLife(ctx)
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("meaningOfLife", pulumi.Int(n))
 		ctx.Export("keyAlgo", key.Algorithm)
 		return nil
 	})

--- a/tests/integration/construct_component_configure_provider/nodejs/index.ts
+++ b/tests/integration/construct_component_configure_provider/nodejs/index.ts
@@ -25,6 +25,7 @@ export = async () => {
     provider: await configurer.tlsProvider()
   });
   return {
-    keyAlgo: key.algorithm
+    keyAlgo: key.algorithm,
+    meaningOfLife: (await configurer.meaningOfLife() + 1 - 1)
   }
 };

--- a/tests/integration/construct_component_configure_provider/python/__main__.py
+++ b/tests/integration/construct_component_configure_provider/python/__main__.py
@@ -17,3 +17,4 @@ key = pulumi_tls.PrivateKey("my-private-key",
                             opts=pulumi.ResourceOptions(provider=tls_provider))
 
 pulumi.export("keyAlgo", key.algorithm)
+pulumi.export("meaningOfLife", configurer.meaning_of_life() + 1 - 1)

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/configurer.go
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/configurer.go
@@ -74,11 +74,23 @@ func NewConfigurer(
 type TlsProviderArgs struct{}
 
 type TlsProviderResult struct {
-	Resource tls.ProviderOutput `pulumi:"resource"`
+	Result tls.ProviderOutput `pulumi:"res"`
 }
 
 func (c *Configurer) TlsProvider(ctx *pulumi.Context, args *TlsProviderArgs) (*TlsProviderResult, error) {
 	return &TlsProviderResult{
-		Resource: c.TlsProviderOutput,
+		Result: c.TlsProviderOutput,
+	}, nil
+}
+
+type MeaningOfLifeArgs struct{}
+
+type MeaningOfLifeResult struct {
+	Result pulumi.IntOutput `pulumi:"res"`
+}
+
+func (c *Configurer) MeaningOfLife(ctx *pulumi.Context, args *MeaningOfLifeArgs) (*MeaningOfLifeResult, error) {
+	return &MeaningOfLifeResult{
+		Result: pulumi.Int(42).ToIntOutputWithContext(ctx.Context()),
 	}, nil
 }

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/main.go
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/main.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	providerName            = "metaprovider"
-	version                 = "0.0.1"
-	mainModule              = "index"
-	configurerResourceToken = "metaprovider:index:Configurer"
-	tlsProviderMethodToken  = "metaprovider:index:Configurer/tlsProvider"
+	providerName             = "metaprovider"
+	version                  = "0.0.1"
+	mainModule               = "index"
+	configurerResourceToken  = "metaprovider:index:Configurer"
+	tlsProviderMethodToken   = "metaprovider:index:Configurer/tlsProvider"
+	meaningOfLifeMethodToken = "metaprovider:index:Configurer/meaningOfLife"
 )
 
 type module struct {
@@ -57,23 +58,34 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 }
 
 func call(ctx *pulumi.Context, tok string, args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
-	if tok != tlsProviderMethodToken {
+	switch tok {
+	case tlsProviderMethodToken:
+		methodArgs := &TlsProviderArgs{}
+		res, err := args.CopyTo(methodArgs)
+		if err != nil {
+			return nil, fmt.Errorf("setting args: %w", err)
+		}
+		component := res.(*Configurer)
+		result, err := component.TlsProvider(ctx, methodArgs)
+		if err != nil {
+			return nil, fmt.Errorf("calling method: %w", err)
+		}
+		return pulumiprovider.NewCallResult(result)
+	case meaningOfLifeMethodToken:
+		methodArgs := &MeaningOfLifeArgs{}
+		res, err := args.CopyTo(methodArgs)
+		if err != nil {
+			return nil, fmt.Errorf("setting args: %w", err)
+		}
+		component := res.(*Configurer)
+		result, err := component.MeaningOfLife(ctx, methodArgs)
+		if err != nil {
+			return nil, fmt.Errorf("calling method: %w", err)
+		}
+		return pulumiprovider.NewCallResult(result)
+	default:
 		return nil, fmt.Errorf("unknown method %s", tok)
 	}
-
-	methodArgs := &TlsProviderArgs{}
-	res, err := args.CopyTo(methodArgs)
-	if err != nil {
-		return nil, fmt.Errorf("setting args: %w", err)
-	}
-	component := res.(*Configurer)
-
-	result, err := component.TlsProvider(ctx, methodArgs)
-	if err != nil {
-		return nil, fmt.Errorf("calling method: %w", err)
-	}
-
-	return pulumiprovider.NewCallResult(result)
 }
 
 func construct(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -558,6 +558,9 @@ func testConstructComponentConfigureProviderCommonOptions() integration.ProgramT
 				"Did not find the inputs of the provider PrivateKey was provisioned with")
 			require.Truef(t, *providerFromEnvSetting,
 				"Expected PrivateKey to be provisioned with a provider with fromEnv=true")
+
+			require.Equalf(t, float64(42), stackInfo.Outputs["meaningOfLife"],
+				"Expectead meaningOfLife output to be set to the integer 42")
 		},
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

On top of https://github.com/pulumi/pulumi/pull/13592

The functionality in 13592 is extended to support returning not just plain Resource values but plain values of any type. Tests are added for returning a plain integer from a method. 

One important change is that the magic "resource" field that is renamed to "res" which can also stand for "result". This change concerns the implementation of the method, not the usage patterns for consumers.


Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
