### PR TITLE
cmdutil: Support errors.Join-based multi-errors

### DIFF
--- a/changelog/pending/20230829--sdk-go--support-multi-errors-built-from-errors-join.yaml
+++ b/changelog/pending/20230829--sdk-go--support-multi-errors-built-from-errors-join.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Support multi-errors built from errors.Join for RunFunc, Exit, and friends.

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
@@ -162,16 +163,34 @@ func exitErrorCodef(code int, format string, args ...interface{}) {
 
 // errorMessage returns a message, possibly cleaning up the text if appropriate.
 func errorMessage(err error) string {
-	if multi, ok := err.(*multierror.Error); ok {
-		wr := multi.WrappedErrors()
-		if len(wr) == 1 {
-			return errorMessage(wr[0])
-		}
-		msg := fmt.Sprintf("%d errors occurred:", len(wr))
-		for i, werr := range wr {
+	contract.Requiref(err != nil, "err", "must not be nil")
+
+	var underlying []error
+	switch multi := err.(type) {
+	case *multierror.Error:
+		underlying = multi.WrappedErrors()
+	case interface{ Unwrap() []error }:
+		// The standard library supported multi-errors (available since Go 1.20)
+		// use this interface.
+		underlying = multi.Unwrap()
+	default:
+		return err.Error()
+	}
+
+	switch len(underlying) {
+	case 0:
+		// This should never happen, but just in case.
+		// Return the original error message.
+		return err.Error()
+
+	case 1:
+		return errorMessage(underlying[0])
+
+	default:
+		msg := fmt.Sprintf("%d errors occurred:", len(underlying))
+		for i, werr := range underlying {
 			msg += fmt.Sprintf("\n    %d) %s", i+1, errorMessage(werr))
 		}
 		return msg
 	}
-	return err.Error()
 }


### PR DESCRIPTION
cmdutil has some special handling for hashicorp/go-multierror
so that multi-errors are printed cleanly in the form:

    %d errors occurred:
        1) foo
        2) bar
        ...

In Go 1.20, the errors package got a native `errors.Join` function.
This adds support for errors.Join-based multi-errors to this logic.

These errors implement an `Unwrap() []error` method
which can be used to access the full list of errors.
We use that and then implement the same logic for formatting as before.
