### PR TITLE
[engine] Check for old resources first by URN and then aliases

### DIFF
--- a/changelog/pending/20230906--engine--check-for-old-resources-first-by-urn-and-then-aliases.yaml
+++ b/changelog/pending/20230906--engine--check-for-old-resources-first-by-urn-and-then-aliases.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Check for old resources first by URN and then aliases

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -348,19 +348,19 @@ func TestGenerateAliases(t *testing.T) {
 		name         string
 		parentAlias  *resource.URN
 		childAliases []resource.Alias
-		expected     map[resource.URN]struct{}
+		expected     []resource.URN
 	}{
 		{
 			name:     "no aliases",
-			expected: map[resource.URN]struct{}{},
+			expected: nil,
 		},
 		{
 			name: "child alias (type), no parent aliases",
 			childAliases: []resource.Alias{
 				{Type: "test:resource:child2"},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child2::myres-child": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child2::myres-child",
 			},
 		},
 		{
@@ -368,8 +368,8 @@ func TestGenerateAliases(t *testing.T) {
 			childAliases: []resource.Alias{
 				{Name: "child2"},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child::child2": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child::child2",
 			},
 		},
 		{
@@ -380,8 +380,8 @@ func TestGenerateAliases(t *testing.T) {
 					NoParent: true,
 				},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:child2::myres-child": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:child2::myres-child",
 			},
 		},
 		{
@@ -392,8 +392,8 @@ func TestGenerateAliases(t *testing.T) {
 					Parent: resource.CreateURN("originalparent", "test:resource:original", "", project, stack),
 				},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:original$test:resource:child2::myres-child": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:original$test:resource:child2::myres-child",
 			},
 		},
 		{
@@ -402,10 +402,10 @@ func TestGenerateAliases(t *testing.T) {
 			childAliases: []resource.Alias{
 				{Name: "myres-child2"},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres-child2":  {},
-				"urn:pulumi:stack::project::test:resource:type2$test:resource:child::myres-child":  {},
-				"urn:pulumi:stack::project::test:resource:type2$test:resource:child::myres-child2": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres-child2",
+				"urn:pulumi:stack::project::test:resource:type2$test:resource:child::myres-child",
+				"urn:pulumi:stack::project::test:resource:type2$test:resource:child::myres-child2",
 			},
 		},
 		{
@@ -414,10 +414,10 @@ func TestGenerateAliases(t *testing.T) {
 			childAliases: []resource.Alias{
 				{Name: "myres-child2"},
 			},
-			expected: map[resource.URN]struct{}{
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres-child2":  {},
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres2-child":  {},
-				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres2-child2": {},
+			expected: []resource.URN{
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres-child2",
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres2-child",
+				"urn:pulumi:stack::project::test:resource:type$test:resource:child::myres2-child2",
 			},
 		},
 	}

--- a/tests/integration/aliases/aliases_py_test.go
+++ b/tests/integration/aliases/aliases_py_test.go
@@ -46,3 +46,33 @@ func TestPythonAliases(t *testing.T) {
 		})
 	}
 }
