### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/changelog/pending/20230920--programgen--use-importlib-metadata-instead-of-pkg_resources.yaml
+++ b/changelog/pending/20230920--programgen--use-importlib-metadata-instead-of-pkg_resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Use importlib.metadata instead of pkg_resources

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3239,6 +3239,7 @@ func calculateDeps(requires map[string]string) ([][2]string, error) {
 	deps := []string{
 		"semver>=2.8.1",
 		"parver>=0.2.1",
+		"importlib-metadata>=6.0.0,<7.0.0;python_version<'3.8'",
 	}
 	for dep := range requires {
 		deps = append(deps, dep)
@@ -3260,7 +3261,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -3269,6 +3269,11 @@ import pulumi.runtime
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -3316,14 +3321,15 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
+    # importlib_metadata is a library that provides access to the metadata of an installed
+    # Distribution Package. The version() function is the quickest way to get a Distribution
+    # Package's version number, as a string.
 
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12414

<blockquote>
<p>Use of <code class="docutils literal notranslate"><span class="pre">pkg_resources</span></code> is deprecated in favor of
<a class="hxr-hoverxref hxr-tooltip reference external tooltipstered" href="https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources"><code class="xref py py-mod docutils literal notranslate"><span class="pre">importlib.resources</span></code></a>, <a class="hxr-hoverxref hxr-tooltip reference external tooltipstered" href="https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata"><code class="xref py py-mod docutils literal notranslate"><span class="pre">importlib.metadata</span></code></a>
and their backports (<a class="reference external" href="https://pypi.org/project/importlib_resources">importlib_resources</a>, <a class="reference external" href="https://pypi.org/project/importlib_metadata">importlib_metadata</a>).
Some useful APIs are also provided by <a class="reference external" href="https://pypi.org/project/packaging">packaging</a> (e.g. requirements
and version parsing).
Users should refrain from new usage of <code class="docutils literal notranslate"><span class="pre">pkg_resources</span></code> and
should work to port to importlib-based solutions.</p>
</blockquote>

https://setuptools.pypa.io/en/latest/pkg_resources.html

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
