### PR TITLE
Change Source.Iterate to return an error

### DIFF
--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -164,9 +164,9 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 	}
 
 	// Begin iterating the source.
-	src, res := ex.deployment.source.Iterate(callerCtx, opts, ex.deployment)
-	if res != nil {
-		return nil, res
+	src, err := ex.deployment.source.Iterate(callerCtx, opts, ex.deployment)
+	if err != nil {
+		return nil, result.FromError(err)
 	}
 
 	// Set up a step generator for this deployment.

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -43,7 +42,7 @@ type Source interface {
 	Info() interface{}
 
 	// Iterate begins iterating the source. Error is non-nil upon failure; otherwise, a valid iterator is returned.
-	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, result.Result)
+	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error)
 }
 
 // A SourceIterator enumerates the list of resources that a source has to offer and tracks associated state.

--- a/pkg/resource/deploy/source_error.go
+++ b/pkg/resource/deploy/source_error.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // NewErrorSource creates a source that panics if it is iterated. This is used by the engine to guard against unexpected
@@ -39,6 +38,6 @@ func (src *errorSource) Info() interface{}           { return nil }
 
 func (src *errorSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource,
-) (SourceIterator, result.Result) {
+) (SourceIterator, error) {
 	panic("internal error: unexpected call to errorSource.Iterate")
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -108,13 +108,13 @@ func (src *evalSource) Info() interface{} { return src.runinfo }
 // Iterate will spawn an evaluator coroutine and prepare to interact with it on subsequent calls to Next.
 func (src *evalSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource,
-) (SourceIterator, result.Result) {
+) (SourceIterator, error) {
 	tracingSpan := opentracing.SpanFromContext(ctx)
 
 	// Decrypt the configuration.
 	config, err := src.runinfo.Target.Config.Decrypt(src.runinfo.Target.Decrypter)
 	if err != nil {
-		return nil, result.FromError(fmt.Errorf("failed to decrypt config: %w", err))
+		return nil, fmt.Errorf("failed to decrypt config: %w", err)
 	}
 
 	// Keep track of any config keys that have secure values.
@@ -127,7 +127,7 @@ func (src *evalSource) Iterate(
 	mon, err := newResourceMonitor(
 		src, providers, regChan, regOutChan, regReadChan, opts, config, configSecretKeys, tracingSpan)
 	if err != nil {
-		return nil, result.FromError(fmt.Errorf("failed to start resource monitor: %w", err))
+		return nil, fmt.Errorf("failed to start resource monitor: %w", err)
 	}
 
 	// Create a new iterator with appropriate channels, and gear up to go!

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // NullSource is a source that never returns any resources.  This may be used in scenarios where the "new"
@@ -42,7 +41,7 @@ func (src *nullSource) Info() interface{}           { return nil }
 
 func (src *nullSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource,
-) (SourceIterator, result.Result) {
+) (SourceIterator, error) {
 	contract.Ignore(ctx)
 	return &nullSourceIterator{}, nil
 }


### PR DESCRIPTION
Continued chipping away at removing `result.Result`.