### PR TITLE
ci: Preliminary support for GitHub merge queues

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
 
 on:
+  merge_group:
   push:
     branches:
       - staging
@@ -48,7 +49,7 @@ jobs:
 
   prepare-release:
     name: prepare
-    if: ${{ github.ref_name == 'staging' }} # only on real merges
+    if: github.ref_name == 'staging' || github.event_name == 'merge_group' # only on real merges
     needs: [info, ci]
     uses: ./.github/workflows/ci-prepare-release.yml
     permissions:
@@ -64,6 +65,14 @@ jobs:
 
   bors-ok:
     name: bors-ok
+    needs: [prepare-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0
+
+  ci-ok:
+    name: ci-ok
     needs: [prepare-release]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -132,6 +132,14 @@ jobs:
       prerelease: true
     secrets: inherit
 
+  ci-ok:
+    name: ci-ok
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0
+
   # release:
   #   name: release
   #   if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/test') }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,7 +11,7 @@ permissions:
 on:
   pull_request:
     paths-ignore:
-      - '.version'
+      - ".version"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,7 +88,7 @@ jobs:
       # codegen tests take quite a while to run.
       # Run them only if ci/test is set,
       # or if one of the codegen files changed.
-      test-codegen:  >- # No newlines or trailing newline.
+      test-codegen: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test') ||
           (needs.inspect.outputs.test-codegen == 'true')
@@ -134,7 +134,7 @@ jobs:
 
   ci-ok:
     name: ci-ok
-    needs: [prepare]
+    needs: [prepare-release]
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/changelog/pending/20230809--ci--adds-support-for-githubs-native-merge-queues.yaml
+++ b/changelog/pending/20230809--ci--adds-support-for-githubs-native-merge-queues.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: chore
+    scope: ci
+    description: Add preliminary support for GitHub's native merge queues


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

See [managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

This is a **no-op** that makes it possible to begin experimenting with GitHub's native merge queues when the team is ready to do so. It does not change anything about existing workflows -- Bors is still required.

After this lands, actually testing the merge queue (and eventually cutting over) will require some coordination. Someone with admin access on the repo will need to edit branch protections to no longer require a Bors check and instead require the merge queue. Some test PRs can be landed while these protections are flipped, but real PRs should not be until the new workflow is confirmed to be working as expected.

Refs https://github.com/pulumi/pulumi/issues/13501

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
