### PR TITLE
ci: Don't upload coverage artifacts on PRs

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -106,7 +106,8 @@ jobs:
           && 'macos-latest windows-latest'
           || ''
         }}
-      enable-coverage: true
+      # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
+      enable-coverage: false
     secrets: inherit
 
   prepare-release:

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -63,7 +63,8 @@ jobs:
       test-version-sets: current
       integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: ''
-      enable-coverage: true
+      # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
+      enable-coverage: false
     secrets:
       # Scope secrets to the minimum required:
       PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
We currently upload coverage artifacts to codecov every 12 hours via the periodic-coverage cron workflow, which runs the full suite of tests against master, as well as during PRs, which runs a subset of tests for the PR.

We currently see some discrepancies in the data in codecov. One theory is the difference in tests between PRs and master.

This change makes it so we no longer upload coverage artifacts during PRs, to helpfully keep the data in codecov clean for trends over time.