### PR TITLE
Remove Logout logic from Backend interface

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -207,10 +207,6 @@ type Backend interface {
 	ExportDeployment(ctx context.Context, stack Stack) (*apitype.UntypedDeployment, error)
 	// ImportDeployment imports the given deployment into the indicated stack.
 	ImportDeployment(ctx context.Context, stack Stack, deployment *apitype.UntypedDeployment) error
-	// Logout logs you out of the backend and removes any stored credentials.
-	Logout() error
-	// LogoutAll logs you out of all the backend and removes any stored credentials.
-	LogoutAll() error
 	// Returns the identity of the current user and any organizations they are in for the backend.
 	CurrentUser() (string, []string, error)
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1266,14 +1266,6 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stk backend.Stack,
 	return err
 }
 
-func (b *localBackend) Logout() error {
-	return workspace.DeleteAccount(b.originalURL)
-}
-
-func (b *localBackend) LogoutAll() error {
-	return workspace.DeleteAllAccounts()
-}
-
 func (b *localBackend) CurrentUser() (string, []string, error) {
 	user, err := user.Current()
 	if err != nil {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -747,16 +747,6 @@ func (b *cloudBackend) cloudConsoleStackPath(stackID client.StackIdentifier) str
 	return path.Join(stackID.Owner, stackID.Project, stackID.Stack)
 }
 
-// Logout logs out of the target cloud URL.
-func (b *cloudBackend) Logout() error {
-	return workspace.DeleteAccount(b.CloudURL())
-}
-
-// LogoutAll logs out of all accounts
-func (b *cloudBackend) LogoutAll() error {
-	return workspace.DeleteAllAccounts()
-}
-
 func inferOrg(ctx context.Context,
 	getDefaultOrg func() (string, error),
 	getUserOrg func() (string, error),

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -57,8 +57,6 @@ type MockBackend struct {
 	UpdateStackTagsF        func(context.Context, Stack, map[apitype.StackTagName]string) error
 	ExportDeploymentF       func(context.Context, Stack) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF       func(context.Context, Stack, *apitype.UntypedDeployment) error
-	LogoutF                 func() error
-	LogoutAllF              func() error
 	CurrentUserF            func() (string, []string, error)
 	PreviewF                func(context.Context, Stack,
 		UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
@@ -340,20 +338,6 @@ func (be *MockBackend) ImportDeployment(ctx context.Context, stack Stack,
 ) error {
 	if be.ImportDeploymentF != nil {
 		return be.ImportDeploymentF(ctx, stack, deployment)
-	}
-	panic("not implemented")
-}
-
-func (be *MockBackend) Logout() error {
-	if be.LogoutF != nil {
-		return be.LogoutF()
-	}
-	panic("not implemented")
-}
-
-func (be *MockBackend) LogoutAll() error {
-	if be.LogoutAllF != nil {
-		return be.LogoutAllF()
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -63,39 +61,31 @@ func newLogoutCmd() *cobra.Command {
 				cloudURL = "file://~"
 			}
 
-			if cloudURL == "" {
-				// Try to read the current project
-				project, _, err := readProject()
-				if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
-					return err
-				}
-
-				cloudURL, err = workspace.GetCurrentCloudURL(project)
-				if err != nil {
-					return fmt.Errorf("could not determine current cloud: %w", err)
-				}
-			}
-
-			var be backend.Backend
 			var err error
-			if filestate.IsFileStateBackendURL(cloudURL) {
-				fmt.Printf("Logged out of %s\n", cloudURL)
-				return workspace.DeleteAccount(cloudURL)
-			}
-
-			be, err = httpstate.New(cmdutil.Diag(), cloudURL, nil, workspace.GetCloudInsecure(cloudURL))
-			if err != nil {
-				return err
-			}
-
-			var logoutErr error
 			if all {
-				logoutErr = be.LogoutAll()
+				err = workspace.DeleteAllAccounts()
 			} else {
-				logoutErr = be.Logout()
+				if cloudURL == "" {
+					// Try to read the current project
+					project, _, err := readProject()
+					if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+						return err
+					}
+
+					cloudURL, err = workspace.GetCurrentCloudURL(project)
+					if err != nil {
+						return fmt.Errorf("could not determine current cloud: %w", err)
+					}
+
+					// Default to the default cloud URL. This means a `pulumi logout` will delete the
+					// credentials for pulumi.com if there's no "current" user set in the credentials file.
+					cloudURL = httpstate.ValueOrDefaultURL(cloudURL)
+				}
+
+				err = workspace.DeleteAccount(cloudURL)
 			}
-			fmt.Printf("Logged out of %s\n", be.URL())
-			return logoutErr
+			fmt.Printf("Logged out of %s\n", cloudURL)
+			return err
 		}),
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Backends themselves don't actually need any logout logic. Logging out is mearly a function of deleting the account from the credentials file and is the same for filestate, httpstate and probably any other state we introduce.

This also simplifies the code "logout --all" which used to try and lookup the project, make up a dummy httpstate object, and then call LogoutAll to call workspace.DeleteAllAccounts. Now it goes straight to that last call.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
