### PR TITLE
Devcontainer: Use microsoft provided base image. Add features for every runtime.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,15 +9,3 @@ RUN apt-get update -y \
         inetutils-ping \
         tmux \
     && rm -rf /var/lib/apt/lists/*
-
-# Install pulumictl
-# RUN version=0.0.42 \
-#     && curl -fsSLO https://github.com/pulumi/pulumictl/releases/download/v$version/pulumictl-v$version-linux-amd64.tar.gz \
-#     && tar -xzf pulumictl-v$version-linux-amd64.tar.gz --directory /usr/local/bin --no-same-owner pulumictl \
-#     && rm -f pulumictl-v$version-linux-amd64.tar.gz \
-#     && pulumictl version
-
-# RUN mkdir -p /go/bin \
-#     && chown -R $USER_NAME: /go \
-#     && mkdir -p $HOME/.pulumi/bin \
-#     && chown -R $USER_NAME: $HOME/.pulumi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,41 +1,23 @@
-FROM pulumi/pulumi
+FROM mcr.microsoft.com/devcontainers/base:1-bullseye
 
-# Install golangci-lint
-RUN version=1.42.1 \
-    && curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /go/bin v$version \
-    && golangci-lint version
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        file \
+        inetutils-ping \
+        tmux \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install pulumictl
-RUN version=0.0.42 \
-    && curl -fsSLO https://github.com/pulumi/pulumictl/releases/download/v$version/pulumictl-v$version-linux-amd64.tar.gz \
-    && tar -xzf pulumictl-v$version-linux-amd64.tar.gz --directory /usr/local/bin --no-same-owner pulumictl \
-    && rm -f pulumictl-v$version-linux-amd64.tar.gz \
-    && pulumictl version
+# RUN version=0.0.42 \
+#     && curl -fsSLO https://github.com/pulumi/pulumictl/releases/download/v$version/pulumictl-v$version-linux-amd64.tar.gz \
+#     && tar -xzf pulumictl-v$version-linux-amd64.tar.gz --directory /usr/local/bin --no-same-owner pulumictl \
+#     && rm -f pulumictl-v$version-linux-amd64.tar.gz \
+#     && pulumictl version
 
-# Add non-root user
-ARG USER_NAME=user
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN groupadd --gid $USER_GID $USER_NAME \
-    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USER_NAME \
-    && mkdir -p /etc/sudoers.d \
-    && echo "$USER_NAME ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER_NAME \
-    && chmod 0440 /etc/sudoers.d/$USER_NAME
-
-RUN mkdir -p /go/bin \
-    && chown -R $USER_NAME: /go \
-    && mkdir -p $HOME/.pulumi/bin \
-    && chown -R $USER_NAME: $HOME/.pulumi
-
-USER $USER_NAME
-
-# The base container sets XDG_CACHE_HOME XDG_CONFIG_HOME specifically for the root user, we can't unset them in a way that vscode will pick up, so we set them to values for the new user.
-# Installing go extensions via vscode use these paths so if we just leave it set to /root/.cache we'll get permission errors.
-ENV XDG_CONFIG_HOME=/home/$USER_NAME/.config
-ENV XDG_CACHE_HOME=/home/$USER_NAME/.cache
-
-RUN echo "export PATH=$HOME/.pulumi:$HOME/.pulumi/bin:$GOPATH/bin:/usr/local/go/bin:$PATH" >> ~/.bashrc \
-    && echo "alias l='ls -aF'" >> ~/.bash_aliases \
-    && echo "alias ll='ls -ahlF'" >> ~/.bash_aliases \
-    && echo "alias ls='ls --color=auto --group-directories-first'" >> ~/.bash_aliases
+# RUN mkdir -p /go/bin \
+#     && chown -R $USER_NAME: /go \
+#     && mkdir -p $HOME/.pulumi/bin \
+#     && chown -R $USER_NAME: $HOME/.pulumi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,13 @@
 {
     "name": "Pulumi",
     "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            "USER_NAME": "user",
-            "USER_UID": "1000"
-        }
+        "dockerfile": "Dockerfile"
     },
     "containerEnv": {
         "PULUMI_ACCESS_TOKEN": "${localEnv:PULUMI_ACCESS_TOKEN}",
         "PULUMI_TEST_ORG": "${localEnv:PULUMI_TEST_ORG}"
     },
-    "remoteUser": "user",
+    "remoteUser": "vscode",
     "postCreateCommand": "make ensure",
     "customizations": {
         "vscode": {
@@ -33,13 +29,33 @@
             "installOhMyZsh": true,
             "configureZshAsDefaultShell": false,
             "upgradePackages": true,
-            "username": "user"
+            "username": "vscode"
         },
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers/features/azure-cli:1": {},
+        "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        // The /root/.dotnet directory is not available to "user"
+        "ghcr.io/dhoeric/features/google-cloud-cli:1": {
+            "installGkeGcloudAuthPlugin": true
+        },
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        // "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         "ghcr.io/devcontainers/features/dotnet:1": {
             "version": "6.0.412",
             "installUsingApt": false
-        }
+        },
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "1.20"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "16"
+        },
+        "ghcr.io/devcontainers/features/python:1": {},
+        "ghcr.io/devcontainers/features/java:1": {
+            "installGradle": true,
+            "installMaven": true
+        },
+        "./pulumi/features/pulumictl": {}
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
     "name": "Pulumi",
-
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
@@ -8,19 +7,39 @@
             "USER_UID": "1000"
         }
     },
-
     "containerEnv": {
         "PULUMI_ACCESS_TOKEN": "${localEnv:PULUMI_ACCESS_TOKEN}",
         "PULUMI_TEST_ORG": "${localEnv:PULUMI_TEST_ORG}"
     },
-
     "remoteUser": "user",
-
-    "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python", "formulahendry.dotnet-test-explorer"],
-
     "postCreateCommand": "make ensure",
-
-    "settings": {
-        "extensions.ignoreRecommendations": true
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.go",
+                "ms-dotnettools.csharp",
+                "ms-python.python",
+                "formulahendry.dotnet-test-explorer"
+            ],
+            "settings": {
+                "extensions.ignoreRecommendations": true,
+                "omnisharp.sdkPath": "/usr/local/dotnet/current"
+            }
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "installOhMyZsh": true,
+            "configureZshAsDefaultShell": false,
+            "upgradePackages": true,
+            "username": "user"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        // The /root/.dotnet directory is not available to "user"
+        "ghcr.io/devcontainers/features/dotnet:1": {
+            "version": "6.0.412",
+            "installUsingApt": false
+        }
     }
 }

--- a/.devcontainer/pulumi/features/pulumictl/devcontainer-feature.json
+++ b/.devcontainer/pulumi/features/pulumictl/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+    "id": "pulumictl",
+    "name": "pulumictl",
+    "description": "Install the pulumictl tool.",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.devcontainer/pulumi/features/pulumictl/install.sh
+++ b/.devcontainer/pulumi/features/pulumictl/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+version="0.0.42"
+arch="amd64"
+filename="pulumictl-v$version-linux-$arch.tar.gz"
+
+curl -fsSLO "https://github.com/pulumi/pulumictl/releases/download/v$version/$filename"
+
+tar -xzf "$filename" --directory /usr/local/bin --no-same-owner pulumictl
+rm "$filename"
+
+pulumictl version


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
- Update the devcontainer to use the current schema.
- Change to using `mcr.microsoft.com/devcontainers/base` as the base image.
- Adds many features, namely adding runtime languages.
    - `aws-cli` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L36
    - `azure-cli` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L52
    - `git` - added to ensure the `git` tool is up to date.
    - `google-cloud-cli` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L54
    - `docker-in-docker` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L53 - not sure if docker-outside-of-docker would be acceptable.
    -  `kubectl-helm-minikube` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L56
    - `dotnet` - added as a required language runtime.
    - `go` - added as a required language runtime. Also installs many common tools like `golanglint-ci`.
    - `node` - added as a required language runtime. Uses `nvm`.
    - `python` - added to parallel original base image https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L4
    - `java` - added to parallel https://github.com/pulumi/pulumi-docker-containers/blob/276c72acb980693d64c88af729b7bc898d7dc158/docker/pulumi/Dockerfile#L72 including gradle & maven.
    - `./pulumi/features/pulumictl` - I separated out this step as a feature. Which allows better control over order. Say for example you wanted to install in the home directory of a newly created user. It also could be extracted one step further as an [official devcontainer feature](https://github.com/devcontainers/feature-starter).

Fixes #13572
See also PR: #13665 as alternative

## Checklist

None of these seem applicable.

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
