### PR TITLE
Update ExecuteRegisterResourceOutputs to use error

### DIFF
--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -402,7 +402,7 @@ func (ex *deploymentExecutor) handleSingleEvent(event SourceEvent) result.Result
 		steps, res = ex.stepGen.GenerateReadSteps(e)
 	case RegisterResourceOutputsEvent:
 		logging.V(4).Infof("deploymentExecutor.handleSingleEvent(...): received register resource outputs")
-		return ex.stepExec.ExecuteRegisterResourceOutputs(e)
+		return result.WrapIfNonNil(ex.stepExec.ExecuteRegisterResourceOutputs(e))
 	}
 
 	if res != nil {

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -364,7 +364,8 @@ func (i *importer) importResources(ctx context.Context) result.Result {
 	}
 
 	if createdStack {
-		i.executor.ExecuteRegisterResourceOutputs(noopOutputsEvent(stackURN))
+		return result.WrapIfNonNil(
+			i.executor.ExecuteRegisterResourceOutputs(noopOutputsEvent(stackURN)))
 	}
 
 	return nil

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 const (
@@ -146,7 +145,7 @@ func (se *stepExecutor) ExecuteParallel(antichain antichain) completionToken {
 }
 
 // ExecuteRegisterResourceOutputs services a RegisterResourceOutputsEvent synchronously on the calling goroutine.
-func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputsEvent) result.Result {
+func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputsEvent) error {
 	// Look up the final state in the pending registration list.
 	urn := e.URN()
 	value, has := se.pendingNews.Load(urn)
@@ -171,11 +170,11 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 	if se.deployment.plan != nil {
 		resourcePlan, ok := se.deployment.plan.ResourcePlans[urn]
 		if !ok {
-			return result.FromError(fmt.Errorf("no plan for resource %v", urn))
+			return fmt.Errorf("no plan for resource %v", urn)
 		}
 
 		if err := resourcePlan.checkOutputs(oldOuts, outs); err != nil {
-			return result.FromError(fmt.Errorf("resource violates plan: %w", err))
+			return fmt.Errorf("resource violates plan: %w", err)
 		}
 	}
 
@@ -185,8 +184,8 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 			resourcePlan.Goal.OutputDiff = NewPlanDiff(oldOuts.Diff(outs))
 			resourcePlan.Outputs = outs
 		} else {
-			return result.FromError(
-				fmt.Errorf("resource should already have a plan from when we called register resources [urn=%v]", urn))
+			return fmt.Errorf(
+				"resource should already have a plan from when we called register resources [urn=%v]", urn)
 		}
 	}
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Part of the yak shave to get rid of the `Result` type. We need to do these changes from the bottom up because we allow converting from `error` to `Result` (we simply discard data), but not the other way (because we'd have to make up an error and `from Result conversion` isn't very informative).

This replaces the `Result` return value in
`ExecuteRegisterResourceOutputs` to `error`. This means we now get errcheck lints which warned that we we're discarding the result from this call in the import code.