### PR TITLE
Devcontainer: Update json schema. Minimal Changes.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
     "name": "Pulumi",
-
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
@@ -8,19 +7,39 @@
             "USER_UID": "1000"
         }
     },
-
     "containerEnv": {
         "PULUMI_ACCESS_TOKEN": "${localEnv:PULUMI_ACCESS_TOKEN}",
         "PULUMI_TEST_ORG": "${localEnv:PULUMI_TEST_ORG}"
     },
-
     "remoteUser": "user",
-
-    "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python", "formulahendry.dotnet-test-explorer"],
-
     "postCreateCommand": "make ensure",
-
-    "settings": {
-        "extensions.ignoreRecommendations": true
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.go",
+                "ms-dotnettools.csharp",
+                "ms-python.python",
+                "formulahendry.dotnet-test-explorer"
+            ],
+            "settings": {
+                "extensions.ignoreRecommendations": true,
+                "omnisharp.sdkPath": "/usr/local/dotnet/current"
+            }
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "installOhMyZsh": true,
+            "configureZshAsDefaultShell": false,
+            "upgradePackages": true,
+            "username": "user"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        // The /root/.dotnet directory is not available to "user"
+        "ghcr.io/devcontainers/features/dotnet:1": {
+            "version": "6.0.412",
+            "installUsingApt": false
+        }
     }
 }


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This is a minimal set of changes to update the devcontainer.json file. It namely adds three basic features.

- `common-utils` - this is automatically added in most cases. I'm adding it explicitly for visibility. This feature is able to create a user, install some basic utilities, and update `apt` packages.
- `github-cli` - Install the [github cli](https://github.com/cli/cli).
- `dotnet` - Install the `dotnet` toolchain because https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L78-L85 installs inside the `/root/.dotnet` directory, which is not accessible by the created `user`.

Fixes #13572
See also: PR #13666 as a more complete alternative.

## Checklist

None seem to be applicable here.

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->

## Issues

VS Code creates the following errors:

![pulumi-devcontainer-minimal](https://github.com/pulumi/pulumi/assets/6373201/6ae0125e-0ac8-4b09-a521-dac272e9507c)

- `C# Extension` - cannot locate a valid dotnet installation. I thought I fixed this with the `"settings"` property of devcontainer.json, but it appeared again when I re-built this image.
- `cannot activate the '.NET Code Test Explorer'...` - usually just the reload will rectify this warning.
- `Go Extension` - The "gopls" command is not available. I don't know the golang toolset well enough to know what needs to be done here.