### PR TITLE
Renormalise URNs on load to fix parent tracking issues

### DIFF
--- a/changelog/pending/20230921--engine--engine-will-try-to-fix-up-statefiles-with-mis-matched-parents-on-load.yaml
+++ b/changelog/pending/20230921--engine--engine-will-try-to-fix-up-statefiles-with-mis-matched-parents-on-load.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine will try to fix up statefiles with mis-matched parents on load.

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -177,6 +177,12 @@ func (b *localBackend) getSnapshot(ctx context.Context,
 		return nil, err
 	}
 
+	// Renormalize URNs to retroacticly work around issues from https://github.com/pulumi/pulumi/issues/13903
+	snapshot, err = snapshot.NormalizeURNReferences()
+	if err != nil {
+		return nil, err
+	}
+
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
 	if !DisableIntegrityChecking {
 		if verifyerr := snapshot.VerifyIntegrity(); verifyerr != nil {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -223,6 +223,12 @@ func (b *cloudBackend) getSnapshot(ctx context.Context,
 		return nil, err
 	}
 
+	// Renormalize URNs to retroacticly work around issues from https://github.com/pulumi/pulumi/issues/13903
+	snapshot, err = snapshot.NormalizeURNReferences()
+	if err != nil {
+		return nil, err
+	}
+
 	return snapshot, nil
 }
 


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13903


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
