### PR TITLE
[org search] Adds both the display of and the ability to open search results URLs

### DIFF
--- a/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
+++ b/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Adheres to default org for org search when one is set

--- a/changelog/pending/20230906--cli-display--displays-search-url-when-results-table-is-rendered.yaml
+++ b/changelog/pending/20230906--cli-display--displays-search-url-when-results-table-is-rendered.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Displays search URL when results table is rendered

--- a/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
+++ b/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Displays total and displayed resource counts for org search

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -116,7 +116,7 @@ type Backend interface {
 
 	// Queries the backend for resources based on the given query parameters.
 	Search(
-		ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
+		ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 	) (*apitype.ResourceSearchResponse, error)
 	NaturalLanguageSearch(
 		ctx context.Context, orgName string, query string, client string,
@@ -1027,9 +1027,9 @@ func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) res
 }
 
 func (b *cloudBackend) Search(
-	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
+	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 ) (*apitype.ResourceSearchResponse, error) {
-	return b.Client().GetSearchQueryResults(ctx, orgName, queryParams, client)
+	return b.Client().GetSearchQueryResults(ctx, orgName, queryParams, b.CloudConsoleURL())
 }
 
 func (b *cloudBackend) NaturalLanguageSearch(

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -116,9 +116,11 @@ type Backend interface {
 
 	// Queries the backend for resources based on the given query parameters.
 	Search(
-		ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
+		ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
 	) (*apitype.ResourceSearchResponse, error)
-	NaturalLanguageSearch(ctx context.Context, orgName string, query string) (*apitype.ResourceSearchResponse, error)
+	NaturalLanguageSearch(
+		ctx context.Context, orgName string, query string, client string,
+	) (*apitype.ResourceSearchResponse, error)
 }
 
 type cloudBackend struct {
@@ -1025,20 +1027,20 @@ func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) res
 }
 
 func (b *cloudBackend) Search(
-	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
+	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
 ) (*apitype.ResourceSearchResponse, error) {
-	return b.Client().GetSearchQueryResults(ctx, orgName, queryParams)
+	return b.Client().GetSearchQueryResults(ctx, orgName, queryParams, client)
 }
 
 func (b *cloudBackend) NaturalLanguageSearch(
-	ctx context.Context, orgName string, queryString string,
+	ctx context.Context, orgName string, queryString string, client string,
 ) (*apitype.ResourceSearchResponse, error) {
 	parsedResults, err := b.Client().GetNaturalLanguageQueryResults(ctx, orgName, queryString)
 	if err != nil {
 		return nil, err
 	}
 	requestBody := apitype.PulumiQueryRequest{Query: parsedResults.Query}
-	results, err := b.Client().GetSearchQueryResults(ctx, orgName, &requestBody)
+	results, err := b.Client().GetSearchQueryResults(ctx, orgName, &requestBody, client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -119,7 +119,7 @@ type Backend interface {
 		ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 	) (*apitype.ResourceSearchResponse, error)
 	NaturalLanguageSearch(
-		ctx context.Context, orgName string, query string, client string,
+		ctx context.Context, orgName string, query string,
 	) (*apitype.ResourceSearchResponse, error)
 }
 
@@ -1033,14 +1033,14 @@ func (b *cloudBackend) Search(
 }
 
 func (b *cloudBackend) NaturalLanguageSearch(
-	ctx context.Context, orgName string, queryString string, client string,
+	ctx context.Context, orgName string, queryString string,
 ) (*apitype.ResourceSearchResponse, error) {
 	parsedResults, err := b.Client().GetNaturalLanguageQueryResults(ctx, orgName, queryString)
 	if err != nil {
 		return nil, err
 	}
 	requestBody := apitype.PulumiQueryRequest{Query: parsedResults.Query}
-	results, err := b.Client().GetSearchQueryResults(ctx, orgName, &requestBody, client)
+	results, err := b.Client().GetSearchQueryResults(ctx, orgName, &requestBody, b.CloudConsoleURL())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1147,20 +1147,20 @@ func getNaturalLanguageSearchPath(orgName string) string {
 	return fmt.Sprintf("/api/orgs/%s/search/resources/parse", url.PathEscape(orgName))
 }
 
-func getPulumiOrgSearchPath(client string, orgName string) string {
-	return fmt.Sprintf("%s/%s/resources", client, url.PathEscape(orgName))
+func getPulumiOrgSearchPath(baseURL string, orgName string) string {
+	return fmt.Sprintf("%s/%s/resources", baseURL, url.PathEscape(orgName))
 }
 
 // Pulumi Cloud Search Functions
 func (pc *Client) GetSearchQueryResults(
-	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
+	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, baseURL string,
 ) (*apitype.ResourceSearchResponse, error) {
 	var resp apitype.ResourceSearchResponse
 	err := pc.restCall(ctx, http.MethodGet, getSearchPath(orgName), queryParams, nil, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("querying search failed: %w", err)
 	}
-	resp.URL = fmt.Sprintf("%s?query=%s", getPulumiOrgSearchPath(client, orgName), url.QueryEscape(queryParams.Query))
+	resp.URL = fmt.Sprintf("%s?query=%s", getPulumiOrgSearchPath(baseURL, orgName), url.QueryEscape(queryParams.Query))
 	return &resp, nil
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1147,6 +1147,10 @@ func getNaturalLanguageSearchPath(orgName string) string {
 	return fmt.Sprintf("/api/orgs/%s/search/resources/parse", url.PathEscape(orgName))
 }
 
+func getPulumiOrgSearchPath(orgName string) string {
+	return fmt.Sprintf("https://app.pulumi.com/%s/resources", url.PathEscape(orgName))
+}
+
 // Pulumi Cloud Search Functions
 func (pc *Client) GetSearchQueryResults(
 	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
@@ -1156,6 +1160,7 @@ func (pc *Client) GetSearchQueryResults(
 	if err != nil {
 		return nil, fmt.Errorf("querying search failed: %w", err)
 	}
+	resp.URL = fmt.Sprintf("%s?query=%s", getPulumiOrgSearchPath(orgName), url.QueryEscape(queryParams.Query))
 	return &resp, nil
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1147,20 +1147,20 @@ func getNaturalLanguageSearchPath(orgName string) string {
 	return fmt.Sprintf("/api/orgs/%s/search/resources/parse", url.PathEscape(orgName))
 }
 
-func getPulumiOrgSearchPath(orgName string) string {
-	return fmt.Sprintf("https://app.pulumi.com/%s/resources", url.PathEscape(orgName))
+func getPulumiOrgSearchPath(client string, orgName string) string {
+	return fmt.Sprintf("%s/%s/resources", client, url.PathEscape(orgName))
 }
 
 // Pulumi Cloud Search Functions
 func (pc *Client) GetSearchQueryResults(
-	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
+	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, client string,
 ) (*apitype.ResourceSearchResponse, error) {
 	var resp apitype.ResourceSearchResponse
 	err := pc.restCall(ctx, http.MethodGet, getSearchPath(orgName), queryParams, nil, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("querying search failed: %w", err)
 	}
-	resp.URL = fmt.Sprintf("%s?query=%s", getPulumiOrgSearchPath(orgName), url.QueryEscape(queryParams.Query))
+	resp.URL = fmt.Sprintf("%s?query=%s", getPulumiOrgSearchPath(client, orgName), url.QueryEscape(queryParams.Query))
 	return &resp, nil
 }
 

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -98,7 +98,6 @@ type searchCmd struct {
 	outputFormat
 	queryParams []string
 	openWeb     bool
-	client      string
 
 	Stdout io.Writer // defaults to os.Stdout
 
@@ -168,7 +167,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	parsedQueryParams := apitype.ParseQueryParams(cmd.queryParams)
-	res, err := cloudBackend.Search(ctx, filterName, parsedQueryParams, cmd.client)
+	res, err := cloudBackend.Search(ctx, filterName, parsedQueryParams)
 	if err != nil {
 		return err
 	}
@@ -227,11 +226,6 @@ func newSearchCmd() *cobra.Command {
 		&scmd.openWeb, "web", false,
 		"Open the search results in a web browser.",
 	)
-	cmd.PersistentFlags().StringVar(
-		&scmd.client, "client", "https://app.pulumi.com",
-		"The base URL of the Pulumi Cloud service to direct to. This defaults to https://app.pulumi.com.",
-	)
-	_ = cmd.PersistentFlags().MarkHidden("client")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -96,8 +96,7 @@ type searchCmd struct {
 	orgName      string
 	csvDelimiter Delimiter
 	outputFormat
-	queryParams []string
-	openWeb     bool
+	openWeb bool
 
 	Stdout io.Writer // defaults to os.Stdout
 
@@ -171,7 +170,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = cmd.outputFormat.Render(&cmd.searchCmd, res.Resources)
+	err = cmd.outputFormat.Render(&cmd.searchCmd, res)
 	if err != nil {
 		return fmt.Errorf("table rendering error: %s", err)
 	}
@@ -309,21 +308,21 @@ func renderSearchJSON(w io.Writer, results []apitype.ResourceResult) error {
 	return err
 }
 
-func (o *outputFormat) Render(cmd *searchCmd, results []apitype.ResourceResult) error {
+func (o *outputFormat) Render(cmd *searchCmd, result *apitype.ResourceSearchResponse) error {
 	switch *o {
 	case outputFormatJSON:
-		return cmd.RenderJSON(results)
+		return cmd.RenderJSON(result)
 	case outputFormatTable:
-		return cmd.RenderTable(results)
+		return cmd.RenderTable(result)
 	case outputFormatYAML:
-		return cmd.RenderYAML(results)
+		return cmd.RenderYAML(result)
 	default:
 		return fmt.Errorf("unknown output format %q", *o)
 	}
 }
 
-func (cmd *searchCmd) RenderJSON(results []apitype.ResourceResult) error {
-	return renderSearchJSON(cmd.Stdout, results)
+func (cmd *searchCmd) RenderJSON(result *apitype.ResourceSearchResponse) error {
+	return renderSearchJSON(cmd.Stdout, result.Resources)
 }
 
 func renderSearchYAML(w io.Writer, results []apitype.ResourceResult) error {
@@ -335,6 +334,6 @@ func renderSearchYAML(w io.Writer, results []apitype.ResourceResult) error {
 	return err
 }
 
-func (cmd *searchCmd) RenderYAML(results []apitype.ResourceResult) error {
-	return renderSearchYAML(cmd.Stdout, results)
+func (cmd *searchCmd) RenderYAML(result *apitype.ResourceSearchResponse) error {
+	return renderSearchYAML(cmd.Stdout, result.Resources)
 }

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/browser"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
@@ -93,6 +94,8 @@ type searchCmd struct {
 	orgName      string
 	csvDelimiter Delimiter
 	outputFormat
+	queryParams []string
+	openWeb     bool
 
 	Stdout io.Writer // defaults to os.Stdout
 
@@ -163,6 +166,12 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("table rendering error: %s", err)
 	}
+	if cmd.openWeb {
+		err = browser.OpenURL(res.URL)
+		if err != nil {
+			return fmt.Errorf("failed to open URL: %s", err)
+		}
+	}
 	return nil
 }
 
@@ -199,6 +208,10 @@ func newSearchCmd() *cobra.Command {
 	cmd.PersistentFlags().Var(
 		&scmd.csvDelimiter, "delimiter",
 		"Delimiter to use when rendering CSV output.",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&scmd.openWeb, "web", false,
+		"Open the search results in a web browser.",
 	)
 
 	return cmd

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -86,11 +86,11 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("user %s is not a member of org %s", userName, cmd.orgName)
 	}
 
-	res, err := cloudBackend.NaturalLanguageSearch(ctx, filterName, cmd.queryString, cmd.client)
+	res, err := cloudBackend.NaturalLanguageSearch(ctx, filterName, cmd.queryString)
 	if err != nil {
 		return err
 	}
-	err = cmd.outputFormat.Render(&cmd.searchCmd, res.Resources)
+	err = cmd.outputFormat.Render(&cmd.searchCmd, res)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "table rendering error: %s\n", err)
 	}
@@ -136,8 +136,5 @@ func newSearchAICmd() *cobra.Command {
 		&scmd.openWeb, "web", false,
 		"Open the search results in a web browser.",
 	)
-	cmd.PersistentFlags().StringVar(
-		&scmd.client, "client", "https://app.pulumi.com", "The base URL of the Pulumi Cloud service to direct to.")
-	_ = cmd.PersistentFlags().MarkHidden("client")
 	return cmd
 }

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -83,7 +83,11 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	return cmd.outputFormat.Render(&cmd.searchCmd, res.Resources)
+	err = cmd.outputFormat.Render(&cmd.searchCmd, res.Resources)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "table rendering error: %s\n", err)
+	}
+	return nil
 }
 
 func newSearchAICmd() *cobra.Command {

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/browser"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
@@ -31,6 +32,7 @@ import (
 type searchAICmd struct {
 	searchCmd
 	queryString string
+	openWeb     bool
 }
 
 func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
@@ -87,6 +89,12 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "table rendering error: %s\n", err)
 	}
+	if cmd.openWeb {
+		err = browser.OpenURL(res.URL)
+		if err != nil {
+			return fmt.Errorf("failed to open URL: %s", err)
+		}
+	}
 	return nil
 }
 
@@ -118,6 +126,10 @@ func newSearchAICmd() *cobra.Command {
 	cmd.PersistentFlags().Var(
 		&scmd.csvDelimiter, "delimiter",
 		"Delimiter to use when rendering CSV output.",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&scmd.openWeb, "web", false,
+		"Open the search results in a web browser.",
 	)
 
 	return cmd

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -81,7 +81,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("user %s is not a member of org %s", userName, cmd.orgName)
 	}
 
-	res, err := cloudBackend.NaturalLanguageSearch(ctx, filterName, cmd.queryString)
+	res, err := cloudBackend.NaturalLanguageSearch(ctx, filterName, cmd.queryString, cmd.client)
 	if err != nil {
 		return err
 	}
@@ -131,6 +131,8 @@ func newSearchAICmd() *cobra.Command {
 		&scmd.openWeb, "web", false,
 		"Open the search results in a web browser.",
 	)
-
+	cmd.PersistentFlags().StringVar(
+		&scmd.client, "client", "https://app.pulumi.com", "The base URL of the Pulumi Cloud service to direct to.")
+	_ = cmd.PersistentFlags().MarkHidden("client")
 	return cmd
 }

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -67,14 +67,19 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
+	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+	if err != nil {
+		return err
+	}
 	userName, orgs, err := cloudBackend.CurrentUser()
 	if err != nil {
 		return err
 	}
-	var filterName string
-	if cmd.orgName == "" {
-		filterName = userName
-	} else {
+	if defaultOrg != "" && cmd.orgName == "" {
+		cmd.orgName = defaultOrg
+	}
+	filterName := userName
+	if cmd.orgName != "" {
 		filterName = cmd.orgName
 	}
 	if !sliceContains(orgs, cmd.orgName) && cmd.orgName != "" {

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -61,7 +61,8 @@ func TestSearchAI_cmd(t *testing.T) {
 	}
 	cmd := searchAICmd{
 		searchCmd: searchCmd{
-			Stdout: &buff,
+			orgName: "org1",
+			Stdout:  &buff,
 			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 				return b, nil
 			},

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -37,6 +37,7 @@ func TestSearchAI_cmd(t *testing.T) {
 	pack := "pack1"
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
+	total := int64(132)
 	b := &stubHTTPBackend{
 		NaturalLanguageSearchF: func(context.Context, string, string) (*apitype.ResourceSearchResponse, error) {
 			return &apitype.ResourceSearchResponse{
@@ -51,6 +52,7 @@ func TestSearchAI_cmd(t *testing.T) {
 						Modified: &modified,
 					},
 				},
+				Total: &total,
 			}, nil
 		},
 		CurrentUserF: func() (string, []string, error) {

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -43,7 +43,8 @@ func TestSearch_cmd(t *testing.T) {
 	total := int64(132)
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
-			Stdout: &buff,
+			orgName: "org1",
+			Stdout:  &buff,
 			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 				return &stubHTTPBackend{
 					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
@@ -59,7 +60,8 @@ func TestSearch_cmd(t *testing.T) {
 									Modified: &modified,
 								},
 							},
-							URL: searchURL,
+							URL:   searchURL,
+							Total: &total,
 						}, nil
 					},
 					CurrentUserF: func() (string, []string, error) {
@@ -99,7 +101,7 @@ func (f *stubHTTPBackend) Search(
 }
 
 func (f *stubHTTPBackend) NaturalLanguageSearch(
-	ctx context.Context, orgName, query string, _ string,
+	ctx context.Context, orgName, query string,
 ) (*apitype.ResourceSearchResponse, error) {
 	return f.NaturalLanguageSearchF(ctx, orgName, query)
 }

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -93,7 +93,7 @@ type stubHTTPBackend struct {
 var _ httpstate.Backend = (*stubHTTPBackend)(nil)
 
 func (f *stubHTTPBackend) Search(
-	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest, _ string,
+	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 ) (*apitype.ResourceSearchResponse, error) {
 	return f.SearchF(ctx, orgName, queryParams)
 }

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -40,6 +40,7 @@ func TestSearch_cmd(t *testing.T) {
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
 	searchURL := "https://app.pulumi.com/pulumi/resources?foo=bar"
+	total := int64(132)
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
 			Stdout: &buff,
@@ -76,6 +77,7 @@ func TestSearch_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), typ)
 	assert.Contains(t, buff.String(), program)
 	assert.Contains(t, buff.String(), fmt.Sprintf("Results are also visible in Pulumi Cloud:\n%s", searchURL))
+	assert.Contains(t, buff.String(), fmt.Sprint(total))
 }
 
 type stubHTTPBackend struct {

--- a/sdk/go/common/apitype/search.go
+++ b/sdk/go/common/apitype/search.go
@@ -25,6 +25,7 @@ type ResourceSearchResponse struct {
 	Resources    []ResourceResult          `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Aggregations map[string]Aggregation    `json:"aggregations,omitempty" yaml:"aggregations,omitempty"`
 	Pagination   *ResourceSearchPagination `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	URL          string
 }
 
 // ResourceResult is the user-facing type for our indexed resources.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Displays to users a copyable URL to view org search results in Pulumi Cloud as well as a `--web` flag to automatically open those results for them.

Fixes https://github.com/pulumi/pulumi.ai/issues/207

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
