### PR TITLE
fix: Include a newline in `pulumi whoami`'s output

### DIFF
--- a/changelog/pending/20230923--cli--include-a-newline-in-pulumi-whoami-s-output.yaml
+++ b/changelog/pending/20230923--cli--include-a-newline-in-pulumi-whoami-s-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Include a newline in `pulumi whoami`'s output

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -107,7 +107,7 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 		fmt.Fprintf(cmd.Stdout, "Organizations: %s\n", strings.Join(orgs, ", "))
 		fmt.Fprintf(cmd.Stdout, "Backend URL: %s\n", b.URL())
 	} else {
-		fmt.Fprint(cmd.Stdout, name)
+		fmt.Fprintf(cmd.Stdout, "%s\n", name)
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami_test.go
@@ -30,7 +30,7 @@ func TestWhoAmICmd_default(t *testing.T) {
 	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, "user1", buff.String())
+	assert.Equal(t, "user1\n", buff.String())
 }
 
 func TestWhoAmICmd_verbose(t *testing.T) {


### PR DESCRIPTION
Looks like we used to output the newline, but unintentionally changed this in #12400 when refactoring to make it testable. This change fixes the command to include the newline character and updates the associated test.

Fixes #14008