### PR TITLE
[org search] Adds resource counts to results display

### DIFF
--- a/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
+++ b/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Displays total and displayed resource counts for org search

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/browser"
@@ -176,6 +177,16 @@ func renderSearchTable(w io.Writer, results *apitype.ResourceSearchResponse) err
 		return err
 	}
 	err = table.RenderTo(w)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(
+		[]byte(
+			fmt.Sprintf(
+				"Displaying %s of %s total results.\n",
+				strconv.Itoa(len(results.Resources)),
+				strconv.FormatInt(*results.Total, 10))),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -37,6 +37,7 @@ func TestSearchAI_cmd(t *testing.T) {
 	pack := "pack1"
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
+	total := int64(132)
 	b := &stubHTTPBackend{
 		NaturalLanguageSearchF: func(context.Context, string, string) (*apitype.ResourceSearchResponse, error) {
 			return &apitype.ResourceSearchResponse{
@@ -51,6 +52,7 @@ func TestSearchAI_cmd(t *testing.T) {
 						Modified: &modified,
 					},
 				},
+				Total: &total,
 			}, nil
 		},
 		CurrentUserF: func() (string, []string, error) {

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -38,6 +38,7 @@ func TestSearch_cmd(t *testing.T) {
 	pack := "pack1"
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
+	total := int64(32)
 	cmd := searchCmd{
 		Stdout: &buff,
 		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
@@ -55,6 +56,7 @@ func TestSearch_cmd(t *testing.T) {
 								Modified: &modified,
 							},
 						},
+						Total: &total,
 					}, nil
 				},
 				CurrentUserF: func() (string, []string, error) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently, there is no way to know how many total resources a given query WOULD display given no account limits, nor how many of that total are being displayed. This adds a small line of text indicating each of these numbers.

Fixes https://github.com/pulumi/pulumi.ai/issues/209

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
