### PR TITLE
Change nodejs waiting on pipes to not panic

### DIFF
--- a/changelog/pending/20230809--sdk-nodejs--fix-a-possible-panic-in-running-nodejs-programs.yaml
+++ b/changelog/pending/20230809--sdk-nodejs--fix-a-possible-panic-in-running-nodejs-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix a possible panic in running NodeJS programs.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -528,25 +528,6 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 	}
 	defer pipes.shutdown()
 
-	// Channel producing the final response we want to issue to our caller. Will get the result of
-	// the actual nodejs process we launch, or any results caused by errors in our server/pipes.
-	responseChannel := make(chan *pulumirpc.RunResponse)
-	defer close(responseChannel)
-
-	// Forward any rpc server or pipe errors to our output channel.
-	go func() {
-		err := <-handle.Done
-		if err != nil {
-			responseChannel <- &pulumirpc.RunResponse{Error: err.Error()}
-		}
-	}()
-	go func() {
-		err := <-pipesDone
-		if err != nil {
-			responseChannel <- &pulumirpc.RunResponse{Error: err.Error()}
-		}
-	}()
-
 	nodeBin, err := exec.LookPath("node")
 	if err != nil {
 		cmdutil.Exit(fmt.Errorf("could not find node on the $PATH: %w", err))
@@ -563,115 +544,130 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 			"It looks like the Pulumi SDK has not been installed. Have you run npm install or yarn install?")
 	}
 
+	// Channel producing the final response we want to issue to our caller. Will get the result of
+	// the actual nodejs process we launch, or any results caused by errors in our server/pipes.
+	responseChannel := make(chan *pulumirpc.RunResponse)
 	// now, launch the nodejs process and actually run the user code in it.
-	go host.execNodejs(ctx, responseChannel, req, nodeBin, runPath,
-		fmt.Sprintf("127.0.0.1:%d", handle.Port), pipes.directory())
+	go func() {
+		defer close(responseChannel)
+		responseChannel <- host.execNodejs(
+			ctx, req, nodeBin, runPath,
+			fmt.Sprintf("127.0.0.1:%d", handle.Port), pipes.directory())
+	}()
 
 	// Wait for one of our launched goroutines to signal that we're done.  This might be our proxy
 	// (in the case of errors), or the launched nodejs completing (either successfully, or with
 	// errors).
-	return <-responseChannel, nil
+	for {
+		select {
+		case err := <-handle.Done:
+			if err != nil {
+				return &pulumirpc.RunResponse{Error: err.Error()}, nil
+			}
+		case err := <-pipesDone:
+			if err != nil {
+				return &pulumirpc.RunResponse{Error: err.Error()}, nil
+			}
+		case response := <-responseChannel:
+			return response, nil
+		}
+	}
 }
 
 // Launch the nodejs process and wait for it to complete.  Report success or any errors using the
 // `responseChannel` arg.
