### PR TITLE
Use context.Background in tests

### DIFF
--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -31,7 +31,7 @@ func TestTokenSource(t *testing.T) {
 	}
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	dur := 20 * time.Millisecond
 	backend := &testTokenBackend{tokens: map[string]time.Time{}}
 
@@ -67,7 +67,7 @@ func TestTokenSourceWithQuicklyExpiringInitialToken(t *testing.T) {
 	}
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	dur := 20 * time.Millisecond
 	backend := &testTokenBackend{tokens: map[string]time.Time{}}
 

--- a/pkg/cmd/pulumi/policy_new_acceptance_test.go
+++ b/pkg/cmd/pulumi/policy_new_acceptance_test.go
@@ -34,7 +34,7 @@ func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
 		templateNameOrURL: "aws-typescript",
 	}
 
-	err := runNewPolicyPack(context.TODO(), args)
+	err := runNewPolicyPack(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(tempdir, "PulumiPolicy.yaml"))

--- a/pkg/cmd/pulumi/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy_new_test.go
@@ -35,7 +35,7 @@ func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
 		templateNameOrURL: "aws-javascript",
 	}
 
-	err := runNewPolicyPack(context.TODO(), args)
+	err := runNewPolicyPack(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(tempdir, "PulumiPolicy.yaml"))
@@ -57,7 +57,7 @@ func TestInvalidPolicyPackTemplateName(t *testing.T) {
 			templateNameOrURL: nonExistantTemplate,
 		}
 
-		err := runNewPolicyPack(context.TODO(), args)
+		err := runNewPolicyPack(context.Background(), args)
 		assert.Error(t, err)
 		assertNotFoundError(t, err)
 	})
@@ -72,7 +72,7 @@ func TestInvalidPolicyPackTemplateName(t *testing.T) {
 			templateNameOrURL: nonExistantTemplate,
 		}
 
-		err := runNewPolicyPack(context.TODO(), args)
+		err := runNewPolicyPack(context.Background(), args)
 		assert.Error(t, err)
 		assertNotFoundError(t, err)
 	})

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -137,15 +137,15 @@ func TestQueryResourceMonitor_UnsupportedOperations(t *testing.T) {
 
 	rm := &queryResmon{}
 
-	_, err := rm.ReadResource(context.TODO(), nil)
+	_, err := rm.ReadResource(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Equal(t, "Query mode does not support reading resources", err.Error())
 
-	_, err = rm.RegisterResource(context.TODO(), nil)
+	_, err = rm.RegisterResource(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Equal(t, "Query mode does not support creating, updating, or deleting resources", err.Error())
 
-	_, err = rm.RegisterResourceOutputs(context.TODO(), nil)
+	_, err = rm.RegisterResourceOutputs(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Equal(t, "Query mode does not support registering resource operations", err.Error())
 }

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -110,7 +110,7 @@ func TestGitClone(t *testing.T) {
 			tmp, err := os.MkdirTemp(tmpDir, "testcase") // i.e., under the tmp dir from earlier
 			assert.NoError(t, err)
 
-			_, err = setupGitRepo(context.TODO(), tmp, repo)
+			_, err = setupGitRepo(context.Background(), tmp, repo)
 			assert.NoError(t, err)
 
 			r, err := git.PlainOpen(tmp)
@@ -144,7 +144,7 @@ func TestGitClone(t *testing.T) {
 			tmp, err := os.MkdirTemp(tmpDir, "testcase") // i.e., under the tmp dir from earlier
 			assert.NoError(t, err)
 
-			_, err = setupGitRepo(context.TODO(), tmp, repo)
+			_, err = setupGitRepo(context.Background(), tmp, repo)
 			assert.Error(t, err)
 		})
 	}

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -565,7 +565,7 @@ func assertOutputEqual(t *testing.T, value interface{}, known bool, secret bool,
 
 	actualDepsSet := urnSet{}
 	for _, res := range actualDeps {
-		urn, uknown, usecret, err := res.URN().awaitURN(context.TODO())
+		urn, uknown, usecret, err := res.URN().awaitURN(context.Background())
 		assert.NoError(t, err)
 		assert.True(t, uknown)
 		assert.False(t, usecret)

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -190,7 +190,7 @@ func TestResourceOptionMergingDependsOn(t *testing.T) {
 	newRes := func(name string) (Resource, URN) {
 		res := &testRes{foo: name}
 		res.urn = CreateURN(String(name), String("t"), nil, String("stack"), String("project"))
-		urn, _, _, err := res.urn.awaitURN(context.TODO())
+		urn, _, _, err := res.urn.awaitURN(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -204,7 +204,7 @@ func TestResourceOptionMergingDependsOn(t *testing.T) {
 	resolveDependsOn := func(opts *resourceOptions) []URN {
 		allDeps := urnSet{}
 		for _, ds := range opts.DependsOn {
-			if err := ds.addURNs(context.TODO(), allDeps, nil /* from */); err != nil {
+			if err := ds.addURNs(context.Background(), allDeps, nil /* from */); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -1329,7 +1329,7 @@ func TestRehydratedComponentConsideredRemote(t *testing.T) {
 			&component))
 		require.False(t, component.keepDependency())
 
-		urn, _, _, err := component.URN().awaitURN(context.TODO())
+		urn, _, _, err := component.URN().awaitURN(context.Background())
 		require.NoError(t, err)
 
 		var rehydrated testComp

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -154,7 +154,7 @@ func TestGetRequiredPlugins(t *testing.T) {
 	}
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.TODO(), &pulumirpc.GetRequiredPluginsRequest{
+	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
 		Program: dir,
 	})
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestGetRequiredPluginsSymlinkCycles(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.TODO(), &pulumirpc.GetRequiredPluginsRequest{
+	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
 		Program: dir,
 	})
 	require.NoError(t, err)
@@ -262,7 +262,7 @@ func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &nodeLanguageHost{}
-	resp, err := host.GetRequiredPlugins(context.TODO(), &pulumirpc.GetRequiredPluginsRequest{
+	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
 		Program: dir,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
As suggested by the [godocs](https://pkg.go.dev/context#Background).

This means a search for `context.TODO` now just shows up places we really do seem to be missing a threaded in context in real code.