### PR TITLE
Correctly roundtrip enums in schema marshalling

### DIFF
--- a/changelog/pending/20230912--sdkgen-go-nodejs-python--fix-a-bug-in-marshalling-enums-across-grpc.yaml
+++ b/changelog/pending/20230912--sdkgen-go-nodejs-python--fix-a-bug-in-marshalling-enums-across-grpc.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go,nodejs,python
+  description: Fix a bug in marshalling enums across gRPC

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1083,8 +1083,12 @@ func (pkg *Package) marshalEnum(t *EnumType) ComplexTypeSpec {
 	}
 
 	return ComplexTypeSpec{
-		ObjectTypeSpec: ObjectTypeSpec{Type: pkg.marshalType(t.ElementType, false).Type, IsOverlay: t.IsOverlay},
-		Enum:           values,
+		ObjectTypeSpec: ObjectTypeSpec{
+			Description: t.Comment,
+			Type:        pkg.marshalType(t.ElementType, false).Type,
+			IsOverlay:   t.IsOverlay,
+		},
+		Enum: values,
 	}
 }
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -96,6 +96,42 @@ func TestRoundtripLocalTypeRef(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+func TestRoundtripEnum(t *testing.T) {
+	// Regression test for https://github.com/pulumi/pulumi/issues/13921
+	t.Parallel()
+
+	assertEnum := func(t *testing.T, pkg *Package) {
+		typ, ok := pkg.GetType("enum:index:Color")
+		assert.True(t, ok)
+		enum, ok := typ.(*EnumType)
+		assert.True(t, ok)
+		assert.Equal(t, "An enum representing a color", enum.Comment)
+		assert.ElementsMatch(t, []*Enum{
+			{Value: "red"},
+			{Value: "green"},
+			{Value: "blue"},
+		}, enum.Elements)
+	}
+
+	testdataPath := filepath.Join("..", "testing", "test", "testdata")
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("enum-1.0.0.json")
+	pkg, diags, err := BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	assertEnum(t, pkg)
+
+	newSpec, err := pkg.MarshalSpec()
+	require.NoError(t, err)
+	require.NotNil(t, newSpec)
+
+	// Try and bind again
+	pkg, diags, err = BindSpec(*newSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	assertEnum(t, pkg)
+}
+
 func TestImportSpec(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/testing/test/testdata/enum-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/enum-1.0.0.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+    "name": "enum",
+    "version": "1.0.0",
+    "//": [
+        "Simple schema with an enum"
+    ],
+    "types": {
+        "enum:index:Color": {
+            "description": "An enum representing a color",
+            "type": "string",
+            "enum": [
+                {
+                    "value": "red"
+                },
+                {
+                    "value": "green"
+                },
+                {
+                    "value": "blue"
+                }
+            ]
+        }
+    }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -89,5 +89,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"using-dashes", "1.0.0"},
 		SchemaProvider{"auto-deploy", "0.0.1"},
 		SchemaProvider{"localref", "1.0.0"},
+		SchemaProvider{"enum", "1.0.0"},
 	)
 }


### PR DESCRIPTION
The code to marshal an enum was not keeping the enum's comment.

Fixes #13921