### PR TITLE
feat(cmdutil): TerminateProcessGroup for graceful termination

### DIFF
--- a/changelog/pending/20230825--sdk-go--add-cmdutil-terminateprocessgroup-to-terminate-processes-gracefully.yaml
+++ b/changelog/pending/20230825--sdk-go--add-cmdutil-terminateprocessgroup-to-terminate-processes-gracefully.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Add cmdutil.TerminateProcessGroup to terminate processes gracefully.

--- a/sdk/go/common/util/cmdutil/child_unix.go
+++ b/sdk/go/common/util/cmdutil/child_unix.go
@@ -18,6 +18,7 @@
 package cmdutil
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -33,6 +34,14 @@ func KillChildren(pid int) error {
 	// "If pid is less than -1, then sig is sent to every process in the
 	// process group whose ID is -pid. "
 	return syscall.Kill(-pid, syscall.SIGKILL)
+}
+
+// killProcessGroup sends SIGKILL to the process group for the given process.
+//
+// This is a helper function for TerminateProcessGroup;
+// a Windows version with the same signature exists in child_windows.go.
+func killProcessGroup(proc *os.Process) error {
+	return KillChildren(proc.Pid)
 }
 
 // RegisterProcessGroup informs the OS that it needs to call `setpgid` on this

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -20,10 +20,27 @@ package cmdutil
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
 	multierror "github.com/hashicorp/go-multierror"
 	ps "github.com/mitchellh/go-ps"
 )
+
+// killProcessGroup kills a process group by calling Process.Kill()
+// (which calls TerminateProcess on Windows) on all processes in the group.
+//
+// This is different from [KillChildren] which only kills child processes.
+//
+// This is a helper function for TerminateProcessGroup;
+// a Unix version with the same signature exists in child_unix.go.
+func killProcessGroup(proc *os.Process) error {
+	if err := KillChildren(proc.Pid); err != nil {
+		return err
+	}
+
+	// Kill the root process since KillChildren only kills child processes.
+	return proc.Kill()
+}
 
 // KillChildren calls os.Process.Kill() on every child process of `pid`'s, stoping after the first error (if any). It
 // also only kills direct child process, not any children they may have. This function is only implemented on Windows.
@@ -74,7 +91,13 @@ func processExistsWithParent(pid int, ppid int) (bool, error) {
 	return false, nil
 }
 
-// RegisterProcessGroup does nothing on Windows.
+// RegisterProcessGroup informs the OS that it should create a new process group
+// rooted at the given process.
+//
+// When it comes time to kill this process,
+// we'll kill all processes in the same process group.
 func RegisterProcessGroup(cmd *exec.Cmd) {
-	// nothing to do on Windows.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
 }

