### PR TITLE
ci: Test with Go 1.20, 1.21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ You'll want to install the following on your machine:
 You can get all required dependencies with brew and npm
 
 ```bash
-brew install node python@3 typescript yarn go@1.19 golangci/tap/golangci-lint gofumpt pulumi/tap/pulumictl coreutils jq
+brew install node python@3 typescript yarn go@1.21 golangci/tap/golangci-lint gofumpt pulumi/tap/pulumictl coreutils jq
 curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/339862f79e/Casks/dotnet-sdk.rb > dotnet-sdk.rb
 brew install --HEAD -s dotnet-sdk.rb
 rm dotnet-sdk.rb

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -115,7 +115,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
-    "go": "1.19.x",
+    "go": "1.20.x",
     "nodejs": "16.x",
     "python": "3.9.x",
 }
@@ -123,7 +123,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
-    "go": "1.20.x",
+    "go": "1.21.x",
     "nodejs": "20.x",
     "python": "3.11.x",
 }


### PR DESCRIPTION
Go 1.21 was recently released.
Switch to testing with Go 1.20 and 1.21.

Fixes #13740