### PR TITLE
[sdk/python] Update grpc-io from 1.56.0 to 1.56.2

### DIFF
--- a/changelog/pending/20230823--sdk-python--update-grpc-io-from-1-56-0-to-1-56-2.yaml
+++ b/changelog/pending/20230823--sdk-python--update-grpc-io-from-1-56-0-to-1-56-2.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Update grpc-io from 1.56.0 to 1.56.2

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -44,7 +44,7 @@ setup(name='pulumi',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',
-          'grpcio==1.56.0',
+          'grpcio==1.56.2',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.13',


### PR DESCRIPTION
# Description

In #13708 Snyk has updated our reference to grpc-io in the requirements.txt to 1.56.2 but didn't update `setup.py` which results in installation conflicts as reported in #13738. This PR updates `setup.py` to be in sync with `requiremments.txt` 

Fixes #13738

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
