### PR TITLE
[engine] Add extra comment on old resource lookup

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -494,6 +494,8 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	var hasOld bool
 	var alias []resource.Alias
 	var createdAt, modifiedAt *time.Time
+	// Important: Check the URN first, then aliases. Otherwise we may pick the wrong resource which
+	// could lead to a corrupt snapshot.
 	for _, urnOrAlias := range append([]resource.URN{urn}, aliases...) {
 		old, hasOld = sg.deployment.Olds()[urnOrAlias]
 		if hasOld {


### PR DESCRIPTION
Add a comment closer to where we actually lookup an old resource, noting that we should check the URN first before aliases and why.

Follow-up from postmortem discussion on https://github.com/pulumi/pulumi/issues/13848