### PR TITLE
When changing parents also fix URNs

### DIFF
--- a/changelog/pending/20230913--engine--fix-aliases-of-parents-tracking-over-partial-deployments.yaml
+++ b/changelog/pending/20230913--engine--fix-aliases-of-parents-tracking-over-partial-deployments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix aliases of parents tracking over partial deployments.

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -66,28 +66,28 @@ func MockSetup(t *testing.T, baseSnap *deploy.Snapshot) (*SnapshotManager, *Mock
 	return NewSnapshotManager(sp, baseSnap), sp
 }
 
-func NewResourceWithDeps(name string, deps []resource.URN) *resource.State {
+func NewResourceWithDeps(urn resource.URN, deps []resource.URN) *resource.State {
 	return &resource.State{
 		Type:         tokens.Type("test"),
-		URN:          resource.URN(name),
+		URN:          urn,
 		Inputs:       make(resource.PropertyMap),
 		Outputs:      make(resource.PropertyMap),
 		Dependencies: deps,
 	}
 }
 
-func NewResourceWithInputs(name string, inputs resource.PropertyMap) *resource.State {
+func NewResourceWithInputs(urn resource.URN, inputs resource.PropertyMap) *resource.State {
 	return &resource.State{
 		Type:         tokens.Type("test"),
-		URN:          resource.URN(name),
+		URN:          urn,
 		Inputs:       inputs,
 		Outputs:      make(resource.PropertyMap),
 		Dependencies: []resource.URN{},
 	}
 }
 
-func NewResource(name string, deps ...resource.URN) *resource.State {
-	return NewResourceWithDeps(name, deps)
+func NewResource(urn resource.URN, deps ...resource.URN) *resource.State {
+	return NewResourceWithDeps(urn, deps)
 }
 
 func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
@@ -98,10 +98,17 @@ func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
 	}, b64.NewBase64SecretsManager(), resources, nil)
 }
 
