### PR TITLE
`pulumi new` with existing project now can be bypassed

### DIFF
--- a/changelog/pending/20231002--cli-new--pulumi-new-now-allows-users-to-bypass-existing-project-name-checks.yaml
+++ b/changelog/pending/20231002--cli-new--pulumi-new-now-allows-users-to-bypass-existing-project-name-checks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: `pulumi new` now allows users to bypass existing project name checks.

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -61,3 +61,8 @@ type Options struct {
 	term                terminal.Terminal
 	deterministicOutput bool
 }
+
+func (opts Options) WithIsInteractive(isInteractive bool) Options {
+	opts.IsInteractive = isInteractive
+	return opts
+}

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"os/exec"
 
-	survey "github.com/AlecAivazis/survey/v2"
-	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/google/shlex"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -186,7 +184,7 @@ func (cmd *stateEditCmd) Run(s backend.Stack) error {
 			}
 		}
 
-		switch response := cmd.promptStateEdit(msg, options, edit); response {
+		switch response := promptUser(msg, options, edit, cmd.Colorizer); response {
 		case accept:
 			return saveSnapshot(cmd.Ctx, s, news, false /* force */)
 		case edit:
@@ -200,25 +198,6 @@ func (cmd *stateEditCmd) Run(s backend.Stack) error {
 			return fmt.Errorf("confirmation cancelled, not proceeding with the state edit")
 		}
 	}
-}
-
-func (cmd *stateEditCmd) promptStateEdit(msg string, options []string, defaultOption string) string {
-	prompt := "\b" + cmd.Colorizer.Colorize(colors.SpecPrompt+msg+colors.Reset)
-	surveycore.DisableColor = true
-	surveyIcons := survey.WithIcons(func(icons *survey.IconSet) {
-		icons.Question = survey.Icon{}
-		icons.SelectFocus = survey.Icon{Text: cmd.Colorizer.Colorize(colors.BrightGreen + ">" + colors.Reset)}
-	})
-
-	var response string
-	if err := survey.AskOne(&survey.Select{
-		Message: prompt,
-		Options: options,
-		Default: defaultOption,
-	}, &response, surveyIcons); err != nil {
-		return ""
-	}
-	return response
 }
 
 func (cmd *stateEditCmd) validateAndPrintState(f *snapshotBuffer) (*deploy.Snapshot, error) {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1115,3 +1115,22 @@ func missingNonInteractiveArg(args ...string) error {
 			strings.Join(args[:len(args)-1], ", "), args[len(args)-1])
 	}
 }
+
+func promptUser(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
+	prompt := "\b" + colorization.Colorize(colors.SpecPrompt+msg+colors.Reset)
+	surveycore.DisableColor = true
+	surveyIcons := survey.WithIcons(func(icons *survey.IconSet) {
+		icons.Question = survey.Icon{}
+		icons.SelectFocus = survey.Icon{Text: colorization.Colorize(colors.BrightGreen + ">" + colors.Reset)}
+	})
+
+	var response string
+	if err := survey.AskOne(&survey.Select{
+		Message: prompt,
+		Options: options,
+		Default: defaultOption,
+	}, &response, surveyIcons); err != nil {
+		return ""
+	}
+	return response
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13832

[asciinema recording](https://asciinema.org/a/zZvO66E31sMZ0t2DCAbnuMUMW)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
