### PR TITLE
[pkg] Update pulumi-yaml, pulumi-java and pulumi-dotnet

### DIFF
--- a/changelog/pending/20230824--pkg--update-pulumi-yaml-v1-2-1-v1-2-2-pulumi-java-v0-9-0-v0-9-6-pulumi-dotnet-v3-54-0-v3-56-1.yaml
+++ b/changelog/pending/20230824--pkg--update-pulumi-yaml-v1-2-1-v1-2-2-pulumi-java-v0-9-0-v0-9-6-pulumi-dotnet-v3-54-0-v3-56-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg
+  description: Update pulumi-yaml (v1.2.1 -> v1.2.2) pulumi-java (v0.9.0 -> v0.9.6) pulumi-dotnet (v3.54.0 -> v3.56.1)

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -81,8 +81,8 @@ require (
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi-java/pkg v0.9.0
-	github.com/pulumi/pulumi-yaml v1.2.1
+	github.com/pulumi/pulumi-java/pkg v0.9.6
+	github.com/pulumi/pulumi-yaml v1.2.2
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1480,10 +1480,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi-java/pkg v0.9.0 h1:8KQG7AJVtVBoPE3+Psmhv/lvGHI8RL3/E5uT59Aken0=
-github.com/pulumi/pulumi-java/pkg v0.9.0/go.mod h1:eHpNTbf4n5X3YvqoDI/+cbVIkQaycBFdsvQb/24ykpc=
-github.com/pulumi/pulumi-yaml v1.2.1 h1:k7p6IZqZ80W/vAnDSYFNNWS9SuXhuSqJfPqQW82Hl9Q=
-github.com/pulumi/pulumi-yaml v1.2.1/go.mod h1:EgakC7b/4+VBNnlgM1RZIea2gUstV8s/7bdFJZt0P64=
+github.com/pulumi/pulumi-java/pkg v0.9.6 h1:UJrOAsYHRchwb4QlfI9Q224qg1TOI3rIsI6DDTUnn30=
+github.com/pulumi/pulumi-java/pkg v0.9.6/go.mod h1:c6rSw/+q4O0IImgJ9axxoC6QesbPYWBaG5gimbHouUQ=
+github.com/pulumi/pulumi-yaml v1.2.2 h1:W6BeUBLhDrJ2GSU0em1AUVelG9PBI4ABY61DdhJOO3E=
+github.com/pulumi/pulumi-yaml v1.2.2/go.mod h1:EgakC7b/4+VBNnlgM1RZIea2gUstV8s/7bdFJZt0P64=
 github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -32,7 +32,7 @@ download_release() {
 }
 
 # shellcheck disable=SC2043
-for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.54.0"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml" "github.com/pulumi/pulumi-dotnet dotnet v3.56.1"; do
   set -- $i # treat strings in loop as args
   REPO="$1"
   PULUMI_LANG="$2"


### PR DESCRIPTION
# Description

Update the following preparing for the CLI release
 - pulumi-yaml (v1.2.1 -> v1.2.2) 
 - pulumi-java (v0.9.0 -> v0.9.6)  
 - pulumi-dotnet (v3.54.0 -> v3.56.1)


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
