### PR TITLE
Fix panic when analyzer plugin is not found.

### DIFF
--- a/changelog/pending/20230824--engine--fix-panic-when-analyzer-plugin-is-not-found-on-path.yaml
+++ b/changelog/pending/20230824--engine--fix-panic-when-analyzer-plugin-is-not-found-on-path.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panic when analyzer plugin is not found on PATH.

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -103,13 +103,15 @@ func NewPolicyAnalyzer(
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
 	pluginPath, err := workspace.GetPluginPath(ctx.Diag,
 		workspace.AnalyzerPlugin, policyAnalyzerName, nil, host.GetProjectPlugins())
-	if err != nil {
-		return nil, rpcerror.Convert(err)
-	} else if pluginPath == "" {
+
+	var e *workspace.MissingError
+	if errors.As(err, &e) {
 		return nil, fmt.Errorf("could not start policy pack %q because the built-in analyzer "+
 			"plugin that runs policy plugins is missing. This might occur when the plugin "+
 			"directory is not on your $PATH, or when the installed version of the Pulumi SDK "+
 			"does not support resource policies", string(name))
+	} else if err != nil {
+		return nil, err
 	}
 
 	// Create the environment variables from the options.


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #10054

Analyzer Plugins may be missing. We should error instead of panic.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
