### PR TITLE
Correctly roundtip overlay type tokens in schema marshalling

### DIFF
--- a/changelog/pending/20230808--programgen-go-nodejs--fix-a-bug-in-marshalling-type-refs-across-grpc.yaml
+++ b/changelog/pending/20230808--programgen-go-nodejs--fix-a-bug-in-marshalling-type-refs-across-grpc.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go,nodejs
+  description: Fix a bug in marshalling type refs across gRPC.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1311,7 +1311,7 @@ func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 
 		return TypeSpec{
 			Type: defaultType,
-			Ref:  t.Token,
+			Ref:  pkg.marshalTypeRef(pkg.Reference(), "types", t.Token),
 		}
 	default:
 		switch t {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -76,6 +76,26 @@ func TestRoundtripRemoteTypeRef(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+func TestRoundtripLocalTypeRef(t *testing.T) {
+	// Regression test for https://github.com/pulumi/pulumi/issues/13671
+	t.Parallel()
+
+	testdataPath := filepath.Join("..", "testing", "test", "testdata")
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("localref-1.0.0.json")
+	pkg, diags, err := BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	newSpec, err := pkg.MarshalSpec()
+	require.NoError(t, err)
+	require.NotNil(t, newSpec)
+
+	// Try and bind again
+	_, diags, err = BindSpec(*newSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+}
+
 func TestImportSpec(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/testing/test/testdata/localref-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/localref-1.0.0.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "localref",
+  "version": "1.0.0",
+  "//": [
+    "Simple schema with a reference to another type and resource"
+  ],
+  "types": {
+    "localref:index/Index:Object": {
+      "type": "object"
+    }
+  },
+  "resources": {
+    "localref:index/Index:Resource": {
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "localref:index/Index:Root": {
+      "properties": {
+        "resource": {
+          "$ref": "#/resources/localref:index/Index:Resource"
+        },
+        "type": {
+          "$ref": "#/types/localref:index/Index:Object"
+        },
+        "overlay": {
+          "$ref": "#/types/localref:index/Index:Overlay"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -88,5 +88,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"snowflake", "0.66.1"},
 		SchemaProvider{"using-dashes", "1.0.0"},
 		SchemaProvider{"auto-deploy", "0.0.1"},
+		SchemaProvider{"localref", "1.0.0"},
 	)
 }


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13671.

The code to marshal a TokenType back to a `$ref` simple copied the token across, but that didn't correctly reconstruct the URL that `$ref`s expect.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