--- a/sdk/go/common/util/cmdutil/term.go
+++ b/sdk/go/common/util/cmdutil/term.go
@@ -1,0 +1,133 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// TerminateProcessGroup terminates the process group
+// of the given process by sending a termination signal to it.
+//
+//   - On Linux and macOS, it sends a SIGINT
+//   - On Windows, it sends a CTRL_BREAK_EVENT
+//
+// If the root process does not exit gracefully within the given duration,
+// all processes in the group are forcibly terminated.
+//
+// Returns true if the process exited gracefully, false otherwise.
+//
+// Returns an error if the process could not be terminated,
+// or if the process exited with a non-zero exit code.
+func TerminateProcessGroup(proc *os.Process, cooldown time.Duration) (ok bool, err error) {
+	// The choice to use SIGINT and CTRL_BREAK_EVENT
+	// merits some explanation.
+	//
+	// On *nix, typically,
+	// SIGTERM is used for programmatic graceful shutdown,
+	// and SIGINT is used when the user presses Ctrl+C.
+	// e.g. Kubernetes sends SIGTERM to signal shutdown.
+	// So in short, SIGTERM is for computers, SIGINT is for humans.
+	//
+	// On Windows,
+	// there's CTRL_C_EVENT which is obviously analogous to SIGINT
+	// because they both handle Ctrl+C,
+	// and CTRL_BREAK_EVENT which is special to Windows,
+	// but we can decide it's analogous to SIGTERM.
+	//
+	// However, when writing a signal handler on Windows,
+	// different languages map these signals differently.
+	// Go maps both, CTRL_BREAK_EVENT and CTRL_C_EVENT to SIGINT,
+	// Node and Python map CTRL_BREAK_EVENT to SIGBREAK
+	// (which exists only on Windows), and CTRL_C_EVENT to SIGINT.
+	//
+	// In short:
+	//
+	//    |  OS  | Signal sent      | Language | Handled as |
+	//    |------|------------------|----------|------------|
+	//    | *nix | SIGTERM          | Go       | SIGTERM    |
+	//    |      |                  | Node     | SIGTERM    |
+	//    |      |                  | Python   | SIGTERM    |
+	//    |      |------------------|----------|------------|
+	//    |      | SIGINT           | Go       | SIGINT     |
+	//    |      |                  | Node     | SIGINT     |
+	//    |      |                  | Python   | SIGINT     |
+	//    |------|------------------|----------|------------|
+	//    | Win  | CTRL_BREAK_EVENT | Go       | SIGINT     |
+	//    |      |                  | Node     | SIGBREAK   |
+	//    |      |                  | Python   | SIGBREAK   |
+	//    |      |------------------|----------|------------|
+	//    |      | CTRL_C_EVENT     | Go       | SIGINT     |
+	//    |      |                  | Node     | SIGINT     |
+	//    |      |                  | Python   | SIGINT     |
+	//
+	// So the SIGINT+CTRL_C_EVENT combo would be the obvious choice here
+	// since it's consistent across languages and platforms;
+	// plugins would define a single SIGINT handler
+	// and it would work in all cases.
+	//
+	// Unfortunately, Winodws does not support sending CTRL_C_EVENT
+	// to a specific child process.
+	// It's "current process and all child processes" or nothing.
+	/// Per the docs [1], the CTRL_C_EVENT
+	// "cannot be limited to a specific process group."
+	//
+	// [1]: https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
+	//
+	// So we have to use CTRL_BREAK_EVENT for Windows instead.
+	// At that point, using SIGINT for *nix makes sense because
+	// users will want to handle SIGINT anyway
+	// so that they can press Ctrl+C in the terminal.
+
+	if err := shutdownProcessGroup(proc.Pid); err != nil {
+		// Couldn't shut down the process gracefully.
+		// Let's just kill it.
+		return false, killProcessGroup(proc)
+	}
+
+	var waitErr error
+	ctx, cancel := context.WithTimeout(context.Background(), cooldown)
+	go func() {
+		defer cancel()
+
+		state, err := proc.Wait()
+		switch {
+		case err == nil && !state.Success():
+			// Non-zero exit code.
+			err = &exec.ExitError{ProcessState: state}
+
+		case isWaitAlreadyExited(err):
+			err = nil
+		}
+
+		waitErr = err
+	}()
+
+	// The context will be canceled when the timeout expires,
+	// or when the process exits, whichever happens first.
+	<-ctx.Done()
+
+	if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
+		// The process didn't exit within the given duration.
+		// Kill it.
+		return false, killProcessGroup(proc)
+	}
+
+	return true, waitErr
+}

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -1,0 +1,465 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	ps "github.com/mitchellh/go-ps"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminate_gracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	// This test runs commands in a child process, signals them,
+	// and expects them to shutdown gracefully.
+	//
+	// The contract for the child process is as follows:
+	//
+	//   - It MUST print something to stdout when it is ready to receive signals.
+	//   - It MUST exit with a zero code if it receives a SIGINT.
+	//   - It MUST exit with a non-zero code if the signal wasn't received within 3 seconds.
+	//   - It MAY print diagnostic messages to stderr.
+
+	tests := []struct {
+		desc string
+		prog testProgram
+	}{
+		{desc: "go", prog: goTestProgram.From("graceful.go")},
+		{desc: "node", prog: nodeTestProgram.From("graceful.js")},
+		{desc: "python", prog: pythonTestProgram.From("graceful.py")},
+		{desc: "with child", prog: goTestProgram.From("graceful_with_child.go")},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := tt.prog.Build(t)
+
+			var stdout lockedBuffer
+			cmd.Stdout = io.MultiWriter(&stdout, iotest.LogWriterPrefixed(t, "stdout: "))
+			cmd.Stderr = iotest.LogWriterPrefixed(t, "stderr: ")
+			require.NoError(t, cmd.Start(), "error starting child process")
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+
+				// Wait until the child process is ready to receive signals.
+				for stdout.Len() == 0 {
+					time.Sleep(10 * time.Millisecond)
+				}
+
+				ok, err := TerminateProcessGroup(cmd.Process, 1*time.Second)
+				assert.True(t, ok, "child process did not exit gracefully")
+				assert.NoError(t, err, "error terminating child process")
+			}()
+
+			err := cmd.Wait()
+			if isWaitAlreadyExited(err) {
+				err = nil
+			}
+			assert.NoError(t, err, "child did not exit cleanly")
+
+			<-done
+		})
+	}
+}
+
+func TestTerminate_gracefulShutdown_exitError(t *testing.T) {
+	t.Parallel()
+
+	// This test runs commands in a child process, signals them,
+	// and expects them to shutdown gracefully
+	// but with a non-zero exit code.
+
+	cmd := goTestProgram.From("graceful.go").Args("-exit-code", "1").Build(t)
+
+	var stdout lockedBuffer
+	cmd.Stdout = io.MultiWriter(&stdout, iotest.LogWriterPrefixed(t, "stdout: "))
+	cmd.Stderr = iotest.LogWriterPrefixed(t, "stderr: ")
+	require.NoError(t, cmd.Start(), "error starting child process")
+
+	// Wait until the child process is ready to receive signals.
+	for stdout.Len() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	ok, err := TerminateProcessGroup(cmd.Process, 1*time.Second)
+	assert.True(t, ok, "child process did not exit gracefully")
+	require.Error(t, err, "child process must exit with non-zero code")
+
+	var exitErr *exec.ExitError
+	if assert.ErrorAs(t, err, &exitErr, "expected ExitError from child process") {
+		assert.Equal(t, 1, exitErr.ExitCode(), "unexpected exit code from child process")
+	}
+}
+
+func TestTerminate_forceKill(t *testing.T) {
+	t.Parallel()
+
+	// This test runs commands in a child process, signals them,
+	// and expects them to not exit in a timely manner.
+	//
+	// The contract for the child process is the same as gracefulShutdown,
+	// except:
+	//
+	//   - It MUST freeze for at least 1 second after it receives a SIGINT.
+	//   - It MAY exit with a non-zero code if it receives a SIGINT.
+
+	tests := []struct {
+		desc string
+		prog testProgram
+	}{
+		{desc: "go", prog: goTestProgram.From("frozen.go")},
+		{desc: "node", prog: nodeTestProgram.From("frozen.js")},
+		{desc: "python", prog: pythonTestProgram.From("frozen.py")},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := tt.prog.Build(t)
+
+			var stdout lockedBuffer
+			cmd.Stdout = io.MultiWriter(&stdout, iotest.LogWriterPrefixed(t, "stdout: "))
+			cmd.Stderr = iotest.LogWriterPrefixed(t, "stderr: ")
+			require.NoError(t, cmd.Start(), "error starting child process")
+
+			// Wait until the child process is ready to receive signals.
+			for stdout.Len() == 0 {
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			pid := cmd.Process.Pid
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+
+				ok, err := TerminateProcessGroup(cmd.Process, 50*time.Millisecond)
+				assert.False(t, ok, "child process should not exit gracefully")
+				assert.NoError(t, err, "error terminating child process")
+			}()
+
+			select {
+			case <-done:
+				// continue
+
+			case <-time.After(200 * time.Millisecond):
+				// If the process is not killed,
+				// cmd.Wait() will block until it exits.
+				t.Fatal("Took too long to kill child process")
+			}
+
+			assert.NoError(t,
+				waitPidDead(pid, 100*time.Millisecond),
+				"error waiting for process to die")
+		})
+	}
+}
+
+func TestTerminate_forceKill_processGroup(t *testing.T) {
+	t.Parallel()
+
+	// This is a variant of TestTerminate_forceKill
+	// that verifies that a child process of the test process
+	// is also killed.
+
+	cmd := goTestProgram.From("frozen_with_child.go").Build(t)
+
+	var stdout lockedBuffer
+	cmd.Stdout = io.MultiWriter(&stdout, iotest.LogWriterPrefixed(t, "stdout: "))
+	cmd.Stderr = iotest.LogWriterPrefixed(t, "stderr: ")
+	require.NoError(t, cmd.Start(), "error starting child process")
+
+	// Wait until the child process is ready to receive signals.
+	for stdout.Len() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	pid := cmd.Process.Pid
+	childPid := -1
+
+	procs, err := ps.Processes()
+	require.NoError(t, err, "error listing processes")
+	for _, proc := range procs {
+		if proc.PPid() == pid {
+			childPid = proc.Pid()
+			break
+		}
+	}
+	require.NotEqual(t, -1, childPid, "child process not found")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		ok, err := TerminateProcessGroup(cmd.Process, time.Millisecond)
+		assert.False(t, ok, "child process should not exit gracefully")
+		assert.NoError(t, err, "error terminating child process")
+	}()
+
+	select {
+	case <-done:
+		// continue
+
+	case <-time.After(100 * time.Millisecond):
+		// If the child process is not killed,
+		// cmd.Wait() will block until it exits.
+		t.Fatal("Took too long to kill child process")
+	}
+
+	for _, pid := range []int{pid, childPid} {
+		assert.NoError(t,
+			waitPidDead(pid, 100*time.Millisecond),
+			"error waiting for process to die")
+	}
+}
+
+func TestTerminate_unhandledInterrupt(t *testing.T) {
+	t.Parallel()
+
+	// This test runs programs that do not have an interrupt handler.
+	// Contract for child process:
+	//
+	// - It MUST print to stdout when it's ready.
+	// - It MUST exit with a non-zero code if it does not get terminated within 3 seconds.
+
+	tests := []struct {
+		desc string
+		prog testProgram
+	}{
+		{desc: "go", prog: goTestProgram.From("unhandled.go")},
+		{desc: "node", prog: nodeTestProgram.From("unhandled.js")},
+		{desc: "python", prog: pythonTestProgram.From("unhandled.py")},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := tt.prog.Build(t)
+
+			var stdout lockedBuffer
+			cmd.Stdout = io.MultiWriter(&stdout, iotest.LogWriterPrefixed(t, "stdout: "))
+			cmd.Stderr = iotest.LogWriterPrefixed(t, "stderr: ")
+			require.NoError(t, cmd.Start(), "error starting child process")
+
+			// Wait until the child process is ready to receive signals.
+			for stdout.Len() == 0 {
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			pid := cmd.Process.Pid
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+
+				ok, err := TerminateProcessGroup(cmd.Process, 200*time.Millisecond)
+				assert.True(t, ok, "child process did not exit gracefully")
+				assert.Error(t, err, "child process should have exited with an error")
+			}()
+
+			select {
+			case <-done:
+				// continue
+
+			case <-time.After(200 * time.Millisecond):
+				// Took too long to kill the child process.
+				t.Fatal("Took too long to kill child process")
+			}
+
+			assert.NoError(t,
+				waitPidDead(pid, 100*time.Millisecond),
+				"error waiting for process to die")
+		})
+	}
+}
+
+type testProgramKind int
+
+const (
+	goTestProgram testProgramKind = iota
+	nodeTestProgram
+	pythonTestProgram
+)
+
+func (k testProgramKind) String() string {
+	switch k {
+	case goTestProgram:
+		return "go"
+	case nodeTestProgram:
+		return "node"
+	case pythonTestProgram:
+		return "python"
+	default:
+		return fmt.Sprintf("testProgramKind(%d)", int(k))
+	}
+}
+
+// From builds a testProgram of this kind
+// with the given source file.
+//
+// Usage:
+//
+//	goTestProgram.From("main.go")
+func (k testProgramKind) From(path string) testProgram {
+	return testProgram{
+		kind: k,
+		src:  path,
+	}
+}
+
+// testProgram is a test program inside the testdata directory.
+type testProgram struct {
+	// kind is the kind of test program.
+	kind testProgramKind
+
+	// src is the path to the source file
+	// relative to the testdata directory.
+	src string
+
+	// args specifies additional arguments to pass to the program.
+	args []string
+}
+
+func (p testProgram) Args(args ...string) testProgram {
+	p.args = args
+	return p
+}
+
+// Build builds an exec.Cmd for the test program.
+// It skips the test if the program runner is not found.
+func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
+	t.Helper()
+
+	defer func() {
+		// Make sure that the returned command
+		// is part of the process group.
+		if cmd != nil {
+			RegisterProcessGroup(cmd)
+		}
+	}()
+
+	src := filepath.Join("testdata", p.src)
+	switch p.kind {
+	case goTestProgram:
+		goBin := lookPathOrSkip(t, "go")
+		bin := filepath.Join(t.TempDir(), "main")
+		if runtime.GOOS == "windows" {
+			bin += ".exe"
+		}
+
+		buildCmd := exec.Command(goBin, "build", "-o", bin, src)
+		buildOutput := iotest.LogWriterPrefixed(t, "build: ")
+		buildCmd.Stdout = buildOutput
+		buildCmd.Stderr = buildOutput
+		require.NoError(t, buildCmd.Run(), "error building test program")
+
+		return exec.Command(bin, p.args...)
+
+	case nodeTestProgram:
+		nodeBin := lookPathOrSkip(t, "node")
+		return exec.Command(nodeBin, append([]string{src}, p.args...)...)
+
+	case pythonTestProgram:
+		pythonBin := lookPathOrSkip(t, "python")
+		return exec.Command(pythonBin, append([]string{src}, p.args...)...)
+
+	default:
+		t.Fatalf("unknown test program kind: %v", p.kind)
+		return nil
+	}
+}
+
+func lookPathOrSkip(t *testing.T, name string) string {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("Skipping test: %q not found: %v", name, err)
+	}
+	return path
+}
+
+// lockedBuffer is a thread-safe bytes.Buffer
+// that can be used to capture stdout/stderr of a command.
+type lockedBuffer struct {
+	mu sync.RWMutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.b.Len()
+}
+
+// Waits until the process with the given pid doesn't exist anymore
+// or the given timeout has elapsed.
+//
+// Returns an error if the timeout has elapsed.
+func waitPidDead(pid int, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var (
+		proc ps.Process
+		err  error
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			var errs []error
+			if proc != nil {
+				errs = append(errs, fmt.Errorf("process %d still exists: %v", pid, proc))
+			}
+			if err != nil {
+				errs = append(errs, fmt.Errorf("find process: %w", err))
+			}
+
+			return fmt.Errorf("waitPidDead %v: %w", pid, errors.Join(errs...))
+
+		default:
+			proc, err = ps.FindProcess(pid)
+			if err == nil && proc == nil {
+				return nil
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/sdk/go/common/util/cmdutil/term_unix.go
+++ b/sdk/go/common/util/cmdutil/term_unix.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package cmdutil
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// shutdownProcessGroup sends a SIGINT to the given process group.
+// It returns immediately, and does not wait for the process to exit.
+//
+// A Windows version of this function is defined in term_windows.go.
+func shutdownProcessGroup(pid int) error {
+	// Processes spawned after calling RegisterProcessGroup
+	// will be part of the same process group as the parent.
+	//
+	// -pid means send the signal to the entire process group.
+	//
+	// See: https://linux.die.net/man/2/kill
+	return unix.Kill(-pid, unix.SIGINT)
+}
+
+// isWaitAlreadyExited returns true
+// if the error is due to the process already having exited.
+//
+// On Linux, this is indicated by ESRCH or ECHILD.
+//
+// A Windows version of this function is defined in term_windows.go.
+func isWaitAlreadyExited(err error) bool {
+	return errors.Is(err, unix.ESRCH) || //  no such process
+		errors.Is(err, unix.ECHILD) //  no child processes
+}

--- a/sdk/go/common/util/cmdutil/term_windows.go
+++ b/sdk/go/common/util/cmdutil/term_windows.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package cmdutil
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// shutdownProcessGroup sends a CTRL_BREAK_EVENT to the given process group.
+// It returns immediately, and does not wait for the process to exit.
+//
+// A Unix version of this function is defined in term_unix.go.
+func shutdownProcessGroup(pid int) error {
+	// If the child processes used RegisterProcessGroup,
+	// the CTRL_BREAK_EVENT signal will be sent to all processes
+	// in the group.
+	//
+	// See: https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
+	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid))
+}
+
+// isWaitAlreadyExited returns true
+// if the error is due to the process already having exited.
+//
+// On Windows, this is indicated by the process handle being invalid.
+//
+// A Unix version of this function is defined in term_unix.go.
+func isWaitAlreadyExited(err error) bool {
+	return errors.Is(err, windows.ERROR_INVALID_HANDLE)
+}

--- a/sdk/go/common/util/cmdutil/testdata/frozen.go
+++ b/sdk/go/common/util/cmdutil/testdata/frozen.go
@@ -1,0 +1,30 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+	// os.Interrupt handles SIGINT and CTRL_BREAK_EVENT.
+
+	fmt.Println("ready")
+	select {
+	case <-sigch:
+		time.Sleep(3 * time.Second)
+		log.Fatal("error: was not forced to exit")
+
+	case <-time.After(3 * time.Second):
+		log.Fatal("error: did not receive signal")
+	}
+}