+
+// TestPythonAliasAfterFailedUpdate is a test for https://github.com/pulumi/pulumi/issues/13848.
+func TestPythonAliasAfterFailedUpdate(t *testing.T) {
+	t.Parallel()
+
+	d := filepath.Join("python", "alias_after_failed_update")
+	t.Run(d, func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir: filepath.Join(d, "step1"),
+			Dependencies: []string{
+				filepath.Join("..", "..", "..", "sdk", "python", "env", "src"),
+			},
+			LocalProviders: []integration.LocalDependency{
+				{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			},
+			Quick: true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:           filepath.Join(d, "step2"),
+					Additive:      true,
+					ExpectFailure: true,
+				},
+				{
+					Dir:      filepath.Join(d, "step3"),
+					Additive: true,
+				},
+			},
+		})
+	})
+}

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: alias_after_failed_update
+runtime: python

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/__main__.py
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/__main__.py
@@ -1,0 +1,15 @@
+# Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+from pulumi import ComponentResource, ResourceOptions
+
+from echo import Echo
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name):
+        super().__init__("my:index:MyComponent", name)
+
+
+# Step 1, create a component and a child resource.
+component = MyComponent("component")
+res1 = Echo("res1", echo="hello", opts=ResourceOptions(parent=component))

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/echo.py
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/echo.py
@@ -1,0 +1,20 @@
+# Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+from typing import Any, Optional
+
+import pulumi
+
+class Echo(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 echo: pulumi.Input[Any],
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        props = {
+            "echo": echo,
+        }
+        super().__init__("testprovider:index:Echo", resource_name, props, opts)
+
+    @property
+    @pulumi.getter
+    def echo(self) -> pulumi.Output[Any]:
+        return pulumi.get(self, "echo")

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/fails_on_create.py
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/fails_on_create.py
@@ -1,0 +1,11 @@
+# Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+from typing import Optional
+
+import pulumi
+
+class FailsOnCreate(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("testprovider:index:FailsOnCreate", resource_name, {}, opts)

--- a/tests/integration/aliases/python/alias_after_failed_update/step2/__main__.py
+++ b/tests/integration/aliases/python/alias_after_failed_update/step2/__main__.py
@@ -1,0 +1,19 @@
+# Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+from pulumi import ComponentResource, ResourceOptions
+
+from echo import Echo
+from fails_on_create import FailsOnCreate
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name):
+        super().__init__("my:index:MyComponent", name)
+
+
+# Step 2:
+#   1. Unparent the resource so the engine will want to do a Create and Delete.
+#   2. Add a new resource that always fails on Create, such that the Delete of res1 will not happen.
+component = MyComponent("component")
+res1 = Echo("res1", echo="hello") # unparent
+res2 = FailsOnCreate("res2")

--- a/tests/integration/aliases/python/alias_after_failed_update/step3/__main__.py
+++ b/tests/integration/aliases/python/alias_after_failed_update/step3/__main__.py
@@ -1,0 +1,16 @@
+# Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+from pulumi import Alias, ComponentResource, ResourceOptions
+
+from echo import Echo
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name):
+        super().__init__("my:index:MyComponent", name)
+
+
+# Step 3: Add the alias for the unparented resource, to prevent the Create and Delete.
+# There's no need to keep around res2 that will always fail on Create.
+component = MyComponent("component")
+res1 = Echo("res1", echo="hello", opts=ResourceOptions(aliases=[Alias(parent=component)])) # add alias

--- a/tests/testprovider/fails_on_create.go
+++ b/tests/testprovider/fails_on_create.go
@@ -1,0 +1,61 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !all
+// +build !all
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	pbempty "github.com/golang/protobuf/ptypes/empty"
+)
+
+type failsOnCreateResourceProvider struct{}
+
+func (p *failsOnCreateResourceProvider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	return &rpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
+}
+
+func (p *failsOnCreateResourceProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	return &rpc.DiffResponse{
+		Changes: rpc.DiffResponse_DIFF_NONE,
+	}, nil
+}
+
+func (p *failsOnCreateResourceProvider) Create(
+	ctx context.Context, req *rpc.CreateRequest,
+) (*rpc.CreateResponse, error) {
+	return nil, errors.New("Create always fails for the FailsOnCreate resource")
+}
+
+func (p *failsOnCreateResourceProvider) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+	return &rpc.ReadResponse{
+		Id:         req.Id,
+		Properties: req.Properties,
+	}, nil
+}
+
+func (p *failsOnCreateResourceProvider) Update(
+	ctx context.Context, req *rpc.UpdateRequest,
+) (*rpc.UpdateResponse, error) {
+	panic("Update not implemented")
+}
+
+func (p *failsOnCreateResourceProvider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -48,6 +48,7 @@ var resourceProviders = map[string]resourceProvider{
 	"testprovider:index:Random":        &randomResourceProvider{},
 	"testprovider:index:Echo":          &echoResourceProvider{},
 	"testprovider:index:FailsOnDelete": &failsOnDeleteResourceProvider{},
+	"testprovider:index:FailsOnCreate": &failsOnCreateResourceProvider{},
 }
 
 func providerForURN(urn string) (resourceProvider, string, bool) {


### PR DESCRIPTION
This change fixes a regression in the step generator when looking for old resources. When generating steps for a register resource event, we previously looked for old resources first by the resource's URN and then by aliases.

This regressed with #10819:

```diff
-	for _, urnOrAlias := range append([]resource.URN{urn}, goal.Aliases...) {
+	aliases[urn] = struct{}{}
+	for urnOrAlias := range aliases {
```

Previously, aliases were in a slice and we always looked for the URN first, then aliases.

With #10819, aliases changed to being stored in a map (a set). The URN was added to the map before iterating over it, but there's no guarantee it will be looked at first (iteration order for maps is unspecified), and with the current behavior when there are aliases in the map, the URN very likely won't come first.

This can lead to duplicate resources in the state (stack corruption) when the wrong old resource is chosen.

The fix is to move back to always checking for old resources using the URN first. We also move back to maintaining aliases in a slice for consistent ordering.

Fixes #13848