### PR TITLE
Move filestate locking to apply time

### DIFF
--- a/changelog/pending/20230913--backend-filestate--file-locks-are-no-longer-taken-during-the-preview-phase-of-update.yaml
+++ b/changelog/pending/20230913--backend-filestate--file-locks-are-no-longer-taken-during-the-preview-phase-of-update.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/filestate
+  description: File locks are no longer taken during the preview phase of update.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -924,24 +924,12 @@ func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
 func (b *localBackend) Update(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, result.Result) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Import(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, imports []deploy.Import,
 ) (sdkDisplay.ResourceChanges, result.Result) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	op.Imports = imports
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply)
 }
@@ -949,24 +937,12 @@ func (b *localBackend) Import(ctx context.Context, stack backend.Stack,
 func (b *localBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, result.Result) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Destroy(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, result.Result) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
@@ -994,6 +970,14 @@ func (b *localBackend) apply(
 
 	if currentProjectContradictsWorkspace(localStackRef) {
 		return nil, nil, result.Errorf("provided project name %q doesn't match Pulumi.yaml", localStackRef.project)
+	}
+
+	if kind != apitype.PreviewUpdate {
+		err := b.Lock(ctx, stackRef)
+		if err != nil {
+			return nil, nil, result.FromError(err)
+		}
+		defer b.Unlock(ctx, stackRef)
 	}
 
 	stackName := stackRef.FullyQualifiedName()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This aligns the filestate behavior with httpstate in that we won't take a lock during the preview phase of an update. Instead we take the lock at the point we start doing a non-preview apply

We've tried this once before (https://github.com/pulumi/pulumi/pull/8806) but got a couple of user reports about locking not working soon after it released, and so reverted it just in case. Further investigation into those user issues suggested they were due to user fault, not this change.

There's one comment from myself on Slack from around that time saying I'm not sure this change is correct, but even with that nudge and looking at it with fresh eyes I think it is. But worth having a hard think about this before hitting approve.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
