### PR TITLE
SameSteps can fail

### DIFF
--- a/changelog/pending/20231004--engine--fix-a-panic-in-the-engine-when-same-steps-failed-due-to-provider-errors.yaml
+++ b/changelog/pending/20231004--engine--fix-a-panic-in-the-engine-when-same-steps-failed-due-to-provider-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic in the engine when same steps failed due to provider errors.

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -284,31 +284,33 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
 	contract.Requiref(step != nil, "step", "must not be nil")
 	contract.Requiref(step.Op() == deploy.OpSame, "step.Op()", "must be %q, got %q", deploy.OpSame, step.Op())
-	contract.Assertf(successful, "expected mutation to be successful")
 	logging.V(9).Infof("SnapshotManager: sameSnapshotMutation.End(..., %v)", successful)
 	return ssm.manager.mutate(func() bool {
 		sameStep := step.(*deploy.SameStep)
 
-		ssm.manager.markDone(step.Old())
+		ssm.manager.markOperationComplete(step.New())
+		if successful {
+			ssm.manager.markDone(step.Old())
 
-		// In the case of a 'resource create' in a program that wasn't specified by the user in the
-		// --target list, we *never* want to write this to the checkpoint.  We treat it as if it
-		// doesn't exist at all.  That way when the program runs the next time, we'll actually
-		// create it.
-		if sameStep.IsSkippedCreate() {
-			return false
-		}
+			// In the case of a 'resource create' in a program that wasn't specified by the user in the
+			// --target list, we *never* want to write this to the checkpoint.  We treat it as if it
+			// doesn't exist at all.  That way when the program runs the next time, we'll actually
+			// create it.
+			if sameStep.IsSkippedCreate() {
+				return false
+			}
 
-		ssm.manager.markNew(step.New())
+			ssm.manager.markNew(step.New())
 
-		// Note that "Same" steps only consider input and provider diffs, so it is possible to see a same step for a
-		// resource with new dependencies, outputs, parent, protection. etc.
-		//
-		// As such, we diff all of the non-input properties of the resource here and write the snapshot if we find any
-		// changes.
-		if !ssm.mustWrite(sameStep) {
-			logging.V(9).Infof("SnapshotManager: sameSnapshotMutation.End() eliding write")
-			return false
+			// Note that "Same" steps only consider input and provider diffs, so it is possible to see a same step for a
+			// resource with new dependencies, outputs, parent, protection. etc.
+			//
+			// As such, we diff all of the non-input properties of the resource here and write the snapshot if we find any
+			// changes.
+			if !ssm.mustWrite(sameStep) {
+				logging.V(9).Infof("SnapshotManager: sameSnapshotMutation.End() eliding write")
+				return false
+			}
 		}
 
 		logging.V(9).Infof("SnapshotManager: sameSnapshotMutation.End() not eliding write")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This should fix the panic in https://github.com/pulumi/pulumi/issues/13923, but will probably just cause a new error to be raised for that use case.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
