### PR TITLE
[sdk/go] Ensure Assets of AssetArchive are non-nil when creating and deserializing

### DIFF
--- a/changelog/pending/20230921--sdk-go--ensure-assets-of-assetarchive-are-non-nil-when-creating-serializing-and-deserializing.yaml
+++ b/changelog/pending/20230921--sdk-go--ensure-assets-of-assetarchive-are-non-nil-when-creating-serializing-and-deserializing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Ensure Assets of AssetArchive are non-nil when creating and deserializing

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -471,6 +471,11 @@ const (
 )
 
 func NewAssetArchive(assets map[string]interface{}) (*Archive, error) {
+	if assets == nil {
+		// when provided assets are nil, create an empty archive
+		assets = make(map[string]interface{})
+	}
+
 	// Ensure all elements are either assets or archives.
 	for _, asset := range assets {
 		switch t := asset.(type) {
@@ -486,12 +491,18 @@ func NewAssetArchive(assets map[string]interface{}) (*Archive, error) {
 }
 
 func NewPathArchive(path string) (*Archive, error) {
+	if path == "" {
+		return nil, errors.New("path cannot be empty when constructing a path archive")
+	}
 	a := &Archive{Sig: ArchiveSig, Path: path}
 	err := a.EnsureHash()
 	return a, err
 }
 
 func NewURIArchive(uri string) (*Archive, error) {
+	if uri == "" {
+		return nil, errors.New("uri cannot be empty when constructing a URI archive")
+	}
 	a := &Archive{Sig: ArchiveSig, URI: uri}
 	err := a.EnsureHash()
 	return a, err
@@ -603,60 +614,71 @@ func DeserializeArchive(obj map[string]interface{}) (*Archive, bool, error) {
 		hash = h
 	}
 
-	var assets map[string]interface{}
-	if v, has := obj[ArchiveAssetsProperty]; has {
-		assets = make(map[string]interface{})
-		if v != nil {
-			m, ok := v.(map[string]interface{})
-			if !ok {
-				return &Archive{}, false, fmt.Errorf("unexpected archive contents of type %T", v)
-			}
+	if path, has := obj[ArchivePathProperty]; has {
+		pathValue, ok := path.(string)
+		if !ok {
+			return &Archive{}, false, fmt.Errorf("unexpected archive path of type %T", path)
+		}
 
-			for k, elem := range m {
-				switch t := elem.(type) {
-				case *Asset:
-					assets[k] = t
-				case *Archive:
-					assets[k] = t
-				case map[string]interface{}:
-					a, isa, err := DeserializeAsset(t)
+		if pathValue != "" {
+			pathArchive := &Archive{Sig: ArchiveSig, Path: pathValue, Hash: hash}
+			return pathArchive, true, nil
+		}
+	}
+
+	if uri, has := obj[ArchiveURIProperty]; has {
+		uriValue, ok := uri.(string)
+		if !ok {
+			return &Archive{}, false, fmt.Errorf("unexpected archive URI of type %T", uri)
+		}
+
+		if uriValue != "" {
+			uriArchive := &Archive{Sig: ArchiveSig, URI: uriValue, Hash: hash}
+			return uriArchive, true, nil
+		}
+	}
+
+	if assetsMap, has := obj[ArchiveAssetsProperty]; has {
+		m, ok := assetsMap.(map[string]interface{})
+		if !ok {
+			return &Archive{}, false, fmt.Errorf("unexpected archive contents of type %T", assetsMap)
+		}
+
+		assets := make(map[string]interface{})
+		for k, elem := range m {
+			switch t := elem.(type) {
+			case *Asset:
+				assets[k] = t
+			case *Archive:
+				assets[k] = t
+			case map[string]interface{}:
+				a, isa, err := DeserializeAsset(t)
+				if err != nil {
+					return &Archive{}, false, err
+				} else if isa {
+					assets[k] = a
+				} else {
+					arch, isarch, err := DeserializeArchive(t)
 					if err != nil {
 						return &Archive{}, false, err
-					} else if isa {
-						assets[k] = a
-					} else {
-						arch, isarch, err := DeserializeArchive(t)
-						if err != nil {
-							return &Archive{}, false, err
-						} else if !isarch {
-							return &Archive{}, false, fmt.Errorf("archive member '%v' is not an asset or archive", k)
-						}
-						assets[k] = arch
+					} else if !isarch {
+						return &Archive{}, false, fmt.Errorf("archive member '%v' is not an asset or archive", k)
 					}
-				default:
-					return &Archive{}, false, fmt.Errorf("archive member '%v' is not an asset or archive", k)
+					assets[k] = arch
 				}
+			default:
+				return &Archive{}, false, fmt.Errorf("archive member '%v' is not an asset or archive", k)
 			}
 		}
-	}
-	var path string
-	if v, has := obj[ArchivePathProperty]; has {
-		p, ok := v.(string)
-		if !ok {
-			return &Archive{}, false, fmt.Errorf("unexpected archive path of type %T", v)
-		}
-		path = p
-	}
-	var uri string
-	if v, has := obj[ArchiveURIProperty]; has {
-		u, ok := v.(string)
-		if !ok {
-			return &Archive{}, false, fmt.Errorf("unexpected archive URI of type %T", v)
-		}
-		uri = u
+
+		assetArchive := &Archive{Sig: ArchiveSig, Assets: assets, Hash: hash}
+		return assetArchive, true, nil
 	}
 
-	return &Archive{Hash: hash, Assets: assets, Path: path, URI: uri}, true, nil
+	// if we reached here, it means the archive is empty,
+	// we didn't find a non-zero path, non-zero uri nor non-nil assets
+	// we will consider this to be an empty assets archive then with zero assets
+	return &Archive{Sig: ArchiveSig, Assets: make(map[string]interface{}), Hash: hash}, true, nil
 }
 
 // HasContents indicates whether or not an archive's contents can be read.

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -537,6 +539,19 @@ func TestFileExtentionSniffing(t *testing.T) {
 	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tgz"))
 	assert.Equal(t, ArchiveFormat(JARArchive), detectArchiveFormat("./some/path/my.file.jar"))
 	assert.Equal(t, ArchiveFormat(NotArchive), detectArchiveFormat("./some/path/who.even.knows"))
+}
+
+func TestEmptyArchiveRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	emptyArchive, err := NewAssetArchive(nil)
+	require.NoError(t, err, "Creating an empty archive should work")
+	assert.True(t, emptyArchive.IsAssets(), "even empty archives should be have empty assets")
+	serialized := emptyArchive.Serialize()
+	deserialized, ok, err := DeserializeArchive(serialized)
+	assert.NoError(t, err, "Deserializing an empty archive should work")
+	assert.True(t, ok, "Deserializing an empty archive should return true")
+	assert.True(t, deserialized.IsAssets(), "Deserialized archive should be an AssetsArchive")
 }
 
 func TestInvalidPathArchive(t *testing.T) {


### PR DESCRIPTION
Fixes #11103

The problem in the issue the distinction between `Assets` or an archive being `nil` vs. being an empty map of assets. When creating and deserializing Archives, `nil` was allowed which leads to panics when asserting `archive.IsAssets()` because the `Assets` is `nil` even though it is a proper archive. 

This PR fixes the issue by ensuring that an instance of `Archive` will have a non-nil `Assets` field whether that is during construction or marshalling. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
