### PR TITLE
Adds StackChangeSecretsProvider to Go automation api

### DIFF
--- a/changelog/pending/20230925--sdk-go--adds-stackchangesecretsprovider-to-go-automation-api.yaml
+++ b/changelog/pending/20230925--sdk-go--adds-stackchangesecretsprovider-to-go-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Adds StackChangeSecretsProvider to Go automation api.

--- a/changelog/pending/20230925--sdk-go--adds-stackchangesecretsprovider-to-go-automation-api.yaml
+++ b/changelog/pending/20230925--sdk-go--adds-stackchangesecretsprovider-to-go-automation-api.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: sdk/go
-  description: Adds StackChangeSecretsProvider to Go automation api.

--- a/changelog/pending/20231121--auto-go--add-changesecretsprovider-to-workspace-and-stack-apis.yaml
+++ b/changelog/pending/20231121--auto-go--add-changesecretsprovider-to-workspace-and-stack-apis.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Add `ChangeSecretsProvider` to workspace and stack APIs.

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -29,6 +29,7 @@ const unknownErrorCode = -2
 func runPulumiCommandSync(
 	ctx context.Context,
 	workdir string,
+	stdin io.Reader,
 	additionalOutput []io.Writer,
 	additionalErrorOutput []io.Writer,
 	additionalEnv []string,
@@ -47,6 +48,7 @@ func runPulumiCommandSync(
 	additionalErrorOutput = append(additionalErrorOutput, &stderr)
 	cmd.Stdout = io.MultiWriter(additionalOutput...)
 	cmd.Stderr = io.MultiWriter(additionalErrorOutput...)
+	cmd.Stdin = stdin
 
 	code := unknownErrorCode
 	err := cmd.Run()

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -463,10 +463,17 @@ func (l *LocalWorkspace) Stack(ctx context.Context) (*StackSummary, error) {
 
 // ChangeStackSecretsProvider edits the secrets provider for the given stack.
 func (l *LocalWorkspace) ChangeStackSecretsProvider(
-	ctx context.Context, stackName, newSecretsProvider, stdin string,
+	ctx context.Context, stackName, newSecretsProvider string, opts *ChangeSecretsProviderOptions,
 ) error {
 	args := []string{"stack", "change-secrets-provider", "--stack", stackName, newSecretsProvider}
-	reader := strings.NewReader(stdin)
+
+	var reader io.Reader
+	if newSecretsProvider == "passphrase" {
+		if opts == nil || opts.NewPassphrase == nil {
+			return fmt.Errorf("new passphrase must be provided")
+		}
+		reader = strings.NewReader(*opts.NewPassphrase)
+	}
 	stdout, stderr, errCode, err := l.runPulumiInputCmdSync(ctx, reader, args...)
 	if err != nil {
 		return newAutoError(fmt.Errorf("failed to change secrets provider: %w", err), stdout, stderr, errCode)

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -461,8 +461,8 @@ func (l *LocalWorkspace) Stack(ctx context.Context) (*StackSummary, error) {
 	return nil, nil
 }
 
-// StackChangeSecretsProvider edits the secrets provider for the given stack.
-func (l *LocalWorkspace) StackChangeSecretsProvider(
+// ChangeStackSecretsProvider edits the secrets provider for the given stack.
+func (l *LocalWorkspace) ChangeStackSecretsProvider(
 	ctx context.Context, stackName, newSecretsProvider, stdin string,
 ) error {
 	args := []string{"stack", "change-secrets-provider", "--stack", stackName, newSecretsProvider}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -123,7 +123,7 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 	assert.Equal(t, true, conf.Secret)
 
 	// -- change passphrase --
-	err = s.Workspace().StackChangeSecretsProvider(ctx, s.Name(), "passphrase", "newpassphrase")
+	err = s.Workspace().ChangeStackSecretsProvider(ctx, s.Name(), "passphrase", "newpassphrase")
 	require.NoError(t, err)
 	s = mkstack("newpassphrase")
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -123,7 +123,10 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 	assert.Equal(t, true, conf.Secret)
 
 	// -- change passphrase --
-	err = s.Workspace().ChangeStackSecretsProvider(ctx, s.Name(), "passphrase", "newpassphrase")
+	newPassphrase := "newpassphrase"
+	err = s.Workspace().ChangeStackSecretsProvider(ctx, s.Name(), "passphrase", &ChangeSecretsProviderOptions{
+		NewPassphrase: &newPassphrase,
+	})
 	require.NoError(t, err)
 	s = mkstack("newpassphrase")
 

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -966,6 +966,7 @@ func (s *Stack) runPulumiCmdSync(
 	stdout, stderr, errCode, err := runPulumiCommandSync(
 		ctx,
 		s.Workspace().WorkDir(),
+		nil,
 		additionalOutput,
 		additionalErrorOutput,
 		env,

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -204,6 +204,11 @@ func (s *Stack) Workspace() Workspace {
 	return s.workspace
 }
 
+// ChangeSecretsProvider edits the secrets provider for the stack.
+func (s *Stack) ChangeSecretsProvider(ctx context.Context, newSecretsProvider, stdin string) error {
+	return s.workspace.ChangeStackSecretsProvider(ctx, s.stackName, newSecretsProvider, stdin)
+}
+
 // Preview preforms a dry-run update to a stack, returning pending changes.
 // https://www.pulumi.com/docs/cli/commands/pulumi_preview/
 func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (PreviewResult, error) {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -205,8 +205,8 @@ func (s *Stack) Workspace() Workspace {
 }
 
 // ChangeSecretsProvider edits the secrets provider for the stack.
-func (s *Stack) ChangeSecretsProvider(ctx context.Context, newSecretsProvider, stdin string) error {
-	return s.workspace.ChangeStackSecretsProvider(ctx, s.stackName, newSecretsProvider, stdin)
+func (s *Stack) ChangeSecretsProvider(ctx context.Context, newSecretsProvider string, opts *ChangeSecretsProviderOptions) error {
+	return s.workspace.ChangeStackSecretsProvider(ctx, s.stackName, newSecretsProvider, opts)
 }
 
 // Preview preforms a dry-run update to a stack, returning pending changes.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -205,7 +205,9 @@ func (s *Stack) Workspace() Workspace {
 }
 
 // ChangeSecretsProvider edits the secrets provider for the stack.
-func (s *Stack) ChangeSecretsProvider(ctx context.Context, newSecretsProvider string, opts *ChangeSecretsProviderOptions) error {
+func (s *Stack) ChangeSecretsProvider(
+	ctx context.Context, newSecretsProvider string, opts *ChangeSecretsProviderOptions,
+) error {
 	return s.workspace.ChangeStackSecretsProvider(ctx, s.stackName, newSecretsProvider, opts)
 }
 

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -106,6 +106,8 @@ type Workspace interface {
 	// WhoAmIDetails returns detailed information about the currently
 	// logged-in Pulumi identity.
 	WhoAmIDetails(ctx context.Context) (WhoAmIResult, error)
+	// StackChangeSecretsProvider edits the secrets provider for the given stack.
+	StackChangeSecretsProvider(ctx context.Context, stackName, newSecretsProvider, stdin string) error
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -107,7 +107,7 @@ type Workspace interface {
 	// logged-in Pulumi identity.
 	WhoAmIDetails(ctx context.Context) (WhoAmIResult, error)
 	// ChangeStackSecretsProvider edits the secrets provider for the given stack.
-	ChangeStackSecretsProvider(ctx context.Context, stackName, newSecretsProvider, stdin string) error
+	ChangeStackSecretsProvider(ctx context.Context, stackName, newSecretsProvider string, opts *ChangeSecretsProviderOptions) error
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.
@@ -174,4 +174,9 @@ type WhoAmIResult struct {
 	User          string   `json:"user"`
 	Organizations []string `json:"organizations,omitempty"`
 	URL           string   `json:"url"`
+}
+
+type ChangeSecretsProviderOptions struct {
+	// NewPassphrase is the new passphrase when changing to a `passphrase` provider
+	NewPassphrase *string
 }

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -106,8 +106,8 @@ type Workspace interface {
 	// WhoAmIDetails returns detailed information about the currently
 	// logged-in Pulumi identity.
 	WhoAmIDetails(ctx context.Context) (WhoAmIResult, error)
-	// StackChangeSecretsProvider edits the secrets provider for the given stack.
-	StackChangeSecretsProvider(ctx context.Context, stackName, newSecretsProvider, stdin string) error
+	// ChangeStackSecretsProvider edits the secrets provider for the given stack.
+	ChangeStackSecretsProvider(ctx context.Context, stackName, newSecretsProvider, stdin string) error
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -107,7 +107,9 @@ type Workspace interface {
 	// logged-in Pulumi identity.
 	WhoAmIDetails(ctx context.Context) (WhoAmIResult, error)
 	// ChangeStackSecretsProvider edits the secrets provider for the given stack.
-	ChangeStackSecretsProvider(ctx context.Context, stackName, newSecretsProvider string, opts *ChangeSecretsProviderOptions) error
+	ChangeStackSecretsProvider(
+		ctx context.Context, stackName, newSecretsProvider string, opts *ChangeSecretsProviderOptions,
+	) error
 	// Stack returns a summary of the currently selected stack, if any.
 	Stack(context.Context) (*StackSummary, error)
 	// CreateStack creates and sets a new stack with the stack name, failing if one already exists.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14035.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
