### PR TITLE
Kp/adds root pulumi ai command

### DIFF
--- a/changelog/pending/20230829--cli--adds-pulumi-ai-and-pulumi-ai-web-commands.yaml
+++ b/changelog/pending/20230829--cli--adds-pulumi-ai-and-pulumi-ai-web-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds Pulumi AI and Pulumi AI Web commands

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -59,6 +59,6 @@ func newAICommand() *cobra.Command {
 		},
 		),
 	}
-	cmd.AddCommand(newAIBrowserCommand())
+	cmd.AddCommand(newAIWebCommand())
 	return cmd
 }

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -55,6 +55,9 @@ func newAICommand() *cobra.Command {
 		Args:   cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
+			if len(args) == 0 {
+				return cmd.Help()
+			}
 			return aiCommand.Run(ctx, args)
 		},
 		),

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
+)
+
+type aiCmd struct {
+	Stdout io.Writer // defaults to os.Stdout
+
+	// currentBackend is a reference to the top-level currentBackend function.
+	// This is used to override the default implementation for testing purposes.
+	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+}
+
+func (cmd *aiCmd) Run(ctx context.Context, args []string) error {
+	if cmd.Stdout == nil {
+		cmd.Stdout = os.Stdout
+	}
+
+	if cmd.currentBackend == nil {
+		cmd.currentBackend = currentBackend
+	}
+	return nil
+}
+
+func newAICommand() *cobra.Command {
+	var aiCommand aiCmd
+	cmd := &cobra.Command{
+		Use:    "ai",
+		Short:  "Basic Pulumi AI CLI commands.",
+		Long:   "Contains the current set of supported CLI functionality for the Pulumi AI service.",
+		Hidden: !hasExperimentalCommands(),
+		Args:   cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
+			return aiCommand.Run(ctx, args)
+		},
+		),
+	}
+	cmd.AddCommand(newAIBrowserCommand())
+	return cmd
+}

--- a/pkg/cmd/pulumi/ai_browser.go
+++ b/pkg/cmd/pulumi/ai_browser.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/pkg/browser"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
+)
+
+type aiBrowserCmd struct {
+	appURL string
+
+	Stdout io.Writer // defaults to os.Stdout
+
+	// currentBackend is a reference to the top-level currentBackend function.
+	// This is used to override the default implementation for testing purposes.
+	currentBackend func(context.Context, *workspace.Project, display.Options) (backend.Backend, error)
+}
+
+func (cmd *aiBrowserCmd) Run(ctx context.Context, args []string) error {
+	if cmd.Stdout == nil {
+		cmd.Stdout = os.Stdout
+	}
+
+	if cmd.currentBackend == nil {
+		cmd.currentBackend = currentBackend
+	}
+
+	err := browser.OpenURL(cmd.appURL)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newAIBrowserCommand() *cobra.Command {
+	var aibcmd aiBrowserCmd
+	aibcmd.appURL = "https://www.pulumi.com/ai/"
+	cmd := &cobra.Command{
+		Use:   "browser",
+		Short: "Opens Pulumi AI in your local browser",
+		Long:  "Opens Pulumi AI in your local browser",
+		Args:  cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
+			return aibcmd.Run(ctx, args)
+		},
+		),
+	}
+	return cmd
+}

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -124,8 +124,18 @@ func newAIWebCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "web",
 		Short: "Opens Pulumi AI in your local browser",
-		Long:  "Opens Pulumi AI in your local browser",
-		Args:  cmdutil.MaximumNArgs(1),
+		Long: `Opens Pulumi AI in your local browser
+
+This command opens the Pulumi AI web app in your local default browser.
+It can be further initialized by providing a prompt to pre-fill in the app,
+with the default behavior then automatically submitting that prompt to Pulumi AI.
+
+If no prompt is provided, the app will be opened with no prompt pre-filled.
+
+If you do not want to submit the prompt to Pulumi AI, you can opt-out of this
+by passing the --no-auto-submit flag.
+`,
+		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext()
 			return aiwebcmd.Run(ctx, args)

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -370,6 +370,14 @@ func NewPulumiCmd() *cobra.Command {
 				newReplayEventsCmd(),
 			},
 		},
+		// AI Commands relating to specifically the Pulumi AI service
+		//     and its related features
+		{
+			Name: "AI Commands",
+			Commands: []*cobra.Command{
+				newAICommand(),
+			},
+		},
 	})
 
 	cmd.PersistentFlags().StringVar(&tracingHeaderFlag, "tracing-header", "",

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -80,3 +80,8 @@ var (
 	SelfManagedStateLegacyLayout = env.Bool("SELF_MANAGED_STATE_LEGACY_LAYOUT",
 		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.")
 )
+
+// Environment variables which affect Pulumi AI integrations
+var (
+	AIServiceEndpoint = env.String("AI_SERVICE_ENDPOINT", "Endpoint for Pulumi AI service")
+)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR is intended to add the beginnings of a set of `pulumi ai` commands to the Pulumi CLI. The first implementation is relatively straightforward - we want to be able to open the Pulumi AI app from the CLI while providing a simple set of operations for users - pre-filling the AI prompt, and optionally not running that prompt when the page is opened. The CLI should open the appropriate URL in the user's default browser, and the app should take over from there.

This was implemented as a subcommand for `pulumi ai` as we intend to add more features both as siblings and at the parent `pulumi ai` command in the future, as this current functionality does not represent the "final default" experience we'd like users to have when running `pulumi ai`.

Fixes https://github.com/pulumi/pulumi.ai/issues/126

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
