### PR TITLE
Auto install converter plugins in 'import' as well as 'convert'

### DIFF
--- a/changelog/pending/20230926--cli-import--import-from-plugin-will-now-try-to-auto-install-the-plugin-if-missing.yaml
+++ b/changelog/pending/20230926--cli-import--import-from-plugin-will-now-try-to-auto-install-the-plugin-if-missing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: `import --from=plugin` will now try to auto-install the plugin if missing.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -489,9 +489,12 @@ func newImportCmd() *cobra.Command {
 				}
 				importFile = f
 			} else if from != "" {
-				converter, err := plugin.NewConverter(pCtx, from, nil)
+				log := func(sev diag.Severity, msg string) {
+					pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
+				}
+				converter, err := loadConverterPlugin(pCtx, from, log)
 				if err != nil {
-					return result.FromError(err)
+					return result.Errorf("load converter plugin: %w", err)
 				}
 				defer contract.IgnoreClose(converter)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When using `--from` in convert it would auto install the converter, but didn't in import. This aligns them.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
