### PR TITLE
[nodejs/sdk-gen] Generate output-versioned invokes for functions without inputs

### DIFF
--- a/changelog/pending/20230808--sdkgen-nodejs--generate-output-versioned-invokes-for-functions-without-inputs.yaml
+++ b/changelog/pending/20230808--sdkgen-nodejs--generate-output-versioned-invokes-for-functions-without-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/nodejs
+  description: Generate output-versioned invokes for functions without inputs

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getClientConfig.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getClientConfig.ts
@@ -35,3 +35,9 @@ export interface GetClientConfigResult {
      */
     readonly tenantId: string;
 }
+/**
+ * Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
+ */
+export function getClientConfigOutput(opts?: pulumi.InvokeOptions): pulumi.Output<GetClientConfigResult> {
+    return pulumi.output(getClientConfig(opts))
+}

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/index.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/index.ts
@@ -40,7 +40,8 @@ utilities.lazyLoad(exports, ["getBastionShareableLink","getBastionShareableLinkO
 
 export { GetClientConfigResult } from "./getClientConfig";
 export const getClientConfig: typeof import("./getClientConfig").getClientConfig = null as any;
-utilities.lazyLoad(exports, ["getClientConfig"], () => require("./getClientConfig"));
+export const getClientConfigOutput: typeof import("./getClientConfig").getClientConfigOutput = null as any;
+utilities.lazyLoad(exports, ["getClientConfig","getClientConfigOutput"], () => require("./getClientConfig"));
 
 export { GetIntegrationRuntimeObjectMetadatumArgs, GetIntegrationRuntimeObjectMetadatumResult, GetIntegrationRuntimeObjectMetadatumOutputArgs } from "./getIntegrationRuntimeObjectMetadatum";
 export const getIntegrationRuntimeObjectMetadatum: typeof import("./getIntegrationRuntimeObjectMetadatum").getIntegrationRuntimeObjectMetadatum = null as any;

--- a/pkg/codegen/testing/test/testdata/regress-8403/nodejs/getCustomDbRoles.ts
+++ b/pkg/codegen/testing/test/testdata/regress-8403/nodejs/getCustomDbRoles.ts
@@ -20,3 +20,6 @@ export interface GetCustomDbRolesArgs {
 export interface GetCustomDbRolesResult {
     readonly result?: outputs.GetCustomDbRolesResult;
 }
+export function getCustomDbRolesOutput(opts?: pulumi.InvokeOptions): pulumi.Output<GetCustomDbRolesResult> {
+    return pulumi.output(getCustomDbRoles(opts))
+}

--- a/pkg/codegen/testing/test/testdata/regress-8403/nodejs/index.ts
+++ b/pkg/codegen/testing/test/testdata/regress-8403/nodejs/index.ts
@@ -7,7 +7,8 @@ import * as utilities from "./utilities";
 // Export members:
 export { GetCustomDbRolesArgs, GetCustomDbRolesResult } from "./getCustomDbRoles";
 export const getCustomDbRoles: typeof import("./getCustomDbRoles").getCustomDbRoles = null as any;
-utilities.lazyLoad(exports, ["getCustomDbRoles"], () => require("./getCustomDbRoles"));
+export const getCustomDbRolesOutput: typeof import("./getCustomDbRoles").getCustomDbRolesOutput = null as any;
+utilities.lazyLoad(exports, ["getCustomDbRoles","getCustomDbRolesOutput"], () => require("./getCustomDbRoles"));
 
 export { ProviderArgs } from "./provider";
 export type Provider = import("./provider").Provider;


### PR DESCRIPTION
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Partially addressing #12449 implements output-versioned invokes for functions without inputs for nodejs

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
