### PR TITLE
Revert "resource/plugin: Shut down plugins gracefully (#13795)"

### DIFF
--- a/changelog/pending/20230826--cli-plugin--give-plugins-a-chance-to-clean-up-before-they-exit.yaml
+++ b/changelog/pending/20230826--cli-plugin--give-plugins-a-chance-to-clean-up-before-they-exit.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: cli/plugin
-  description: Give plugins a chance to clean up before they exit. Plugins will receive SIGINT on Unix systems or CTRL_BREAK on Windows before termination.

--- a/changelog/pending/20230826--sdk-go--deprecate-cmdutil-killchildren-please-use-cmdutil-terminateprocessgroup-instead.yaml
+++ b/changelog/pending/20230826--sdk-go--deprecate-cmdutil-killchildren-please-use-cmdutil-terminateprocessgroup-instead.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: sdk/go
-  description: Deprecate cmdutil.KillChildren. Please use cmdutil.TerminateProcessGroup instead.

--- a/sdk/go/common/resource/plugin/plugin_test.go
+++ b/sdk/go/common/resource/plugin/plugin_test.go
@@ -15,18 +15,9 @@
 package plugin
 
 import (
-	"bufio"
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
 	"testing"
 
-	"github.com/opentracing/opentracing-go/mocktracer"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLogFlowArgumentPropagation(t *testing.T) {
@@ -63,84 +54,4 @@ func TestLogFlowArgumentPropagation(t *testing.T) {
 		verbose:         9,
 		tracingEndpoint: "127.0.0.1:6007",
 	}), []string{"--logtostderr", "-v=9", "--tracing", "127.0.0.1:6007", "127.0.0.1:12345"})
-}
-
-// Verifies that when the plugin is an external binary,
-// the process is sent a SIGINT signal when the plugin is closed.
-//
-// Because other processes and signal handling is involved,
-// this test relies on a second fake test: TestExecPlugin_fakePlugin.
-func TestExecPlugin_gracefulTermination(t *testing.T) {
-	t.Parallel()
-
-	sink := diagtest.LogSink(t)
-	pwd, root := t.TempDir(), t.TempDir()
-	ctx, err := NewContextWithRoot(
-		sink,
-		sink,
-		nil, // host
-		pwd,
-		root,
-		nil,   // runtimeOptions
-		false, // disableProviderPreview
-		mocktracer.New().StartSpan("root"),
-		nil, // plugins
-		nil, // config
-	)
-	require.NoError(t, err)
-
-	exe, err := os.Executable()
-	require.NoError(t, err)
-
-	p, err := execPlugin(ctx, exe, "" /* prefix */, workspace.LanguagePlugin,
-		[]string{"-test.run=^TestExecPlugin_fakePlugin$"},
-		pwd,
-		[]string{"FAKE_PLUGIN=1"},
-	)
-	require.NoError(t, err)
-
-	// Wait until the plugin is ready. It'll print "okay" to stdout when it's ready.
-	scanner := bufio.NewScanner(p.Stdout)
-
-	// Scans the next token from Stdout and returns it.
-	// Fails the test if the scanner encounters an error.
-	requireScan := func() string {
-		t.Helper()
-
-		require.True(t, scanner.Scan())
-		require.NoError(t, scanner.Err())
-		return scanner.Text()
-	}
-
-	assert.Equal(t, "okay", requireScan(), "plugin should be ready")
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		assert.NoError(t, p.Close(), "plugin should close gracefully")
-	}()
-	assert.Equal(t, "received interrupt", requireScan(),
-		"plugin should receive SIGINT")
-
-	<-done
-}
-
-// TestExecPlugin_fakePlugin acts like a main() function for a fake plugin
-// for TestExecPlugin_gracefulTermination to terminate.
-//
-// It installs a signal handler and prints messages that will be verified
-// by TestExecPlugin_gracefulTermination.
-//
-//nolint:paralleltest // not a real test
-func TestExecPlugin_fakePlugin(t *testing.T) {
-	if os.Getenv("FAKE_PLUGIN") != "1" {
-		return // this is not a real test
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
-
-	fmt.Println("okay")
-	<-ctx.Done()
-	fmt.Println("received interrupt")
 }

--- a/sdk/go/common/util/cmdutil/child_unix.go
+++ b/sdk/go/common/util/cmdutil/child_unix.go
@@ -25,8 +25,6 @@ import (
 
 // KillChildren calls os.Process.Kill() on every child process of `pid`'s, stoping after the first error (if any). It
 // also only kills direct child process, not any children they may have.
-//
-// Deprecated: Use [TerminateProcessGroup] instead.
 func KillChildren(pid int) error {
 	// A subprocess that was launched after calling `RegisterProcessGroup` below will
 	// belong to a process group whose ID is the same as the PID. Passing the negation
@@ -43,7 +41,7 @@ func KillChildren(pid int) error {
 // This is a helper function for TerminateProcessGroup;
 // a Windows version with the same signature exists in child_windows.go.
 func killProcessGroup(proc *os.Process) error {
-	return KillChildren(proc.Pid) //nolint:staticcheck // deprecated function
+	return KillChildren(proc.Pid)
 }
 
 // RegisterProcessGroup informs the OS that it needs to call `setpgid` on this

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -44,8 +44,6 @@ func killProcessGroup(proc *os.Process) error {
 
 // KillChildren calls os.Process.Kill() on every child process of `pid`'s, stoping after the first error (if any). It
 // also only kills direct child process, not any children they may have. This function is only implemented on Windows.
-//
-// Deprecated: Use [TerminateProcessGroup] instead.
 func KillChildren(pid int) error {
 	procs, err := ps.Processes()
 	if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13831

This reverts commit 25901d95c4b108755abaa8452e71e23b356cd384.

On linux, `pulumi up` hung during a `pulumi-command provider` panic after this change was introduced.