### PR TITLE
[policy] support premium policies

### DIFF
--- a/changelog/pending/20230911--cli-new--pulumi-policy-new-now-injects-pulumi_access_token-when-necessary-to-support-downloading-premium-policies.yaml
+++ b/changelog/pending/20230911--cli-new--pulumi-policy-new-now-injects-pulumi_access_token-when-necessary-to-support-downloading-premium-policies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: `pulumi policy new` now injects `PULUMI_ACCESS_TOKEN` when necessary to support downloading Premium Policies.

--- a/tests/policy_new_test.go
+++ b/tests/policy_new_test.go
@@ -15,6 +15,8 @@
 package tests
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
@@ -25,4 +27,27 @@ func TestPolicyNewNonInteractive(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 	e.RunCommand("pulumi", "policy", "new", "aws-typescript", "--force", "--generate-only")
+}
+
+func TestPremiumPolicyAuth(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
+	}
+
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+
+	e.RunCommand("pulumi", "login")
+	defer e.RunCommand("pulumi", "logout")
+	// Remove `PULUMI_ACCESS_TOKEN` so that `pulumi policy new` automatically sets it for installation.
+	for i, elem := range e.Env {
+		if strings.HasPrefix(elem, "PULUMI_ACCESS_TOKEN=") {
+			_ = i
+			e.Env = append(e.Env[:i], e.Env[i+1:]...)
+			break
+		}
+	}
+
+	e.RunCommand("pulumi", "policy", "new", "kubernetes-premium-policies-typescript", "--force")
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13881

`pulumi policy new` now injects PULUMI_ACCESS_TOKEN for Premium Policies 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
