### PR TITLE
make(sdk/go): Use -C instead of cd for 'go' commands

### DIFF
--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -20,12 +20,12 @@ gen::
 ensure: go.ensure
 
 build:: gen
-	cd pulumi-language-go && \
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go install -C pulumi-language-go \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install_plugin::
-	cd pulumi-language-go && \
-	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	GOBIN=$(PULUMI_BIN) go install -C pulumi-language-go \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install:: install_plugin
 
@@ -34,25 +34,26 @@ test_all:: test_fast test_auto
 test_fast:: $(TEST_ALL_DEPS)
 	@$(GO_TEST_FAST) $(TEST_FAST_PKGS)
 
-	@cd pulumi-language-go && $(GO_TEST_FAST) $(shell go list ./... | grep -v /vendor/ | grep -v templates)
+	@cd pulumi-language-go && \
+		$(GO_TEST_FAST) $(shell go list ./... | grep -v /vendor/ | grep -v templates)
 
 test_auto:: $(TEST_ALL_DEPS)
 	@$(GO_TEST) $(TEST_AUTO_PKGS)
 
 dist::
-	cd pulumi-language-go && \
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	go install -C pulumi-language-go \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
-	cd pulumi-language-go && \
-	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
+	go install -C pulumi-language-go \
+		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 
 lint:: golangci-lint.ensure
-	cd .. && golangci-lint run -c ../.golangci.yml --timeout 5m
+	cd .. && golangci-lint run -c ../.golangci.yml --timeout 5m --path-prefix ..
 
 	cd pulumi-language-go && \
-	golangci-lint run -c ../../../.golangci.yml --timeout 5m
+		golangci-lint run -c ../../../.golangci.yml --timeout 5m --path-prefix pulumi-language-go
 
 publish:
 	git tag sdk/v${VERSION}


### PR DESCRIPTION
For `go` commands where we can,
prefer using the -C flag to change directories
instead of `cd` in the Makefile.

For the lint target, have golangci-lint print paths
relative to the directory containing the Makefile
by using its --path-prefix flag.
