### PR TITLE
Add an envar to disable automatic provider installation

### DIFF
--- a/changelog/pending/20231002--cli--users-can-now-set-pulumi_disable_automatic_plugin_acquisition-to-disable-the-engine-trying-to-auto-install-missing-plugins.yaml
+++ b/changelog/pending/20231002--cli--users-can-now-set-pulumi_disable_automatic_plugin_acquisition-to-disable-the-engine-trying-to-auto-install-missing-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Users can now set PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION to disable the engine trying to auto install missing plugins.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -545,6 +546,11 @@ func newImportCmd() *cobra.Command {
 				pCtx.Diag.Warningf(diag.RawMessage("", "Plugin converters are currently experimental"))
 
 				installProvider := func(provider tokens.Package) *semver.Version {
+					// If auto plugin installs are disabled just return nil, the mapper will still carry on
+					if env.DisableAutomaticPluginAcquisition.Value() {
+						return nil
+					}
+
 					log := func(sev diag.Severity, msg string) {
 						pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
 					}

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/blang/semver"
@@ -157,6 +158,11 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 			// There is an executable with the same name, so suggest that
 			if info, statErr := os.Stat(pkg); statErr == nil && isExecutable(info) {
 				return nil, fmt.Errorf("could not find installed plugin %s, did you mean ./%[1]s: %w", pkg, err)
+			}
+
+			// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
+			if env.DisableAutomaticPluginAcquisition.Value() {
+				return nil, err
 			}
 
 			var missingError *workspace.MissingError

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -25,6 +25,7 @@ import (
 
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -163,8 +164,12 @@ func loadProvider(pkg tokens.Package, version *semver.Version, downloadURL strin
 		return nil, err
 	}
 
-	// Try to install the plugin, we have all the specific information we need to do so here while once we
-	// call into `host.Provider` we no longer have the download URL or checksums.
+	// Try to install the plugin, unless auto plugin installs are turned off, we have all the specific information we
+	// need to do so here while once we call into `host.Provider` we no longer have the download URL or checksums.
+	if env.DisableAutomaticPluginAcquisition.Value() {
+		return nil, err
+	}
+
 	pluginSpec := workspace.PluginSpec{
 		Kind:              workspace.ResourcePlugin,
 		Name:              string(pkg),

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -59,6 +59,9 @@ var DisableOutputValues = env.Bool("DISABLE_OUTPUT_VALUES", "")
 var IgnoreAmbientPlugins = env.Bool("IGNORE_AMBIENT_PLUGINS",
 	"Discover additional plugins by examining $PATH.")
 
+var DisableAutomaticPluginAcquisition = env.Bool("DISABLE_AUTOMATIC_PLUGIN_ACQUISITION",
+	"Disables the automatic installation of missing plugins.")
+
 var SkipConfirmations = env.Bool("SKIP_CONFIRMATIONS",
 	`Whether or not confirmation prompts should be skipped. This should be used by pass any requirement
 that a --yes parameter has been set for non-interactive scenarios.

--- a/tests/testdata/aws_tf/main.tf
+++ b/tests/testdata/aws_tf/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "app_server" {
+  ami           = "ami-830c94e3"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "ExampleAppServerInstance"
+  }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is primarily for the providers team to enable during builds so they can have more confidence about reproducibility of builds (especially examples conversion), but I imagine some customers would enable this as well.

Fixes #14086

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