--- a/sdk/go/common/util/cmdutil/testdata/frozen.js
+++ b/sdk/go/common/util/cmdutil/testdata/frozen.js
@@ -1,0 +1,15 @@
+function handleSignal() {
+	setTimeout(function() {
+		console.errro("error: was not forced to exit");
+		process.exit(2);
+	}, 3000);
+}
+
+process.on('SIGINT', handleSignal);
+process.on('SIGBREAK', handleSignal); // ctrl-break on windows
+console.log('ready');
+
+setTimeout(function() {
+	console.error('error: did not receive signal');
+	process.exit(1);
+}, 3000);

--- a/sdk/go/common/util/cmdutil/testdata/frozen.py
+++ b/sdk/go/common/util/cmdutil/testdata/frozen.py
@@ -1,0 +1,18 @@
+import signal
+import sys
+import time
+
+def signal_handler(signal, frame):
+    time.sleep(3)
+    print("error: was not forced to exit", file=sys.stderr)
+    sys.exit(2)
+
+signal.signal(signal.SIGINT, signal_handler)
+if hasattr(signal, "SIGBREAK"):
+    # SIGBREAK is only available on Windows
+    signal.signal(signal.SIGBREAK, signal_handler)
+print("ready", flush=True)
+
+time.sleep(3)
+print("error: signal not received", file=sys.stderr)
+sys.exit(1)

