### PR TITLE
ci/goteststats: Update repository location

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -223,7 +223,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
-          repo: t0yv0/goteststats
+          repo: pulumi/goteststats
           tag: v0.0.7
           cache: enable
       - name: Generate artifact name


### PR DESCRIPTION
goteststats has moved to pulumi/goteststats.
This updates the path we use to install it.

The version number is the same because we have a pre-built binary
on that release for that version.
