### PR TITLE
PoC: cli/new: Use bubbletea for template list

### DIFF
--- a/changelog/pending/20230914--cli-new--use-bubbletea-to-render-pulumi-new-template-selection.yaml
+++ b/changelog/pending/20230914--cli-new--use-bubbletea-to-render-pulumi-new-template-selection.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Use bubbletea to render `pulumi new` template selection.

--- a/cmd/pulumi-test-language/go.mod
+++ b/cmd/pulumi-test-language/go.mod
@@ -170,6 +170,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect

--- a/cmd/pulumi-test-language/go.sum
+++ b/cmd/pulumi-test-language/go.sum
@@ -305,6 +305,7 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -347,6 +348,7 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -1485,6 +1487,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=

--- a/pkg/backend/display/selector.go
+++ b/pkg/backend/display/selector.go
@@ -1,0 +1,216 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+const (
+	_brokenTemplateDescription = "(This template is currently broken)"
+	_colorCyan                 = "#00AAAA"
+	_colorWhite                = "#FFFFFF"
+	_colorGreen                = "#00FF00"
+)
+
+// ChooseTemplate will prompt the user to choose amongst the available templates.
+func ChooseTemplate(templates []workspace.Template, opts Options) (workspace.Template, error) {
+	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
+	if !opts.IsInteractive {
+		return workspace.Template{}, errors.New(chooseTemplateErr)
+	}
+
+	picker := newTemplatePicker(templates)
+	final, err := tea.NewProgram(picker).Run()
+	if err != nil {
+		return workspace.Template{}, errors.New(chooseTemplateErr)
+	}
+	picker = final.(templatePicker)
+	if picker.choice == nil {
+		return workspace.Template{}, errors.New(chooseTemplateErr)
+	}
+
+	return picker.choice.Template(), nil
+}
+
+// templatePicker renders a list of templates to choose from.
+type templatePicker struct {
+	// choice is set to the selected item
+	// when the user presses enter.
+	//
+	// Its value is nil if a template was not selected.
+	choice *templatePickerItem
+
+	list      list.Model
+	templates []workspace.Template
+}
+
+var _ tea.Model = (*templatePicker)(nil)
+
+func (t templatePicker) Init() tea.Cmd { return nil }
+
+func (t templatePicker) View() string { return t.list.View() }
+
+func (t templatePicker) Update(msg tea.Msg) (_ tea.Model, cmd tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		t.list.SetSize(msg.Width, msg.Height)
+		t.list.Styles.TitleBar = t.list.Styles.TitleBar.Width(t.list.Width())
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return t, tea.Quit
+
+		case tea.KeyEnter:
+			if t.list.FilterState() == list.Filtering {
+				// If we're filtering, let the list handle the Enter key.
+				// This will just accept the filter value.
+				break
+			}
+
+			t.choice = t.list.SelectedItem().(*templatePickerItem)
+			return t, tea.Quit
+		}
+	}
+
+	t.list, cmd = t.list.Update(msg)
+	return t, cmd
+}
+
+// newTemplatePicker builds a templatePicker model
+// that lets users pick from the given template.
+func newTemplatePicker(templates []workspace.Template) templatePicker {
+	items := make([]list.Item, len(templates))
+	for i, t := range templates {
+		items[i] = newTemplatePickerItem(t)
+	}
+	// Width and height are determined by the terminal size on startup.
+	delegate := newTemplatePickerItemDelegate(templates)
+	list := list.New(items, &delegate, 0 /* width */, 0 /* height */)
+
+	list.Title = "Please choose a template"
+	list.Styles.Title = list.Styles.Title.
+		Foreground(lipgloss.Color(_colorCyan)).
+		Background(lipgloss.NoColor{})
+
+	// Show Enter in the help menu (accessible with ?).
+	list.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("enter"),
+				key.WithHelp("enter", "select template"),
+			),
+		}
+	}
+
+	return templatePicker{
+		list:      list,
+		templates: templates,
+	}
+}
+
+// templatePickerItem is a single item in the templatePicker list.
+type templatePickerItem struct{ t workspace.Template }
+
+var _ list.DefaultItem = (*templatePickerItem)(nil)
+
+// Template returns the actual template in the choice.
+func (i *templatePickerItem) Template() workspace.Template { return i.t }
+
+// FilterValue is the value that will be used to filter this item when the user types.
+func (i *templatePickerItem) FilterValue() string { return i.t.Name }
+
+// Title reports the title to display for this item in the list.
+func (i *templatePickerItem) Title() string { return i.t.Name }
+
+// Description reports the description for this item.
+func (i *templatePickerItem) Description() string {
+	return workspace.ValueOrDefaultProjectDescription("", i.t.ProjectDescription, i.t.Description)
+}
+
+func newTemplatePickerItem(t workspace.Template) *templatePickerItem {
+	return &templatePickerItem{t: t}
+}
+
+// templatePickerItemDelegate renders *templatePickerItem values as items in the list.
+type templatePickerItemDelegate struct {
+	// Width of the column where the title is displayed.
+	// This should be larger than the width of the longest title.
+	titleWidth int
+
+	// Style used for the ">" marker when an item is selected.
+	arrowStyle lipgloss.Style
+}
+
+// Height reports the height each item will take up when rendered.
+func (d *templatePickerItemDelegate) Height() int { return 1 }
+
+// Spacing is the gap between cells.
+func (d *templatePickerItemDelegate) Spacing() int { return 0 }
+
+// Update receives messages all events on the list.
+// We don't have any per-tick updates to perform so this is a no-op.
+func (d *templatePickerItemDelegate) Update(_ tea.Msg, m *list.Model) tea.Cmd { return nil }
+
+// Render writes a single item to the given io.Writer.
+// and highlights the portions of the item name that match the filter value.
+func (d *templatePickerItemDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	t, ok := item.(*templatePickerItem)
+	contract.Assertf(ok, "expected *templatePickerItem, got %T", item)
+
+	// Whether the item is selected.
+	selectorCol := "  "
+	if index == m.Index() {
+		selectorCol = d.arrowStyle.Render("> ")
+	}
+	title := t.Title()
+	padding := d.titleWidth - len(title)
+	// Add an extra 4 columns of padding between the title and description.
+	padding += 4
+
+	if padding < 1 {
+		// This is not possible because we set the column width
+		// to more than the length of the longest title.
+		// Guard against it nonetheless.
+		padding = 1
+	}
+	fmt.Fprintf(w, "%s%s%s%s", selectorCol, title, strings.Repeat(" ", padding), t.Description())
+}
+
+func newTemplatePickerItemDelegate(templates []workspace.Template) templatePickerItemDelegate {
+	delegate := templatePickerItemDelegate{
+		arrowStyle: lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(_colorGreen)),
+	}
+	// Set the delegate.titleWidth to fit the largest title.
+	for _, t := range templates {
+		curWidth := len(t.Name)
+		if curWidth > delegate.titleWidth {
+			delegate.titleWidth = curWidth
+		}
+	}
+	return delegate
+}

