### PR TITLE
Cleanup use of result.Result in step_generator.go

### DIFF
--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -308,11 +308,11 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 	// If the step generator and step executor were both successful, then we send all the resources
 	// observed to be analyzed. Otherwise, this step is skipped.
 	if res == nil && !ex.stepExec.Errored() {
-		res := ex.stepGen.AnalyzeResources()
-		if res != nil {
-			if resErr := res.Error(); resErr != nil {
-				logging.V(4).Infof("deploymentExecutor.Execute(...): error analyzing resources: %v", resErr)
-				ex.reportError("", resErr)
+		err := ex.stepGen.AnalyzeResources()
+		if err != nil {
+			if !result.IsBail(err) {
+				logging.V(4).Infof("deploymentExecutor.Execute(...): error analyzing resources: %v", err)
+				ex.reportError("", err)
 			}
 			return nil, result.Bail()
 		}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1915,7 +1915,7 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 	return toReplace, nil
 }
 
-func (sg *stepGenerator) AnalyzeResources() result.Result {
+func (sg *stepGenerator) AnalyzeResources() error {
 	var resources []plugin.AnalyzerStackResource
 	sg.deployment.news.mapRange(func(urn resource.URN, v *resource.State) bool {
 		goal, ok := sg.deployment.goals.get(urn)
@@ -1956,9 +1956,9 @@ func (sg *stepGenerator) AnalyzeResources() result.Result {
 
 	analyzers := sg.deployment.ctx.Host.ListAnalyzers()
 	for _, analyzer := range analyzers {
-		diagnostics, aErr := analyzer.AnalyzeStack(resources)
-		if aErr != nil {
-			return result.FromError(aErr)
+		diagnostics, err := analyzer.AnalyzeStack(resources)
+		if err != nil {
+			return err
 		}
 		for _, d := range diagnostics {
 			sg.sawError = sg.sawError || (d.EnforcementLevel == apitype.Mandatory)


### PR DESCRIPTION
Continued result cleanup.