### PR TITLE
[python/sdk-gen] Generate output-versioned invokes for functions without inputs

### DIFF
--- a/changelog/pending/20230809--sdkgen-python--generate-output-versioned-invokes-for-functions-without-inputs.yaml
+++ b/changelog/pending/20230809--sdkgen-python--generate-output-versioned-invokes-for-functions-without-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/python
+  description: Generate output-versioned invokes for functions without inputs

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
@@ -13,6 +13,7 @@ __all__ = [
     'GetClientConfigResult',
     'AwaitableGetClientConfigResult',
     'get_client_config',
+    'get_client_config_output',
 ]
 
 @pulumi.output_type
@@ -92,3 +93,11 @@ def get_client_config(opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableG
         object_id=pulumi.get(__ret__, 'object_id'),
         subscription_id=pulumi.get(__ret__, 'subscription_id'),
         tenant_id=pulumi.get(__ret__, 'tenant_id'))
+
+
+@_utilities.lift_output_func(get_client_config)
+def get_client_config_output(opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetClientConfigResult]:
+    """
+    Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
+    """
+    ...

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
@@ -14,6 +14,7 @@ __all__ = [
     'GetCustomDbRolesResult',
     'AwaitableGetCustomDbRolesResult',
     'get_custom_db_roles',
+    'get_custom_db_roles_output',
 ]
 
 @pulumi.output_type
@@ -48,3 +49,11 @@ def get_custom_db_roles(opts: Optional[pulumi.InvokeOptions] = None) -> Awaitabl
 
     return AwaitableGetCustomDbRolesResult(
         result=pulumi.get(__ret__, 'result'))
+
+
+@_utilities.lift_output_func(get_custom_db_roles)
+def get_custom_db_roles_output(opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetCustomDbRolesResult]:
+    """
+    Use this data source to access information about an existing resource.
+    """
+    ...


### PR DESCRIPTION
# Description 

Partially addressing https://github.com/pulumi/pulumi/issues/12449 implements output-versioned invokes for functions without inputs for python SDKs

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
