### PR TITLE
make running tests less dependent on users env

### DIFF
--- a/changelog/pending/20231003--build--make-running-tests-less-dependent-on-users-env.yaml
+++ b/changelog/pending/20231003--build--make-running-tests-less-dependent-on-users-env.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: build
+  description: Make running tests less dependent on users env

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -2005,7 +2005,13 @@ function serveLanguageHostProcess(engineAddr: string): { proc: childProcess.Chil
     // directory which is changed by by the pwd option.
 
     process.env.PULUMI_LANGUAGE_NODEJS_RUN_PATH = path.normalize(path.join(__dirname, "..", "..", "..", "cmd", "run"));
-    const proc = childProcess.spawn("pulumi-language-nodejs", [engineAddr]);
+    let gobin = path.join(process.env.HOME as string, "go", "bin");
+    if (process.env.GOBIN !== undefined) {
+        gobin = process.env.GOBIN as string;
+    } else if (process.env.GOPATH !== undefined) {
+        gobin = path.join(process.env.GOPATH as string, "bin");
+    }
+    const proc = childProcess.spawn(path.join(gobin, "pulumi-language-nodejs"), [engineAddr]);
 
     // Hook the first line so we can parse the address.  Then we hook the rest to print for debugging purposes, and
     // hand back the resulting process object plus the address we plucked out.

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -22,7 +22,7 @@ import unittest
 from collections import namedtuple
 from concurrent import futures
 from inspect import signature
-from os import path
+from os import path, environ
 
 import grpc
 from google.protobuf import empty_pb2, struct_pb2
@@ -344,8 +344,13 @@ class LanghostTest(unittest.TestCase):
 
     def _create_language_host(self, port):
         exec_path = path.join(path.dirname(__file__), "..", "..", "..", "cmd", "pulumi-language-python-exec")
+        gobin = path.join(environ["HOME"], "go", "bin")
+        if environ.get("GOBIN") is not None:
+            gobin = environ["GOBIN"]
+        elif environ.get("GOPATH") is not None:
+            gobin = path.join(environ["GOPATH"], "bin")
         proc = subprocess.Popen(
-            ["pulumi-language-python", "--use-executor", exec_path, "localhost:%d" % port],
+            [path.join(gobin, "pulumi-language-python"), "--use-executor", exec_path, "localhost:%d" % port],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True)


### PR DESCRIPTION
Currently running the tests using `make` depends on the user having $GOBIN in their $PATH. We're relying on $PATH  to find the `pulumi-language-{nodejs,python}` libraries that we're installing using `go install` earlier. It however shouldn't be necessary to rely on the $PATH to find those libraries, as we know where go will install them.

This was a bit of a sidequest, while I was trying to get the tests to run locally.  I could just set the environment up so it works, but I figured it would be better to have this work independently of the users environment. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [ x I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
  This doesn't add any new features, the changes are in the tests only, so CI should prove it works.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
