### PR TITLE
ci: No-op to test merge queue

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -46,8 +46,7 @@ jobs:
       is-snapshot: true
     secrets: inherit
 
-  # Determines which files have changed
-  # so we can avoid running expensive tests
+  # Determines which files have changed so we can avoid running expensive tests
   # if they're not necessary.
   inspect:
     name: Inspect changed files
@@ -131,6 +130,14 @@ jobs:
       draft: true
       prerelease: true
     secrets: inherit
+
+  ci-ok:
+    name: ci-ok
+    needs: [ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0
 
   # release:
   #   name: release

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -132,14 +132,6 @@ jobs:
       prerelease: true
     secrets: inherit
 
-  ci-ok:
-    name: ci-ok
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - name: CI succeeded
-        run: exit 0
-
   # release:
   #   name: release
   #   if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/test') }}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

We're investigating odd behavior with the queue. I've disabled the "Require linear history" check and I want to test whether that affects the merge behavior.

Refs https://github.com/pulumi/pulumi/issues/13741.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