--- a/sdk/go/common/util/cmdutil/testdata/frozen_with_child.go
+++ b/sdk/go/common/util/cmdutil/testdata/frozen_with_child.go
@@ -1,0 +1,70 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	// If the process name is "child", then we are the child process.
+	switch filepath.Base(os.Args[0]) {
+	case "child":
+		log.SetPrefix("child: ")
+		childMain()
+	default:
+		log.SetPrefix("parent: ")
+		parentMain()
+	}
+}
+
+func parentMain() {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+
+	cmd := exec.Command(exe)
+	cmd.Args[0] = "child" // process dispatches on args[0]
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	select {
+	case <-sigch:
+		time.Sleep(3 * time.Second)
+		log.Fatal("error: was not forced to exit")
+
+	case <-time.After(5 * time.Second):
+		log.Fatal("error: did not receive signal")
+	}
+}
+
+func childMain() {
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+	fmt.Println("child: ready")
+
+	select {
+	case <-sigch:
+		time.Sleep(2 * time.Second)
+		log.Fatal("error: was not forced to exit")
+
+	case <-time.After(3 * time.Second):
+		log.Fatal("error: did not receive signal")
+	}
+}

--- a/sdk/go/common/util/cmdutil/testdata/graceful.go
+++ b/sdk/go/common/util/cmdutil/testdata/graceful.go
@@ -1,0 +1,34 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+)
+
+var _exitCode = flag.Int("exit-code", 0, "exit code to use when the signal is received")
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+	// os.Interrupt handles SIGINT and CTRL_BREAK_EVENT.
+
+	fmt.Println("ready")
+	select {
+	case <-sigch:
+		log.Println("exiting cleanly")
+		os.Exit(*_exitCode)
+
+	case <-time.After(3 * time.Second):
+		log.Fatal("error: did not receive signal")
+	}
+}

