### PR TITLE
Fix Homebrew install test

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -13,6 +13,11 @@ jobs:
     name: Install Pulumi with Homebrew on macOS
     runs-on: macos-11
     steps:
+      # Workaround for https://github.com/pulumi/pulumi/issues/13938
+      - name: Delete default golang installed on the runner
+        run: |
+          rm /usr/local/bin/go || true
+          rm /usr/local/bin/gofmt || true
       - name: homedate homebrew formulae
         run: brew update
       - name: homebrew install


### PR DESCRIPTION
Our cron job that tests installing Pulumi has been failing when installing from Homebrew on macOS. The `pulumi` package depends on `go`, and Homebrew fails installing `go` due to conflicting files on the GitHub action. This happens because the runner image already has Go installed in the same places that Homebrew is trying to install go.

The workaround is to delete the conflicting Go files on the runner before running the Homebrew install.

A successful test run with this fix is available here: https://github.com/pulumi/pulumi/actions/runs/6383582011/job/17324492547

Fixes #13938