### PR TITLE
[engine] RegisterResourceOutputs errors instead of panics when called twice

### DIFF
--- a/changelog/pending/20230927--engine--calling-registerresourceoutputs-twice-no-longer-panics-and-returns-an-error-instead.yaml
+++ b/changelog/pending/20230927--engine--calling-registerresourceoutputs-twice-no-longer-panics-and-returns-an-error-instead.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Calling RegisterResourceOutputs twice no longer panics and returns an error instead.

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -149,7 +149,9 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 	// Look up the final state in the pending registration list.
 	urn := e.URN()
 	value, has := se.pendingNews.Load(urn)
-	contract.Assertf(has, "cannot complete a resource '%v' whose registration isn't pending", urn)
+	if !has {
+		return fmt.Errorf("cannot complete a resource '%v' whose registration isn't pending", urn)
+	}
 	reg := value.(Step)
 	contract.Assertf(reg != nil, "expected a non-nil resource step ('%v')", urn)
 	se.pendingNews.Delete(urn)

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterResourceErrorsOnMissingPendingNew(t *testing.T) {
+	t.Parallel()
+
+	se := &stepExecutor{
+		pendingNews: sync.Map{},
+	}
+	urn := resource.URN("urn:pulumi:stack::project::my:example:Foo::foo")
+	err := se.ExecuteRegisterResourceOutputs(&mockRegisterResourceOutputsEvent{
+		urn: urn,
+	})
+	// Should error, but not panic since the resource is being registered twice.
+	assert.Error(t, err)
+}
+
+type mockRegisterResourceOutputsEvent struct {
+	urn resource.URN
+}
+
+var _ = RegisterResourceOutputsEvent((*mockRegisterResourceOutputsEvent)(nil))
+
+func (e *mockRegisterResourceOutputsEvent) event() {}
+
+func (e *mockRegisterResourceOutputsEvent) URN() resource.URN { return e.urn }
+
+func (e *mockRegisterResourceOutputsEvent) Outputs() resource.PropertyMap {
+	return resource.PropertyMap{}
+}
+
+func (e *mockRegisterResourceOutputsEvent) Done() {}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #2394
Fixes https://github.com/pulumi/pulumi-dotnet/issues/39

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