--- a/sdk/go/common/util/cmdutil/testdata/graceful.js
+++ b/sdk/go/common/util/cmdutil/testdata/graceful.js
@@ -1,0 +1,13 @@
+function handleSignal() {
+	console.log('exiting cleanly');
+	process.exit(0);
+}
+
+process.on('SIGINT', handleSignal);
+process.on('SIGBREAK', handleSignal); // ctrl-break on windows
+console.log('ready');
+
+setTimeout(function() {
+	console.error('error: did not receive signal');
+	process.exit(1);
+}, 3000);

--- a/sdk/go/common/util/cmdutil/testdata/graceful.py
+++ b/sdk/go/common/util/cmdutil/testdata/graceful.py
@@ -1,0 +1,24 @@
+import signal
+import sys
+import time
+
+def signal_handler(signal, frame):
+    print("exiting cleanly", flush=True)
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, signal_handler)
+if hasattr(signal, "SIGBREAK"):
+    # SIGBREAK is only available on Windows
+    signal.signal(signal.SIGBREAK, signal_handler)
+print("ready", flush=True)
+
+# HACK:
+# time.sleep on Windows doesn't seem to be interruptible by signals
+# so we'll sleep in small increments.
+timeout = 3.0
+while timeout > 0:
+    time.sleep(0.05)
+    timeout -= 0.05
+
+print("error: signal not received", file=sys.stderr)
+sys.exit(1)

