### PR TITLE
Trim Python version

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -889,7 +889,7 @@ func (host *pythonLanguageHost) About(ctx context.Context, req *pbempty.Empty) (
 	if out, err = cmd.Output(); err != nil {
 		return errCouldNotGet(err)
 	}
-	version := strings.TrimPrefix(string(out), "Python ")
+	version := strings.TrimSpace(strings.TrimPrefix(string(out), "Python "))
 
 	return &pulumirpc.AboutResponse{
 		Executable: pyexe,


### PR DESCRIPTION
# Description

Python version has an extra newline at the end. This patch trims Python version so that doesn't happen.

This is visible when doing `pulumi about`:

```
This project is written in python: executable='/usr/bin/python3' version='3.11.5
'
```