### PR TITLE
[org search] Supports default org configuration

### DIFF
--- a/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
+++ b/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Adheres to default org for org search when one is set

--- a/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
+++ b/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Displays total and displayed resource counts for org search

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -80,9 +80,16 @@ func (cmd *searchCmd) Run(ctx context.Context, args []string) error {
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
+	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+	if err != nil {
+		return err
+	}
 	userName, orgs, err := cloudBackend.CurrentUser()
 	if err != nil {
 		return err
+	}
+	if defaultOrg != "" && cmd.orgName == "" {
+		cmd.orgName = defaultOrg
 	}
 	filterName := userName
 	if cmd.orgName != "" {

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/browser"
@@ -187,6 +188,16 @@ func renderSearchTable(w io.Writer, results *apitype.ResourceSearchResponse) err
 		return err
 	}
 	err = table.RenderTo(w)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(
+		[]byte(
+			fmt.Sprintf(
+				"Displaying %s of %s total results.\n",
+				strconv.Itoa(len(results.Resources)),
+				strconv.FormatInt(*results.Total, 10))),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -76,14 +76,19 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if !isCloud {
 		return errors.New("Pulumi AI search is only supported for the Pulumi Cloud")
 	}
+	defaultOrg, err := workspace.GetBackendConfigDefaultOrg(project)
+	if err != nil {
+		return err
+	}
 	userName, orgs, err := cloudBackend.CurrentUser()
 	if err != nil {
 		return err
 	}
-	var filterName string
-	if cmd.orgName == "" {
-		filterName = userName
-	} else {
+	if defaultOrg != "" && cmd.orgName == "" {
+		cmd.orgName = defaultOrg
+	}
+	filterName := userName
+	if cmd.orgName != "" {
 		filterName = cmd.orgName
 	}
 	if !sliceContains(orgs, cmd.orgName) && cmd.orgName != "" {

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -37,6 +37,7 @@ func TestSearchAI_cmd(t *testing.T) {
 	pack := "pack1"
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
+	total := int64(132)
 	b := &stubHTTPBackend{
 		NaturalLanguageSearchF: func(context.Context, string, string) (*apitype.ResourceSearchResponse, error) {
 			return &apitype.ResourceSearchResponse{
@@ -51,6 +52,7 @@ func TestSearchAI_cmd(t *testing.T) {
 						Modified: &modified,
 					},
 				},
+				Total: &total,
 			}, nil
 		},
 		CurrentUserF: func() (string, []string, error) {

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -40,6 +40,7 @@ func TestSearch_cmd(t *testing.T) {
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
 	searchURL := "https://app.pulumi.com/pulumi/resources?foo=bar"
+	total := int64(132)
 	cmd := searchCmd{
 		Stdout: &buff,
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
@@ -57,7 +58,8 @@ func TestSearch_cmd(t *testing.T) {
 								Modified: &modified,
 							},
 						},
-						URL: searchURL,
+						URL:   searchURL,
+						Total: &total,
 					}, nil
 				},
 				CurrentUserF: func() (string, []string, error) {
@@ -74,6 +76,7 @@ func TestSearch_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), typ)
 	assert.Contains(t, buff.String(), program)
 	assert.Contains(t, buff.String(), fmt.Sprintf("Results are also visible in Pulumi Cloud:\n%s", searchURL))
+	assert.Contains(t, buff.String(), fmt.Sprint(total))
 }
 
 type stubHTTPBackend struct {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently, `pulumi org search` will use the individual user account as the default org when none is provided via `--org`. It would be ideal if it also respected any org set by `pulumi org set-default`. This PR accomplishes that.

Fixes https://github.com/pulumi/pulumi.ai/issues/208

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
