### PR TITLE
Move SecretsManager from SnapshotPersister to SnapshotManager

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1038,8 +1038,8 @@ func (b *localBackend) apply(
 	}()
 
 	// Create the management machinery.
-	persister := b.newSnapshotPersister(ctx, localStackRef, op.SecretsManager)
-	manager := backend.NewSnapshotManager(persister, update.GetTarget().Snapshot)
+	persister := b.newSnapshotPersister(ctx, localStackRef)
+	manager := backend.NewSnapshotManager(persister, op.SecretsManager, update.GetTarget().Snapshot)
 	engineCtx := &engine.Context{
 		Cancel:          scope.Context(),
 		Events:          engineEvents,

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 )
 
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
@@ -30,22 +29,16 @@ type localSnapshotPersister struct {
 
 	ref     *localBackendReference
 	backend *localBackend
-	sm      secrets.Manager
-}
-
-func (sp *localSnapshotPersister) SecretsManager() secrets.Manager {
-	return sp.sm
 }
 
 func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	_, err := sp.backend.saveStack(sp.ctx, sp.ref, snapshot, sp.sm)
+	_, err := sp.backend.saveStack(sp.ctx, sp.ref, snapshot, snapshot.SecretsManager)
 	return err
 }
 
 func (b *localBackend) newSnapshotPersister(
 	ctx context.Context,
 	ref *localBackendReference,
-	sm secrets.Manager,
 ) *localSnapshotPersister {
-	return &localSnapshotPersister{ctx: ctx, ref: ref, backend: b, sm: sm}
+	return &localSnapshotPersister{ctx: ctx, ref: ref, backend: b}
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1222,15 +1222,8 @@ func (b *cloudBackend) runEngineAction(
 		close(eventsDone)
 	}()
 
-	// The backend.SnapshotManager and backend.SnapshotPersister will keep track of any changes to
-	// the Snapshot (checkpoint file) in the HTTP backend. We will reuse the snapshot's secrets manager when possible
-	// to ensure that secrets are not re-encrypted on each update.
-	sm := op.SecretsManager
-	if secrets.AreCompatible(sm, u.GetTarget().Snapshot.SecretsManager) {
-		sm = u.GetTarget().Snapshot.SecretsManager
-	}
-	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource, sm)
-	snapshotManager := backend.NewSnapshotManager(persister, u.GetTarget().Snapshot)
+	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource)
+	snapshotManager := backend.NewSnapshotManager(persister, op.SecretsManager, u.GetTarget().Snapshot)
 
 	// Depending on the action, kick off the relevant engine activity.  Note that we don't immediately check and
 	// return error conditions, because we will do so below after waiting for the display channels to close.

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -33,18 +32,13 @@ type cloudSnapshotPersister struct {
 	update              client.UpdateIdentifier // The UpdateIdentifier for this update sequence.
 	tokenSource         tokenSourceCapability   // A token source for interacting with the service.
 	backend             *cloudBackend           // A backend for communicating with the service
-	sm                  secrets.Manager
 	deploymentDiffState *deploymentDiffState
-}
-
-func (persister *cloudSnapshotPersister) SecretsManager() secrets.Manager {
-	return persister.sm
 }
 
 func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	ctx := persister.context
 
-	deploymentV3, err := stack.SerializeDeployment(snapshot, persister.sm, false /* showSecrets */)
+	deploymentV3, err := stack.SerializeDeployment(snapshot, nil, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}
@@ -107,14 +101,13 @@ func (persister *cloudSnapshotPersister) saveFullVerbatim(ctx context.Context,
 var _ backend.SnapshotPersister = (*cloudSnapshotPersister)(nil)
 
 func (cb *cloudBackend) newSnapshotPersister(ctx context.Context, update client.UpdateIdentifier,
-	tokenSource tokenSourceCapability, sm secrets.Manager,
+	tokenSource tokenSourceCapability,
 ) *cloudSnapshotPersister {
 	p := &cloudSnapshotPersister{
 		context:     ctx,
 		update:      update,
 		tokenSource: tokenSource,
 		backend:     cb,
-		sm:          sm,
 	}
 
 	caps := cb.capabilities(ctx)

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -191,7 +191,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 			StackIdentifier: stackID,
 			UpdateKind:      apitype.UpdateUpdate,
 			UpdateID:        updateID,
-		}, newMockTokenSource(), nil)
+		}, newMockTokenSource())
 		return persister
 	}
 

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -48,10 +47,6 @@ func (m *MockStackPersister) Save(snap *deploy.Snapshot) error {
 	return nil
 }
 
-func (m *MockStackPersister) SecretsManager() secrets.Manager {
-	return b64.NewBase64SecretsManager()
-}
-
 func (m *MockStackPersister) LastSnap() *deploy.Snapshot {
 	return m.SavedSnapshots[len(m.SavedSnapshots)-1]
 }
@@ -63,7 +58,7 @@ func MockSetup(t *testing.T, baseSnap *deploy.Snapshot) (*SnapshotManager, *Mock
 	}
 
 	sp := &MockStackPersister{}
-	return NewSnapshotManager(sp, baseSnap), sp
+	return NewSnapshotManager(sp, baseSnap.SecretsManager, baseSnap), sp
 }
 
 func NewResourceWithDeps(urn resource.URN, deps []resource.URN) *resource.State {


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

It should never have really been the role of the persister to decide what SecretsManager to use, and they were in practice always being setup with a SnapshotManager anyway so not a lot of code to move the secrets manager around. This also gets the httpstate and filestate backends in alignment over which SecretsManager variable they're going to use.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
