### PR TITLE
Safeguards org search against unset default orgs

### DIFF
--- a/changelog/pending/20230913--cli--fixes-panic-when-default-org-is-not-set-and-no-org-is-provided-to-org-search.yaml
+++ b/changelog/pending/20230913--cli--fixes-panic-when-default-org-is-not-set-and-no-org-is-provided-to-org-search.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fixes panic when default org is not set and no org is provided to org search

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1030,8 +1030,11 @@ func (b *cloudBackend) Search(
 	ctx context.Context, orgName string, queryParams *apitype.PulumiQueryRequest,
 ) (*apitype.ResourceSearchResponse, error) {
 	results, err := b.Client().GetSearchQueryResults(ctx, orgName, queryParams, b.CloudConsoleURL())
+	if err != nil {
+		return nil, err
+	}
 	results.Query = queryParams.Query
-	return results, err
+	return results, nil
 }
 
 func (b *cloudBackend) NaturalLanguageSearch(

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -161,6 +161,8 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		if !sliceContains(orgs, cmd.orgName) {
 			return fmt.Errorf("user %s is not a member of organization %s", userName, cmd.orgName)
 		}
+	} else {
+		cmd.orgName = userName
 	}
 
 	parsedQueryParams := apitype.ParseQueryParams(cmd.queryParams)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently, if a user has no default org set, and no org is provided via --org, `GetBackendConfigDefaultOrg` returns nothing, which means no org is provided when querying the Pulumi Cloud service - this results in a 404, and a nil pointer error when attempting to retrieve query parameters from that API call. This falls back to the user name when no org is provided by the user or retrieved by `GetBackendConfigDefaultOrg`, as well as returning an error when one arises from the service call rather than returning the error later.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