--- a/pkg/backend/display/selector_test.go
+++ b/pkg/backend/display/selector_test.go
@@ -1,0 +1,231 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockTemplates() []workspace.Template {
+	return []workspace.Template{
+		{
+			Name:        "moolumi-typescript",
+			Description: "Deploys moolumi buckets to moolumi cloud in Typescript",
+		},
+		{
+			Name:        "moolumi-python",
+			Description: "Deploys moolumi buckets to moolumi cloud in Python",
+		},
+		{
+			Name:        "moolumi-csharp",
+			Description: "Deploys moolumi buckets to moolumi cloud in CSharp",
+		},
+		{
+			Name:        "moolumi-go",
+			Description: "Deploys moolumi buckets to moolumi cloud in Go",
+		},
+		{
+			Name:        "moolumi-yaml",
+			Description: "Deploys moolumi buckets to moolumi cloud in YAML",
+		},
+	}
+}
+
+// TestTemplatePickerItemDelegatePadding checks that all entries are equal length including padding.
+func TestTemplatePickerItemDelegatePadding(t *testing.T) {
+	t.Parallel()
+	templates := mockTemplates()
+	items := make([]list.Item, len(templates))
+	for i, t := range templates {
+		items[i] = newTemplatePickerItem(t)
+	}
+
+	delegate := newTemplatePickerItemDelegate(templates)
+	l := list.New(items, &delegate, 0 /* width */, 0 /* height */)
+
+	entries := make([]string, len(templates))
+
+	for i, template := range templates {
+		item := &templatePickerItem{t: template}
+
+		var builder strings.Builder
+		delegate.Render(&builder, l, 0, item)
+		entries[i] = builder.String()
+	}
+
+	// Check that all entries are the same width.
+	expectedLength := len(entries[0])
+	assert.NotZero(t, expectedLength)
+	for _, entry := range entries[1:] {
+		assert.Len(t, entry, expectedLength)
+	}
+}
+
+// TestTemplatePicker_search checks that filtering works properly.
+func TestTemplatePicker_filter(t *testing.T) {
+	t.Parallel()
+	templates := mockTemplates()
+	items := make([]list.Item, len(templates))
+	for i, t := range templates {
+		items[i] = newTemplatePickerItem(t)
+	}
+
+	picker := newTemplatePicker(templates)
+	tm := teatest.NewTestModel(
+		t,
+		picker,
+		teatest.WithInitialTermSize(300, 100),
+	)
+
+	teatest.WaitFor(
+		t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("moolumi-typescript"))
+		},
+		teatest.WithCheckInterval(time.Millisecond*100),
+		teatest.WithDuration(time.Second*3),
+	)
+
+	tm.Send(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("/"),
+	})
+
+	teatest.WaitFor(
+		t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("Filter:"))
+		},
+		teatest.WithCheckInterval(time.Millisecond*100),
+		teatest.WithDuration(time.Second*3),
+	)
+
+	tm.Send(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("moolumi-csharp"),
+	})
+
+	teatest.WaitFor(
+		t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("moolumi-csharp")) &&
+				!bytes.Contains(bts, []byte("moolumi-typescript"))
+		},
+		teatest.WithCheckInterval(time.Millisecond*100),
+		teatest.WithDuration(time.Second*3),
+	)
+
+	tm.Send(tea.KeyMsg{
+		Type: tea.KeyEnter,
+	})
+
+	tm.Send(tea.KeyMsg{
+		Type: tea.KeyEnter,
+	})
+
+	teatest.WaitFor(
+		t, tm.Output(),
+		func(bts []byte) bool {
+			return true
+		},
+		teatest.WithCheckInterval(time.Millisecond*100),
+		teatest.WithDuration(time.Second*3),
+	)
+
+	err := tm.Quit()
+	assert.NoError(t, err)
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+
+	final := tm.FinalModel(t)
+	picker = final.(templatePicker)
+
+	// Verify the return value of the program.
+	assert.Equal(t, "moolumi-csharp", picker.choice.Template().Name)
+}
+
+// TestTemplatePicker_pick checks that the picker selects the right template based on arrow keys.
+func TestTemplatePicker_pick(t *testing.T) {
+	t.Parallel()
+
+	var model tea.Model = newTemplatePicker([]workspace.Template{
+		{Name: "foo", ProjectDescription: "my fancy template"},
+		{Name: "bar", ProjectDescription: "another template to do things"},
+		{Name: "baz", ProjectDescription: "a third template"},
+	})
+	model.Init()
+
+	// Set the initial window size.
+	model, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	// Verify that all templates are shown in the initial view.
+	view := model.View()
+	assert.Contains(t, view, "Please choose a template")
+	assert.Regexp(t, `foo\s+my fancy template`, view)
+	assert.Regexp(t, `bar\s+another template to do things`, view)
+	assert.Regexp(t, `baz\s+a third template`, view)
+
+	// The first template is selected.
+	assert.Regexp(t, `>.+foo`, view, "foo must be selected")
+
+	// Select the second template.
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	view = model.View()
+	assert.Regexp(t, `>.+bar`, view, "bar must be selected")
+
+	// Pick this template.
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	final := model.(templatePicker)
+
+	require.NotNil(t, final.choice, "a template must be selected")
+	assert.Equal(t, "bar", final.choice.t.Name, "bar must be selected")
+}
+
+// TestTemplatePicker_cancel checks that the picker handles Control+C and has a nil choice.
+func TestTemplatePicker_cancel(t *testing.T) {
+	t.Parallel()
+
+	var model tea.Model = newTemplatePicker([]workspace.Template{
+		{Name: "foo", ProjectDescription: "my fancy template"},
+		{Name: "bar", ProjectDescription: "another template to do things"},
+		{Name: "baz", ProjectDescription: "a third template"},
+	})
+	model.Init()
+
+	// Set the initial window size.
+	model, _ = model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	// Sanity check.
+	view := model.View()
+	assert.Contains(t, view, "Please choose a template")
+
+	// The first template is selected.
+	assert.Regexp(t, `>.+foo`, view, "foo must be selected")
+
+	// Cancel the template picker.
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	final := model.(templatePicker)
+
+	assert.Nil(t, final.choice, "no template must be selected")
+}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"unicode"
 
