### PR TITLE
 Don't dispatch the smoke-test-cli workflow to pulumi/examples on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,6 @@ jobs:
         job:
           - name: Update Templates Version
             run-command: pulumictl dispatch -r pulumi/templates -c update-templates "${PULUMI_VERSION}"
-          - name: Examples Templates Version
-            run-command: pulumictl dispatch -r pulumi/examples -c smoke-test-cli "${PULUMI_VERSION}"
           - name: Chocolatey Update
             run-command: pulumictl create choco-deploy "${PULUMI_VERSION}"
           - name: Winget Update


### PR DESCRIPTION
This call to the examples repo always fails for the same reason as https://github.com/pulumi/pulumi/pull/12693:

> Today, when we do a release, we dispatch the trigger-cron workflow on the pulumi/templates repo, but this workflow consistently fails on new releases because it installs the Pulumi CLI with pulumi/actions, which [relies on pulumi/docs for its list of available versions](https://github.com/pulumi/actions/blob/e50e616f7d8f4c92d3d22abdd8cfd048e6e672de/src/libs/libs/get-version.ts#L23-L45) (a list that doesn't get updated until much later as part of a different process). As a result, every new release causes a pulumi/templates workflow failure (and alerts us in the #builds channel).

So this change just removes this call from the release workflow as #12693 did.

Fixes https://github.com/pulumi/examples/issues/1464.