### PR TITLE
ProgramTest: Always write output to log file

### DIFF
--- a/changelog/pending/20230808--pkg-testing--programtest-now-streams-output-to-log-files-as-the-program-runs-instead-of-writing-it-after-the-run-finishes.yaml
+++ b/changelog/pending/20230808--pkg-testing--programtest-now-streams-output-to-log-files-as-the-program-runs-instead-of-writing-it-after-the-run-finishes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg/testing
+  description: ProgramTest now streams output to log files as the program runs instead of writing it after the run finishes.

--- a/changelog/pending/20230808--pkg-testing--programtest-now-writes-output-to-the-testing-t-log-allowing-for-easier-correlation-of-error-messages-to-tests-that-caused-them.yaml
+++ b/changelog/pending/20230808--pkg-testing--programtest-now-writes-output-to-the-testing-t-log-allowing-for-easier-correlation-of-error-messages-to-tests-that-caused-them.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg/testing
+  description: ProgramTest now writes output to the `testing.T` log, allowing for easier correlation of error messages to tests that caused them.

--- a/pkg/testing/integration/command_test.go
+++ b/pkg/testing/integration/command_test.go
@@ -1,0 +1,164 @@
+// Copyright 2016-2013, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockedWriter(t *testing.T) {
+	t.Parallel()
+
+	// We run our tests with '-race'
+	// so to verify that lockedWriter is safe for concurrent use,
+	// we just write to it from multiple goroutines.
+	// The race-detector will complain if there's a problem.
+
+	const (
+		NumWorkers = 10
+		NumWrites  = 1000
+		Message    = "potatoes"
+	)
+
+	var buf bytes.Buffer
+	w := &lockedWriter{W: &buf}
+
+	// Two wait groups:
+	// 'ready' makes sure that all workers are ready before we start,
+	// increasing the chances of hitting a race condition.
+	// 'done' makes sure that all workers are done before we check the results.
+	var ready, done sync.WaitGroup
+	ready.Add(NumWorkers)
+	done.Add(NumWorkers)
+	for i := 0; i < NumWorkers; i++ {
+		go func() {
+			defer done.Done()
+
+			ready.Done() // I'm ready.
+			ready.Wait() // Wait for everyone else to be ready.
+
+			for j := 0; j < NumWrites; j++ {
+				_, err := io.WriteString(w, Message)
+				assert.NoError(t, err)
+			}
+		}()
+	}
+	done.Wait() // Wait for workers to finish.
+
+	// We can't assert the exact contents of the buffer because
+	// writes from different goroutines can interleave
+	// between calls to Writer.Write.
+	// We can, however, assert that the total length is correct.
+	assert.Equal(t, NumWorkers*NumWrites*len(Message), buf.Len())
+}
+
+func TestRunCommand_verbose(t *testing.T) {
+	t.Parallel()
+
+	echo, err := exec.LookPath("echo")
+	if err != nil {
+		t.Skipf("Couldn't find echo on PATH: %v", err)
+	}
+
+	wd := t.TempDir()
+	fakeT := fakeTestingT{TB: t}
+	err = RunCommand(&fakeT, "echo", []string{echo, "hello", "world"}, wd, &ProgramTestOptions{
+		Verbose: true,
+	})
+	require.NoError(t, err)
+
+	logs := fakeT.logs.String()
+	assert.Contains(t, logs, "echo hello world")
+	assert.Contains(t, logs, "Logging to")
+	assert.Contains(t, logs, "[echo] hello world\n")
+}
+
+func TestRunCommand_failure(t *testing.T) {
+	t.Parallel()
+
+	falseExe, err := exec.LookPath("false")
+	if err != nil {
+		t.Skipf("Couldn't find false on PATH: %v", err)
+	}
+
+	wd := t.TempDir()
+	fakeT := fakeTestingT{TB: t}
+	err = RunCommand(&fakeT, "false", []string{falseExe}, wd, nil /* opts */)
+	assert.Error(t, err)
+
+	logs := fakeT.logs.String()
+	assert.Contains(t, logs, "false' failed")
+}
+
+func TestRunCommand_failureStdoutStderr(t *testing.T) {
+	t.Parallel()
+
+	// Verifies that the provided stdout, stderr are written to if the command fails
+	// regardless of verbose mode.
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skipf("Couln't find node on PATH: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		verbose bool
+	}{
+		{"verbose", true},
+		{"not verbose", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			err = RunCommand(t,
+				"node",
+				[]string{node, "-e", "console.log('stdout'); console.error('stderr'); process.exit(1);"},
+				t.TempDir(),
+				&ProgramTestOptions{
+					Verbose: tt.verbose,
+					Stdout:  &stdout,
+					Stderr:  &stderr,
+				})
+			assert.Error(t, err, "expected command to fail")
+
+			assert.Equal(t, "stdout\n", stdout.String())
+			assert.Equal(t, "stderr\n", stderr.String())
+		})
+	}
+}
+
+// fakeTestingT is a testing.TB that records all Logf calls.
+type fakeTestingT struct {
+	testing.TB
+
+	logs bytes.Buffer
+}
+
+func (t *fakeTestingT) Logf(format string, args ...interface{}) {
+	fmt.Fprintf(&t.logs, format+"\n", args...)
+}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -91,16 +91,17 @@ const (
 	commandOutputFolderName = "command-output"
 )
 
