### PR TITLE
Warn about ambient plugins loaded from $PATH

### DIFF
--- a/changelog/pending/20230808--cli-plugin--cli-will-now-warn-when-loading-ambient-plugins-from-path.yaml
+++ b/changelog/pending/20230808--cli-plugin--cli-will-now-warn-when-loading-ambient-plugins-from-path.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: CLI will now warn when loading ambient plugins from $PATH.

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -86,8 +86,10 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 		return nil, err
 	}
 
+	d := cmdutil.Diag()
+
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	_, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
+	_, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, d, d, false, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,7 @@ func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, err
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	var results []workspace.PluginInfo
 	for _, plugin := range plugins {
-		info, err := workspace.GetPluginInfo(plugin.Kind, plugin.Name, plugin.Version, ctx.Host.GetProjectPlugins())
+		info, err := workspace.GetPluginInfo(d, plugin.Kind, plugin.Name, plugin.Version, ctx.Host.GetProjectPlugins())
 		if err != nil {
 			err = info.SetFileMetadata(info.Path)
 			if err != nil {

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -77,7 +77,7 @@ func newDestroySource(
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
 
-	if err := ensurePluginsAreInstalled(plugctx.Request(), plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(plugctx.Request(), plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newDestroySource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -178,7 +179,9 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 // ensurePluginsAreInstalled inspects all plugins in the plugin set and, if any plugins are not currently installed,
 // uses the given backend client to install them. Installations are processed in parallel, though
 // ensurePluginsAreInstalled does not return until all installations are completed.
-func ensurePluginsAreInstalled(ctx context.Context, plugins pluginSet, projectPlugins []workspace.ProjectPlugin) error {
+func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
+	plugins pluginSet, projectPlugins []workspace.ProjectPlugin,
+) error {
 	logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): beginning")
 	var installTasks errgroup.Group
 	for _, plug := range plugins.Values() {
@@ -187,7 +190,7 @@ func ensurePluginsAreInstalled(ctx context.Context, plugins pluginSet, projectPl
 			continue
 		}
 
-		path, err := workspace.GetPluginPath(plug.Kind, plug.Name, plug.Version, projectPlugins)
+		path, err := workspace.GetPluginPath(d, plug.Kind, plug.Name, plug.Version, projectPlugins)
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(
 				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -79,7 +79,7 @@ func newRefreshSource(client deploy.BackendClient, opts deploymentOptions, proj 
 	}
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
-	if err := ensurePluginsAreInstalled(plugctx.Request(), plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(plugctx.Request(), plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -244,7 +244,7 @@ func installPlugins(
 	// Note that this is purely a best-effort thing. If we can't install missing plugins, just proceed; we'll fail later
 	// with an error message indicating exactly what plugins are missing. If `returnInstallErrors` is set, then return
 	// the error.
-	if err := ensurePluginsAreInstalled(plugctx.Request(), allPlugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(plugctx.Request(), plugctx.Diag, allPlugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		if returnInstallErrors {
 			return nil, nil, err

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -58,7 +58,7 @@ var _ Analyzer = (*analyzer)(nil)
 // could not be found by name on the PATH, or an error occurs while creating the child process, an error is returned.
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(
+	path, err := workspace.GetPluginPath(ctx.Diag,
 		workspace.AnalyzerPlugin, strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
 		nil, host.GetProjectPlugins())
 	if err != nil {
@@ -101,7 +101,7 @@ func NewPolicyAnalyzer(
 	}
 
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
-	pluginPath, err := workspace.GetPluginPath(
+	pluginPath, err := workspace.GetPluginPath(ctx.Diag,
 		workspace.AnalyzerPlugin, policyAnalyzerName, nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -44,7 +44,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	prefix := fmt.Sprintf("%v (converter)", name)
 
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(workspace.ConverterPlugin, name, version, ctx.Host.GetProjectPlugins())
+	path, err := workspace.GetPluginPath(ctx.Diag, workspace.ConverterPlugin, name, version, ctx.Host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -484,7 +484,7 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Fla
 func (host *defaultHost) ResolvePlugin(
 	kind workspace.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
-	return workspace.GetPluginInfo(kind, name, version, host.GetProjectPlugins())
+	return workspace.GetPluginInfo(host.ctx.Diag, kind, name, version, host.GetProjectPlugins())
 }
 
 func (host *defaultHost) GetProjectPlugins() []workspace.ProjectPlugin {

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -55,7 +55,7 @@ type langhost struct {
 func NewLanguageRuntime(host Host, ctx *Context, root, pwd, runtime string,
 	options map[string]interface{},
 ) (LanguageRuntime, error) {
-	path, err := workspace.GetPluginPath(
+	path, err := workspace.GetPluginPath(ctx.Diag,
 		workspace.LanguagePlugin, strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"), nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -167,7 +167,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		}
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
-		path, err := workspace.GetPluginPath(
+		path, err := workspace.GetPluginPath(ctx.Diag,
 			workspace.ResourcePlugin, strings.ReplaceAll(string(pkg), tokens.QNameDelimiter, "_"),
 			version, host.GetProjectPlugins())
 		if err != nil {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -29,6 +29,9 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1080,15 +1083,120 @@ func TestBundledPluginSearch(t *testing.T) {
 	err = os.WriteFile(ambientPath, []byte{}, 0o700) //nolint: gosec
 	require.NoError(t, err)
 
+	d := diagtest.LogSink(t)
+
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(LanguagePlugin, "nodejs", nil, nil)
+	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(LanguagePlugin, "nodejs", nil, nil)
+	path, err = GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
+}
+
+//nolint:paralleltest // modifies environment variables
+func TestAmbientPluginsWarn(t *testing.T) {
+	// Create a fake plugin in the path
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	ambientPath := filepath.Join(pathDir, "pulumi-resource-mock")
+	err := os.WriteFile(ambientPath, []byte{}, 0o700) //nolint: gosec
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	d := diag.DefaultSink(
+		iotest.LogWriter(t), // stdout
+		&stderr,
+		diag.FormatOptions{Color: "never"},
+	)
+
+	// Lookup the plugin with ambient search turned on
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(d, ResourcePlugin, "mock", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ambientPath, path)
+
+	// Check we get a warning about loading this plugin
+	expectedMessage := fmt.Sprintf("warning: using pulumi-resource-mock from $PATH at %s\n", ambientPath)
+	assert.Equal(t, expectedMessage, stderr.String())
+}
+
+//nolint:paralleltest // modifies environment variables
+func TestBundledPluginsDoNotWarn(t *testing.T) {
+	// Get the path of this executable
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
+	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
+	err = os.WriteFile(bundledPath, []byte{}, 0o700) //nolint: gosec // we intended to write an executable file here
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Remove(bundledPath)
+		require.NoError(t, err)
+	})
+
+	// Add the executable directory to PATH
+	t.Setenv("PATH", filepath.Dir(exe))
+
+	var stderr bytes.Buffer
+	d := diag.DefaultSink(
+		iotest.LogWriter(t), // stdout
+		&stderr,
+		diag.FormatOptions{Color: "never"},
+	)
+
+	// Lookup the plugin with ambient search turned on
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, bundledPath, path)
+
+	// Check we don't get a warning about loading this plugin, because it's the bundled one _even_ though it's also on PATH
+	assert.Empty(t, stderr.String())
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/13656
+//
+//nolint:paralleltest // modifies environment variables
+func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
+	// Get the path of this executable
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	// Create a fake side-by-side plugin next to this executable, it must match one of our bundled names
+	bundledPath := filepath.Join(filepath.Dir(exe), "pulumi-language-nodejs")
+	err = os.WriteFile(bundledPath, []byte{}, 0o700) //nolint: gosec
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Remove(bundledPath)
+		require.NoError(t, err)
+	})
+
+	// Create a fake plugin in the path that is a symlink to the bundled plugin
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	ambientPath := filepath.Join(pathDir, "pulumi-language-nodejs")
+	err = os.Symlink(bundledPath, ambientPath)
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	d := diag.DefaultSink(
+		iotest.LogWriter(t), // stdout
+		&stderr,
+		diag.FormatOptions{Color: "never"},
+	)
+
+	// Lookup the plugin with ambient search turned on
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
+	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	require.NoError(t, err)
+	// We expect the ambient path to be returned, but not to warn because it resolves to the same file as the
+	// bundled path.
+	assert.Equal(t, ambientPath, path)
+	assert.Empty(t, stderr.String())
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

By default Pulumi will load ambient plugins from $PATH before looking in the plugins directory or at bundled plugins.

While this is very useful for development it often causes confusion when people have forgotten that they have plugins left on $PATH.

This makes the use of these $PATH plugins a diagnostic warning to try and make that failure mode a little less silent.

Normal users shouldn't ever have plugins on $PATH and so won't see this new warning.

Re-instates https://github.com/pulumi/pulumi/pull/13607 with a fix for symlinks included.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
