### PR TITLE
Use fallback project name rather than "pulum"

### DIFF
--- a/changelog/pending/20230914--cli-new--pulumi-new-no-longer-defaults-to-a-project-name-of-pulum-if-ran-in-a-folder-called-pulumi.yaml
+++ b/changelog/pending/20230914--cli-new--pulumi-new-no-longer-defaults-to-a-project-name-of-pulum-if-ran-in-a-folder-called-pulumi.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: `pulumi new` no longer defaults to a project name of "pulum" if ran in a folder called "pulumi".

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -44,6 +44,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
 const (
@@ -83,8 +85,8 @@ func runNew(ctx context.Context, args newArgs) error {
 	}
 
 	// Validate name (if specified) before further prompts/operations.
-	if args.name != "" && workspace.ValidateProjectName(args.name) != nil {
-		return fmt.Errorf("'%s' is not a valid project name: %w", args.name, workspace.ValidateProjectName(args.name))
+	if args.name != "" && pkgWorkspace.ValidateProjectName(args.name) != nil {
+		return fmt.Errorf("'%s' is not a valid project name: %w", args.name, pkgWorkspace.ValidateProjectName(args.name))
 	}
 
 	// Validate secrets provider type
@@ -228,7 +230,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Prompt for the project name, if it wasn't already specified.
 	if args.name == "" {
-		defaultValue := workspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
+		defaultValue := pkgWorkspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
 		if err := validateProjectName(ctx, b, orgName, defaultValue, args.generateOnly, opts); err != nil {
 			// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
 			// this case it can lead to a confusing error message because we set the defaultValue to "" below.
@@ -249,10 +251,10 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Prompt for the project description, if it wasn't already specified.
 	if args.description == "" {
-		defaultValue := workspace.ValueOrDefaultProjectDescription(
+		defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
 			args.description, template.ProjectDescription, template.Description)
 		args.description, err = args.prompt(
-			args.yes, "project description", defaultValue, false, workspace.ValidateProjectDescription, opts)
+			args.yes, "project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts)
 		if err != nil {
 			return err
 		}
@@ -571,7 +573,7 @@ func errorIfNotEmptyDirectory(path string) error {
 func validateProjectName(ctx context.Context, b backend.Backend,
 	orgName string, projectName string, generateOnly bool, opts display.Options,
 ) error {
-	err := workspace.ValidateProjectName(projectName)
+	err := pkgWorkspace.ValidateProjectName(projectName)
 	if err != nil {
 		return err
 	}
@@ -1101,7 +1103,7 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 		}
 
 		// Create the option string that combines the name, padding, and description.
-		desc := workspace.ValueOrDefaultProjectDescription("", template.ProjectDescription, template.Description)
+		desc := pkgWorkspace.ValueOrDefaultProjectDescription("", template.ProjectDescription, template.Description)
 		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, desc)
 
 		nameToTemplateMap[option] = template

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -256,9 +257,9 @@ func newUpCmd() *cobra.Command {
 
 		// Prompt for the project name, if we don't already have one from an existing stack.
 		if name == "" {
-			defaultValue := workspace.ValueOrSanitizedDefaultProjectName(name, template.ProjectName, template.Name)
+			defaultValue := pkgWorkspace.ValueOrSanitizedDefaultProjectName(name, template.ProjectName, template.Name)
 			name, err = promptForValue(
-				yes, "project name", defaultValue, false, workspace.ValidateProjectName, opts.Display)
+				yes, "project name", defaultValue, false, pkgWorkspace.ValidateProjectName, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -266,10 +267,10 @@ func newUpCmd() *cobra.Command {
 
 		// Prompt for the project description, if we don't already have one from an existing stack.
 		if description == "" {
-			defaultValue := workspace.ValueOrDefaultProjectDescription(
+			defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
 				description, template.ProjectDescription, template.Description)
 			description, err = promptForValue(
-				yes, "project description", defaultValue, false, workspace.ValidateProjectDescription, opts.Display)
+				yes, "project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -1,0 +1,110 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+const (
+	defaultProjectName = "project"
+)
+
+// ValidateProjectName ensures a project name is valid, if it is not it returns an error with a message suitable
+// for display to an end user.
+func ValidateProjectName(s string) error {
+	if err := tokens.ValidateProjectName(s); err != nil {
+		return err
+	}
+
+	// This is needed to stop cyclic imports in DotNet projects
+	if strings.ToLower(s) == "pulumi" || strings.HasPrefix(strings.ToLower(s), "pulumi.") {
+		return errors.New("project name must not be `Pulumi` and must not start with the prefix `Pulumi.` " +
+			"to avoid collision with standard libraries")
+	}
+
+	return nil
+}
+
+// ValueOrSanitizedDefaultProjectName returns the value or a sanitized valid project name
+// based on defaultNameToSanitize.
+func ValueOrSanitizedDefaultProjectName(name string, projectName string, defaultNameToSanitize string) string {
+	// If we have a name, use it.
+	if name != "" {
+		return name
+	}
+
+	// If the project already has a name that isn't a replacement string, use it.
+	if projectName != "${PROJECT}" {
+		return projectName
+	}
+
+	// Otherwise, get a sanitized version of `defaultNameToSanitize`.
+	return getValidProjectName(defaultNameToSanitize)
+}
+
+// ValueOrDefaultProjectDescription returns the value or defaultDescription.
+func ValueOrDefaultProjectDescription(
+	description string, projectDescription string, defaultDescription string,
+) string {
+	// If we have a description, use it.
+	if description != "" {
+		return description
+	}
+
+	// If the project already has a description that isn't a replacement string, use it.
+	if projectDescription != "${DESCRIPTION}" {
+		return projectDescription
+	}
+
+	// Otherwise, use the default, which may be an empty string.
+	return defaultDescription
+}
+
+// getValidProjectName returns a valid project name based on the passed-in name.
+func getValidProjectName(name string) string {
+	// If the name is valid, return it.
+	if ValidateProjectName(name) == nil {
+		return name
+	}
+
+	// Strip any invalid chars from the name.
+	r := regexp.MustCompile("[^a-zA-Z0-9_.-]")
+	name = r.ReplaceAllString(name, "")
+
+	// See if the name is now valid
+	if ValidateProjectName(name) == nil {
+		return name
+	}
+
+	// If we couldn't come up with a valid project name, fallback to a default.
+	return defaultProjectName
+}
+
+// ValidateProjectDescription ensures a project description name is valid, if it is not it returns an error with a
+// message suitable for display to an end user.
+func ValidateProjectDescription(s string) error {
+	const maxTagValueLength = 256
+
+	if len(s) > maxTagValueLength {
+		return errors.New("a project description must be 256 characters or less")
+	}
+
+	return nil
+}

--- a/pkg/workspace/templates_test.go
+++ b/pkg/workspace/templates_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getValidProjectNamePrefixes() []string {
+	var results []string
+	for ch := 'A'; ch <= 'Z'; ch++ {
+		results = append(results, string(ch))
+	}
+	for ch := 'a'; ch <= 'z'; ch++ {
+		results = append(results, string(ch))
+	}
+	results = append(results, "_")
+	results = append(results, ".")
+	return results
+}
+
+func TestGetValidDefaultProjectName(t *testing.T) {
+	t.Parallel()
+
+	// Valid names remain the same.
+	for _, name := range getValidProjectNamePrefixes() {
+		assert.Equal(t, name, getValidProjectName(name))
+	}
+	assert.Equal(t, "foo", getValidProjectName("foo"))
+	assert.Equal(t, "foo1", getValidProjectName("foo1"))
+	assert.Equal(t, "foo-", getValidProjectName("foo-"))
+	assert.Equal(t, "foo-bar", getValidProjectName("foo-bar"))
+	assert.Equal(t, "foo_", getValidProjectName("foo_"))
+	assert.Equal(t, "foo_bar", getValidProjectName("foo_bar"))
+	assert.Equal(t, "foo.", getValidProjectName("foo."))
+	assert.Equal(t, "foo.bar", getValidProjectName("foo.bar"))
+
+	// Invalid characters are left off.
+	assert.Equal(t, "foo", getValidProjectName("!foo"))
+	assert.Equal(t, "foo", getValidProjectName("@foo"))
+	assert.Equal(t, "foo", getValidProjectName("#foo"))
+	assert.Equal(t, "foo", getValidProjectName("$foo"))
+	assert.Equal(t, "foo", getValidProjectName("%foo"))
+	assert.Equal(t, "foo", getValidProjectName("^foo"))
+	assert.Equal(t, "foo", getValidProjectName("&foo"))
+	assert.Equal(t, "foo", getValidProjectName("*foo"))
+	assert.Equal(t, "foo", getValidProjectName("(foo"))
+	assert.Equal(t, "foo", getValidProjectName(")foo"))
+
+	// Invalid names are replaced with a fallback name.
+	assert.Equal(t, "project", getValidProjectName("!"))
+	assert.Equal(t, "project", getValidProjectName("@"))
+	assert.Equal(t, "project", getValidProjectName("#"))
+	assert.Equal(t, "project", getValidProjectName("$"))
+	assert.Equal(t, "project", getValidProjectName("%"))
+	assert.Equal(t, "project", getValidProjectName("^"))
+	assert.Equal(t, "project", getValidProjectName("&"))
+	assert.Equal(t, "project", getValidProjectName("*"))
+	assert.Equal(t, "project", getValidProjectName("("))
+	assert.Equal(t, "project", getValidProjectName(")"))
+	assert.Equal(t, "project", getValidProjectName("!@#$%^&*()"))
+	assert.Equal(t, "project", getValidProjectName("pulumi"))
+	assert.Equal(t, "project", getValidProjectName("pulumi.test"))
+}

--- a/sdk/go/common/tokens/project_test.go
+++ b/sdk/go/common/tokens/project_test.go
@@ -43,6 +43,31 @@ func TestValidateProjectName(t *testing.T) {
 			give:    "foo bar",
 			wantErr: "project names may only contain alphanumerics, hyphens, underscores, and periods",
 		},
+		{
+			desc:    "Correct Project Name",
+			give:    "SampleProject",
+			wantErr: "",
+		},
+		{
+			desc:    "Project Name with unsupported punctuation",
+			give:    "SampleProject!",
+			wantErr: "project names may only contain alphanumerics, hyphens, underscores, and periods",
+		},
+		{
+			desc:    "Project Name starting with the word Pulumi",
+			give:    "PulumiProject",
+			wantErr: "",
+		},
+		{
+			desc:    "Project Name greater than 100 characters",
+			give:    "cZClTe6xrjgKzH5QS8rFEPqYK1z4bbMeMr6n89n87djq9emSAlznQXXkkCEpBBCaZAFNlCvbfqVcqoifYlfPl11hvekIDjXVIY7m1",
+			wantErr: "project names are limited to 100 characters",
+		},
+		{
+			desc:    "Empty Project Name",
+			give:    "",
+			wantErr: "project names may not be empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -22,61 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetValidDefaultProjectName(t *testing.T) {
-	t.Parallel()
-
-	// Valid names remain the same.
-	for _, name := range getValidProjectNamePrefixes() {
-		assert.Equal(t, name, getValidProjectName(name))
-	}
-	assert.Equal(t, "foo", getValidProjectName("foo"))
-	assert.Equal(t, "foo1", getValidProjectName("foo1"))
-	assert.Equal(t, "foo-", getValidProjectName("foo-"))
-	assert.Equal(t, "foo-bar", getValidProjectName("foo-bar"))
-	assert.Equal(t, "foo_", getValidProjectName("foo_"))
-	assert.Equal(t, "foo_bar", getValidProjectName("foo_bar"))
-	assert.Equal(t, "foo.", getValidProjectName("foo."))
-	assert.Equal(t, "foo.bar", getValidProjectName("foo.bar"))
-
-	// Invalid characters are left off.
-	assert.Equal(t, "foo", getValidProjectName("!foo"))
-	assert.Equal(t, "foo", getValidProjectName("@foo"))
-	assert.Equal(t, "foo", getValidProjectName("#foo"))
-	assert.Equal(t, "foo", getValidProjectName("$foo"))
-	assert.Equal(t, "foo", getValidProjectName("%foo"))
-	assert.Equal(t, "foo", getValidProjectName("^foo"))
-	assert.Equal(t, "foo", getValidProjectName("&foo"))
-	assert.Equal(t, "foo", getValidProjectName("*foo"))
-	assert.Equal(t, "foo", getValidProjectName("(foo"))
-	assert.Equal(t, "foo", getValidProjectName(")foo"))
-
-	// Invalid names are replaced with a fallback name.
-	assert.Equal(t, "project", getValidProjectName("!"))
-	assert.Equal(t, "project", getValidProjectName("@"))
-	assert.Equal(t, "project", getValidProjectName("#"))
-	assert.Equal(t, "project", getValidProjectName("$"))
-	assert.Equal(t, "project", getValidProjectName("%"))
-	assert.Equal(t, "project", getValidProjectName("^"))
-	assert.Equal(t, "project", getValidProjectName("&"))
-	assert.Equal(t, "project", getValidProjectName("*"))
-	assert.Equal(t, "project", getValidProjectName("("))
-	assert.Equal(t, "project", getValidProjectName(")"))
-	assert.Equal(t, "project", getValidProjectName("!@#$%^&*()"))
-}
-
-func getValidProjectNamePrefixes() []string {
-	var results []string
-	for ch := 'A'; ch <= 'Z'; ch++ {
-		results = append(results, string(ch))
-	}
-	for ch := 'a'; ch <= 'z'; ch++ {
-		results = append(results, string(ch))
-	}
-	results = append(results, "_")
-	results = append(results, ".")
-	return results
-}
-
 //nolint:paralleltest // uses shared state in pulumi dir
 func TestRetrieveNonExistingTemplate(t *testing.T) {
 	tests := []struct {
@@ -255,71 +200,6 @@ func TestRetrieveFileTemplate(t *testing.T) {
 			// Both Root and SubDirectory just point to the (existing) specified folder
 			assert.Equal(t, ".", repository.Root)
 			assert.Equal(t, ".", repository.SubDirectory)
-		})
-	}
-}
-
-func TestProjectNames(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		testName    string
-		projectName string
-		expectError bool
-	}{
-		{
-			testName:    "Correct Project Name",
-			projectName: "SampleProject",
-			expectError: false,
-		},
-		{
-			testName:    "Project Name with unsupported punctuation",
-			projectName: "SampleProject!",
-			expectError: true,
-		},
-		{
-			testName:    "Project Name starting with the word Pulumi",
-			projectName: "PulumiProject",
-			expectError: false,
-		},
-		{
-			testName:    "Project Name greater than 100 characters",
-			projectName: "cZClTe6xrjgKzH5QS8rFEPqYK1z4bbMeMr6n89n87djq9emSAlznQXXkkCEpBBCaZAFNlCvbfqVcqoifYlfPl11hvekIDjXVIY7m1",
-			expectError: true,
-		},
-		{
-			testName:    "Project Name is Pulumi",
-			projectName: "Pulumi",
-			expectError: true,
-		},
-		{
-			testName:    "Project Name is Pulumi - mixed case",
-			projectName: "pUlumI",
-			expectError: true,
-		},
-		{
-			testName:    "Project Name is Pulumi.Test",
-			projectName: "Pulumi.Test",
-			expectError: true,
-		},
-		{
-			testName:    "Empty Project Name",
-			projectName: "",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.testName, func(t *testing.T) {
-			t.Parallel()
-
-			err := ValidateProjectName(tt.projectName)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.Nil(t, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13946.

This also moves some of the logic from sdk/go/common to pkg/ as it's only used be `new` and `up.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
