### PR TITLE
Add support for testing dryruns with Go mocks

### DIFF
--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -20,6 +20,14 @@ type MockResourceMonitor interface {
 	NewResource(args MockResourceArgs) (string, resource.PropertyMap, error)
 }
 
+// WithDryRun can set the pulumi context to run in "preview" mode. This is useful for testing that unknown
+// values are handled correctly.
+func WithDryRun(dryRun bool) RunOption {
+	return func(r *RunInfo) {
+		r.DryRun = dryRun
+	}
+}
+
 func WithMocks(project, stack string, mocks MockResourceMonitor) RunOption {
 	return func(info *RunInfo) {
 		info.Project, info.Stack, info.Mocks = project, stack, mocks
@@ -100,6 +108,7 @@ func (m *mockMonitor) Invoke(ctx context.Context, in *pulumirpc.ResourceInvokeRe
 	args, err := plugin.UnmarshalProperties(in.GetArgs(), plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: true,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -115,6 +124,7 @@ func (m *mockMonitor) Invoke(ctx context.Context, in *pulumirpc.ResourceInvokeRe
 		result, err := plugin.MarshalProperties(registeredResource, plugin.MarshalOptions{
 			KeepSecrets:   true,
 			KeepResources: true,
+			KeepUnknowns:  true,
 		})
 		if err != nil {
 			return nil, err
@@ -135,6 +145,7 @@ func (m *mockMonitor) Invoke(ctx context.Context, in *pulumirpc.ResourceInvokeRe
 	result, err := plugin.MarshalProperties(resultV, plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: in.GetAcceptResources(),
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -163,6 +174,7 @@ func (m *mockMonitor) ReadResource(ctx context.Context, in *pulumirpc.ReadResour
 	stateIn, err := plugin.UnmarshalProperties(in.GetProperties(), plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: true,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -192,6 +204,7 @@ func (m *mockMonitor) ReadResource(ctx context.Context, in *pulumirpc.ReadResour
 	stateOut, err := plugin.MarshalProperties(state, plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: true,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -215,6 +228,7 @@ func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.Regist
 	inputs, err := plugin.UnmarshalProperties(in.GetObject(), plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: true,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -244,6 +258,7 @@ func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.Regist
 	stateOut, err := plugin.MarshalProperties(state, plugin.MarshalOptions{
 		KeepSecrets:   true,
 		KeepResources: true,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

See https://github.com/pulumi/pulumi-yaml/pull/490 for some context on this.

It would be handy to be able to use the mock system to test that previews are correctly handled. That is that `unknown` values don't cause any issues.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
