### PR TITLE
Type check props in the `Resource` initializer

### DIFF
--- a/changelog/pending/20230923--sdk-python--resource-property-parameters-are-now-runtime-type-checked-to-ensure-they-are-a-mapping-object.yaml
+++ b/changelog/pending/20230923--sdk-python--resource-property-parameters-are-now-runtime-type-checked-to-ensure-they-are-a-mapping-object.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Resource property parameters are now runtime type checked to ensure they are a `Mapping` object.

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -781,11 +781,14 @@ class Resource:
         # If `props` is an input type, convert it into an untranslated dictionary.
         # Translation of the keys will happen later using the type's and resource's type/name metadata.
         # If `props` is not an input type, set `typ` to None to make translation behave as it has previously.
-        typ = type(props)
+        typ: Optional[type] = type(props)
+        assert typ is not None
         if _types.is_input_type(typ):
             props = _types.input_type_to_untranslated_dict(props)
         else:
-            typ = None  # type: ignore
+            if not isinstance(props, Mapping):
+                raise TypeError("Execpted resource properties to be a mapping")
+            typ = None
 
         # Before anything else - if there are transformations registered, give them a chance to run to modify the user
         # provided properties and options assigned to this resource.

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -295,3 +295,13 @@ def test_complex_parent_child_dependencies():
         parent=a.b,
         depends_on=[a.b]
     ))
+
+# Regression test for https://github.com/pulumi/pulumi/issues/13997
+@pulumi.runtime.test
+def test_bad_component_super_call():
+    class C(pulumi.ComponentResource):
+        def __init__(self, name: str, arg: int, opts=None):
+            super().__init__("my:module:C", name, arg, opts)
+
+    with pytest.raises(TypeError):
+        C("test", 4, None)


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13997.

It would be a little nicer if every input type _actually_ implemented the `Mapping` interface, but that trying to do that turned into a much deeper fix than this one.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
