### PR TITLE
Lock access to the plugin loading channels

### DIFF
--- a/changelog/pending/20230809--engine--fixes-some-synchronization-in-plugin-shutdown-to-prevent-panics-on-ctrl-c.yaml
+++ b/changelog/pending/20230809--engine--fixes-some-synchronization-in-plugin-shutdown-to-prevent-panics-on-ctrl-c.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fixes some synchronization in plugin shutdown to prevent panics on Ctrl-C.

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClosePanic(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+	ctx, err := NewContext(sink, sink, nil, nil, "", nil, false, nil)
+	require.NoError(t, err)
+	host, ok := ctx.Host.(*defaultHost)
+	require.True(t, ok)
+
+	// Spin up a load of loadPlugin calls and then Close the context. This should not panic.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// We expect some of these to error that the host is shutting down, that's fine this test is just
+			// checking nothing panics.
+			_, _ = host.loadPlugin(host.loadRequests, func() (interface{}, error) {
+				return nil, nil
+			})
+		}()
+	}
+	err = host.Close()
+	require.NoError(t, err)
+
+	wg.Wait()
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12371.

This locks access to the plugin request channels with a RWLock. Before trying to write to the channel we try to take a Read lock (yes this sounds the wrong way round, carry on). Many loaders are free to send to the loadRequest channel at once, but we use the read lock to atomiclly track if any are currently in progress.

When we go to close the plugin host the first thing we do is take a Write lock. Firstly this can't be taken until all the read locks are released indicating that no plugins are currently loading, but secondly while the write lock is taken no more read locks can be taken blocking any further plugin loads from starting.

We never release this write lock, thus permenatly blocking plugin loads once `Close` is called. So that we don't indefinently block inside load calls we do a `TryRLock` and return an error if the read lock can't be taken.

With this locking in place the rest of `Close` is then free to shut down all current plugins and close of the request channels, assured that they shouldn't be posted to again as the lock stays held.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
