### PR TITLE
[display] fix ComponentResource deletion not stopping time elapsed timer

### DIFF
--- a/changelog/pending/20230927--engine--non-custom-componentresources-now-emit-resourceoutputevent-on-deletion-this-fixes-the-time-elapsed-timer-not-ending-when-the-resource-is-deleted.yaml
+++ b/changelog/pending/20230927--engine--non-custom-componentresources-now-emit-resourceoutputevent-on-deletion-this-fixes-the-time-elapsed-timer-not-ending-when-the-resource-is-deleted.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: ComponentResources now emit resourceOutputEvent on Deletion. This fixes the time elapsed timer not ending when the resource is deleted.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -578,7 +578,8 @@ func (acts *updateActions) OnResourceStepPost(
 		// Also show outputs here for custom resources, since there might be some from the initial registration. We do
 		// not show outputs for component resources at this point: any that exist must be from a previous execution of
 		// the Pulumi program, as component resources only report outputs via calls to RegisterResourceOutputs.
-		if step.Res().Custom || acts.Opts.Refresh && step.Op() == deploy.OpRefresh {
+		// Deletions emit the resourceOutputEvent so the display knows when to stop the time elapsed counter.
+		if step.Res().Custom || acts.Opts.Refresh && step.Op() == deploy.OpRefresh || step.Op() == deploy.OpDelete {
 			acts.Opts.Events.resourceOutputsEvent(op, step, false /*planning*/, acts.Opts.Debug)
 		}
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13357

ComponentResources now emit resourceOutputEvent on delete
steps. This fixes the time elapsed timer not stopping when the resource
is deleted.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