--- a/sdk/go/common/util/cmdutil/testdata/graceful_with_child.go
+++ b/sdk/go/common/util/cmdutil/testdata/graceful_with_child.go
@@ -1,0 +1,79 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	// If the process name is "child", then we are the child process.
+	switch filepath.Base(os.Args[0]) {
+	case "child":
+		log.SetPrefix("child: ")
+		childMain()
+	default:
+		log.SetPrefix("parent: ")
+		parentMain()
+	}
+}
+
+func parentMain() {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+
+	cmd := exec.Command(exe)
+	cmd.Args[0] = "child" // process dispatches on args[0]
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	select {
+	case <-sigch:
+		log.Println("waiting for child to exit")
+		if err := cmd.Wait(); err != nil {
+			log.Fatal(err)
+		}
+		log.Println("exiting cleanly")
+		os.Exit(0)
+
+	case <-time.After(5 * time.Second):
+		log.Println("did not receive signal, killing child")
+		if err := cmd.Process.Kill(); err != nil {
+			log.Fatal(err)
+		}
+		os.Exit(1)
+	}
+}
+
+func childMain() {
+	sigch := make(chan os.Signal, 1)
+	signal.Notify(sigch, os.Interrupt)
+	fmt.Println("child: ready")
+
+	select {
+	case <-sigch:
+		fmt.Println("child: exiting cleanly")
+		os.Exit(0)
+
+	case <-time.After(3 * time.Second):
+		log.Println("error: did not receive signal")
+		os.Exit(1)
+	}
+}

