### PR TITLE
ci: Report ci-ok on version bumps

### DIFF
--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -2,7 +2,7 @@
 # except where `on-pr.yml` skips over changes in paths-ignore,
 # this event fires on the inverse.
 # This is an officially blessed pattern for handling skipped but
-# required status checks. See 
+# required status checks. See
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 # for more information.
 name: Pull Request
@@ -10,8 +10,8 @@ name: Pull Request
 on:
   pull_request:
     paths-ignore:
-      - '**' # Skip all files…
-      - '!.version' # …except if only this file changes and nothing else.
+      - "**" # Skip all files…
+      - "!.version" # …except if only this file changes and nothing else.
 jobs:
   no-op:
     name: Skip CI on .version changes
@@ -19,3 +19,5 @@ jobs:
     steps:
       - name: Skip CI on .version changes
         run: echo 'No need to run CI tests when only .version changes'
+      - name: ci-ok
+        run: exit 0


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This reports `ci-ok` when CI is skipped for version bumps, otherwise PRs are blocked from merging.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