-func writeCommandOutput(commandName, runDir string, output []byte) (string, error) {
+// Opens a log file for the output of the given command.
+// The caller must close the file when done.
+func openLogFile(commandName, runDir string) (*os.File, error) {
 	logFileDir := filepath.Join(runDir, commandOutputFolderName)
 	if err := os.MkdirAll(logFileDir, 0o700); err != nil {
-		return "", fmt.Errorf("Failed to create '%s': %w", logFileDir, err)
+		return nil, fmt.Errorf("create log directory: %w", err)
 	}
 
-	logFile := filepath.Join(logFileDir, commandName+uniqueSuffix()+".log")
-
-	if err := os.WriteFile(logFile, output, 0o600); err != nil {
-		return "", fmt.Errorf("Failed to write '%s': %w", logFile, err)
+	logFile, err := os.Create(filepath.Join(logFileDir, commandName+uniqueSuffix()+".log"))
+	if err != nil {
+		return nil, fmt.Errorf("create log file: %w", err)
 	}
 
 	return logFile, nil

--- a/pkg/testing/integration/util_test.go
+++ b/pkg/testing/integration/util_test.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenLogFile(t *testing.T) {
+	t.Parallel()
+
+	runDir := t.TempDir()
+
+	log1, err := openLogFile("foo", runDir)
+	require.NoError(t, err)
+
+	assert.Contains(t, log1.Name(), "foo",
+		"log file name should contain the name of the command")
+	assert.Contains(t, log1.Name(), commandOutputFolderName,
+		"log file name should contain the name of the command output folder")
+
+	log2, err := openLogFile("foo", runDir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, log1.Name(), log2.Name(),
+		"log file names should be unique")
+
+	_, err = io.WriteString(log1, "hello")
+	require.NoError(t, err)
+
+	_, err = io.WriteString(log2, "world")
+	require.NoError(t, err)
+
+	require.NoError(t, log1.Close())
+	require.NoError(t, log2.Close())
+
+	log1Body, err := os.ReadFile(log1.Name())
+	require.NoError(t, err)
+
+	log2Body, err := os.ReadFile(log2.Name())
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", string(log1Body))
+	assert.Equal(t, "world", string(log2Body))
+}


### PR DESCRIPTION
I'm having trouble debugging some test timeouts
and part of the problem is that the command outputs
are not recorded to a file until after the command finishes running.

To help debug problems such as this,
I've changed RunCommand to always create the output log file,
and to stream output to it as the command runs.
So even if the test times out and we aren't able to print anything,
it'll report where the log file resides.

On top of that, RunCommand retains its original behavior
with some minor QoL improvements:

- In verbose mode, if either stdout or stderr is unset,
  that stream is written to the testing.T log so it's not lost.
- In non-verbose mode, output is always written to the testing.T.
  This has two nice properties:
  if the test fails, logs are correlated to the failing test,
  and if `go test -v` is used, output is streamed to stderr directly.
  These properties of `t.Logf` also obviate the need
  to print the log output to stderr explicitly if the command failed.
- RunCommand takes a testing.TB instead of a testing.T.
  This allows us to test these beahviors.

Note that to retain the old expectations,
RunCommand still has to write to stdout/stderr in non-verbose mode
if the command failed.