### PR TITLE
Fix `pulumi new` erroring when the project already exists.

### DIFF
--- a/changelog/pending/20230825--cli-new--fix-regression-where-pulumi-new-s-org-project-stack-would-fail-if-the-project-already-exists.yaml
+++ b/changelog/pending/20230825--cli-new--fix-regression-where-pulumi-new-s-org-project-stack-would-fail-if-the-project-already-exists.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix regression where `pulumi new -s org/project/stack` would fail if the project already exists.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13774

When `pulumi new -s org/project/stack` parses out the project name, it runs a validation of the project name which will throw an error if the project already exists and cause `pulumi new` to fail. This PR causes `pulumi new` to no longer fail. This also checks if the getStack value is nil and falls back on the projectName specified in the `-s` parameter.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
