### PR TITLE
Addresses initial Org Search feedback

### DIFF
--- a/changelog/pending/20230802--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
+++ b/changelog/pending/20230802--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
@@ -3,31 +3,21 @@ changes:
   scope: cli
   prs: [13611, 13846, 13879, 13888]
   description: |-
-    Adds `pulumi org search` and `pulumi org search ai` for Pulumi Insights in the CLI.
-    These commands render a table containing all resources in a given organization matching the
-    query provided.
+    Adds `pulumi org search` and `pulumi org search ai` for Pulumi Insights in the CLI. These commands render a table containing all resources in a given organization matching the query provided.
 
-      The `-o <json|csv|yaml>` flag customizes the output.
+      `-q <query>` will search for resources in the organization using a query provided in Pulumi Query Syntax.
 
-      `pulumi org search -q <query>` will search for resources in the organization using
-    a query provided in Pulumi Query Syntax. 
-    
-      `pulumi org search ai -q <query>` will translate a plaintext query into Pulumi Query Syntax
-    and then search for resources in the organization using that query.
+      `-o <json|csv|yaml>` flag customizes the output.
 
-      Default table output will show a count of displayed resources out of the total. Additional
-    output includes the query run, a URL to view and explore search results in the Pulumi Console
-    and the query, and the query run.
+      The `ai` command uses AI Assist to translate a natural language query into Pulumi Query Syntax.
 
-      Additional output is suppressed for non-table output formats such that they can be
-    easily piped into other tools.
+      Default table output will show a count of displayed resources out of the total. Additional output includes the query run, a URL to view and explore search results in the Pulumi Console and the query, and the query run.
+
+      Additional output is suppressed for non-table output formats such that they can be easily piped into other tools.
 
       The `--web` flag will open the search results in a default browser.
 - type: feat
   scope: cli
   prs: [13808]
   description: |-
-    Adds `pulumi ai` command - currently the only functionality in this group is `pulumi ai web`, which will
-    open the Pulumi AI application in a default browser. An optional `--prompt/-p` flag can be provided with
-    a query to pre-populate the search bar in the Pulumi AI application. By default, that prompt will be submitted
-    automatically, but passing `--no-auto-submit` will prevent that. 
+    Adds `pulumi ai` command - currently the only functionality in this group is `pulumi ai web`, which will open the Pulumi AI application in a default browser. An optional `--prompt/-p` flag can be provided with a query to pre-populate the search bar in the Pulumi AI application. By default, that prompt will be submitted automatically, but passing `--no-auto-submit` will prevent that.

--- a/changelog/pending/20230802--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
+++ b/changelog/pending/20230802--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
@@ -1,4 +1,33 @@
 changes:
 - type: feat
   scope: cli
-  description: Adds basic Search and AI-assisted Search functionality
+  prs: [13611, 13846, 13879, 13888]
+  description: |-
+    Adds `pulumi org search` and `pulumi org search ai` for Pulumi Insights in the CLI.
+    These commands render a table containing all resources in a given organization matching the
+    query provided.
+
+      The `-o <json|csv|yaml>` flag customizes the output.
+
+      `pulumi org search -q <query>` will search for resources in the organization using
+    a query provided in Pulumi Query Syntax. 
+    
+      `pulumi org search ai -q <query>` will translate a plaintext query into Pulumi Query Syntax
+    and then search for resources in the organization using that query.
+
+      Default table output will show a count of displayed resources out of the total. Additional
+    output includes the query run, a URL to view and explore search results in the Pulumi Console
+    and the query, and the query run.
+
+      Additional output is suppressed for non-table output formats such that they can be
+    easily piped into other tools.
+
+      The `--web` flag will open the search results in a default browser.
+- type: feat
+  scope: cli
+  prs: [13808]
+  description: |-
+    Adds `pulumi ai` command - currently the only functionality in this group is `pulumi ai web`, which will
+    open the Pulumi AI application in a default browser. An optional `--prompt/-p` flag can be provided with
+    a query to pre-populate the search bar in the Pulumi AI application. By default, that prompt will be submitted
+    automatically, but passing `--no-auto-submit` will prevent that. 

