### PR TITLE
ci: Add required `--squash` flag to `gh pr merge`

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -78,5 +78,5 @@ jobs:
           PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}" --body "")
 
           if [ "${QUEUE_MERGE}" = "true" ]; then
-            gh pr merge --auto "${PR}"
+            gh pr merge --auto --squash "${PR}"
           fi


### PR DESCRIPTION
As part of the release workflow, we use the GitHub CLI to open a PR to update the changelog and go.mod files. This has been failing when running `gh pr merge` with:

```
--merge, --rebase, or --squash required when not running interactively
```

This adds the `--squash` flag to make it happy, which is the same setting for the merge queue.

The need to specify this seems like a bug in the GH CLI. When trying this out locally with `--squash` it works, but says "The merge strategy for master is set by the merge queue". Anyway, we'll specify it for now so it works.

Fixes #13858