### PR TITLE
Fixes rendering v1.2.3-alpha.8 style of versions to valid PyPI version

### DIFF
--- a/changelog/pending/20230810--sdkgen-python--fixes-rendering-v1-2-3-alpha-8-style-of-versions-to-valid-pypi-versions-when-respectschemaversions-option-is-set-in-sdkgen.yaml
+++ b/changelog/pending/20230810--sdkgen-python--fixes-rendering-v1-2-3-alpha-8-style-of-versions-to-valid-pypi-versions-when-respectschemaversions-option-is-set-in-sdkgen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fixes rendering v1.2.3-alpha.8 style of versions to valid PyPI versions when respectSchemaVersions option is set in sdkgen

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -91,6 +91,9 @@ func TestMakePyPiVersion(t *testing.T) {
 		{"1.2.3-dev321", "1.2.3.dev321"},
 		{"1.2.3-post456", "1.2.3.post456"},
 		{"1.2.3-posttt456", "1.2.3+posttt456"},
+		{"0.0.1-alpha.18", "0.0.1a18"},
+		{"0.0.1-beta.18", "0.0.1b18"},
+		{"0.0.1-rc.18", "0.0.1rc18"},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes rendering v1.2.3-alpha.8 style of versions to valid PyPI versions.

Fixes #13706 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