--- a/changelog/pending/20230831--cli--adds-csv-as-an-output-option-for-org-search.yaml
+++ b/changelog/pending/20230831--cli--adds-csv-as-an-output-option-for-org-search.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli
-  description: adds csv as an output option for org search

--- a/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
+++ b/changelog/pending/20230906--cli-config--adheres-to-default-org-for-org-search-when-one-is-set.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli/config
-  description: Adheres to default org for org search when one is set

--- a/changelog/pending/20230906--cli-display--displays-search-url-when-results-table-is-rendered.yaml
+++ b/changelog/pending/20230906--cli-display--displays-search-url-when-results-table-is-rendered.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli/display
-  description: Displays search URL when results table is rendered

--- a/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
+++ b/changelog/pending/20230906--cli-display--displays-total-and-displayed-resource-counts-for-org-search.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli/display
-  description: Displays total and displayed resource counts for org search

--- a/changelog/pending/20230910--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
+++ b/changelog/pending/20230910--cli--adds-basic-search-and-ai-assisted-search-functionality.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli
-  description: Adds basic Search and AI-assisted Search functionality

--- a/changelog/pending/20230910--cli--adds-pulumi-ai-and-pulumi-ai-web-commands.yaml
+++ b/changelog/pending/20230910--cli--adds-pulumi-ai-and-pulumi-ai-web-commands.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli
-  description: Adds Pulumi AI and Pulumi AI Web commands

--- a/changelog/pending/20230911--cli-config-display--adds-display-of-query-individual-org-validation-console-query-syntax-alignment.yaml
+++ b/changelog/pending/20230911--cli-config-display--adds-display-of-query-individual-org-validation-console-query-syntax-alignment.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli/config,display
-  description: Adds display of query, individual org validation, console query syntax alignment

--- a/changelog/pending/20230911--cli-config-display--adds-display-of-query-individual-org-validation-console-query-syntax-alignment.yaml
+++ b/changelog/pending/20230911--cli-config-display--adds-display-of-query-individual-org-validation-console-query-syntax-alignment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config,display
+  description: Adds display of query, individual org validation, console query syntax alignment

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1029,7 +1029,9 @@ func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) res
 func (b *cloudBackend) Search(
 	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 ) (*apitype.ResourceSearchResponse, error) {
-	return b.Client().GetSearchQueryResults(ctx, orgName, queryParams, b.CloudConsoleURL())
+	results, err := b.Client().GetSearchQueryResults(ctx, orgName, queryParams, b.CloudConsoleURL())
+	results.Query = queryParams.Query
+	return results, err
 }
 
 func (b *cloudBackend) NaturalLanguageSearch(
@@ -1041,6 +1043,7 @@ func (b *cloudBackend) NaturalLanguageSearch(
 	}
 	requestBody := apitype.PulumiQueryRequest{Query: parsedResults.Query}
 	results, err := b.Client().GetSearchQueryResults(ctx, orgName, &requestBody, b.CloudConsoleURL())
+	results.Query = parsedResults.Query
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -104,12 +105,16 @@ func (cmd *aiWebCmd) Run(ctx context.Context, args []string) error {
 		}
 		query.Set("autoSubmit", "true")
 	}
+	if cmd.language == "" {
+		cmd.language = TypeScript // TODO: default to the language of the current project if one is present
+	}
 	query.Set("language", cmd.language.String())
 
 	requestURL.RawQuery = query.Encode()
