### PR TITLE
Support bailing from RunFunc

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -42,7 +42,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	aferoUtil "github.com/pulumi/pulumi/pkg/v3/util/afero"
@@ -66,10 +65,10 @@ func newConvertCmd() *cobra.Command {
 		Long: "Convert Pulumi programs from a supported source program into other supported languages.\n" +
 			"\n" +
 			"The source program to convert will default to the current working directory.\n",
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return result.FromError(fmt.Errorf("get current working directory: %w", err))
+				return fmt.Errorf("get current working directory: %w", err)
 			}
 
 			return runConvert(env.Global(), cwd, mappings, from, language, outDir, generateOnly, strict)
@@ -211,10 +210,10 @@ func runConvert(
 	e env.Env,
 	cwd string, mappings []string, from string, language string,
 	outDir string, generateOnly bool, strict bool,
-) result.Result {
+) error {
 	pCtx, err := newPluginContext(cwd)
 	if err != nil {
-		return result.FromError(fmt.Errorf("create plugin host: %w", err))
+		return fmt.Errorf("create plugin host: %w", err)
 	}
 	defer contract.IgnoreClose(pCtx.Host)
 
@@ -294,7 +293,7 @@ func runConvert(
 	if outDir != "." {
 		err := os.MkdirAll(outDir, 0o755)
 		if err != nil {
-			return result.FromError(fmt.Errorf("create output directory: %w", err))
+			return fmt.Errorf("create output directory: %w", err)
 		}
 	}
 
@@ -320,12 +319,12 @@ func runConvert(
 		convert.DefaultWorkspace(), convert.ProviderFactoryFromHost(pCtx.Host),
 		from, mappings, installProvider)
 	if err != nil {
-		return result.FromError(fmt.Errorf("create provider mapper: %w", err))
+		return fmt.Errorf("create provider mapper: %w", err)
 	}
 
 	pclDirectory, err := os.MkdirTemp("", "pulumi-convert")
 	if err != nil {
-		return result.FromError(fmt.Errorf("create temporary directory: %w", err))
+		return fmt.Errorf("create temporary directory: %w", err)
 	}
 	defer os.RemoveAll(pclDirectory)
 
@@ -333,18 +332,18 @@ func runConvert(
 	if from == "yaml" {
 		proj, program, err := yamlgen.Eject(cwd, loader)
 		if err != nil {
-			return result.FromError(fmt.Errorf("load yaml program: %w", err))
+			return fmt.Errorf("load yaml program: %w", err)
 		}
 		err = writeProgram(pclDirectory, proj, program)
 		if err != nil {
-			return result.FromError(fmt.Errorf("write program to intermediate directory: %w", err))
+			return fmt.Errorf("write program to intermediate directory: %w", err)
 		}
 	} else if from == "pcl" {
 		// The source code is PCL, we don't need to do anything here, just repoint pclDirectory to it, but
 		// remove the temp dir we just created first
 		err = os.RemoveAll(pclDirectory)
 		if err != nil {
-			return result.FromError(fmt.Errorf("remove temporary directory: %w", err))
+			return fmt.Errorf("remove temporary directory: %w", err)
 		}
 		pclDirectory = cwd
 	} else {
@@ -356,7 +355,7 @@ func runConvert(
 			var me *workspace.MissingError
 			if !errors.As(err, &me) {
 				// Not a MissingError, return the original error.
-				return result.FromError(fmt.Errorf("load plugin source %q: %w", from, err))
+				return fmt.Errorf("load plugin source %q: %w", from, err)
 			}
 
 			pluginSpec := workspace.PluginSpec{
@@ -366,12 +365,12 @@ func runConvert(
 
 			_, err = pkgWorkspace.InstallPlugin(pluginSpec, log)
 			if err != nil {
-				return result.FromError(fmt.Errorf("install plugin source %q: %w", from, err))
+				return fmt.Errorf("install plugin source %q: %w", from, err)
 			}
 
 			converter, err = plugin.NewConverter(pCtx, from, nil)
 			if err != nil {
-				return result.FromError(fmt.Errorf("load plugin source %q: %w", from, err))
+				return fmt.Errorf("load plugin source %q: %w", from, err)
 			}
 		}
 		defer contract.IgnoreClose(converter)
@@ -382,7 +381,7 @@ func runConvert(
 			convert.MapperRegistration(mapperServer),
 			schema.LoaderRegistration(loaderServer))
 		if err != nil {
-			return result.FromError(err)
+			return err
 		}
 		defer contract.IgnoreClose(grpcServer)
 
@@ -393,7 +392,7 @@ func runConvert(
 			LoaderTarget:    grpcServer.Addr(),
 		})
 		if err != nil {
-			return result.FromError(err)
+			return err
 		}
 
 		// We're done with the converter plugin now so can close it
@@ -414,7 +413,7 @@ func runConvert(
 		if resp.Diagnostics.HasErrors() {
 			// If we've got error diagnostics then program generation failed, we've printed the error above so
 			// just return a plain message here.
-			return result.FromError(fmt.Errorf("conversion failed"))
+			return fmt.Errorf("conversion failed")
 		}
 	}
 
@@ -425,7 +424,7 @@ func runConvert(
 	if path != "" {
 		proj, err = workspace.LoadProject(path)
 		if err != nil {
-			return result.FromError(fmt.Errorf("load project: %w", err))
+			return fmt.Errorf("load project: %w", err)
 		}
 	}
 
@@ -445,14 +444,14 @@ func runConvert(
 		}
 		printDiagnostics(pCtx.Diag, diagnostics)
 		if err != nil {
-			return result.FromError(fmt.Errorf("could not generate output program: %w", err))
+			return fmt.Errorf("could not generate output program: %w", err)
 		}
 
-		return result.FromError(fmt.Errorf("could not generate output program"))
+		return fmt.Errorf("could not generate output program")
 	}
 
 	if err != nil {
-		return result.FromError(fmt.Errorf("could not generate output program: %w", err))
+		return fmt.Errorf("could not generate output program: %w", err)
 	}
 
 	// If we've got code generation warnings only print them if we've got PULUMI_DEV set or emitting pcl
@@ -464,23 +463,23 @@ func runConvert(
 	if !generateOnly {
 		// Change the working directory to the specified directory.
 		if err := os.Chdir(outDir); err != nil {
-			return result.FromError(fmt.Errorf("changing the working directory: %w", err))
+			return fmt.Errorf("changing the working directory: %w", err)
 		}
 
 		proj, root, err := readProject()
 		if err != nil {
-			return result.FromError(err)
+			return err
 		}
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pwd, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
 		if err != nil {
-			return result.FromError(err)
+			return err
 		}
 		defer ctx.Close()
 
 		if err := installDependencies(ctx, &proj.Runtime, pwd); err != nil {
-			return result.FromError(err)
+			return err
 		}
 	}
 

--- a/pkg/cmd/pulumi/env.go
+++ b/pkg/cmd/pulumi/env.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 func newEnvCmd() *cobra.Command {
@@ -39,7 +39,7 @@ func newEnvCmd() *cobra.Command {
 		// unhide once most existing variables are using the new env var framework and
 		// show up here.
 		Hidden: !env.Experimental.Value(),
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			table := cmdutil.Table{
 				Headers: []string{"Variable", "Description", "Value"},
 			}
@@ -52,7 +52,7 @@ func newEnvCmd() *cobra.Command {
 			}
 			cmdutil.PrintTable(table)
 			if foundError {
-				return result.Error("Invalid environmental variables found")
+				return errors.New("invalid environmental variables found")
 			}
 			return nil
 		}),

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -15,11 +15,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -46,13 +47,13 @@ func newStackRmCmd() *cobra.Command {
 			"`destroy` command for removing a resources, as this is a distinct operation.\n" +
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
-		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {
-					return result.Error("only one of --stack or argument stack name may be specified, not both")
+					return errors.New("only one of --stack or argument stack name may be specified, not both")
 				}
 				stack = args[0]
 			}
@@ -63,26 +64,25 @@ func newStackRmCmd() *cobra.Command {
 
 			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
-				return result.FromError(err)
+				return err
 			}
 
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
 			if !yes && !confirmPrompt(prompt, s.Ref().String(), opts) {
-				fmt.Println("confirmation declined")
-				return result.Bail()
+				return result.FprintBailf(os.Stdout, "confirmation declined")
 			}
 
 			hasResources, err := s.Remove(ctx, force)
 			if err != nil {
 				if hasResources {
-					return result.Errorf(
+					return fmt.Errorf(
 						"'%s' still has resources; removal rejected. Possible actions:\n"+
 							"- Make sure that '%[1]s' is the stack that you want to destroy\n"+
 							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`\n"+
 							"- Run `pulumi stack rm --force` to override this error", s.Ref())
 				}
-				return result.FromError(err)
+				return err
 			}
 
 			if !preserveConfig {
@@ -93,7 +93,7 @@ func newStackRmCmd() *cobra.Command {
 					stackProject, has := s.Ref().Project()
 					if has && stackProject == tokens.Name(proj.Name) {
 						if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
-							return result.FromError(err)
+							return err
 						}
 					}
 				}

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -91,6 +91,8 @@ func runPostCommandHooks(c *cobra.Command, args []string) error {
 // callstack which might prohibit reaping of child processes, resources, etc.  And we wish to avoid
 // the default Cobra unhandled error behavior, because it is formatted incorrectly and needlessly
 // prints usage.
+//
+// If run returns a BailError, we will not print an error message, but will still be a non-zero exit code.
 func RunFunc(run func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) {
 	return RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 		if err := run(cmd, args); err != nil {

--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -1,0 +1,70 @@
+package cmdutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunFunc_Bail(t *testing.T) {
+	t.Parallel()
+
+	// Verifies that a use of RunFunc that returns BailError
+	// will cause the program to exit with a non-zero exit code
+	// without printing an error message.
+	//
+	// Unfortunately, we can't test this directly,
+	// because the `os.Exit` call in RunResultFunc.
+	//
+	// Instead, we'll re-run the test binary,
+	// and have it run TestFakeCommand.
+	// We'll verify the output of that binary instead.
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cmd := exec.Command(exe, "-test.run=^TestFakeCommand$")
+	cmd.Env = append(os.Environ(), "TEST_FAKE=1")
+
+	// Write output to the buffer and to the test logger.
+	var buff bytes.Buffer
+	output := io.MultiWriter(&buff, iotest.LogWriter(t))
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Run()
+	require.Error(t, err)
+	if exitErr := new(exec.ExitError); assert.ErrorAs(t, err, &exitErr) {
+		assert.NotZero(t, exitErr.ExitCode())
+	}
+
+	assert.Empty(t, buff.String())
+}
+
+//nolint:paralleltest // not a real test
+func TestFakeCommand(t *testing.T) {
+	if os.Getenv("TEST_FAKE") != "1" {
+		// This is not a real test.
+		// It's a fake test that we'll run as a subprocess
+		// to verify that the RunFunc function works correctly.
+		// See TestRunFunc_Bail for more details.
+		return
+	}
+
+	cmd := &cobra.Command{
+		Run: RunFunc(func(cmd *cobra.Command, args []string) error {
+			return result.BailErrorf("bail")
+		}),
+	}
+	err := cmd.Execute()
+	// Unreachable: RunFunc should have called os.Exit.
+	assert.Fail(t, "unreachable", "RunFunc should have called os.Exit: %v", err)
+}

--- a/sdk/go/common/util/result/result_test.go
+++ b/sdk/go/common/util/result/result_test.go
@@ -1,0 +1,122 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBail(t *testing.T) {
+	t.Parallel()
+
+	err := BailError(errors.New("big boom"))
+	assert.Equal(t, "BAIL: big boom", err.Error())
+}
+
+func TestBailf(t *testing.T) {
+	t.Parallel()
+
+	err := BailErrorf("%d booms", 5)
+	assert.Equal(t, "BAIL: 5 booms", err.Error())
+}
+
+func TestFprintBailf(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	err := FprintBailf(&buff, "%d booms", 5)
+	assert.Equal(t, "BAIL: 5 booms", err.Error())
+	assert.Equal(t, "5 booms\n", buff.String())
+}
+
+func TestIsBail(t *testing.T) {
+	t.Parallel()
+
+	inner := errors.New("big boom")
+	bail := BailError(inner)
+	wrapped := fmt.Errorf("wrapped: %w", bail)
+
+	assert.False(t, IsBail(nil))
+	assert.False(t, IsBail(inner))
+	assert.True(t, IsBail(bail))
+	assert.True(t, IsBail(wrapped))
+}
+
+func TestFromError(t *testing.T) {
+	t.Parallel()
+
+	errBail := BailErrorf("bail")
+	errSimilarToBail := errors.New("bail")
+	errSadness := errors.New("great sadness")
+
+	tests := []struct {
+		desc string
+		give error
+
+		// Properties of the Result:
+		wantIsBail bool
+		wantErr    error
+	}{
+		{
+			desc:       "bail",
+			give:       errBail,
+			wantIsBail: true,
+			wantErr:    nil,
+		},
+		{
+			// an error with the same message as ErrBail
+			// should not be considered a bail.
+			desc:    "similar to bail",
+			give:    errSimilarToBail,
+			wantErr: errSimilarToBail,
+		},
+		{
+			desc:       "wraps bail",
+			give:       fmt.Errorf("wraps bail: %w", errBail),
+			wantIsBail: true,
+			wantErr:    nil,
+		},
+		{
+			desc:       "other error",
+			give:       errSadness,
+			wantIsBail: false,
+			wantErr:    errSadness,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res := FromError(tt.give)
+			assert.Equal(t, tt.wantIsBail, res.IsBail(), "Result.IsBail")
+			assert.ErrorIs(t, res.Error(), tt.wantErr, "Result.Error")
+		})
+	}
+}
+
+func TestFromError_nil(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		FromError(nil)
+	})
+}


### PR DESCRIPTION
**Background**

The result.Result type is used by our CLI implementation to communicate how we want to exit the program.

Most `result.Result` values (built from errors with `result.FromError`) cause the program to print the message to stderr and exit the program with exit code -1.
The exception is `result.Bail()`, which indicates that we've already printed the error message, and we simply need to `exit(-1)` now.

Our CLI command implementation use `cmdutil.RunResultFunc` which takes a `func(...) result.Result` to implement this logic.

`cmdutil` additionally includes a `cmdutil.RunFunc` which takes a `func(...) error` and wraps it in `RunResultFunc`, relying on `result.FromError` for the conversion:

    func RunFunc(run func(...) error) func(...) {
        return RunResultFunc(func(...) result.Result {
            if err := run(...); err != nil {
                return result.FromError(err)
            }
            return nil
        })
    }

**Problem**

In CLI contexts where we're using an `error`, and we want to print an error message to the user and exit, it's desirable to use diag.Sink to print the message to the user with the appropriate level (error, warning, etc.) and exit without printing anything else.

However, the only way to do that currently is by converting that function to return `result.Result`, turn all error returns to `result.FromError`, and then return `result.Bail()`.

**Solution**

This change introduces a `result.BailError` error that gets converted into a `result.Bail()` when it passes through `result.FromError`.

It allows commands implementations that use `error` to continue returning errors and still provide an ideal CLI experience.

It relies on `errors.As` for matching, so even if an intermediate layer wraps the error with `fmt.Errorf("..: %w", ErrBail)`, we'll recognize the request to bail.

BailError keep track of the internal error that triggered it, which (when everything is moved off of result and onto error) means we'll still be able to see the internal errors that triggered a bail during debugging.

Currently debugging engine tests is pretty horrible because you often just get back a `result.Result{err:nil}` with no information where in the engine stack that came from.

**Testing**

Besides unit tests, this includes an end-to-end test for using RunResultFunc with a bail error.
The test operates by putting the mock behavior in a fake test, and re-running the test binary to execute *just that test*.

**Demonstration**

This change also ports the following commands to use BailError: cancel, convert, env, policy rm, stack rm.

These command implementations are simple and were able to switch easily, without bubbling into a change to a bunch of other code.