### PR TITLE
[go/sdk-gen] Generate output-versioned invokes for functions without inputs

### DIFF
--- a/changelog/pending/20230809--sdkgen-go--generate-output-versioned-invokes-for-functions-without-inputs.yaml
+++ b/changelog/pending/20230809--sdkgen-go--generate-output-versioned-invokes-for-functions-without-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: Generate output-versioned invokes for functions without inputs

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -205,13 +205,18 @@ func (b *binder) signatureForArgs(fn *schema.Function, args model.Expression) (m
 // It decides to return `true` if doing so avoids the need to introduce an `apply` form to
 // accommodate `Output` args (`Promise` args do not count).
 func (b *binder) useOutputVersion(fn *schema.Function, args model.Expression) bool {
-	if !fn.NeedsOutputVersion() {
+	if fn.ReturnType == nil {
 		// No code emitted for an `fnOutput` form, impossible.
 		return false
 	}
 
 	if b.options.preferOutputVersionedInvokes {
 		return true
+	}
+
+	if fn.Inputs == nil || len(fn.Inputs.Properties) == 0 {
+		// use the output version when there are actual args to use
+		return false
 	}
 
 	outputFormParamType := b.schemaTypeToType(fn.Inputs.InputShape)

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -557,22 +557,7 @@ func (fun *Function) NeedsOutputVersion() bool {
 	// support them and return `Task`, but there are no such
 	// functions in `pulumi-azure-native` or `pulumi-aws` so we
 	// omit to simplify.
-	if fun.ReturnType == nil {
-		return false
-	}
-
-	// Skip functions that have no inputs. The user can simply
-	// lift the `Task` to `Output` manually.
-	if fun.Inputs == nil {
-		return false
-	}
-
-	// No properties is kind of like no inputs.
-	if len(fun.Inputs.Properties) == 0 {
-		return false
-	}
-
-	return true
+	return fun.ReturnType != nil
 }
 
 // Package describes a Pulumi package.

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
@@ -19,6 +19,11 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 
 ## Using getClientConfig {#using}
 
+Two invocation forms are available. The direct form accepts plain
+arguments and either blocks until the result value is available, or
+returns a Promise-wrapped result. The output form accepts
+Input-wrapped arguments and returns an Output-wrapped result.
+
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -29,6 +34,8 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 <div class="highlight"
 ><pre class="chroma"><code class="language-typescript" data-lang="typescript"
 ><span class="k">function </span>getClientConfig<span class="p">(</span><span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Promise&lt;<span class="nx"><a href="#result">GetClientConfigResult</a></span>></span
+><span class="k">
+function </span>getClientConfigOutput<span class="p">(</span><span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Output&lt;<span class="nx"><a href="#result">GetClientConfigResult</a></span>></span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -38,6 +45,8 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 <pulumi-choosable type="language" values="python">
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"
 ><span class="k">def </span>get_client_config<span class="p">(</span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetClientConfigResult</span
+><span class="k">
+def </span>get_client_config_output<span class="p">(</span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetClientConfigResult]</span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -47,6 +56,8 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 <pulumi-choosable type="language" values="go">
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"
 ><span class="k">func </span>GetClientConfig<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) (*<span class="nx"><a href="#result">GetClientConfigResult</a></span>, error)</span
+><span class="k">
+func </span>GetClientConfigOutput<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) GetClientConfigResultOutput</span
 ></code></pre></div>
 
 &gt; Note: This function is named `GetClientConfig` in the Go SDK.
@@ -59,7 +70,8 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 <pulumi-choosable type="language" values="csharp">
 <div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">GetClientConfig </span><span class="p">
 {</span><span class="k">
-    public static </span>Task&lt;<span class="nx"><a href="#result">GetClientConfigResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
+    public static </span>Task&lt;<span class="nx"><a href="#result">GetClientConfigResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="k">
+    public static </span>Output&lt;<span class="nx"><a href="#result">GetClientConfigResult</a></span>> <span class="p">Invoke(</span><span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
 }</span></code></pre></div>
 </pulumi-choosable>
 </div>

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getClientConfig.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getClientConfig.go
@@ -4,7 +4,11 @@
 package mypkg
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -29,4 +33,60 @@ type GetClientConfigResult struct {
 	SubscriptionId string `pulumi:"subscriptionId"`
 	// Azure Tenant ID
 	TenantId string `pulumi:"tenantId"`
+}
+
+func GetClientConfigOutput(ctx *pulumi.Context, opts ...pulumi.InvokeOption) GetClientConfigResultOutput {
+	return pulumi.ToOutput(0).ApplyT(func(int) (GetClientConfigResult, error) {
+		r, err := GetClientConfig(ctx, opts...)
+		var s GetClientConfigResult
+		if r != nil {
+			s = *r
+		}
+		return s, err
+	}).(GetClientConfigResultOutput)
+}
+
+// Configuration values returned by getClientConfig.
+type GetClientConfigResultOutput struct{ *pulumi.OutputState }
+
+func (GetClientConfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*GetClientConfigResult)(nil)).Elem()
+}
+
+func (o GetClientConfigResultOutput) ToGetClientConfigResultOutput() GetClientConfigResultOutput {
+	return o
+}
+
+func (o GetClientConfigResultOutput) ToGetClientConfigResultOutputWithContext(ctx context.Context) GetClientConfigResultOutput {
+	return o
+}
+
+func (o GetClientConfigResultOutput) ToOutput(ctx context.Context) pulumix.Output[GetClientConfigResult] {
+	return pulumix.Output[GetClientConfigResult]{
+		OutputState: o.OutputState,
+	}
+}
+
+// Azure Client ID (Application Object ID).
+func (o GetClientConfigResultOutput) ClientId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClientConfigResult) string { return v.ClientId }).(pulumi.StringOutput)
+}
+
+// Azure Object ID of the current user or service principal.
+func (o GetClientConfigResultOutput) ObjectId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClientConfigResult) string { return v.ObjectId }).(pulumi.StringOutput)
+}
+
+// Azure Subscription ID
+func (o GetClientConfigResultOutput) SubscriptionId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClientConfigResult) string { return v.SubscriptionId }).(pulumi.StringOutput)
+}
+
+// Azure Tenant ID
+func (o GetClientConfigResultOutput) TenantId() pulumi.StringOutput {
+	return o.ApplyT(func(v GetClientConfigResult) string { return v.TenantId }).(pulumi.StringOutput)
+}
+
+func init() {
+	pulumi.RegisterOutputType(GetClientConfigResultOutput{})
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/x/getClientConfig.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/x/getClientConfig.go
@@ -4,7 +4,11 @@
 package mypkg
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"output-funcs/mypkg/internal"
 )
 