-	err = browser.OpenURL(requestURL.String())
-	if err != nil {
-		return err
+	if err = browser.OpenURL(requestURL.String()); err != nil {
+		fmt.Printf("We couldn't launch your web browser for some reason. Please visit:\n\n%s\n\n"+
+			"to continue your Pulumi AI session.\n", requestURL)
+		return errors.Join(err, fmt.Errorf("failed to open URL: %s", requestURL.String()))
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -159,7 +159,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	}
 	if cmd.orgName == userName {
 		return fmt.Errorf(
-			"%s is an individual account, not an organization."+
+			"%s is an individual account, not an organization. "+
 				"Organization search is not supported for individual accounts",
 			userName,
 		)

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -204,14 +204,15 @@ func newSearchCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(
 		&scmd.orgName, "org", "",
-		"Name of the organization to search. Defaults to the current user's organization.",
+		"Name of the organization to search. Defaults to the current user's default organization.",
 	)
 	cmd.PersistentFlags().StringArrayVarP(
 		&scmd.queryParams, "query", "q", nil,
-		"Key-value pairs to use as query parameters. "+
-			"Must be formatted like: -q key1=value1 -q key2=value2. "+
-			"Alternately, each parameter provided here can be in raw Pulumi query syntax form. "+
-			"At least one query parameter must be provided.",
+		"A Pulumi Query to send to Pulumi Cloud for resource search."+
+			"May be formatted as a single query, or multiple:\n"+
+			"\t-q \"type:aws:s3/bucket:Bucket modified:>=2023-09-01\"\n"+
+			"\t-q \"type:aws:s3/bucket:Bucket\" -q \"modified:>=2023-09-01\"\n"+
+			"See https://www.pulumi.com/docs/pulumi-cloud/insights/search/#query-syntax for syntax reference.",
 	)
 	cmd.PersistentFlags().VarP(
 		&scmd.outputFormat, "output", "o",

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -324,6 +324,8 @@ func (o *outputFormat) Render(cmd *searchCmd, result *apitype.ResourceSearchResp
 		return cmd.RenderTable(result)
 	case outputFormatYAML:
 		return cmd.RenderYAML(result)
+	case outputFormatCSV:
+		return cmd.RenderCSV(result.Resources, cmd.csvDelimiter.Rune())
 	default:
 		return fmt.Errorf("unknown output format %q", *o)
 	}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -268,11 +268,13 @@ func renderSearchTable(w io.Writer, results *apitype.ResourceSearchResponse) err
 	if err != nil {
 		return err
 	}
-	_, err = w.Write([]byte(urlInfo + "\n"))
+	_, err = w.Write([]byte(urlInfo + "\n" + results.URL + "\n"))
 	if err != nil {
 		return err
 	}
-	_, err = w.Write([]byte(results.URL))
+	_, err = w.Write(
+		[]byte(fmt.Sprintf("\nResources displayed are the result of the following Pulumi query:\n%s\n", results.Query)),
+	)
 	return err
 }
 

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -157,16 +157,21 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	if defaultOrg != "" && cmd.orgName == "" {
 		cmd.orgName = defaultOrg
 	}
-	filterName := userName
+	if cmd.orgName == userName {
+		return fmt.Errorf(
+			"%s is an individual account, not an organization."+
+				"Organization search is not supported for individual accounts",
+			userName,
+		)
+	}
 	if cmd.orgName != "" {
 		if !sliceContains(orgs, cmd.orgName) {
 			return fmt.Errorf("user %s is not a member of organization %s", userName, cmd.orgName)
 		}
-		filterName = cmd.orgName
 	}
 
 	parsedQueryParams := apitype.ParseQueryParams(cmd.queryParams)
-	res, err := cloudBackend.Search(ctx, filterName, parsedQueryParams)
+	res, err := cloudBackend.Search(ctx, cmd.orgName, parsedQueryParams)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -32,7 +31,6 @@ import (
 
 type searchAICmd struct {
 	searchCmd
-	orgName     string
 	queryString string
 	openWeb     bool
 }
@@ -145,8 +143,4 @@ func newSearchAICmd() *cobra.Command {
 		"Open the search results in a web browser.",
 	)
 	return cmd
-}
-
-func (cmd *searchAICmd) RenderTable(result *apitype.ResourceSearchResponse) error {
-	return renderSearchTable(cmd.Stdout, result)
 }

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -78,15 +78,21 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if defaultOrg != "" && cmd.orgName == "" {
 		cmd.orgName = defaultOrg
 	}
-	filterName := userName
-	if cmd.orgName != "" {
-		filterName = cmd.orgName
+	if cmd.orgName == "" {
+		cmd.orgName = userName
+	}
+	if cmd.orgName == userName {
+		return fmt.Errorf(
+			"%s is an individual account, not an organization."+
+				"Organization search is not supported for individual accounts",
+			userName,
+		)
 	}
 	if !sliceContains(orgs, cmd.orgName) && cmd.orgName != "" {
 		return fmt.Errorf("user %s is not a member of org %s", userName, cmd.orgName)
 	}
 
-	res, err := cloudBackend.NaturalLanguageSearch(ctx, filterName, cmd.queryString)
+	res, err := cloudBackend.NaturalLanguageSearch(ctx, cmd.orgName, cmd.queryString)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -42,6 +42,10 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 		cmd.Stdout = os.Stdout
 	}
 
+	if cmd.outputFormat == "" {
+		cmd.outputFormat = outputFormatTable
+	}
+
 	if cmd.currentBackend == nil {
 		cmd.currentBackend = currentBackend
 	}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ import (
 
 type searchAICmd struct {
 	searchCmd
+	orgName     string
 	queryString string
 	openWeb     bool
 }
@@ -98,7 +100,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	}
 	err = cmd.outputFormat.Render(&cmd.searchCmd, res)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "table rendering error: %s\n", err)
+		fmt.Fprintf(os.Stderr, "rendering error: %s\n", err)
 	}
 	if cmd.openWeb {
 		err = browser.OpenURL(res.URL)
@@ -143,4 +145,8 @@ func newSearchAICmd() *cobra.Command {
 		"Open the search results in a web browser.",
 	)
 	return cmd
+}
+
+func (cmd *searchAICmd) RenderTable(result *apitype.ResourceSearchResponse) error {
+	return renderSearchTable(cmd.Stdout, result)
 }

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -38,6 +38,7 @@ func TestSearchAI_cmd(t *testing.T) {
 	mod := "mod1"
 	modified := "2023-01-01T00:00:00.000Z"
 	total := int64(132)
+	orgName := "org1"
 	b := &stubHTTPBackend{
 		NaturalLanguageSearchF: func(context.Context, string, string) (*apitype.ResourceSearchResponse, error) {
 			return &apitype.ResourceSearchResponse{
@@ -61,7 +62,7 @@ func TestSearchAI_cmd(t *testing.T) {
 	}
 	cmd := searchAICmd{
 		searchCmd: searchCmd{
-			orgName: "org1",
+			orgName: orgName,
 			Stdout:  &buff,
 			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 				return b, nil
@@ -76,4 +77,50 @@ func TestSearchAI_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), name)
 	assert.Contains(t, buff.String(), typ)
 	assert.Contains(t, buff.String(), program)
+}
+
+func TestAISearchUserOrgFailure_cmd(t *testing.T) {
+	t.Parallel()
+	var buff bytes.Buffer
+	name := "foo"
+	typ := "bar"
+	program := "program1"
+	stack := "stack1"
+	pack := "pack1"
+	mod := "mod1"
+	modified := "2023-01-01T00:00:00.000Z"
+	orgName := "user"
+	cmd := searchAICmd{
+		searchCmd: searchCmd{
+			orgName: orgName,
+			Stdout:  &buff,
+			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+				return &stubHTTPBackend{
+					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
+						return &apitype.ResourceSearchResponse{
+							Resources: []apitype.ResourceResult{
+								{
+									Name:     &name,
+									Type:     &typ,
+									Program:  &program,
+									Stack:    &stack,
+									Package:  &pack,
+									Module:   &mod,
+									Modified: &modified,
+								},
+							},
+						}, nil
+					},
+					CurrentUserF: func() (string, []string, error) {
+						return "user", []string{"org1", "org2"}, nil
+					},
+				}, nil
+			},
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "user is an individual account, not an organization")
 }

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -41,9 +41,10 @@ func TestSearch_cmd(t *testing.T) {
 	modified := "2023-01-01T00:00:00.000Z"
 	searchURL := "https://app.pulumi.com/pulumi/resources?foo=bar"
 	total := int64(132)
+	orgName := "org1"
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
-			orgName: "org1",
+			orgName: orgName,
 			Stdout:  &buff,
 			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
 				return &stubHTTPBackend{
@@ -80,6 +81,52 @@ func TestSearch_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), program)
 	assert.Contains(t, buff.String(), fmt.Sprintf("Results are also visible in Pulumi Cloud:\n%s", searchURL))
 	assert.Contains(t, buff.String(), fmt.Sprint(total))
+}
+
+func TestSearchUserOrgFailure_cmd(t *testing.T) {
+	t.Parallel()
+	var buff bytes.Buffer
+	name := "foo"
+	typ := "bar"
+	program := "program1"
+	stack := "stack1"
+	pack := "pack1"
+	mod := "mod1"
+	modified := "2023-01-01T00:00:00.000Z"
+	orgName := "user"
+	cmd := orgSearchCmd{
+		searchCmd: searchCmd{
+			orgName: orgName,
+			Stdout:  &buff,
+			currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+				return &stubHTTPBackend{
+					SearchF: func(context.Context, string, *apitype.PulumiQueryRequest) (*apitype.ResourceSearchResponse, error) {
+						return &apitype.ResourceSearchResponse{
+							Resources: []apitype.ResourceResult{
+								{
+									Name:     &name,
+									Type:     &typ,
+									Program:  &program,
+									Stack:    &stack,
+									Package:  &pack,
+									Module:   &mod,
+									Modified: &modified,
+								},
+							},
+						}, nil
+					},
+					CurrentUserF: func() (string, []string, error) {
+						return "user", []string{"org1", "org2"}, nil
+					},
+				}, nil
+			},
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "user is an individual account, not an organization")
 }
 
 type stubHTTPBackend struct {

--- a/sdk/go/common/apitype/search.go
+++ b/sdk/go/common/apitype/search.go
@@ -16,7 +16,6 @@ package apitype
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -80,19 +79,11 @@ type PulumiQueryRequest struct {
 }
 
 // ParseQueryParams takes a list of parameters passed into the CLI
-// Search commands (either in the form of `key=value` or a bare Pulumi query)
+// Search commands (in the form of a Pulumi query)
 // and returns a PulumiQueryRequest struct that can be used to make a request
 // to the Pulumi API.
 //
 // See https://www.pulumi.com/docs/pulumi-cloud/insights/search/#query-syntax for reference
 func ParseQueryParams(rawParams []string) *PulumiQueryRequest {
-	var queryString strings.Builder
-	for _, param := range rawParams {
-		if key, value, ok := strings.Cut(param, "="); ok {
-			fmt.Fprintf(&queryString, "%s:%s", key, value)
-		} else {
-			queryString.WriteString(param)
-		}
-	}
-	return &PulumiQueryRequest{Query: queryString.String()}
+	return &PulumiQueryRequest{Query: strings.Join(rawParams, " ")}
 }

--- a/sdk/go/common/apitype/search.go
+++ b/sdk/go/common/apitype/search.go
@@ -25,6 +25,7 @@ type ResourceSearchResponse struct {
 	Aggregations map[string]Aggregation    `json:"aggregations,omitempty" yaml:"aggregations,omitempty"`
 	Pagination   *ResourceSearchPagination `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 	URL          string
+	Query        string `json:"query,omitempty" yaml:"query,omitempty"`
 }
 
 // ResourceResult is the user-facing type for our indexed resources.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Based on initial Org Search feedback, we were missing a few things in the original implementation. This adds the following:
- Displays the raw query which was submitted to Pulumi for both basic org search and AI assisted search
- Validates whether the org provided is the user's individual org - AI assist and search is not supported for individual orgs
- Aligns `pulumi org search` syntax with that supported in the console.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
