### PR TITLE
ci(lint): Upgrade to latest golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.53
+  GOLANGCI_LINT_VERSION: v1.54.2
 
 jobs:
   golangci:

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -51,6 +51,7 @@ type Resource struct {
 
 func registerResources(t *testing.T, monitor *deploytest.ResourceMonitor, resources []Resource) error {
 	for _, r := range resources {
+		r := r
 		_, _, _, err := monitor.RegisterResource(r.t, r.name, true, deploytest.ResourceOptions{
 			Parent:              r.parent,
 			Dependencies:        r.dependencies,

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -177,7 +177,7 @@ func (p *builtinProvider) Construct(info plugin.ConstructInfo, typ tokens.Type, 
 
 const (
 	readStackOutputs         = "pulumi:pulumi:readStackOutputs"
-	readStackResourceOutputs = "pulumi:pulumi:readStackResourceOutputs"
+	readStackResourceOutputs = "pulumi:pulumi:readStackResourceOutputs" //nolint:gosec // not a credential
 	getResource              = "pulumi:pulumi:getResource"
 )
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -433,6 +433,7 @@ func (host *pluginHost) ResolvePlugin(
 	plugins := slice.Prealloc[workspace.PluginInfo](len(host.pluginLoaders))
 
 	for _, v := range host.pluginLoaders {
+		v := v
 		p := workspace.PluginInfo{
 			Kind:       v.kind,
 			Name:       v.name,

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -509,7 +509,7 @@ func TestPluginDownload(t *testing.T) {
 			return newMockReadCloser(expectedBytes)
 		}
 
-		chksum := "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
+		chksum := "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81" //nolint:gosec
 
 		t.Run("Invalid Checksum", func(t *testing.T) {
 			spec := PluginSpec{


### PR DESCRIPTION
Upgrade to latest version of golangci-lint
and fix or opt-out the issues it caught.

The false positives are:

```
sdk/go/common/workspace/plugins_test.go:512:3: G101: Potential hardcoded credentials (gosec)
pkg/resource/deploy/builtins.go:180:2: G101: Potential hardcoded credentials (gosec)
```

The fixed issues are:

```
pkg/resource/deploy/deploytest/pluginhost.go:440:16: G601: Implicit memory aliasing in for loop. (gosec)
                        Version:    &v.version,
                                    ^
pkg/engine/lifecycletest/alias_test.go:58:25: G601: Implicit memory aliasing in for loop. (gosec)
                        DeleteBeforeReplace: &r.deleteBeforeReplace,
                                             ^
```