-func (host *nodeLanguageHost) execNodejs(ctx context.Context,
-	responseChannel chan<- *pulumirpc.RunResponse, req *pulumirpc.RunRequest,
+func (host *nodeLanguageHost) execNodejs(ctx context.Context, req *pulumirpc.RunRequest,
 	nodeBin, runPath, address, pipesDirectory string,
-) {
+) *pulumirpc.RunResponse {
 	// Actually launch nodejs and process the result of it into an appropriate response object.
-	response := func() *pulumirpc.RunResponse {
-		args := host.constructArguments(req, runPath, address, pipesDirectory)
-		config, err := host.constructConfig(req)
-		if err != nil {
-			err = fmt.Errorf("failed to serialize configuration: %w", err)
-			return &pulumirpc.RunResponse{Error: err.Error()}
-		}
-		configSecretKeys, err := host.constructConfigSecretKeys(req)
-		if err != nil {
-			err = fmt.Errorf("failed to serialize configuration secret keys: %w", err)
-			return &pulumirpc.RunResponse{Error: err.Error()}
-		}
+	args := host.constructArguments(req, runPath, address, pipesDirectory)
+	config, err := host.constructConfig(req)
+	if err != nil {
+		err = fmt.Errorf("failed to serialize configuration: %w", err)
+		return &pulumirpc.RunResponse{Error: err.Error()}
+	}
+	configSecretKeys, err := host.constructConfigSecretKeys(req)
+	if err != nil {
+		err = fmt.Errorf("failed to serialize configuration secret keys: %w", err)
+		return &pulumirpc.RunResponse{Error: err.Error()}
+	}
 
-		env := os.Environ()
-		env = append(env, pulumiConfigVar+"="+config)
-		env = append(env, pulumiConfigSecretKeysVar+"="+configSecretKeys)
+	env := os.Environ()
+	env = append(env, pulumiConfigVar+"="+config)
+	env = append(env, pulumiConfigSecretKeysVar+"="+configSecretKeys)
 
-		if host.typescript {
-			env = append(env, "PULUMI_NODEJS_TYPESCRIPT=true")
-		}
-		if host.tsconfigpath != "" {
-			env = append(env, "PULUMI_NODEJS_TSCONFIG_PATH="+host.tsconfigpath)
-		}
+	if host.typescript {
+		env = append(env, "PULUMI_NODEJS_TYPESCRIPT=true")
+	}
+	if host.tsconfigpath != "" {
+		env = append(env, "PULUMI_NODEJS_TSCONFIG_PATH="+host.tsconfigpath)
+	}
 
-		nodeargs, err := shlex.Split(host.nodeargs)
-		if err != nil {
-			return &pulumirpc.RunResponse{Error: err.Error()}
-		}
-		nodeargs = append(nodeargs, args...)
+	nodeargs, err := shlex.Split(host.nodeargs)
+	if err != nil {
+		return &pulumirpc.RunResponse{Error: err.Error()}
+	}
+	nodeargs = append(nodeargs, args...)
 
-		if logging.V(5) {
-			commandStr := strings.Join(nodeargs, " ")
-			logging.V(5).Infoln("Language host launching process: ", nodeBin, commandStr)
-		}
+	if logging.V(5) {
+		commandStr := strings.Join(nodeargs, " ")
+		logging.V(5).Infoln("Language host launching process: ", nodeBin, commandStr)
+	}
 
-		// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
-		var errResult string
-		// #nosec G204
-		cmd := exec.Command(nodeBin, nodeargs...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = env
+	// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
+	var errResult string
+	// #nosec G204
+	cmd := exec.Command(nodeBin, nodeargs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
 
-		tracingSpan, _ := opentracing.StartSpanFromContext(ctx,
-			"execNodejs",
-			opentracing.Tag{Key: "component", Value: "exec.Command"},
-			opentracing.Tag{Key: "command", Value: nodeBin},
-			opentracing.Tag{Key: "args", Value: nodeargs})
-		defer tracingSpan.Finish()
+	tracingSpan, _ := opentracing.StartSpanFromContext(ctx,
+		"execNodejs",
+		opentracing.Tag{Key: "component", Value: "exec.Command"},
+		opentracing.Tag{Key: "command", Value: nodeBin},
+		opentracing.Tag{Key: "args", Value: nodeargs})
+	defer tracingSpan.Finish()
 
-		if err := cmd.Run(); err != nil {
-			// NodeJS stdout is complicated enough that we should explicitly flush stdout and stderr here. NodeJS does
-			// process writes using console.out and console.err synchronously, but it does not process writes using
-			// `process.stdout.write` or `process.stderr.write` synchronously, and it is possible that there exist unflushed
-			// writes on those file descriptors at the time that the Node process exits.
-			//
-			// Because of this, we explicitly flush stdout and stderr so that we are absolutely sure that we capture any
-			// error messages in the engine.
-			contract.IgnoreError(os.Stdout.Sync())
-			contract.IgnoreError(os.Stderr.Sync())
-			if exiterr, ok := err.(*exec.ExitError); ok {
-				// If the program ran, but exited with a non-zero error code.  This will happen often,
-				// since user errors will trigger this.  So, the error message should look as nice as
-				// possible.
-				switch code := exiterr.ExitCode(); code {
-				case 0:
-					// This really shouldn't happen, but if it does, we don't want to render "non-zero exit code"
-					err = fmt.Errorf("Program exited unexpectedly: %w", exiterr)
-				case nodeJSProcessExitedAfterShowingUserActionableMessage:
-					// Check if we got special exit code that means "we already gave the user an
-					// actionable message". In that case, we can simply bail out and terminate `pulumi`
-					// without showing any more messages.
-					return &pulumirpc.RunResponse{Error: "", Bail: true}
-				default:
-					err = fmt.Errorf("Program exited with non-zero exit code: %d", code)
-				}
-			} else {
-				// Otherwise, we didn't even get to run the program.  This ought to never happen unless there's
-				// a bug or system condition that prevented us from running the language exec.  Issue a scarier error.
-				err = fmt.Errorf("Problem executing program (could not run language executor): %w", err)
+	if err := cmd.Run(); err != nil {
+		// NodeJS stdout is complicated enough that we should explicitly flush stdout and stderr here. NodeJS does
+		// process writes using console.out and console.err synchronously, but it does not process writes using
+		// `process.stdout.write` or `process.stderr.write` synchronously, and it is possible that there exist unflushed
+		// writes on those file descriptors at the time that the Node process exits.
+		//
+		// Because of this, we explicitly flush stdout and stderr so that we are absolutely sure that we capture any
+		// error messages in the engine.
+		contract.IgnoreError(os.Stdout.Sync())
+		contract.IgnoreError(os.Stderr.Sync())
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// If the program ran, but exited with a non-zero error code.  This will happen often,
+			// since user errors will trigger this.  So, the error message should look as nice as
+			// possible.
+			switch code := exiterr.ExitCode(); code {
+			case 0:
+				// This really shouldn't happen, but if it does, we don't want to render "non-zero exit code"
+				err = fmt.Errorf("Program exited unexpectedly: %w", exiterr)
+			case nodeJSProcessExitedAfterShowingUserActionableMessage:
+				// Check if we got special exit code that means "we already gave the user an
+				// actionable message". In that case, we can simply bail out and terminate `pulumi`
+				// without showing any more messages.
+				return &pulumirpc.RunResponse{Error: "", Bail: true}
+			default:
+				err = fmt.Errorf("Program exited with non-zero exit code: %d", code)
 			}
-
-			errResult = err.Error()
+		} else {
+			// Otherwise, we didn't even get to run the program.  This ought to never happen unless there's
+			// a bug or system condition that prevented us from running the language exec.  Issue a scarier error.
+			err = fmt.Errorf("Problem executing program (could not run language executor): %w", err)
 		}
 
-		return &pulumirpc.RunResponse{Error: errResult}
-	}()
+		errResult = err.Error()
+	}
 
 	// notify our caller of the response we got from the nodejs process.  Note: this is done
 	// unilaterally. this is how we signal to nodeLanguageHost.Run that we are done and it can
 	// return to its caller.
-	responseChannel <- response
+	return &pulumirpc.RunResponse{Error: errResult}
 }
 
 // constructArguments constructs a command-line for `pulumi-language-nodejs`


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Hit this while testing with matrix testing. Fairly frequently the go routine waiting for `pipesDone` would try to write to the response channel and panic because it was already closed.

This rewrites the method to only use the response channel for the running program, and we just explictly wait on all three events (pipes, handle, program) and return the first one that triggers.

Also it refactors execNodejs to just be a sync method that returns the response. The management of that running in a goroutine and writing to a channel is just kept in Run.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Current tests should cover current use of this, and matrix testing will verify that this fix is in place for that.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
