### PR TITLE
Always set a plugin version during engine tests

### DIFF
--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -104,7 +104,7 @@ func TestPlannedUpdate(t *testing.T) {
 
 	// Change the provider's planned operation to a same step.
 	// Remove the provider from the plan.
-	plan.ResourcePlans["urn:pulumi:test::test::pulumi:providers:pkgA::default"].Ops = []display.StepOp{deploy.OpSame}
+	plan.ResourcePlans["urn:pulumi:test::test::pulumi:providers:pkgA::default_1_0_0"].Ops = []display.StepOp{deploy.OpSame}
 
 	// Attempt to run an update using the plan.
 	ins = resource.NewPropertyMapFromMap(map[string]interface{}{

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -246,6 +246,12 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 		}
 	}
 
+	if opts.Version == "" {
+		// Always send a Version so that we don't repeatedly try and hit github to ask what the latest version
+		// is during tests.
+		opts.Version = "1.0.0"
+	}
+
 	requestInput := &pulumirpc.RegisterResourceRequest{
 		Type:                       string(t),
 		Name:                       name,

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -318,7 +318,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 		}
 
 		if providers.IsProviderType(goal.Type) {
-			assert.Equal(t, "default", string(goal.Name))
+			assert.Equal(t, "default_1_0_0", string(goal.Name))
 			ref, err := providers.NewReference(urn, id)
 			assert.NoError(t, err)
 			_, ok := defaults[ref.String()]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We have a lot of engine tests that call RegisterResource but don't set Version. This is unusual as SDKs nearly always do set version. Part of the engine startup process is checking that all the plugins we need are installed, and to install a plugin we have to have a version. But engine test doesn't use real plugins, but also doesn't fake out the "lookup plugin" logic, so we end up thinking none of these plugins are installed, and so try to get the latest version for them and then try to install them.

_None_ of this good. The right fix here is probably to mock out the plugin workspace parts in the engine such that in engine tests we don't try to lookup test plugins from ~/.pulumi/plugins at all. 

But as a short term make things better vis-a-vis hitting GitHub rate limits we can at least make sure the version is always filled in to something so we don't do all the get latest version checks. We'll still try to download from github releases, but this is gonna half the number of requests we do.
