### PR TITLE
make(sdk/py): Fix install, dist, test_go, brew

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME     := Pulumi Python SDK
-LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/python/cmd/pulumi-language-python
+LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ../../scripts/pulumi-version.sh))
 PYPI_VERSION 	   := $(if ${PYPI_VERSION},${PYPI_VERSION},$(shell ../../scripts/pulumi-version.sh python))
 
@@ -38,7 +38,8 @@ build_package:: ensure
 	. venv/*/activate && python -m pip install -e $(PYENVSRC)
 
 build_plugin::
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go install -C cmd/pulumi-language-python \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 build:: build_package build_plugin
 
@@ -60,7 +61,7 @@ install_package:: build_package
 	cp ./dist/pulumi-analyzer-policy-python "$(PULUMI_BIN)"
 
 install_plugin:: build_plugin
-	GOBIN=$(PULUMI_BIN) go install \
+	GOBIN=$(PULUMI_BIN) go install -C cmd/pulumi-language-python \
 		  -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install:: install_package install_plugin

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -13,7 +13,7 @@ PYENVSRC := $(PYENV)/src
 
 BLACK_FLAGS := ./lib/pulumi --exclude lib/pulumi/runtime/proto
 
-PROJECT_PKGS    := $(shell go list ./cmd/...)
+PROJECT_PKGS    := $(shell go list -C cmd/pulumi-language-python ./...)
 
 include ../../build/common.mk
 
@@ -67,7 +67,8 @@ install_plugin:: build_plugin
 install:: install_package install_plugin
 
 test_go:: $(TEST_ALL_DEPS)
-	@$(GO_TEST) ${PROJECT_PKGS}
+	@cd cmd/pulumi-language-python && \
+		$(GO_TEST) ${PROJECT_PKGS}
 
 test_fast:: $(TEST_ALL_DEPS)
 	. venv/*/activate && ./scripts/test_fast.sh
@@ -78,14 +79,16 @@ test_auto:: $(TEST_ALL_DEPS)
 test_all:: test_fast test_auto test_go
 
 dist::
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go install -C cmd/pulumi-language-python \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
+	go install -C cmd/pulumi-language-python \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/


### PR DESCRIPTION
Some `make` targets broke 
when we turned pulumi-language-python into
an independent Go module.
It also has a different import path than it did before.

This updates the Makefile to match the new path
and uses `-C` to cd into that directory for relevant Go commands.
