### PR TITLE
Deepcopy event payloads on construction _not_ on access

### DIFF
--- a/changelog/pending/20231001--engine--fix-a-race-condition-in-the-engine-access-step-event-data.yaml
+++ b/changelog/pending/20231001--engine--fix-a-race-condition-in-the-engine-access-step-event-data.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a race condition in the engine access step event data.

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -66,7 +66,7 @@ func NewEvent(typ EventType, payload interface{}) Event {
 	contract.Assertf(ok, "invalid payload of type %T for event type %v", payload, typ)
 	return Event{
 		Type:    typ,
-		payload: payload,
+		payload: deepcopy.Copy(payload),
 	}
 }
 
@@ -86,7 +86,7 @@ const (
 )
 
 func (e Event) Payload() interface{} {
-	return deepcopy.Copy(e.payload)
+	return e.payload
 }
 
 func cancelEvent() Event {

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -347,10 +347,15 @@ func (ex *deploymentExecutor) performDeletes(
 
 	logging.V(7).Infof("performDeletes(...): beginning")
 
+	// GenerateDeletes mutates state we need to lock the step executor while we do this.
+	ex.stepExec.Lock()
+
 	// At this point we have generated the set of resources above that we would normally want to
 	// delete.  However, if the user provided -target's we will only actually delete the specific
 	// resources that are in the set explicitly asked for.
 	deleteSteps, err := ex.stepGen.GenerateDeletes(targetsOpt)
+	// Regardless of if this error'd or not the step executor needs unlocking
+	ex.stepExec.Unlock()
 	if err != nil {
 		logging.V(7).Infof("performDeletes(...): generating deletes produced error result")
 		return result.FromError(err)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14036.

Not sure this is perfect (it's pretty hard to reason about mutation of the whole system given what Go gives us to work with), but it seems better.

We copy event payloads on construction, which should be synchronous with step execution, rather than on access which could be in parallel with the step executor or deployment executor mutating resource state.

Just copying on construction flagged up that the deployment executor and step executor both race to modify resource state when the deployment executor starts scheduling deletes. We add a synchronisation point between the two parts in this change so that the deployment executor waits for the step executor to go quite, and keeps it quite while it computes the deletes, once it starts scheduling them the step executor can run again.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