@@ -29,4 +33,40 @@ type GetClientConfigResult struct {
 	SubscriptionId string `pulumi:"subscriptionId"`
 	// Azure Tenant ID
 	TenantId string `pulumi:"tenantId"`
+}
+
+func GetClientConfigOutput(ctx *pulumi.Context, opts ...pulumi.InvokeOption) GetClientConfigResultOutput {
+	outputResult := pulumix.ApplyErr[int](pulumix.Val(0), func(_ int) (*GetClientConfigResult, error) {
+		return GetClientConfig(ctx, opts...)
+	})
+
+	return pulumix.Cast[GetClientConfigResultOutput, *GetClientConfigResult](outputResult)
+}
+
+type GetClientConfigResultOutput struct{ *pulumi.OutputState }
+
+func (GetClientConfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*GetClientConfigResult)(nil)).Elem()
+}
+
+func (o GetClientConfigResultOutput) ToOutput(context.Context) pulumix.Output[*GetClientConfigResult] {
+	return pulumix.Output[*GetClientConfigResult]{
+		OutputState: o.OutputState,
+	}
+}
+
+func (o GetClientConfigResultOutput) ClientId() pulumix.Output[string] {
+	return pulumix.Apply[*GetClientConfigResult](o, func(v *GetClientConfigResult) string { return v.ClientId })
+}
+
+func (o GetClientConfigResultOutput) ObjectId() pulumix.Output[string] {
+	return pulumix.Apply[*GetClientConfigResult](o, func(v *GetClientConfigResult) string { return v.ObjectId })
+}
+
+func (o GetClientConfigResultOutput) SubscriptionId() pulumix.Output[string] {
+	return pulumix.Apply[*GetClientConfigResult](o, func(v *GetClientConfigResult) string { return v.SubscriptionId })
+}
+
+func (o GetClientConfigResultOutput) TenantId() pulumix.Output[string] {
+	return pulumix.Apply[*GetClientConfigResult](o, func(v *GetClientConfigResult) string { return v.TenantId })
 }

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
@@ -17,6 +17,11 @@ no_edit_this_page: true
 
 ## Using getCustomDbRoles {#using}
 
