### PR TITLE
Fix duplicate resource error from failed delete operations 

### DIFF
--- a/changelog/pending/20230925--engine--fixes-the-engine-using-aliases-from-old-deployments-when-writing-out-statefiles.yaml
+++ b/changelog/pending/20230925--engine--fixes-the-engine-using-aliases-from-old-deployments-when-writing-out-statefiles.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fixes the engine using aliases from old deployments when writing out statefiles.

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -108,6 +108,7 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 			withUpdatedDependencies(fixUrn).
 			withUpdatedPropertyDependencies(fixUrn).
 			withUpdatedProvider(fixProvider).
+			withUpdatedAliases().
 			build()
 	}
 

--- a/pkg/resource/deploy/state_builder.go
+++ b/pkg/resource/deploy/state_builder.go
@@ -70,6 +70,15 @@ func (sb *stateBuilder) withUpdatedPropertyDependencies(update func(resource.URN
 	return sb
 }
 
+// Removes all "Aliases" from the state. Once URN normalisation is done we don't want to write aliases out.
+func (sb *stateBuilder) withUpdatedAliases() *stateBuilder {
+	if len(sb.state.Aliases) > 0 {
+		sb.state.Aliases = nil
+		sb.edited = true
+	}
+	return sb
+}
+
 func (sb *stateBuilder) build() *resource.State {
 	if !sb.edited {
 		return sb.original


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14041.

Fixes a URN normalisation error from respecting aliases from old deployments.
We no longer write out aliases to snapshot files, so will no longer pick these
aliases up on later deployments.

Longer term it would be good to refactor state and snapshot code so that
Aliases isn't on state at all, but side-channeled to snapshot code some other
way. But this is a quick fix that starts the process of removing aliases from
state now with minimal blast radius.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
