### PR TITLE
Replace Bail result with BailError

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -62,7 +62,6 @@ import (
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -1083,19 +1082,19 @@ func surveyStack(interactions ...func() error) error {
 	return nil
 }
 
-// Format a non-nil result.Result that indicates some arguments are missing for a
+// Format a non-nil error that indicates some arguments are missing for a
 // non-interactive session.
-func missingNonInteractiveArg(args ...string) result.Result {
+func missingNonInteractiveArg(args ...string) error {
 	switch len(args) {
 	case 0:
 		panic("cannot create an error message for missing zero args")
 	case 1:
-		return result.Errorf("Must supply <%s> unless pulumi is run interactively", args[0])
+		return fmt.Errorf("Must supply <%s> unless pulumi is run interactively", args[0])
 	default:
 		for i, s := range args {
 			args[i] = "<" + s + ">"
 		}
-		return result.Errorf("Must supply %s and %s unless pulumi is run interactively",
+		return fmt.Errorf("Must supply %s and %s unless pulumi is run interactively",
 			strings.Join(args[:len(args)-1], ", "), args[len(args)-1])
 	}
 }


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Replaces most instances of bail results outside the core engine with BailErorr instead.

The only parts of the codebase still using `result.Bail()` are in pkg/resource/deploy.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