+var (
+	aUniqueUrn          = resource.NewURN("test-stack", "test-project", "", "pkg:typ", "a-unique-urn")
+	aUniqueUrnResourceA = resource.NewURN("test-stack", "test-project", "", "pkg:typ", "a-unique-urn-resource-a")
+	aUniqueUrnResourceB = resource.NewURN("test-stack", "test-project", "", "pkg:typ", "a-unique-urn-resource-b")
+	aUniqueUrnResourceP = resource.NewURN("test-stack", "test-project", "", "pkg:typ", "a-unique-urn-resource-p")
+)
+
 func TestIdenticalSames(t *testing.T) {
 	t.Parallel()
 
-	sameState := NewResource("a-unique-urn")
+	sameState := NewResource(aUniqueUrn)
 	snap := NewSnapshot([]*resource.State{
 		sameState,
 	})
@@ -109,7 +116,7 @@ func TestIdenticalSames(t *testing.T) {
 	manager, sp := MockSetup(t, snap)
 
 	// The engine generates a SameStep on sameState.
-	engineGeneratedSame := NewResource(string(sameState.URN))
+	engineGeneratedSame := NewResource(sameState.URN)
 	same := deploy.NewSameStep(nil, nil, sameState, engineGeneratedSame)
 
 	mutation, err := manager.BeginMutation(same)
@@ -138,12 +145,12 @@ func TestIdenticalSames(t *testing.T) {
 func TestSamesWithEmptyDependencies(t *testing.T) {
 	t.Parallel()
 
-	res := NewResourceWithDeps("a-unique-urn-resource-a", nil)
+	res := NewResourceWithDeps(aUniqueUrnResourceA, nil)
 	snap := NewSnapshot([]*resource.State{
 		res,
 	})
 	manager, sp := MockSetup(t, snap)
-	resUpdated := NewResourceWithDeps(string(res.URN), []resource.URN{})
+	resUpdated := NewResourceWithDeps(res.URN, []resource.URN{})
 	same := deploy.NewSameStep(nil, nil, res, resUpdated)
 	mutation, err := manager.BeginMutation(same)
 	assert.NoError(t, err)
@@ -160,7 +167,7 @@ func TestSamesWithEmptyArraysInInputs(t *testing.T) {
 	inputs, err := stack.DeserializeProperties(state, config.NopDecrypter, config.NopEncrypter)
 	assert.NoError(t, err)
 
-	res := NewResourceWithInputs("a-unique-urn-resource-a", inputs)
+	res := NewResourceWithInputs(aUniqueUrnResourceA, inputs)
 	snap := NewSnapshot([]*resource.State{
 		res,
 	})
@@ -172,7 +179,7 @@ func TestSamesWithEmptyArraysInInputs(t *testing.T) {
 	inputsUpdated, err := plugin.UnmarshalProperties(marshalledInputs, plugin.MarshalOptions{})
 	assert.NoError(t, err)
 
-	resUpdated := NewResourceWithInputs(string(res.URN), inputsUpdated)
+	resUpdated := NewResourceWithInputs(res.URN, inputsUpdated)
 	same := deploy.NewSameStep(nil, nil, res, resUpdated)
 	mutation, err := manager.BeginMutation(same)
 	assert.NoError(t, err)
@@ -190,8 +197,8 @@ func TestSamesWithEmptyArraysInInputs(t *testing.T) {
 func TestSamesWithDependencyChanges(t *testing.T) {
 	t.Parallel()
 
-	resourceA := NewResource("a-unique-urn-resource-a")
-	resourceB := NewResource("a-unique-urn-resource-b", resourceA.URN)
+	resourceA := NewResource(aUniqueUrnResourceA)
+	resourceB := NewResource(aUniqueUrnResourceB, resourceA.URN)
 
 	// The setup: the snapshot contains two resources, A and B, where
 	// B depends on A. We're going to begin a mutation in which B no longer
@@ -203,10 +210,10 @@ func TestSamesWithDependencyChanges(t *testing.T) {
 
 	manager, sp := MockSetup(t, snap)
 
-	resourceBUpdated := NewResource(string(resourceB.URN))
+	resourceBUpdated := NewResource(resourceB.URN)
 	// note: no dependencies
 
-	resourceAUpdated := NewResource(string(resourceA.URN), resourceBUpdated.URN)
+	resourceAUpdated := NewResource(resourceA.URN, resourceBUpdated.URN)
 	// note: now depends on B
 
 	// The engine first generates a Same for b:
@@ -275,7 +282,7 @@ func TestWriteCheckpointOnceUnsafe(t *testing.T) {
 	manager, sp := MockSetup(t, snap)
 
 	// Generate a same for the provider.
-	provUpdated := NewResource(string(provider.URN))
+	provUpdated := NewResource(provider.URN)
 	provUpdated.Custom, provUpdated.Type = true, provider.Type
 	provSame := deploy.NewSameStep(nil, nil, provider, provUpdated)
 	mutation, err := manager.BeginMutation(provSame)
@@ -286,7 +293,7 @@ func TestWriteCheckpointOnceUnsafe(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The engine generates a meaningful change, the DEFAULT behavior is that a snapshot is written:
-	pUpdated := NewResource(string(resourceP.URN))
+	pUpdated := NewResource(resourceP.URN)
 	pUpdated.Protect = !resourceP.Protect
 	pSame := deploy.NewSameStep(nil, nil, resourceP, pUpdated)
 	mutation, err = manager.BeginMutation(pSame)
@@ -295,7 +302,7 @@ func TestWriteCheckpointOnceUnsafe(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The engine generates a meaningful change, the DEFAULT behavior is that a snapshot is written:
-	aUpdated := NewResource(string(resourceA.URN))
+	aUpdated := NewResource(resourceA.URN)
 	aUpdated.Protect = !resourceA.Protect
 	aSame := deploy.NewSameStep(nil, nil, resourceA, aUpdated)
 	mutation, err = manager.BeginMutation(aSame)
@@ -321,29 +328,33 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 	provider := NewResource("urn:pulumi:foo::bar::pulumi:providers:pkgA::provider")
 	provider.Custom, provider.Type, provider.ID = true, "pulumi:providers:pkgA", "id"
 
-	resourceP := NewResource("a-unique-urn-resource-p")
-	resourceA := NewResource("a-unique-urn-resource-a")
+	resourceP := NewResource(aUniqueUrnResourceP)
+	resourceA := NewResource(aUniqueUrnResourceA)
 
 	var changes []*resource.State
 
 	// Change the "custom" bit.
-	changes = append(changes, NewResource(string(resourceA.URN)))
+	changes = append(changes, NewResource(resourceA.URN))
 	changes[0].Custom, changes[0].Provider = true, "urn:pulumi:foo::bar::pulumi:providers:pkgA::provider::id"
 
-	// Change the parent.
-	changes = append(changes, NewResource(string(resourceA.URN)))
+	// Change the parent, this also has to change the URN.
+	changes = append(changes, NewResource(resourceA.URN))
+	changes[1].URN = resource.NewURN(
+		resourceA.URN.Stack(), resourceA.URN.Project(),
+		resourceP.URN.QualifiedType(), resourceA.URN.Type(),
+		resourceA.URN.Name())
 	changes[1].Parent = resourceP.URN
 
 	// Change the "protect" bit.
-	changes = append(changes, NewResource(string(resourceA.URN)))
+	changes = append(changes, NewResource(resourceA.URN))
 	changes[2].Protect = !resourceA.Protect
 
 	// Change the resource outputs.
-	changes = append(changes, NewResource(string(resourceA.URN)))
+	changes = append(changes, NewResource(resourceA.URN))
 	changes[3].Outputs = resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
 
 	// Change the resource source position.
-	changes = append(changes, NewResource(string(resourceA.URN)))
+	changes = append(changes, NewResource(resourceA.URN))
 	changes[4].SourcePosition = "project:///foo.ts#1,2"
 
 	snap := NewSnapshot([]*resource.State{
@@ -356,7 +367,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		manager, sp := MockSetup(t, snap)
 
 		// Generate a same for the provider.
-		provUpdated := NewResource(string(provider.URN))
+		provUpdated := NewResource(provider.URN)
 		provUpdated.Custom, provUpdated.Type = true, provider.Type
 		provSame := deploy.NewSameStep(nil, nil, provider, provUpdated)
 		mutation, err := manager.BeginMutation(provSame)
@@ -368,7 +379,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		assert.Empty(t, sp.SavedSnapshots)
 
 		// The engine generates a Same for p. This is not a meaningful change, so the snapshot is not written.
-		pUpdated := NewResource(string(resourceP.URN))
+		pUpdated := NewResource(resourceP.URN)
 		pSame := deploy.NewSameStep(nil, nil, resourceP, pUpdated)
 		mutation, err = manager.BeginMutation(pSame)
 		assert.NoError(t, err)
@@ -387,6 +398,8 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		assert.NotEmpty(t, sp.SavedSnapshots[0].Resources)
 
 		inSnapshot := sp.SavedSnapshots[0].Resources[2]
+		// The snapshot might edit the URN so don't check against that
+		c.URN = inSnapshot.URN
 		assert.Equal(t, c, inSnapshot)
 
 		err = manager.Close()
@@ -407,14 +420,14 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		resourceA,
 	})
 
-	changes = []*resource.State{NewResource(string(resourceA.URN))}
+	changes = []*resource.State{NewResource(resourceA.URN)}
 	changes[0].Custom, changes[0].Provider = true, "urn:pulumi:foo::bar::pulumi:providers:pkgA::provider2::id2"
 
 	for _, c := range changes {
 		manager, sp := MockSetup(t, snap)
 
 		// Generate sames for the providers.
-		provUpdated := NewResource(string(provider.URN))
+		provUpdated := NewResource(provider.URN)
 		provUpdated.Custom, provUpdated.Type = true, provider.Type
 		provSame := deploy.NewSameStep(nil, nil, provider, provUpdated)
 		mutation, err := manager.BeginMutation(provSame)
@@ -426,7 +439,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		assert.Empty(t, sp.SavedSnapshots)
 
 		// The engine generates a Same for p. This is not a meaningful change, so the snapshot is not written.
-		prov2Updated := NewResource(string(provider2.URN))
+		prov2Updated := NewResource(provider2.URN)
 		prov2Updated.Custom, prov2Updated.Type = true, provider.Type
 		prov2Same := deploy.NewSameStep(nil, nil, provider2, prov2Updated)
 		mutation, err = manager.BeginMutation(prov2Same)
@@ -543,11 +556,11 @@ func TestVexingDeployment(t *testing.T) {
 	}
 
 	// b now depends on nothing
-	bPrime := NewResource(string(b.URN))
+	bPrime := NewResource(b.URN)
 	applyStep(deploy.NewSameStep(nil, MockRegisterResourceEvent{}, b, bPrime))
 
 	// c now only depends on b
-	cPrime := NewResource(string(c.URN), bPrime.URN)
+	cPrime := NewResource(c.URN, bPrime.URN)
 
 	// mocking out the behavior of a provider indicating that this resource needs to be deleted
 	createReplacement := deploy.NewCreateReplacementStep(nil, MockRegisterResourceEvent{}, c, cPrime, nil, nil, nil, true)
@@ -559,7 +572,7 @@ func TestVexingDeployment(t *testing.T) {
 
 	// cPrime now exists, c is now pending deletion
 	// dPrime now depends on cPrime, which got replaced
-	dPrime := NewResource(string(d.URN), cPrime.URN)
+	dPrime := NewResource(d.URN, cPrime.URN)
 	applyStep(deploy.NewUpdateStep(nil, MockRegisterResourceEvent{}, d, dPrime, nil, nil, nil, nil))
 
 	lastSnap := sp.SavedSnapshots[len(sp.SavedSnapshots)-1]

--- a/pkg/cmd/pulumi/state_rename_test.go
+++ b/pkg/cmd/pulumi/state_rename_test.go
@@ -117,7 +117,7 @@ func TestStateRename_updatesChildren(t *testing.T) {
 
 	provider := resource.URN("urn:pulumi:dev::pets::random::provider")
 	parent := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet::parent")
-	child := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet::child")
+	child := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet$random:index/randomPet:RandomPet::child")
 
 	snap := deploy.Snapshot{
 		Resources: []*resource.State{

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -681,7 +681,7 @@ func TestImportPlanExistingImport(t *testing.T) {
 	}}).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, _ result.Result) result.Result {
 			for _, e := range entries {
-				assert.Equal(t, e.Step.Op(), deploy.OpSame)
+				assert.Equal(t, deploy.OpSame, e.Step.Op())
 			}
 			return nil
 		})

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -190,7 +190,7 @@ func (p *TestPlan) NewURN(typ tokens.Type, name string, parent resource.URN) res
 	stack, project, _ := p.getNames()
 	var pt tokens.Type
 	if parent != "" {
-		pt = parent.Type()
+		pt = parent.QualifiedType()
 	}
 	return resource.NewURN(stack.Q(), project, pt, typ, tokens.QName(name))
 }

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // Snapshot is a view of a collection of resources in an stack at a point in time.  It describes resources; their
@@ -72,11 +73,20 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 			}
 			aliased[alias] = state.URN
 		}
+		// If our parent has changed URN, then we need to update our URN as well.
+		if parent, has := aliased[state.Parent]; has {
+			if parent != "" && parent.Type() != resource.RootStackType {
+				aliased[state.URN] = resource.NewURN(
+					state.URN.Stack(), state.URN.Project(),
+					parent.QualifiedType(), state.URN.Type(),
+					state.URN.Name())
+			}
+		}
 	}
 
 	fixUrn := func(urn resource.URN) resource.URN {
 		if newUrn, has := aliased[urn]; has {
-			// TODO should this recur to see if newUrn is simiarly aliased?
+			// TODO should this recur to see if newUrn is similarly aliased?
 			return newUrn
 		}
 		return urn
@@ -93,6 +103,7 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 
 	fixResource := func(old *resource.State) *resource.State {
 		return newStateBuilder(old).
+			withUpdatedURN(fixUrn).
 			withUpdatedParent(fixUrn).
 			withUpdatedDependencies(fixUrn).
 			withUpdatedPropertyDependencies(fixUrn).
@@ -154,6 +165,18 @@ func (snap *Snapshot) VerifyIntegrity() error {
 						}
 					}
 					return fmt.Errorf("child resource %s refers to missing parent %s", urn, par)
+				}
+
+				// Ensure that our URN is a child of the parent's URN.
+				expectedType := urn.Type()
+				if par.QualifiedType() != resource.RootStackType {
+					expectedType = par.QualifiedType() + "$" + expectedType
+				}
+
+				if urn.QualifiedType() != expectedType {
+					logging.Warningf("child resource %s has parent %s but it's URN doesn't match", urn, par)
+					// TODO: Change this to an error once we're sure users won't hit this in the wild.
+					// return fmt.Errorf("child resource %s has parent %s but it's URN doesn't match", urn, par)
 				}
 			}
 

--- a/pkg/resource/deploy/state_builder.go
+++ b/pkg/resource/deploy/state_builder.go
@@ -29,6 +29,11 @@ func newStateBuilder(state *resource.State) *stateBuilder {
 	return &stateBuilder{*state, state, false}
 }
 
+func (sb *stateBuilder) withUpdatedURN(update func(resource.URN) resource.URN) *stateBuilder {
+	sb.setURN(&sb.state.URN, update(sb.state.URN))
+	return sb
+}
+
 func (sb *stateBuilder) withUpdatedParent(update func(resource.URN) resource.URN) *stateBuilder {
 	if sb.state.Parent != "" {
 		sb.setURN(&sb.state.Parent, update(sb.state.Parent))

--- a/pkg/resource/deploy/state_builder_test.go
+++ b/pkg/resource/deploy/state_builder_test.go
@@ -24,9 +24,12 @@ import (
 
 func TestStateBuilder(t *testing.T) {
 	t.Parallel()
-	s0 := &resource.State{}
+	s0 := &resource.State{
+		URN: "urn:pulumi:prod::st::cust:res:R::a-res",
+	}
 
 	s1 := &resource.State{
+		URN:      "urn:pulumi:prod::st::cust:res:R$cust:res:R::a-res",
 		Parent:   "urn:pulumi:prod::st::cust:res:R::my-res",
 		Provider: "urn:pulumi:prod::st::cust:prov:P::my-prov",
 		Dependencies: []resource.URN{

--- a/sdk/go/common/resource/urn.go
+++ b/sdk/go/common/resource/urn.go
@@ -78,7 +78,7 @@ func ParseOptionalURN(s string) (URN, error) {
 // NewURN creates a unique resource URN for the given resource object.
 func NewURN(stack tokens.QName, proj tokens.PackageName, parentType, baseType tokens.Type, name tokens.QName) URN {
 	typ := string(baseType)
-	if parentType != "" {
+	if parentType != "" && parentType != RootStackType {
 		typ = string(parentType) + URNTypeDelimiter + typ
 	}
 

--- a/tests/integration/aliases/python/retype_parents/step1/__main__.py
+++ b/tests/integration/aliases/python/retype_parents/step1/__main__.py
@@ -2,6 +2,7 @@
 
 from pulumi import Alias, ComponentResource, ResourceOptions
 
+
 class Resource(ComponentResource):
     def __init__(self, name, opts=None):
         super().__init__("my:module:Resource", name, None, opts)

--- a/tests/integration/aliases/python/retype_parents/step2/__main__.py
+++ b/tests/integration/aliases/python/retype_parents/step2/__main__.py
@@ -4,6 +4,7 @@ import copy
 
 from pulumi import Alias, ComponentResource, ResourceOptions
 
+
 class Resource(ComponentResource):
     def __init__(self, name, opts=None):
         super().__init__("my:module:Resource", name, None, opts)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13903
    
When we change parents in a statefile we also need to fix up the URN.
This is needed so aliases can track over partial updates.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
