### PR TITLE
Replace result.Result in SourceIterator

### DIFF
--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -182,15 +182,15 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
 	// respond to cancellation requests promptly.
 	type nextEvent struct {
-		Event  SourceEvent
-		Result result.Result
+		Event SourceEvent
+		Error error
 	}
 	incomingEvents := make(chan nextEvent)
 	go func() {
 		for {
-			event, sourceErr := src.Next()
+			event, err := src.Next()
 			select {
-			case incomingEvents <- nextEvent{event, sourceErr}:
+			case incomingEvents <- nextEvent{event, err}:
 				if event == nil {
 					return
 				}
@@ -215,11 +215,11 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 			select {
 			case event := <-incomingEvents:
 				logging.V(4).Infof("deploymentExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil,
-					event.Result)
+					event.Error)
 
-				if event.Result != nil {
-					if !event.Result.IsBail() {
-						ex.reportError("", event.Result.Error())
+				if event.Error != nil {
+					if !result.IsBail(event.Error) {
+						ex.reportError("", event.Error)
 					}
 					cancel()
 

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -51,7 +51,7 @@ type SourceIterator interface {
 	io.Closer
 
 	// Next returns the next event from the source.
-	Next() (SourceEvent, result.Result)
+	Next() (SourceEvent, error)
 }
 
 // SourceResourceMonitor directs resource operations from the `Source` to various resource

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -54,6 +54,6 @@ func (iter *nullSourceIterator) Close() error {
 	return nil // nothing to do.
 }
 
-func (iter *nullSourceIterator) Next() (SourceEvent, result.Result) {
+func (iter *nullSourceIterator) Next() (SourceEvent, error) {
 	return nil, nil // means "done"
 }


### PR DESCRIPTION
Continued cleanup of `result.Bail`.