### PR TITLE
Replace result.Result in Query with error

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -189,7 +189,7 @@ type Backend interface {
 	Watch(ctx context.Context, stack Stack, op UpdateOperation, paths []string) result.Result
 
 	// Query against the resource outputs in a stack's state checkpoint.
-	Query(ctx context.Context, op QueryOperation) result.Result
+	Query(ctx context.Context, op QueryOperation) error
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order (newest first).

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -970,7 +970,7 @@ func (b *localBackend) Destroy(ctx context.Context, stack backend.Stack,
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
-func (b *localBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {
+func (b *localBackend) Query(ctx context.Context, op backend.QueryOperation) error {
 	return b.query(ctx, op, nil /*events*/)
 }
 
@@ -1157,7 +1157,7 @@ func (b *localBackend) apply(
 // query executes a query program against the resource outputs of a locally hosted stack.
 func (b *localBackend) query(ctx context.Context, op backend.QueryOperation,
 	callerEventsOpt chan<- engine.Event,
-) result.Result {
+) error {
 	return backend.RunQuery(ctx, b, op, callerEventsOpt, b.newQuery)
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1022,7 +1022,7 @@ func (b *cloudBackend) Watch(ctx context.Context, stk backend.Stack,
 	return backend.Watch(ctx, b, stk, op, b.apply, paths)
 }
 
-func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {
+func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) error {
 	return b.query(ctx, op, nil /*events*/)
 }
 
@@ -1181,7 +1181,7 @@ func (b *cloudBackend) getPermalink(update client.UpdateIdentifier, version int,
 // Cloud.
 func (b *cloudBackend) query(ctx context.Context, op backend.QueryOperation,
 	callerEventsOpt chan<- engine.Event,
-) result.Result {
+) error {
 	return backend.RunQuery(ctx, b, op, callerEventsOpt, b.newQuery)
 }
 

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -51,7 +51,7 @@ type MockBackend struct {
 		[]StackSummary, ContinuationToken, error)
 	RenameStackF            func(context.Context, Stack, tokens.QName) (StackReference, error)
 	GetStackCrypterF        func(StackReference) (config.Crypter, error)
-	QueryF                  func(context.Context, QueryOperation) result.Result
+	QueryF                  func(context.Context, QueryOperation) error
 	GetLatestConfigurationF func(context.Context, Stack) (config.Map, error)
 	GetHistoryF             func(context.Context, StackReference, int, int) ([]UpdateInfo, error)
 	UpdateStackTagsF        func(context.Context, Stack, map[apitype.StackTagName]string) error
@@ -280,7 +280,7 @@ func (be *MockBackend) Watch(ctx context.Context, stack Stack,
 	panic("not implemented")
 }
 
-func (be *MockBackend) Query(ctx context.Context, op QueryOperation) result.Result {
+func (be *MockBackend) Query(ctx context.Context, op QueryOperation) error {
 	if be.QueryF != nil {
 		return be.QueryF(ctx, op)
 	}

--- a/pkg/backend/query.go
+++ b/pkg/backend/query.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 type MakeQuery func(context.Context, QueryOperation) (engine.QueryInfo, error)
@@ -15,10 +14,10 @@ type MakeQuery func(context.Context, QueryOperation) (engine.QueryInfo, error)
 // RunQuery executes a query program against the resource outputs of a locally hosted stack.
 func RunQuery(ctx context.Context, b Backend, op QueryOperation,
 	callerEventsOpt chan<- engine.Event, newQuery MakeQuery,
-) result.Result {
+) error {
 	q, err := newQuery(ctx, op)
 	if err != nil {
-		return result.FromError(err)
+		return err
 	}
 
 	// Render query output to CLI.

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -73,7 +73,7 @@ func newQueryCmd() *cobra.Command {
 				Experimental: hasExperimentalCommands(),
 			}
 
-			res := b.Query(ctx, backend.QueryOperation{
+			err = b.Query(ctx, backend.QueryOperation{
 				Proj:            project,
 				Root:            root,
 				Opts:            opts,
@@ -81,10 +81,10 @@ func newQueryCmd() *cobra.Command {
 				SecretsProvider: stack.DefaultSecretsProvider,
 			})
 			switch {
-			case res != nil && res.Error() == context.Canceled:
+			case err != nil && err == context.Canceled:
 				return nil
-			case res != nil:
-				return PrintEngineResult(res)
+			case err != nil:
+				return PrintEngineResult(result.FromError(err))
 			default:
 				return nil
 			}


### PR DESCRIPTION
Continued cleanup of result.Bail with error. This cleans up the codepath using Query.