### PR TITLE
[sdk/nodejs] closure serializtion, lookup package.json from current directory up to parent directories

### DIFF
--- a/changelog/pending/20230824--sdk-nodejs--when-using-closure-serializtion-lookup-package-json-up-from-current-working-directory-up-to-parent-directories-recursively.yaml
+++ b/changelog/pending/20230824--sdk-nodejs--when-using-closure-serializtion-lookup-package-json-up-from-current-working-directory-up-to-parent-directories-recursively.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: When using closure serializtion, lookup package.json up from current working directory up to parent directories recursively

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -163,7 +163,7 @@ function isSubsumedByHigherPath(normalizedPath: string, normalizedPathSet: Set<s
 }
 
 /**
- * searchUp searches for and returns the parent directory path
+ * searchUp searches for and returns the first directory path
  * starting from a given directory that contains the given file to find.
  * Recursively searches up the directory tree until it finds the file or returns null
  * when it can't find anything.

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -162,11 +162,13 @@ function isSubsumedByHigherPath(normalizedPath: string, normalizedPathSet: Set<s
     return false;
 }
 
-// parentDirectory searches for and returns the parent directory path
-// starting from a given directory that contains the given file to find.
-// recursively searches up the directory tree until it finds the file or returns null
-// when it can't find anything.
-function parentDirectory(currentDir: string, fileToFind: string): string | null {
+/**
+ * searchUp searches for and returns the parent directory path
+ * starting from a given directory that contains the given file to find.
+ * Recursively searches up the directory tree until it finds the file or returns null
+ * when it can't find anything.
+ * */
+function searchUp(currentDir: string, fileToFind: string): string | null {
     if (fs.existsSync(upath.join(currentDir, fileToFind))) {
         return currentDir;
     }
@@ -174,7 +176,7 @@ function parentDirectory(currentDir: string, fileToFind: string): string | null 
     if (currentDir === parentDir) {
         return null;
     }
-    return parentDirectory(parentDir, fileToFind);
+    return searchUp(parentDir, fileToFind);
 }
 
 // allFolders computes the set of package folders that are transitively required by the root
@@ -186,7 +188,7 @@ function allFoldersForPackages(
 ): Promise<Set<string>> {
     return new Promise((resolve, reject) => {
         // the working directory is the directory containing the package.json file
-        const workingDir = parentDirectory(".", "package.json");
+        const workingDir = searchUp(".", "package.json");
         if (workingDir === null) {
             // we couldn't find a directory containing package.json
             // searching up from the current directory

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -167,14 +167,14 @@ function isSubsumedByHigherPath(normalizedPath: string, normalizedPathSet: Set<s
 // recursively searches up the directory tree until it finds the file or returns null
 // when it can't find anything.
 function parentDirectory(currentDir: string, fileToFind: string): string | null {
-  if (fs.existsSync(upath.join(currentDir, fileToFind))) {
-      return currentDir;
-  }
-  const parentDir = upath.resolve(currentDir, "..");
-  if (currentDir === parentDir) {
-      return null;
-  }
-  return parentDirectory(parentDir, fileToFind);
+    if (fs.existsSync(upath.join(currentDir, fileToFind))) {
+        return currentDir;
+    }
+    const parentDir = upath.resolve(currentDir, "..");
+    if (currentDir === parentDir) {
+        return null;
+    }
+    return parentDirectory(parentDir, fileToFind);
 }
 
 // allFolders computes the set of package folders that are transitively required by the root

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -162,7 +162,7 @@ function isSubsumedByHigherPath(normalizedPath: string, normalizedPathSet: Set<s
     return false;
 }
 
-// parentDirectory searches for and returns the parent directory path 
+// parentDirectory searches for and returns the parent directory path
 // starting from a given directory that contains the given file to find.
 // recursively searches up the directory tree until it finds the file or returns null
 // when it can't find anything.
@@ -170,7 +170,7 @@ function parentDirectory(currentDir: string, fileToFind: string): string | null 
   if (fs.existsSync(upath.join(currentDir, fileToFind))) {
       return currentDir;
   }
-  const parentDir = upath.resolve(currentDir, '..');
+  const parentDir = upath.resolve(currentDir, "..");
   if (currentDir === parentDir) {
       return null;
   }
@@ -192,7 +192,6 @@ function allFoldersForPackages(
             // searching up from the current directory
             throw new ResourceError("Failed to find package.json.", logResource);
         }
-        
         readPackageTree(workingDir, <any>undefined, (err: any, root: readPackageTree.Node) => {
             try {
                 if (err) {


### PR DESCRIPTION
# Description

When using closure serialization, we lookup `package.json` inside of the current working directory `.`. However, if users put their `package.json` file in a parent directory and their pulumi program in a child directory, then it can't find `package.json` and fails to create inline lambdas. 

This PR addresses the issue by looking up `package.json` starting from the current working directory recursively up parent directories until it finds the closest `package.json` file and uses that as the "root" of the project from which the dependencies are inferred.

Fixes #13764 

Didn't know how to write an integration test for this since the issue is using pulumi/aws but locally testing these code changes succeed the program.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
