### PR TITLE
chore(cmdutil): Rename build-tagged files

### DIFF
--- a/sdk/go/common/util/cmdutil/child_unix.go
+++ b/sdk/go/common/util/cmdutil/child_unix.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build !windows
 // +build !windows
 

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build windows
 // +build windows
 


### PR DESCRIPTION
Files tagged with OS-specific build tags
should usually have a suffix in their name
indicating which OS they're narrowing to.

child_windows.go already does this,
but child.go aimed at Linux and macOS does not.
This change renames child.go to child_unix.go.

Further, it moves the go:build directives
outside the copyright block.
