### PR TITLE
Stop defensive copying of entire event payloads

### DIFF
--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"gopkg.in/yaml.v3"
 )
@@ -404,6 +405,8 @@ func getResourceOutputsPropertiesString(
 		// If this is the root stack type, we want to strip out any nested resource outputs that are not known if
 		// they have no corresponding output in the old state.
 		if planning && step.URN.Type() == resource.RootStackType {
+			// Deeply copy outputDiff, since we may be mutating it to strip out nested outputs.
+			outputDiff = deepcopy.Copy(outputDiff).(*resource.ObjectDiff)
 			massageStackPreviewOutputDiff(outputDiff, false)
 		}
 

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -86,7 +85,7 @@ const (
 )
 
 func (e Event) Payload() interface{} {
-	return deepcopy.Copy(e.payload)
+	return e.payload
 }
 
 func cancelEvent() Event {


### PR DESCRIPTION
The deep copy of engine payloads was originally added because certain operations during display mutate engine events. However, this has become problematic as internals of the payload itself can mutate concurrently with operations in the engine, leading to panics due to concurrent iteration and writing of maps.

Rather than take a defensive copy of the entire payload, only make a defensive copy of the specific things being mutated inside display.