### PR TITLE
ctrl-c should cause Pulumi to call Cancel operation on providers

### DIFF
--- a/changelog/pending/20230929--engine--ctrl-c-should-cause-pulumi-to-send-cancellation-signal-to-providers.yaml
+++ b/changelog/pending/20230929--engine--ctrl-c-should-cause-pulumi-to-send-cancellation-signal-to-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: ctrl-c should cause Pulumi to send cancellation signal to providers

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -199,7 +199,8 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 	opts.trustDependencies = proj.TrustResourceDependencies()
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,
 	// for example, loading any plugins which will be required to execute a program, among other things.
-	source, err := opts.SourceFunc(cancelCtx, ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx, dryRun)
+	source, err := opts.SourceFunc(
+		cancelCtx, ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx, dryRun)
 	if err != nil {
 		contract.IgnoreClose(plugctx)
 		return nil, err

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -153,7 +153,7 @@ type deploymentOptions struct {
 
 // deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
 type deploymentSourceFunc func(
-	cancel context.Context,
+	ctx context.Context,
 	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error)
 

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -152,6 +153,7 @@ type deploymentOptions struct {
 
 // deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
 type deploymentSourceFunc func(
+	cancel context.Context,
 	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error)
 
@@ -181,12 +183,23 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 	if err != nil {
 		return nil, err
 	}
-	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Canceled())
+
+	// Keep the plugin context open until the context is terminated, to allow for graceful provider cancellation.
+	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Terminated())
+
+	// Set up a goroutine that will signal cancellation to the source if the caller context
+	// is cancelled.
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Cancel.Canceled()
+		logging.V(7).Infof("engine.newDeployment(...): received cancellation signal")
+		cancelFunc()
+	}()
 
 	opts.trustDependencies = proj.TrustResourceDependencies()
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,
 	// for example, loading any plugins which will be required to execute a program, among other things.
