### PR TITLE
[`pulumi state edit`] handle multi-part EDITOR variables (i.e. `emacs -nw`)

### DIFF
--- a/changelog/pending/20230911--cli-state--pulumi-state-edit-now-supports-multi-part-editor-env-vars-i-e-emacs-nw.yaml
+++ b/changelog/pending/20230911--cli-state--pulumi-state-edit-now-supports-multi-part-editor-env-vars-i-e-emacs-nw.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: `pulumi state edit` now handles multi-part EDITOR env vars (i.e. `emacs -nw`).

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -23,6 +23,7 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
+	"github.com/google/shlex"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -30,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
 )
@@ -252,8 +254,19 @@ func openInEditor(filename string) error {
 	if editor == "" {
 		return fmt.Errorf("no EDITOR environment variable set")
 	}
+	return openInEditorInternal(editor, filename)
+}
 
-	cmd := exec.Command(editor, filename)
+func openInEditorInternal(editor, filename string) error {
+	contract.Requiref(editor != "", "editor", "must not be empty")
+
+	args, err := shlex.Split(editor)
+	if err != nil {
+		return err
+	}
+	args = append(args, filename)
+
+	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/cmd/pulumi/state_edit_test.go
+++ b/pkg/cmd/pulumi/state_edit_test.go
@@ -86,3 +86,37 @@ func TestSnapshotFrontendRoundTrip(t *testing.T) {
 	// The round-tripped snapshot text should be the same as the original.
 	assert.Equal(t, text, roundTrippedText)
 }
+
+func TestOpenInEditorMultiPart(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		command  string
+		filename string
+	}{
+		{
+			name:     "Simple command",
+			command:  "echo",
+			filename: "filename.txt",
+		},
+		{
+			name:     "Command with arguments",
+			command:  "echo Hello",
+			filename: "filename.txt",
+		},
+		{
+			name:     "Complex command",
+			command:  "echo --foo --bar a",
+			filename: "filename.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := openInEditorInternal(tt.command, tt.filename)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/creack/pty v1.1.17
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/go-git/go-git/v5 v5.6.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/json-iterator/go v1.1.12
@@ -163,7 +164,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

`pulumi state edit` now properly handles multi-part EDITOR variables (i.e. `emacs -nw`).

Fixes #13850

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
