### PR TITLE
[policy/new] make `pulumi policy new <template-name>` runnable in non-interactive mode

### DIFF
--- a/changelog/pending/20230908--cli-new--fixes-pulumi-policy-new-template-name-to-not-require-yes-when-run-non-interactively.yaml
+++ b/changelog/pending/20230908--cli-new--fixes-pulumi-policy-new-template-name-to-not-require-yes-when-run-non-interactively.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fixes `pulumi policy new <template-name>` to not require `--yes` when run non-interactively.

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -39,16 +39,12 @@ type newPolicyArgs struct {
 	dir               string
 	force             bool
 	generateOnly      bool
-	interactive       bool
 	offline           bool
 	templateNameOrURL string
-	yes               bool
 }
 
 func newPolicyNewCmd() *cobra.Command {
-	args := newPolicyArgs{
-		interactive: cmdutil.Interactive(),
-	}
+	args := newPolicyArgs{}
 
 	cmd := &cobra.Command{
 		Use:        "new [template|url]",
@@ -89,14 +85,10 @@ func newPolicyNewCmd() *cobra.Command {
 }
 
 func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
-	if !args.interactive && !args.yes {
-		return errors.New("--yes must be passed in to proceed when running in non-interactive mode")
-	}
-
 	// Prepare options.
 	opts := display.Options{
 		Color:         cmdutil.GetGlobalColorization(),
-		IsInteractive: args.interactive,
+		IsInteractive: cmdutil.Interactive(),
 	}
 
 	// Get the current working directory.
@@ -141,6 +133,8 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 		return errors.New("no templates")
 	} else if len(templates) == 1 {
 		template = templates[0]
+	} else if !opts.IsInteractive {
+		return fmt.Errorf("a template must be provided when running in non-interactive mode")
 	} else {
 		if template, err = choosePolicyPackTemplate(templates, opts); err != nil {
 			return err

--- a/pkg/cmd/pulumi/policy_new_acceptance_test.go
+++ b/pkg/cmd/pulumi/policy_new_acceptance_test.go
@@ -31,8 +31,6 @@ func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
 	chdir(t, tempdir)
 
 	args := newPolicyArgs{
-		interactive:       false,
-		yes:               true,
 		templateNameOrURL: "aws-typescript",
 	}
 

--- a/pkg/cmd/pulumi/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy_new_test.go
@@ -32,7 +32,6 @@ func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
 	chdir(t, tempdir)
 
 	args := newPolicyArgs{
-		interactive:       true,
 		templateNameOrURL: "aws-javascript",
 	}
 
@@ -55,8 +54,6 @@ func TestInvalidPolicyPackTemplateName(t *testing.T) {
 		chdir(t, tempdir)
 
 		args := newPolicyArgs{
-			interactive:       false,
-			yes:               true,
 			templateNameOrURL: nonExistantTemplate,
 		}
 
@@ -73,7 +70,6 @@ func TestInvalidPolicyPackTemplateName(t *testing.T) {
 			generateOnly:      true,
 			offline:           true,
 			templateNameOrURL: nonExistantTemplate,
-			yes:               true,
 		}
 
 		err := runNewPolicyPack(context.TODO(), args)

--- a/tests/policy_new_test.go
+++ b/tests/policy_new_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+)
+
+func TestPolicyNewNonInteractive(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+	e.RunCommand("pulumi", "policy", "new", "aws-typescript", "--force", "--generate-only")
+}

--- a/tests/remote_test.go
+++ b/tests/remote_test.go
@@ -154,10 +154,3 @@ func TestRemoteLifecycle(t *testing.T) {
 
 	e.RunCommand("pulumi", "stack", "rm", "--stack", fullyQualifiedStack, "--yes")
 }
-
-func TestPolicyNewNonInteractive(t *testing.T) {
-	t.Parallel()
-	e := ptesting.NewEnvironment(t)
-	defer deleteIfNotFailed(e)
-	e.RunCommand("pulumi", "policy", "new", "aws-typescript", "--force", "--generate-only")
-}

--- a/tests/remote_test.go
+++ b/tests/remote_test.go
@@ -154,3 +154,10 @@ func TestRemoteLifecycle(t *testing.T) {
 
 	e.RunCommand("pulumi", "stack", "rm", "--stack", fullyQualifiedStack, "--yes")
 }
+
+func TestPolicyNewNonInteractive(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+	e.RunCommand("pulumi", "policy", "new", "aws-typescript", "--force", "--generate-only")
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13901

`pulumi policy new <template-name>` would fail requiring a `--yes` argument that did not exist when being run non-interactively.

This changes `pulumi policy new <template-name>` to not require `--yes` when a template-name is provided.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
