### PR TITLE
ci(release-pr): gh pr create needs a body

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -75,7 +75,7 @@ jobs:
           git push origin "pkg/v${PULUMI_VERSION}"
           git push -u origin HEAD
 
-          PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}")
+          PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}" --body "")
 
           if [ "${QUEUE_MERGE}" = "true" ]; then
             gh pr merge --auto "${PR}"


### PR DESCRIPTION
The release PR job currently fails with the error:

    must provide `--title` and `--body` (or `--fill` or `fill-first`) when not running interactively

Previously, body used to be `""` or `"bors merge"`.
Now that we no longer use bors, the body needs something in it.