-	source, err := opts.SourceFunc(ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx, dryRun)
+	source, err := opts.SourceFunc(cancelCtx, ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx, dryRun)
 	if err != nil {
 		contract.IgnoreClose(plugctx)
 		return nil, err
@@ -200,7 +213,7 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 			plugctx, target, target.Snapshot, opts.Plan, source,
 			localPolicyPackPaths, dryRun, ctx.BackendClient)
 	} else {
-		_, defaultProviderInfo, pluginErr := installPlugins(proj, pwd, main, target, plugctx,
+		_, defaultProviderInfo, pluginErr := installPlugins(cancelCtx, proj, pwd, main, target, plugctx,
 			false /*returnInstallErrors*/)
 		if pluginErr != nil {
 			return nil, pluginErr

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -1,0 +1,168 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type updateInfo struct {
+	project workspace.Project
+	target  deploy.Target
+}
+
+func (u *updateInfo) GetRoot() string {
+	return ""
+}
+
+func (u *updateInfo) GetProject() *workspace.Project {
+	return &u.project
+}
+
+func (u *updateInfo) GetTarget() *deploy.Target {
+	return &u.target
+}
+
+func makeUpdateInfo() *updateInfo {
+	return &updateInfo{
+		project: workspace.Project{
+			Name:    "test",
+			Runtime: workspace.NewProjectRuntimeInfo("test", nil),
+		},
+		target: deploy.Target{Name: "test"},
+	}
+}
+
+type testContext struct {
+	Context
+	wg      sync.WaitGroup
+	events  chan Event
+	journal *Journal
+
+	firedEvents []Event
+}
+
+func makeTestContext(t testing.TB, cancelCtx *cancel.Context) *testContext {
+	events := make(chan Event)
+	journal := NewJournal()
+
+	ctx := &testContext{
+		Context: Context{
+			Cancel:          cancelCtx,
+			Events:          events,
+			SnapshotManager: journal,
+			BackendClient:   nil,
+		},
+		events:  events,
+		journal: journal,
+	}
+
+	// Begin draining events.
+	ctx.wg.Add(1)
+	go func() {
+		for e := range events {
+			ctx.firedEvents = append(ctx.firedEvents, e)
+		}
+		ctx.wg.Done()
+	}()
+
+	return ctx
+}
+
+func (ctx *testContext) makeEventEmitter(t testing.TB) eventEmitter {
+	emitter, err := makeQueryEventEmitter(ctx.events)
+	assert.NoError(t, err)
+	return emitter
+}
+
+func (ctx *testContext) Close() error {
+	contract.IgnoreClose(ctx.journal)
+	close(ctx.events)
+	return nil
+}
+
+func makePluginHost(t testing.TB, program deploytest.ProgramFunc) plugin.Host {
+	sink := diagtest.LogSink(t)
+	statusSink := diagtest.LogSink(t)
+	lang := deploytest.NewLanguageRuntime(program)
+	return deploytest.NewPluginHost(sink, statusSink, lang)
+}
+
+// Tests cancellation during early stage of deployment, e.g. plugin installation.
+func TestSourceFuncCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Set up a cancelable context for the operation.
+	cancelCtx, cancelSrc := cancel.NewContext(context.Background())
+
+	// Wait for our source func, then cancel.
+	var ops sync.WaitGroup
+	ops.Add(1)
+	go func() {
+		ops.Wait()
+		cancelSrc.Cancel()
+	}()
+
+	// Create a source func that waits for cancellation.
+	sourceF := func(cancel context.Context,
+		client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
+		target *deploy.Target, plugctx *plugin.Context, dryRun bool,
+	) (deploy.Source, error) {
+		// Wait for the cancellation signal.
+		ops.Done()
+		<-cancel.Done()
+		return nil, cancel.Err()
+	}
+	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
+		return nil
+	}
+
+	ctx := makeTestContext(t, cancelCtx)
+	defer ctx.Close()
+
+	info, err := newDeploymentContext(makeUpdateInfo(), "test", nil)
+	assert.NoError(t, err)
+	defer info.Close()
+
+	host := makePluginHost(t, program)
+	defer host.Close()
+	
+	opts := deploymentOptions{
+		UpdateOptions: UpdateOptions{
+			Host: host,
+		},
+		SourceFunc: sourceF,
+		Events:     ctx.makeEventEmitter(t),
+		Diag:       diagtest.LogSink(t),
+		StatusDiag: diagtest.LogSink(t),
+	}
+
+	_, err = newDeployment(&ctx.Context, info, opts, false)
+	if !assert.ErrorIs(t, err, context.Canceled) {
+		t.FailNow()
+	}
+}

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -127,14 +127,14 @@ func TestSourceFuncCancellation(t *testing.T) {
 	}()
 
 	// Create a source func that waits for cancellation.
-	sourceF := func(cancel context.Context,
+	sourceF := func(ctx context.Context,
 		client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 		target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 	) (deploy.Source, error) {
 		// Send ops completion then wait for the cancellation signal.
 		close(ops)
-		<-cancel.Done()
-		return nil, cancel.Err()
+		<-ctx.Done()
+		return nil, ctx.Err()
 	}
 	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
 		return nil

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -15,6 +15,8 @@
 package engine
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -64,6 +66,7 @@ func Destroy(
 }
 
 func newDestroySource(
+	cancel context.Context,
 	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
@@ -77,7 +80,7 @@ func newDestroySource(
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
 
-	if err := ensurePluginsAreInstalled(plugctx.Request(), plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(cancel, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newDestroySource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -66,7 +66,7 @@ func Destroy(
 }
 
 func newDestroySource(
-	cancel context.Context,
+	ctx context.Context,
 	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
@@ -80,7 +80,7 @@ func newDestroySource(
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
 
-	if err := ensurePluginsAreInstalled(cancel, plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newDestroySource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -463,7 +463,6 @@ func TestBadResourceType(t *testing.T) {
 
 // Tests that provider cancellation occurs as expected.
 func TestProviderCancellation(t *testing.T) {
-	t.SkipNow() // fix: https://github.com/pulumi/pulumi/pull/14057
 	t.Parallel()
 
 	const resourceCount = 4

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -655,7 +655,6 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 
 // Tests that an interrupted refresh leaves behind an expected state.
 func TestCanceledRefresh(t *testing.T) {
-	t.SkipNow() // fix: https://github.com/pulumi/pulumi/pull/14057
 	t.Parallel()
 
 	p := &TestPlan{}

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -70,7 +70,7 @@ func Refresh(
 }
 
 func newRefreshSource(
-	cancel context.Context, client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
+	ctx context.Context, client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
 	projectRoot string, target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
 	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.
@@ -82,7 +82,7 @@ func newRefreshSource(
 	}
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
-	if err := ensurePluginsAreInstalled(cancel, plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -69,7 +69,8 @@ func Refresh(
 	}, dryRun)
 }
 
-func newRefreshSource(cancel context.Context, client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
+func newRefreshSource(
+	cancel context.Context, client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
 	projectRoot string, target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
 	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -15,6 +15,8 @@
 package engine
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -67,7 +69,7 @@ func Refresh(
 	}, dryRun)
 }
 
-func newRefreshSource(client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
+func newRefreshSource(cancel context.Context, client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main,
 	projectRoot string, target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
 	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.
@@ -79,7 +81,7 @@ func newRefreshSource(client deploy.BackendClient, opts deploymentOptions, proj 
 	}
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
-	if err := ensurePluginsAreInstalled(plugctx.Request(), plugctx.Diag, plugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(cancel, plugctx.Diag, plugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -208,7 +208,7 @@ func RunInstallPlugins(
 	return err
 }
 
-func installPlugins(cancel context.Context,
+func installPlugins(ctx context.Context,
 	proj *workspace.Project, pwd, main string, target *deploy.Target,
 	plugctx *plugin.Context, returnInstallErrors bool,
 ) (pluginSet, map[tokens.Package]workspace.PluginSpec, error) {
@@ -244,7 +244,7 @@ func installPlugins(cancel context.Context,
 	// Note that this is purely a best-effort thing. If we can't install missing plugins, just proceed; we'll fail later
 	// with an error message indicating exactly what plugins are missing. If `returnInstallErrors` is set, then return
 	// the error.
-	if err := ensurePluginsAreInstalled(cancel, plugctx.Diag, allPlugins.Deduplicate(),
+	if err := ensurePluginsAreInstalled(ctx, plugctx.Diag, allPlugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins()); err != nil {
 		if returnInstallErrors {
 			return nil, nil, err
@@ -367,7 +367,7 @@ func installAndLoadPolicyPlugins(ctx context.Context, plugctx *plugin.Context, d
 	return nil
 }
 
-func newUpdateSource(cancel context.Context,
+func newUpdateSource(ctx context.Context,
 	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool,
 ) (deploy.Source, error) {
@@ -375,7 +375,7 @@ func newUpdateSource(cancel context.Context,
 	// Step 1: Install and load plugins.
 	//
 
-	allPlugins, defaultProviderVersions, err := installPlugins(cancel, proj, pwd, main, target,
+	allPlugins, defaultProviderVersions, err := installPlugins(ctx, proj, pwd, main, target,
 		plugctx, false /*returnInstallErrors*/)
 	if err != nil {
 		return nil, err
@@ -405,7 +405,7 @@ func newUpdateSource(cancel context.Context,
 		Config:       config,
 		DryRun:       dryRun,
 	}
-	if err := installAndLoadPolicyPlugins(cancel, plugctx, opts.Diag, opts.RequiredPolicies, opts.LocalPolicyPacks,
+	if err := installAndLoadPolicyPlugins(ctx, plugctx, opts.Diag, opts.RequiredPolicies, opts.LocalPolicyPacks,
 		&analyzerOpts); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Fixes #14054

This PR fixes a problem that the engine cannot forward a cancellation signal to the provider, because the plugin context is already closed. An [earlier commit](https://github.com/pulumi/pulumi/pull/9793/commits/a9ae602867834efc9821abd866ef388c1b051114) made the plugin context be closed too eagerly, with the intent of cancelling plugin installation. This PR attempts to decouple the cancellation of plugin installation from the lifecycle of the plugin context, so that plugin installation may be cancelled during the cancelation phase as opposed to the termination phase. Then, it closes the plugin context in termination phase.

There's an existing test case in the engine lifecycle tests called `TestProviderCancellation`, but it didn't catch the problem because it uses a fake plugin host that behaves differently after being closed. The issue was fixed in https://github.com/pulumi/pulumi/pull/14063 and the test was temporarily disabled. This PR re-enables the test case.

A new test case `TestSourceFuncCancellation` is added to test cancellation of the source func (where plugin installation happens, see [update.go](https://github.com/pulumi/pulumi/pull/14057/files#diff-7d2ca3e83a05073b332435271496050e28466b4f7af8c0c91bbc77947a75a3a2R378)), as this was the original motivation of https://github.com/pulumi/pulumi/pull/9793/commits/a9ae602867834efc9821abd866ef388c1b051114.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] ~Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version~
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
