### PR TITLE
Restore secrets provider in config refresh

### DIFF
--- a/changelog/pending/20230908--cli-config--config-refresh-will-now-restore-secret-provider-config-from-the-last-deployment.yaml
+++ b/changelog/pending/20230908--cli-config--config-refresh-will-now-restore-secret-provider-config-from-the-last-deployment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: `config refresh` will now restore secret provider config from the last deployment.

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -124,6 +124,20 @@ func (m *Manager) State() json.RawMessage               { return m.state }
 func (m *Manager) Encrypter() (config.Encrypter, error) { return m.crypter, nil }
 func (m *Manager) Decrypter() (config.Decrypter, error) { return m.crypter, nil }
 
+func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {
+	info.EncryptionSalt = ""
+
+	var s cloudSecretsManagerState
+	err := json.Unmarshal(state, &s)
+	if err != nil {
+		return fmt.Errorf("unmarshalling cloud state: %w", err)
+	}
+
+	info.SecretsProvider = s.URL
+	info.EncryptedKey = base64.StdEncoding.EncodeToString(s.EncryptedKey)
+	return nil
+}
+
 // NewCloudSecretsManagerFromState deserialize configuration from state and returns a secrets
 // manager that uses the target cloud key management service to encrypt/decrypt a data key used for
 // envelope encryption of secrets values.

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -115,6 +115,19 @@ func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
 	return sm.crypter, nil
 }
 
+func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {
+	info.EncryptedKey = ""
+	info.SecretsProvider = ""
+
+	var s localSecretsManagerState
+	err := json.Unmarshal(state, &s)
+	if err != nil {
+		return fmt.Errorf("unmarshalling passphrase state: %w", err)
+	}
+	info.EncryptionSalt = s.Salt
+	return nil
+}
+
 var (
 	lock  sync.Mutex
 	cache map[string]secrets.Manager


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/7282

This is fairly simple, just grab the last deployment from the stack (we should have one otherwise we wouldn't have any config to fetch either) and pull the SecretsProviders data out the deployment data and translate and insert it into the stack config.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - I've manually checked this with a passphrase deployment. Need to do the command split for "config refresh" to write up some unit tests to cover this.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
