### PR TITLE
Don't close LanguageRuntime in forkRun

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -220,9 +220,6 @@ func (iter *evalSourceIterator) forkRun(opts Options, config map[config.Key]stri
 			}
 			contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
 
-			// Make sure to clean up before exiting.
-			defer contract.IgnoreClose(langhost)
-
 			// Now run the actual program.
 			progerr, bail, err := langhost.Run(plugin.RunInfo{
 				MonitorAddress:   iter.mon.Address(),

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -147,9 +147,6 @@ func runLangPlugin(src *querySource) error {
 	}
 	contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
 
-	// Make sure to clean up before exiting.
-	defer contract.IgnoreClose(langhost)
-
 	// Decrypt the configuration.
 	var config map[config.Key]string
 	if src.runinfo.Target != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The LanguageRuntime in forkRun is from a plugin host, which will cache the runtimes it's asked for and close them when the host is closed.

Closing the runtime here leads to _at least_ an error in the logs when the host tries to close it later and finds the process already gone, and could potentially result in another part of the code asking for the same runtime object and having it killed unexpectedly.
