### PR TITLE
Add a simple yaml convert smoke test

### DIFF
--- a/tests/testdata/random_yaml/Pulumi.yaml
+++ b/tests/testdata/random_yaml/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: random_yaml
+runtime: yaml
+resources:
+  pet:
+    type: random:RandomPet
+    options: {}
+outputs:
+  name: ${pet.id}


### PR DESCRIPTION
In preparation for YAML moving over to the convert interface this is just a small test to ensure that we can continue to call convert on it.