### PR TITLE
[import] `pulumi import` add `--allow-duplicate-names`

### DIFF
--- a/changelog/pending/20230915--cli-import--pulumi-import-now-has-the-allow-duplicate-names-flag-to-enable-codegen-to-succeed-when-resource-names-are-the-same.yaml
+++ b/changelog/pending/20230915--cli-import--pulumi-import-now-has-the-allow-duplicate-names-flag-to-enable-codegen-to-succeed-when-resource-names-are-the-same.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: `pulumi import` now has the `--allow-duplicate-names` flag to enable codegen to succeed when resource names are the same, but with differing types.

--- a/pkg/importer/language.go
+++ b/pkg/importer/language.go
@@ -62,7 +62,7 @@ func (e *DiagnosticsError) String() string {
 
 // GenerateLanguageDefintions generates a list of resource definitions from the given resource states.
 func GenerateLanguageDefinitions(w io.Writer, loader schema.Loader, gen LanguageGenerator, states []*resource.State,
-	names NameTable,
+	names NameTable, opts ...pcl.BindOption,
 ) error {
 	var hcl2Text bytes.Buffer
 	for i, state := range states {
@@ -91,7 +91,8 @@ func GenerateLanguageDefinitions(w io.Writer, loader schema.Loader, gen Language
 		})
 	}
 
-	program, diags, err := pcl.BindProgram(parser.Files, pcl.Loader(loader), pcl.AllowMissingVariables)
+	opts = append([]pcl.BindOption{pcl.Loader(loader), pcl.AllowMissingVariables}, opts...)
+	program, diags, err := pcl.BindProgram(parser.Files, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/6032

During `pulumi import`, the `--allow-duplicate-names` flag allows
codegen to not fail if two resources share the same resource name.

Note: If the two resources also share the SAME TYPE, `pulumi import`
will fail during the import prior to codegen.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
