### PR TITLE
Allow setting plugin directory

### DIFF
--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -18,7 +18,14 @@
 
 package env
 
-import "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+import (
+	"fmt"
+	"path/filepath"
+
+	user "github.com/tweekmonster/luser"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+)
 
 // Re-export some types and functions from the env library.
 
@@ -58,6 +65,26 @@ var DisableOutputValues = env.Bool("DISABLE_OUTPUT_VALUES", "")
 
 var IgnoreAmbientPlugins = env.Bool("IGNORE_AMBIENT_PLUGINS",
 	"Discover additional plugins by examining $PATH.")
+
+var PluginCache = env.String("PLUGIN_CACHE",
+	"The location where plugins are installed to and stored",
+	env.DefaultF(func() (string, error) {
+		return filepath.Join(PulumiHomeDiretory.Value(), "plugins"), nil
+	}), env.Needs(Dev))
+
+// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
+const BookkeepingDir = ".pulumi"
+
+var PulumiHomeDiretory = env.String("HOME",
+	"The path to the .pulumi folder with plugins, access tokens, etc.",
+	env.DefaultF(func() (string, error) {
+		user, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("getting current user: %w", err)
+		}
+
+		return filepath.Join(user.HomeDir, BookkeepingDir), nil
+	}))
 
 var SkipConfirmations = env.Bool("SKIP_CONFIRMATIONS",
 	`Whether or not confirmation prompts should be skipped. This should be used by pass any requirement

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -22,9 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	user "github.com/tweekmonster/luser"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 )
@@ -33,7 +32,7 @@ const (
 	// BackupDir is the name of the folder where backup stack information is stored.
 	BackupDir = "backups"
 	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
-	BookkeepingDir = ".pulumi"
+	BookkeepingDir = env.BookkeepingDir
 	// ConfigDir is the name of the folder that holds local configuration information.
 	ConfigDir = "config"
 	// GitDir is the name of the folder git uses to store information.
@@ -242,28 +241,13 @@ func GetCachedVersionFilePath() (string, error) {
 
 // GetPulumiHomeDir returns the path of the '.pulumi' folder where Pulumi puts its artifacts.
 func GetPulumiHomeDir() (string, error) {
-	// Allow the folder we use to be overridden by an environment variable
-	dir := os.Getenv(PulumiHomeEnvVar)
-	if dir != "" {
-		return dir, nil
-	}
-
-	// Otherwise, use the current user's home dir + .pulumi
-	user, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("getting current user: %w", err)
-	}
-
-	return filepath.Join(user.HomeDir, BookkeepingDir), nil
+	return env.PulumiHomeDiretory.Value(), nil
 }
 
 // GetPulumiPath returns the path to a file or directory under the '.pulumi' folder. It joins the path of
 // the '.pulumi' folder with elements passed as arguments.
 func GetPulumiPath(elem ...string) (string, error) {
-	homeDir, err := GetPulumiHomeDir()
-	if err != nil {
-		return "", err
-	}
+	homeDir := env.PulumiHomeDiretory.Value()
 
 	return filepath.Join(append([]string{homeDir}, elem...)...), nil
 }

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -66,14 +66,14 @@ const (
 	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
 	CachedVersionFile = ".cachedVersionInfo"
 
-	// PulumiHomeEnvVar is a path to the '.pulumi' folder with plugins, access token, etc.
-	// The folder can have any name, not necessarily '.pulumi'.
-	// It defaults to the '<user's home>/.pulumi' if not specified.
-	PulumiHomeEnvVar = "PULUMI_HOME"
-
 	// PolicyPackFile is the base name of a Pulumi policy pack file.
 	PolicyPackFile = "PulumiPolicy"
 )
+
+// PulumiHomeEnvVar is a path to the '.pulumi' folder with plugins, access token, etc.
+// The folder can have any name, not necessarily '.pulumi'.
+// It defaults to the '<user's home>/.pulumi' if not specified.
+var PulumiHomeEnvVar = env.PulumiHomeDiretory.Var().Name
 
 // DetectProjectPath locates the closest project from the current working directory, or an error if not found.
 func DetectProjectPath() (string, error) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1592,7 +1592,8 @@ func GetPolicyPath(orgName, name, version string) (string, bool, error) {
 
 // GetPluginDir returns the directory in which plugins on the current machine are managed.
 func GetPluginDir() (string, error) {
-	return GetPulumiPath(PluginDir)
+	cache := env.PluginCache.Value()
+	return filepath.Abs(cache)
 }
 
 // GetPlugins returns a list of installed plugins without size info and last accessed metadata.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add an env var to specify the plugin directory to use. Setting this to a provider specific value will allow the providers team to build providers without nuking the plugin cache.

```sh
PULUMI_DEV=true PULUMI_PLUGIN_CACHE=bin/plugins make tfgen
```

---

I'm not sure if this needs a changelog, since the only user visible changes are not directed at end users. Let me know what you think.

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
- [ ] I have formatted my code using `gofumpt` (doesn't `make lint` verify this?)

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
