### PR TITLE
[cli/convert] Allow arbitrary flags to be passed to pulumi convert and send args to converter plugins

### DIFF
--- a/changelog/pending/20230923--cli--allow-arbitrary-flags-to-be-passed-to-pulumi-convert-and-send-args-to-converter-plugins.yaml
+++ b/changelog/pending/20230923--cli--allow-arbitrary-flags-to-be-passed-to-pulumi-convert-and-send-args-to-converter-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Allow arbitrary flags to be passed to pulumi convert and send args to converter plugins

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -63,13 +63,14 @@ func newConvertCmd() *cobra.Command {
 		Long: "Convert Pulumi programs from a supported source program into other supported languages.\n" +
 			"\n" +
 			"The source program to convert will default to the current working directory.\n",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get current working directory: %w", err)
 			}
 
-			return runConvert(env.Global(), args, cwd, mappings, from, language, outDir, generateOnly, strict)
+			return runConvert(env.Global(), os.Args, cwd, mappings, from, language, outDir, generateOnly, strict)
 		}),
 	}
 


### PR DESCRIPTION
# Description

#13973 added a feature that would allow sending the input args from pulumi convert down to the converter plugins, this would enable supporting extra options the converters use. However, `pulumi convert` doesn't allow arbitrary flags to be passed. This PR fixes that using `FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}`

Also now we send `os.Args` to the converter plugins, because testing locally, the `args` coming from 
```go
cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { ... })
```
Were always empty 😓 (not sure why) using `os.Args` seems more reliable. It's on the converters to parse and find the flags they care about which should be quite doable. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
