### PR TITLE
Support `pulumi new <ai-url>`

### DIFF
--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -16,6 +16,7 @@ package workspace
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -202,4 +203,15 @@ func TestRetrieveFileTemplate(t *testing.T) {
 			assert.Equal(t, ".", repository.SubDirectory)
 		})
 	}
+}
+
+func TestAIBuild(t *testing.T) {
+	repository, err := buildAIRepository("https://www.pulumi.com/ai/answers/6c060c2d-e754-47d2-af8c-0d6a761634e3")
+	assert.NoError(t, err)
+	_, err = os.ReadFile(path.Join(repository.SubDirectory, "Pulumi.yaml"))
+	assert.NoError(t, err)
+	_, err = os.ReadFile(path.Join(repository.SubDirectory, "package.json"))
+	assert.NoError(t, err)
+	_, err = os.ReadFile(path.Join(repository.SubDirectory, "index.ts"))
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
This adds support for Pulumi AI URLs as sources for `pulumi new`.   This can support both conversations and answers URLs, such as https://www.pulumi.com/ai/answers/6c060c2d-e754-47d2-af8c-0d6a761634e3.

__This implementation is likely not what we ultimately want to ship__.  It builds out a fake "template" from the content of the HTML page from within the Pulumi CLI.  Instead, we almost certainly want to push this logic into the Pulumi AI service itself, and only generalize the CLI slightly beyond it's current support to allow pulling a ZIP or other simpler asset in place of a Git repo.

But the end result shows what is possible:

```
$ pulumi new https://www.pulumi.com/ai/answers/6c060c2d-e754-47d2-af8c-0d6a761634e3
```
![Screen Recording 2023-09-24 at 9 19 51 PM](https://github.com/pulumi/pulumi/assets/223467/5c5be02c-9f49-462c-b94b-f44cfa69742b)

Notably, the AI answer can be `new`d then `up`d with no other intervention (other than providing AWS credentials), and results in exports which show the useful outputs of the code snippet.

A few challenges:
* This needs to support templating in all languages, and ideally without re-creating all the login in the existing language templates
* The code is scraped to infer the package.json dependencies needed (without knowing versions) and also to guess what required config should be specified (like `aws:region`). (TypeScript only currently)
* The code itself is scraped out of the HTML in a way that may not be guarnteed to work going forward.