-	survey "github.com/AlecAivazis/survey/v2"
-	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 
@@ -161,7 +159,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	} else if len(templates) == 1 {
 		template = templates[0]
 	} else {
-		if template, err = chooseTemplate(templates, opts); err != nil {
+		if template, err = display.ChooseTemplate(templates, opts); err != nil {
 			return err
 		}
 	}
@@ -811,34 +809,6 @@ func pythonCommands() []string {
 	commands = append(commands, "python -m pip install -r requirements.txt")
 
 	return commands
-}
-
-// chooseTemplate will prompt the user to choose amongst the available templates.
-func chooseTemplate(templates []workspace.Template, opts display.Options) (workspace.Template, error) {
-	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
-	if !opts.IsInteractive {
-		return workspace.Template{}, errors.New(chooseTemplateErr)
-	}
-
-	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
-	surveycore.DisableColor = true
-
-	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
-	nopts := len(options)
-	pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
-	message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", pageSize, nopts)
-	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
-
-	var option string
-	if err := survey.AskOne(&survey.Select{
-		Message:  message,
-		Options:  options,
-		PageSize: pageSize,
-	}, &option, surveyIcons(opts.Color)); err != nil {
-		return workspace.Template{}, errors.New(chooseTemplateErr)
-	}
-
-	return optionToTemplateMap[option], nil
 }
 
 // parseConfig parses the config values passed via command line flags.

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -214,7 +214,7 @@ func newUpCmd() *cobra.Command {
 		} else if len(templates) == 1 {
 			template = templates[0]
 		} else {
-			if template, err = chooseTemplate(templates, opts.Display); err != nil {
+			if template, err = display.ChooseTemplate(templates, opts.Display); err != nil {
 				return result.FromError(err)
 			}
 		}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -69,6 +69,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10
+	github.com/charmbracelet/bubbles v0.16.1
+	github.com/charmbracelet/bubbletea v0.24.2
+	github.com/charmbracelet/lipgloss v0.7.1
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f
 	github.com/creack/pty v1.1.17
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/go-git/go-git/v5 v5.6.0
@@ -142,10 +146,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymanbagabas/go-udiff v0.1.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
-	github.com/charmbracelet/bubbles v0.16.1 // indirect
-	github.com/charmbracelet/bubbletea v0.24.2 // indirect
-	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
@@ -223,6 +225,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -313,6 +313,8 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
+github.com/aymanbagabas/go-udiff v0.1.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -355,6 +357,8 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f/go.mod h1:TckAxPtan3aJ5wbTgBkySpc50SZhXJRZ8PtYICnZJEw=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -1540,6 +1544,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -171,6 +171,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect

--- a/sdk/go/pulumi-language-go/go.sum
+++ b/sdk/go/pulumi-language-go/go.sum
@@ -308,6 +308,7 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -350,6 +351,7 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -1494,6 +1496,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -170,6 +170,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
@@ -308,6 +308,7 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -350,6 +351,7 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -1495,6 +1497,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -170,6 +170,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.sum
+++ b/sdk/python/cmd/pulumi-language-python/go.sum
@@ -310,6 +310,7 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -352,6 +353,7 @@ github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -1495,6 +1497,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -179,6 +179,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -854,6 +854,7 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.1.0 h1:9Dpklm2oBBhMxIFbMffmPvDaF7vOYfv9B5HXVr42KMU=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -903,6 +904,7 @@ github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FD
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20230904163802-ca705a396e0f h1:kI7ZjLqp210CeIUKhjdLmtnc9UIVcfKSePgwGTxQ0J4=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -2118,6 +2120,7 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=


### PR DESCRIPTION
Switches the survey-based list picker we use to pick a template
to use bubbletea with the bubbles/list widget.
Instead of using any of the default bubbles/list renderings,
this implements a custom renderer for list items (the delegate)
that provides an experience closer in look to the 'pulumi new' today.

Related to #13815 in spirit.

Fixes #11812
Fixes #8169

---

Demos

<details>
<summary>Basic usage</summary>

[![asciicast](https://asciinema.org/a/NeecyanZP2iyzlrAOKRiKckJZ.svg)](https://asciinema.org/a/NeecyanZP2iyzlrAOKRiKckJZ)

</details>

<details>
<summary>Handling of really small terminals</summary>

[![asciicast](https://asciinema.org/a/RZW3NfX5SQ8rL4mR1iRLQ6yi1.svg)](https://asciinema.org/a/RZW3NfX5SQ8rL4mR1iRLQ6yi1)

</details>