### PR TITLE
Require Go 1.20 for Go Programgen

### DIFF
--- a/changelog/pending/20230816--programgen-go--fixes-go-mod-version-requirement.yaml
+++ b/changelog/pending/20230816--programgen-go--fixes-go-mod-version-requirement.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fixes go.mod version requirement

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -479,7 +479,7 @@ func GenerateProjectFiles(project workspace.Project, program *pcl.Program) (map[
 	var gomod bytes.Buffer
 	gomod.WriteString("module " + project.Name.String() + "\n")
 	gomod.WriteString(`
-go 1.17
+go 1.20
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-for f in $(git ls-files | grep go.mod)
+for f in $(git ls-files | grep "go\.mod")
 do
-    (cd "$(dirname "${f}")" && go mod tidy -compat=1.18)
+    (cd "$(dirname "${f}")" && go mod tidy -compat=1.20)
 done


### PR DESCRIPTION
We added program generation that assumes availability of generics as part of https://github.com/pulumi/pulumi/pull/13149, but didn't bump the version of Go required in the generated go.mod.  Currently, Pulumi is supported on the supported versions of Go, which includes Go 1.20 and 1.21, so here we bump the Go version to the minimum currently supported version, which also supports all of the code we generate today.

I was curious how this was not already failing tests, and it appears it's because we delete the `go.mod` file in our tests and recreate it with `go mod init`.  I am unclear why we do that, but it feels like we should not, exactly to avoid this sort of problem in the future and to test the actual code we generate.

https://github.com/pulumi/pulumi/blob/8696695cdba039bffdb5aaa83cae8df208cff9a7/pkg/codegen/go/test.go#L25-L28

Fixes #13728. 