+Two invocation forms are available. The direct form accepts plain
+arguments and either blocks until the result value is available, or
+returns a Promise-wrapped result. The output form accepts
+Input-wrapped arguments and returns an Output-wrapped result.
+
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -27,6 +32,8 @@ no_edit_this_page: true
 <div class="highlight"
 ><pre class="chroma"><code class="language-typescript" data-lang="typescript"
 ><span class="k">function </span>getCustomDbRoles<span class="p">(</span><span class="nx">args</span><span class="p">:</span> <span class="nx">GetCustomDbRolesArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Promise&lt;<span class="nx"><a href="#result">GetCustomDbRolesResult</a></span>></span
+><span class="k">
+function </span>getCustomDbRolesOutput<span class="p">(</span><span class="nx">args</span><span class="p">:</span> <span class="nx">GetCustomDbRolesOutputArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Output&lt;<span class="nx"><a href="#result">GetCustomDbRolesResult</a></span>></span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -36,6 +43,8 @@ no_edit_this_page: true
 <pulumi-choosable type="language" values="python">
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"
 ><span class="k">def </span>get_custom_db_roles<span class="p">(</span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetCustomDbRolesResult</span
+><span class="k">
+def </span>get_custom_db_roles_output<span class="p">(</span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetCustomDbRolesResult]</span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -45,6 +54,8 @@ no_edit_this_page: true
 <pulumi-choosable type="language" values="go">
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"
 ><span class="k">func </span>LookupCustomDbRoles<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">args</span><span class="p"> *</span><span class="nx">LookupCustomDbRolesArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) (*<span class="nx"><a href="#result">LookupCustomDbRolesResult</a></span>, error)</span
+><span class="k">
+func </span>LookupCustomDbRolesOutput<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">args</span><span class="p"> *</span><span class="nx">LookupCustomDbRolesOutputArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) LookupCustomDbRolesResultOutput</span
 ></code></pre></div>
 
 &gt; Note: This function is named `LookupCustomDbRoles` in the Go SDK.
@@ -57,7 +68,8 @@ no_edit_this_page: true
 <pulumi-choosable type="language" values="csharp">
 <div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">GetCustomDbRoles </span><span class="p">
 {</span><span class="k">
-    public static </span>Task&lt;<span class="nx"><a href="#result">GetCustomDbRolesResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx">GetCustomDbRolesArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
+    public static </span>Task&lt;<span class="nx"><a href="#result">GetCustomDbRolesResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx">GetCustomDbRolesArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="k">
+    public static </span>Output&lt;<span class="nx"><a href="#result">GetCustomDbRolesResult</a></span>> <span class="p">Invoke(</span><span class="nx">GetCustomDbRolesInvokeArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
 }</span></code></pre></div>
 </pulumi-choosable>
 </div>

--- a/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/getCustomDbRoles.go
+++ b/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/getCustomDbRoles.go
@@ -4,7 +4,11 @@
 package mongodbatlas
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"regress-8403/mongodbatlas/internal"
 )
 
@@ -23,4 +27,52 @@ type LookupCustomDbRolesArgs struct {
 
 type LookupCustomDbRolesResult struct {
 	Result *GetCustomDbRolesResult `pulumi:"result"`
+}
+
+func LookupCustomDbRolesOutput(ctx *pulumi.Context, args LookupCustomDbRolesOutputArgs, opts ...pulumi.InvokeOption) LookupCustomDbRolesResultOutput {
+	return pulumi.ToOutputWithContext(context.Background(), args).
+		ApplyT(func(v interface{}) (LookupCustomDbRolesResult, error) {
+			args := v.(LookupCustomDbRolesArgs)
+			r, err := LookupCustomDbRoles(ctx, &args, opts...)
+			var s LookupCustomDbRolesResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
+		}).(LookupCustomDbRolesResultOutput)
+}
+
+type LookupCustomDbRolesOutputArgs struct {
+}
+
+func (LookupCustomDbRolesOutputArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*LookupCustomDbRolesArgs)(nil)).Elem()
+}
+
+type LookupCustomDbRolesResultOutput struct{ *pulumi.OutputState }
+
+func (LookupCustomDbRolesResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*LookupCustomDbRolesResult)(nil)).Elem()
+}
+
+func (o LookupCustomDbRolesResultOutput) ToLookupCustomDbRolesResultOutput() LookupCustomDbRolesResultOutput {
+	return o
+}
+
+func (o LookupCustomDbRolesResultOutput) ToLookupCustomDbRolesResultOutputWithContext(ctx context.Context) LookupCustomDbRolesResultOutput {
+	return o
+}
+
+func (o LookupCustomDbRolesResultOutput) ToOutput(ctx context.Context) pulumix.Output[LookupCustomDbRolesResult] {
+	return pulumix.Output[LookupCustomDbRolesResult]{
+		OutputState: o.OutputState,
+	}
+}
+
+func (o LookupCustomDbRolesResultOutput) Result() GetCustomDbRolesResultPtrOutput {
+	return o.ApplyT(func(v LookupCustomDbRolesResult) *GetCustomDbRolesResult { return v.Result }).(GetCustomDbRolesResultPtrOutput)
+}
+
+func init() {
+	pulumi.RegisterOutputType(LookupCustomDbRolesResultOutput{})
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/argFunction.go
@@ -4,7 +4,11 @@
 package example
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"simple-yaml-schema/example/internal"
 )
 
