### PR TITLE
[dotnet/sdk-gen] Fixes potential conflicts when generating resources called System

### DIFF
--- a/changelog/pending/20230922--sdkgen-dotnet--fixes-potential-conflicts-when-generating-resources-called-system.yaml
+++ b/changelog/pending/20230922--sdkgen-dotnet--fixes-potential-conflicts-when-generating-resources-called-system.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet
+  description: Fixes potential conflicts when generating resources called System

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1888,7 +1888,7 @@ func (mod *modContext) genConfig(variables []*schema.Property) (string, error) {
 	fmt.Fprintf(w, "    public static class Config\n")
 	fmt.Fprintf(w, "    {\n")
 
-	fmt.Fprintf(w, "        [System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Design\", \"IDE1006\", Justification = \n")
+	fmt.Fprintf(w, "        [global::System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Design\", \"IDE1006\", Justification = \n")
 	fmt.Fprintf(w, "        \"Double underscore prefix used to avoid conflicts with variable names.\")]\n")
 	fmt.Fprintf(w, "        private sealed class __Value<T>\n")
 	fmt.Fprintf(w, "        {\n")

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Config/Config.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Config/Config.cs
@@ -8,7 +8,7 @@ namespace Configstation.Pulumi.Configstation
 {
     public static class Config
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "IDE1006", Justification = 
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "IDE1006", Justification = 
         "Double underscore prefix used to avoid conflicts with variable names.")]
         private sealed class __Value<T>
         {


### PR DESCRIPTION
# Description

When generating a C# package that has a resource called `System`, it fails to compile when we fully qualify `System.Diagnostics.CodeAnalysis.SuppressMessage` in the generated `Config.cs` file since it thinks that `System.Diagnostics` is referring to a static class on the `System` resource definition. 

The fix is to prefix the attribute with `global::` so that type resolution works as expected. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
