### PR TITLE
[sdkgen/dotnet] Generate output-versioned invokes for functions without inputs

### DIFF
--- a/changelog/pending/20230808--sdkgen-dotnet--generate-output-versioned-invokes-for-functions-without-inputs.yaml
+++ b/changelog/pending/20230808--sdkgen-dotnet--generate-output-versioned-invokes-for-functions-without-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/dotnet
+  description: Generate output-versioned invokes for functions without inputs

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetClientConfig.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetClientConfig.cs
@@ -16,6 +16,12 @@ namespace Pulumi.Mypkg
         /// </summary>
         public static Task<GetClientConfigResult> InvokeAsync(InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetClientConfigResult>("mypkg::getClientConfig", InvokeArgs.Empty, options.WithDefaults());
+
+        /// <summary>
+        /// Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
+        /// </summary>
+        public static Output<GetClientConfigResult> Invoke(InvokeOptions? options = null)
+            => global::Pulumi.Deployment.Instance.Invoke<GetClientConfigResult>("mypkg::getClientConfig", InvokeArgs.Empty, options.WithDefaults());
     }
 
 

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
@@ -13,6 +13,9 @@ namespace Pulumi.Mongodbatlas
     {
         public static Task<GetCustomDbRolesResult> InvokeAsync(GetCustomDbRolesArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetCustomDbRolesResult>("mongodbatlas::getCustomDbRoles", args ?? new GetCustomDbRolesArgs(), options.WithDefaults());
+
+        public static Output<GetCustomDbRolesResult> Invoke(InvokeOptions? options = null)
+            => global::Pulumi.Deployment.Instance.Invoke<GetCustomDbRolesResult>("mongodbatlas::getCustomDbRoles", InvokeArgs.Empty, options.WithDefaults());
     }
 
 


### PR DESCRIPTION
# Description

Partially addressing #12449 implements output-versioned invokes for functions without inputs for dotnet. 

Creating multiple PRs for each sdk-gen feature to make reviewing easier


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