@@ -24,4 +28,53 @@ type ArgFunctionArgs struct {
 
 type ArgFunctionResult struct {
 	Result *Resource `pulumi:"result"`
+}
+
+func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...pulumi.InvokeOption) ArgFunctionResultOutput {
+	return pulumi.ToOutputWithContext(context.Background(), args).
+		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
+			args := v.(ArgFunctionArgs)
+			r, err := ArgFunction(ctx, &args, opts...)
+			var s ArgFunctionResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
+		}).(ArgFunctionResultOutput)
+}
+
+type ArgFunctionOutputArgs struct {
+	Arg1 ResourceInput `pulumi:"arg1"`
+}
+
+func (ArgFunctionOutputArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ArgFunctionArgs)(nil)).Elem()
+}
+
+type ArgFunctionResultOutput struct{ *pulumi.OutputState }
+
+func (ArgFunctionResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ArgFunctionResult)(nil)).Elem()
+}
+
+func (o ArgFunctionResultOutput) ToArgFunctionResultOutput() ArgFunctionResultOutput {
+	return o
+}
+
+func (o ArgFunctionResultOutput) ToArgFunctionResultOutputWithContext(ctx context.Context) ArgFunctionResultOutput {
+	return o
+}
+
+func (o ArgFunctionResultOutput) ToOutput(ctx context.Context) pulumix.Output[ArgFunctionResult] {
+	return pulumix.Output[ArgFunctionResult]{
+		OutputState: o.OutputState,
+	}
+}
+
+func (o ArgFunctionResultOutput) Result() ResourceOutput {
+	return o.ApplyT(func(v ArgFunctionResult) *Resource { return v.Result }).(ResourceOutput)
+}
+
+func init() {
+	pulumi.RegisterOutputType(ArgFunctionResultOutput{})
 }


### PR DESCRIPTION
# Description

Partially addressing #12449 implements output-versioned invokes for functions without inputs for go. 


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
