### PR TITLE
Consecutive markdown heading levels CLI docs

### DIFF
--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -31,6 +31,9 @@ import (
 // Used to replace the `## <command>` line in generated markdown files.
 var replaceH2Pattern = regexp.MustCompile(`(?m)^## .*$`)
 
+// Used to promote the `###` headings to `##` in generated markdown files.
+var h3Pattern = regexp.MustCompile(`(?m)^###`)
+
 // newGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
 // It is hidden by default since it's not commonly used outside of our own build processes.
 func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
@@ -84,6 +87,11 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// Replace the `## <command>` line with an empty string.
 				// We do this because we're already including the command as the front matter title.
 				result := replaceH2Pattern.ReplaceAllString(string(b), "")
+
+				// Promote the `###` to `##` headings. We removed the command name above which was
+				// a level 2 heading (##), so need to promote the ### to ## so there is no gap in
+				// heading levels when these files are used to render the CLI docs on the docs site.
+				result = h3Pattern.ReplaceAllString(result, "##")
 
 				if err := os.WriteFile(file, []byte(result), 0o600); err != nil {
 					return err

--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -32,7 +32,7 @@ import (
 var replaceH2Pattern = regexp.MustCompile(`(?m)^## .*$`)
 
 // Used to promote the `###` headings to `##` in generated markdown files.
-var h3Pattern = regexp.MustCompile(`(?m)^###`)
+var h3Pattern = regexp.MustCompile(`(?m)^###\s`)
 
 // newGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
 // It is hidden by default since it's not commonly used outside of our own build processes.
@@ -91,7 +91,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// Promote the `###` to `##` headings. We removed the command name above which was
 				// a level 2 heading (##), so need to promote the ### to ## so there is no gap in
 				// heading levels when these files are used to render the CLI docs on the docs site.
-				result = h3Pattern.ReplaceAllString(result, "##")
+				result = h3Pattern.ReplaceAllString(result, "## ")
 
 				if err := os.WriteFile(file, []byte(result), 0o600); err != nil {
 					return err


### PR DESCRIPTION
# Description

Currently the pages for the CLI docs jump from H1 to H3 headings because we remove the H2s that are generated for the command name, since they are already present in the title. This gap does not align with best SEO practices. This promotes the H3 headings (### in markdown) to H2 (##) so we can get rid of the gap.

Fixes: https://github.com/pulumi/docs/issues/9537

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
