### PR TITLE
plugin(go, node, py): Exit cleanly on interrupt

### DIFF
--- a/changelog/pending/20230828--sdk-go-nodejs-python--language-plugins-clean-up-resources-and-exit-cleanly-with-status-code-zero.yaml
+++ b/changelog/pending/20230828--sdk-go-nodejs-python--language-plugins-clean-up-resources-and-exit-cleanly-with-status-code-zero.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go,nodejs,python
+  description: Language plugins now clean up resources and exit cleanly on receiving SIGINT or CTRL_BREAK signals.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -37,6 +37,7 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -117,11 +118,12 @@ func main() {
 		engineAddress = args[0]
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	// map the context Done channel to the rpcutil boolean cancel channel
 	cancelChannel := make(chan bool)
 	go func() {
 		<-ctx.Done()
+		cancel() // deregister the interrupt handler
 		close(cancelChannel)
 	}()
 	err := rpcutil.Healthcheck(ctx, engineAddress, 5*time.Minute, cancel)

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -33,6 +33,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -135,11 +136,12 @@ func main() {
 		engineAddress = args[0]
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	// map the context Done channel to the rpcutil boolean cancel channel
 	cancelChannel := make(chan bool)
 	go func() {
 		<-ctx.Done()
+		cancel() // deregister signal handler
 		close(cancelChannel)
 	}()
 	err = rpcutil.Healthcheck(ctx, engineAddress, 5*time.Minute, cancel)


### PR DESCRIPTION
This changes the language plugins for Go, Node, and Python
to watch for the os.Interrupt signal (SIGINT on Unix, CTRL_BREAK on Windows)
that the plugin lifetime manager sends (per #13795)
and exit cleanly on receiving the signal.

This is a no-op for users.
An immediate effect it'll have for us is that
we'll begin seeing test coverage data come out of these binaries.

A similar change is necessary in other language plugin binaries.
I did not touch uses of rpcutil.ServeWithOptions outside `main` packages
because whether a signal handler should be installed there or not
requires more knowledge of individual cases.

Note that this uses [signal.NotifyContext][1].
Calling the returned `cancel()` function removes the signal handler.
This is desirable so that if a user sends the signal again
(e.g., presses Ctrl-C again), we don't capture it
and let the OS kill the process.

  [1]: https://pkg.go.dev/os/signal#NotifyContext

Refs #9780