--- a/sdk/go/common/util/cmdutil/testdata/unhandled.go
+++ b/sdk/go/common/util/cmdutil/testdata/unhandled.go
@@ -1,0 +1,20 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+)
+
+func main() {
+	flag.Parse()
+	log.SetFlags(0)
+
+	fmt.Println("ready")
+	<-time.After(3 * time.Second)
+	log.Fatal("error: was not terminated")
+}

--- a/sdk/go/common/util/cmdutil/testdata/unhandled.js
+++ b/sdk/go/common/util/cmdutil/testdata/unhandled.js
@@ -1,0 +1,5 @@
+console.log('ready');
+setTimeout(function() {
+	console.error('error: was not terminated');
+	process.exit(1);
+}, 3000);

--- a/sdk/go/common/util/cmdutil/testdata/unhandled.py
+++ b/sdk/go/common/util/cmdutil/testdata/unhandled.py
@@ -1,0 +1,15 @@
+import sys
+import time
+
+print('ready', flush=True)
+
+# HACK:
+# time.sleep on Windows doesn't seem to be interruptible by signals
+# so we'll sleep in small increments.
+timeout = 3.0
+while timeout > 0:
+    time.sleep(0.05)
+    timeout -= 0.05
+
+print("error: was not terminated", file=sys.stderr)
+sys.exit(1)


### PR DESCRIPTION
Adds a new **currently unused** function TerminateProcessGroup
that terminates all processes in a group gracefully.

It does so by first sending the process
a SIGINT on Unix systems, and CTRL_BREAK_EVENT on Windows,
and waiting a specified duration for the process to exit.
The choice of signals was very deliberate
and is documented in the comments for TerminateProcessGroup.

If the process does not exit in the given duration,
it and its child processes are forcibly terminated
with SIGKILL or equivalent.

Testing:
The core behaviors are tested against Python, Go, and Node.
The corner cases of signal handling are tested
against rogue Go processes.
The changes were experimented with in #13760.

Refs #9780
