### PR TITLE
Allow default values

### DIFF
--- a/sdk/go/common/util/env/bool.go
+++ b/sdk/go/common/util/env/bool.go
@@ -1,0 +1,55 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package env
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// A boolean retrieved from the environment.
+type BoolValue struct{ *value[bool, boolT] }
+
+type boolT struct{}
+
+func (boolT) Type() string { return "bool" }
+
+//nolint:unused
+func (boolT) parse(s string) bool { return cmdutil.IsTruthy(s) }
+
+//nolint:unused
+func (boolT) format(b bool) string { return fmt.Sprintf("%#v", b) }
+
+//nolint:unused
+func (boolT) validate(v string) ValidateError {
+	if cmdutil.IsTruthy(v) || v == "0" || strings.EqualFold(v, "false") {
+		return ValidateError{}
+	}
+	return ValidateError{
+		Warning: fmt.Errorf("%#v is falsy, but doesn't look like a boolean", v),
+	}
+}
+
+// Declare a new environmental value of type bool.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=1" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func Bool(name, description string, opts ...Option) BoolValue {
+	return newValue(name, description, opts, BoolValue{&value[bool, boolT]{}})
+}

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
@@ -8,7 +9,8 @@ import (
 )
 
 func init() {
-	env.Global = env.MapStore{
+	// This makes env.Global comparable.
+	env.Global = &env.MapStore{
 		"PULUMI_FOO": "1",
 		// "PULUMI_NOT_SET": explicitly not set
 		"FOO":           "bar",
@@ -16,6 +18,8 @@ func init() {
 		"PULUMI_SECRET": "hidden",
 		"PULUMI_SET":    "SET",
 		"UNSET":         "SET",
+
+		"PULUMI_INVALID_INT": "forty two",
 	}
 }
 
@@ -27,6 +31,28 @@ var (
 	UnsetString = env.String("PULUMI_UNSET", "Should be unset", env.Needs(SomeFalse))
 	SetString   = env.String("SET", "Should be set", env.Needs(SomeBool))
 	AnInt       = env.Int("MY_INT", "Should be 3")
+
+	DefaultInt = env.Int("DEFAULT_INT", "An int with a default value",
+		env.Default("42"))
+
+	dependentDefaultCount = 0
+	DependentDefault      = env.Bool("DEPENDENT_DEFAULT", "A value that depends on another value",
+		env.DefaultF(func(e env.Env) (string, error) {
+			v := e.GetInt(DefaultInt)
+			if v == 42 {
+				dependentDefaultCount++
+			}
+
+			if v > 0 {
+				return "true", nil
+			} else if v < 0 {
+				return "false", nil
+			}
+			return "", fmt.Errorf("%s is zero", DefaultInt.Var().Name())
+		}))
+
+	DefaultWithNeeds = env.String("HAS_FOO", "A default that only triggers when SomeBool is true",
+		env.Needs(SomeBool), env.Default("no"))
 )
 
 func TestInt(t *testing.T) {
@@ -41,6 +67,7 @@ func TestInt(t *testing.T) {
 func TestBool(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, true, SomeBool.Value())
+	assert.Equal(t, false, SomeFalse.Value())
 }
 
 func TestString(t *testing.T) {
@@ -58,4 +85,64 @@ func TestNeeds(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "", UnsetString.Value())
 	assert.Equal(t, "SET", SetString.Value())
+}
+
+func TestGlobalDefaults(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 42, DefaultInt.Value())
+
+	assert.Equal(t, true, DependentDefault.Value())
+	assert.Equal(t, true, DependentDefault.Value())
+	assert.Equal(t, true, DependentDefault.Value())
+
+	assert.Equal(t, 1, dependentDefaultCount)
+}
+
+func TestLocalDefaults(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 42, DefaultInt.Value())
+	assert.Equal(t, true, DependentDefault.Value())
+
+	local := env.NewEnv(env.MapStore{
+		"PULUMI_DEFAULT_INT": "-99",
+	})
+
+	assert.Equal(t, -99, local.GetInt(DefaultInt))
+	assert.Equal(t, false, local.GetBool(DependentDefault))
+}
+
+func TestNeedsDefault(t *testing.T) {
+	t.Parallel()
+
+	local := env.NewEnv(env.MapStore{
+		"PULUMI_FOO":     "true",
+		"PULUMI_HAS_FOO": "yes",
+	})
+
+	assert.Equal(t, "yes", local.GetString(DefaultWithNeeds))
+
+	local = env.NewEnv(env.MapStore{
+		"PULUMI_FOO":     "false",
+		"PULUMI_HAS_FOO": "yes",
+	})
+
+	assert.Equal(t, "no", local.GetString(DefaultWithNeeds))
+}
+
+func TestInvalidDefaults(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, env.ValidateError{}, AnInt.Validate())
+
+	local := env.NewEnv(env.MapStore{
+		"PULUMI_MY_INT": "three",
+	})
+
+	validation := local.Int(AnInt).Validate()
+	assert.Nil(t, validation.Warning)
+	assert.NotNil(t, validation.Error)
+
+	assert.Equal(t, 0, local.Int(AnInt).Value())
 }

--- a/sdk/go/common/util/env/int.go
+++ b/sdk/go/common/util/env/int.go
@@ -1,0 +1,54 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package env
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// An integer retrieved from the environment.
+type IntValue struct{ *value[int, intT] }
+
+type intT struct{}
+
+func (intT) Type() string { return "int" }
+
+//nolint:unused
+func (intT) format(i int) string { return fmt.Sprintf("%#v", i) }
+
+//nolint:unused
+func (intT) validate(v string) ValidateError {
+	_, err := strconv.ParseInt(v, 10, 64)
+	return ValidateError{
+		Error: err,
+	}
+}
+
+//nolint:unused
+func (intT) parse(s string) int {
+	i, _ := strconv.ParseInt(s, 10, 64)
+	return int(i)
+}
+
+// Declare a new environmental value of type integer.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=1" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func Int(name, description string, opts ...Option) IntValue {
+	return newValue(name, description, opts, IntValue{&value[int, intT]{}})
+}

--- a/sdk/go/common/util/env/string.go
+++ b/sdk/go/common/util/env/string.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package env
+
+import "fmt"
+
+// A string retrieved from the environment.
+type StringValue struct{ *value[string, stringT] }
+
+type stringT struct{}
+
+func (stringT) Type() string { return "string" }
+
+//nolint:unused
+func (stringT) validate(string) ValidateError { return ValidateError{} }
+
+//nolint:unused
+func (stringT) parse(s string) string { return s }
+
+//nolint:unused
+func (stringT) format(s string) string { return fmt.Sprintf("%#v", s) }
+
+// Declare a new environmental value.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=val" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func String(name, description string, opts ...Option) StringValue {
+	return newValue(name, description, opts, StringValue{&value[string, stringT]{}})
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As part of writing this PR, I took @abhinav's advice on cleaning up the `Value` interface. To clarify what it takes to define a new `Value*` type, I have moved each implementation to it's own file.

This does not change the behavior of pulumi. This is the first PR from https://github.com/pulumi/pulumi/pull/13747. It will be depended upon by the forthcoming PR that allows setting the plugin cache.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
