### PR TITLE
Add SelfManaged env vars

### DIFF
--- a/changelog/pending/20230922--cli--add-self_manged_state_gzip-to-pulumi-env.yaml
+++ b/changelog/pending/20230922--cli--add-self_manged_state_gzip-to-pulumi-env.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Add filestate variables to `pulumi env`.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -64,10 +64,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// PulumiFilestateGzipEnvVar is an env var that must be truthy
-// to enable gzip compression when using the filestate backend.
-const PulumiFilestateGzipEnvVar = "PULUMI_SELF_MANAGED_STATE_GZIP"
-
 // TODO[pulumi/pulumi#12539]:
 // This section contains names of environment variables
 // that affect the behavior of the backend.
@@ -89,6 +85,18 @@ var (
 	//
 	// This opt-out is intended to be removed in a future release.
 	PulumiFilestateLegacyLayoutEnvVar = env.SelfManagedStateLegacyLayout.Var().Name()
+
+	// PulumiFilestateGzipEnvVar is an env var that must be truthy
+	// to enable gzip compression when using the filestate backend.
+	PulumiFilestateGzipEnvVar = env.SelfManagedGzip.Var().Name()
+
+	// PulumiFilestateRetainCheckpoints is an env var that must be truthy
+	// to write out timestamped state files.
+	PulumiFilestateRetainCheckpoints = env.SelfManagedRetainCheckpoints.Var().Name()
+
+	// PulumiFilestateRetainCheckpoints is an env var that must be truthy
+	// to disable checkpoint backups.
+	PulumiFilestateDisableCheckpointBackups = env.SelfManagedDisableCheckpointBackups.Var().Name()
 )
 
 // UpgradeOptions customizes the behavior of the upgrade operation.

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -44,8 +44,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-const DisableCheckpointBackupsEnvVar = "PULUMI_DISABLE_CHECKPOINT_BACKUPS"
-
 // DisableIntegrityChecking can be set to true to disable checkpoint state integrity verification.  This is not
 // recommended, because it could mean proceeding even in the face of a corrupted checkpoint state file, but can
 // be used as a last resort when a command absolutely must be run.
@@ -283,7 +281,7 @@ func (b *localBackend) saveCheckpoint(
 	logging.V(7).Infof("Saved stack %s checkpoint to: %s (backup=%s)", ref.FullyQualifiedName(), file, backupFile)
 
 	// And if we are retaining historical checkpoint information, write it out again
-	if cmdutil.IsTruthy(b.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
+	if cmdutil.IsTruthy(b.Getenv(PulumiFilestateRetainCheckpoints)) {
 		if err = b.bucket.WriteAll(ctx, fmt.Sprintf("%v.%v", file, time.Now().UnixNano()), byts, nil); err != nil {
 			return backupFile, "", fmt.Errorf("An IO error occurred while writing the new snapshot file: %w", err)
 		}
@@ -360,7 +358,7 @@ func (b *localBackend) backupStack(ctx context.Context, ref *localBackendReferen
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 
 	// Exit early if backups are disabled.
-	if cmdutil.IsTruthy(b.Getenv(DisableCheckpointBackupsEnvVar)) {
+	if cmdutil.IsTruthy(b.Getenv(PulumiFilestateDisableCheckpointBackups)) {
 		return nil
 	}
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -693,7 +693,7 @@ func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
 
 	// Disable stack backups for tests to avoid filling up ~/.pulumi/backups with unnecessary
 	// backups of test stacks.
-	opts.Env = append(opts.Env, fmt.Sprintf("%s=1", filestate.DisableCheckpointBackupsEnvVar))
+	opts.Env = append(opts.Env, fmt.Sprintf("%s=1", filestate.PulumiFilestateDisableCheckpointBackups))
 
 	// We want tests to default into being ran in parallel, hence the odd double negative.
 	if !opts.NoParallel && !opts.DestroyOnCleanup {

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -79,6 +79,15 @@ var (
 
 	SelfManagedStateLegacyLayout = env.Bool("SELF_MANAGED_STATE_LEGACY_LAYOUT",
 		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.")
+
+	SelfManagedGzip = env.Bool("SELF_MANAGED_STATE_GZIP",
+		"Enables gzip compression when writing state files.")
+
+	SelfManagedRetainCheckpoints = env.Bool("RETAIN_CHECKPOINTS",
+		"If set every checkpoint will be duplicated to a timestamped file.")
+
+	SelfManagedDisableCheckpointBackups = env.Bool("DISABLE_CHECKPOINT_BACKUPS",
+		"If set checkpoint backups will not be written the to the backup folder.")
 )
 
 // Environment variables which affect Pulumi AI integrations

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -13,8 +13,8 @@ import (
 func TestMain(m *testing.M) {
 	// Disable stack backups for tests to avoid filling up ~/.pulumi/backups with unnecessary
 	// backups of test stacks.
-	if err := os.Setenv(filestate.DisableCheckpointBackupsEnvVar, "1"); err != nil {
-		fmt.Printf("error setting env var '%s': %v\n", filestate.DisableCheckpointBackupsEnvVar, err)
+	if err := os.Setenv(filestate.PulumiFilestateDisableCheckpointBackups, "1"); err != nil {
+		fmt.Printf("error setting env var '%s': %v\n", filestate.PulumiFilestateDisableCheckpointBackups, err)
 		os.Exit(1)
 	}
 

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -361,9 +361,9 @@ func TestStackBackups(t *testing.T) {
 		e.ImportDirectory("integration/stack_outputs/nodejs")
 
 		// We're testing that backups are created so ensure backups aren't disabled.
-		if env := os.Getenv(filestate.DisableCheckpointBackupsEnvVar); env != "" {
-			os.Unsetenv(filestate.DisableCheckpointBackupsEnvVar)
-			defer os.Setenv(filestate.DisableCheckpointBackupsEnvVar, env)
+		if env := os.Getenv(filestate.PulumiFilestateDisableCheckpointBackups); env != "" {
+			os.Unsetenv(filestate.PulumiFilestateDisableCheckpointBackups)
+			defer os.Setenv(filestate.PulumiFilestateDisableCheckpointBackups, env)
 		}
 
 		const stackName = "imulup"


### PR DESCRIPTION
Tiny fix up to env vars. This wasn't showing in `pulumi env`.