### PR TITLE
Removes PULUMI_DEV flag for org search features

### DIFF
--- a/changelog/pending/20230906--cli-config--removes-pulumi_dev-flag-for-org-search.yaml
+++ b/changelog/pending/20230906--cli-config--removes-pulumi_dev-flag-for-org-search.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Removes PULUMI_DEV flag for org search

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -65,9 +64,7 @@ func newOrgCmd() *cobra.Command {
 
 	cmd.AddCommand(newOrgSetDefaultCmd())
 	cmd.AddCommand(newOrgGetDefaultCmd())
-	if env.Dev.Value() {
-		cmd.AddCommand(newSearchCmd())
-	}
+	cmd.AddCommand(newSearchCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -114,10 +113,7 @@ func newSearchCmd() *cobra.Command {
 		),
 	}
 
-	// TODO: Remove this branch once we release this feature fully.
-	if env.Dev.Value() {
-		cmd.AddCommand(newSearchAICmd())
-	}
+	cmd.AddCommand(newSearchAICmd())
 
 	cmd.PersistentFlags().StringVar(
 		&scmd.orgName, "org", "",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

In order to release this feature to our users, we should no longer gate it behind `PULUMI_DEV`, so it is available by default.

Fixes https://github.com/pulumi/pulumi.ai/issues/210

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
