### PR TITLE
sdk/go/pulumix: Rename Cast to ConvertTyped

### DIFF
--- a/sdk/go/pulumix/types.go
+++ b/sdk/go/pulumix/types.go
@@ -155,14 +155,14 @@ func Val[T any](v T) Output[T] {
 	return Output[T]{OutputState: state}
 }
 
-// Cast builds an [Output] with the given untyped pulumi.Output,
+// ConvertTyped builds an [Output] with the given untyped pulumi.Output,
 // which must produce a value assignable to type T.
 //
 // Returns an error if o does not produce a compatible value.
-func Cast[T any](o internal.Output) (Output[T], error) {
+func ConvertTyped[T any](o internal.Output) (Output[T], error) {
 	typ := typeOf[T]()
 	if elt := o.ElementType(); !elt.AssignableTo(typ) {
-		return Output[T]{}, fmt.Errorf("cannot cast %v to %v", elt, typ)
+		return Output[T]{}, fmt.Errorf("cannot convert %v to %v", elt, typ)
 	}
 
 	return Output[T]{
@@ -170,10 +170,10 @@ func Cast[T any](o internal.Output) (Output[T], error) {
 	}, nil
 }
 
-// MustCast is a variant of [Cast] that panics if the type of value
+// MustConvertTyped is a variant of [ConvertTyped] that panics if the type of value
 // returned by o is not assignable to T.
-func MustCast[T any](o internal.Output) Output[T] {
-	v, err := Cast[T](o)
+func MustConvertTyped[T any](o internal.Output) Output[T] {
+	v, err := ConvertTyped[T](o)
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/go/pulumix/types_ext_test.go
+++ b/sdk/go/pulumix/types_ext_test.go
@@ -57,23 +57,45 @@ func TestOutput_AsAny(t *testing.T) {
 	assert.Equal(t, "foo", v)
 }
 
-func TestOutput_MustCast(t *testing.T) {
+func TestOutput_ConvertTyped(t *testing.T) {
 	t.Parallel()
 
 	stringOut := pulumi.String("bar").ToStringOutput()
-	out := pulumix.MustCast[string](stringOut)
+	out, err := pulumix.ConvertTyped[string](stringOut)
+	require.NoError(t, err)
 
 	v, _, _, _, err := internal.AwaitOutput(context.Background(), out)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", v)
 }
 
-func TestOutput_MustCast_error(t *testing.T) {
+func TestOutput_ConvertTyped_error(t *testing.T) {
 	t.Parallel()
 
 	stringOut := pulumi.String("bar").ToStringOutput()
 
-	assert.PanicsWithError(t, "cannot cast string to int", func() {
-		pulumix.MustCast[int](stringOut)
+	_, err := pulumix.ConvertTyped[int](stringOut)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot convert string to int")
+}
+
+func TestOutput_MustConvertTyped(t *testing.T) {
+	t.Parallel()
+
+	stringOut := pulumi.String("bar").ToStringOutput()
+	out := pulumix.MustConvertTyped[string](stringOut)
+
+	v, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", v)
+}
+
+func TestOutput_MustConvertTyped_error(t *testing.T) {
+	t.Parallel()
+
+	stringOut := pulumi.String("bar").ToStringOutput()
+
+	assert.PanicsWithError(t, "cannot convert string to int", func() {
+		pulumix.MustConvertTyped[int](stringOut)
 	})
 }


### PR DESCRIPTION
Per discussion in Ideation today,
rename the Cast and MustCast functions
to ConvertTyped and MustConvertTyped.

This is intended to make room for
renaming SpecializeOutput to Cast
which we expect users to use more often.
