### PR TITLE
[python/program-gen] Fix panic in python program-gen when rewriting index expressions

### DIFF
--- a/changelog/pending/20231004--programgen-python--fix-panic-in-python-program-gen-when-rewriting-index-expressions.yaml
+++ b/changelog/pending/20231004--programgen-python--fix-panic-in-python-program-gen-when-rewriting-index-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Fix panic in python program-gen when rewriting index expressions

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -68,7 +68,9 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 
 		if objectKey && isLegalIdentifier(keyVal) {
 			currentTraversal = append(currentTraversal, traverser)
-			currentParts = append(currentParts, parts[i+1])
+			if i < len(traversal)-1 {
+				currentParts = append(currentParts, parts[i+1])
+			}
 			continue
 		}
 

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -379,6 +379,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Directory:   "empty-list-property",
 		Description: "Tests compiling empty list expressions of object properties",
 	},
+	{
+		Directory:   "python-regress-14037",
+		Description: "Regression test for rewriting qoutes in python",
+		Skip:        allProgLanguages.Except("python"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python-regress-14037.pp
+++ b/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python-regress-14037.pp
@@ -1,0 +1,14 @@
+data = ["bob", "john", "carl"]
+
+resource "user" "random:index/randomPassword:RandomPassword" {
+  options { range = data }
+  length = 16
+}
+resource "dbUsers" "aws:secretsmanager/secretVersion:SecretVersion" {
+  options { range = data }
+  secretId = "mySecret"
+  secretString = toJSON({
+    username = range.value
+    password = user[range.value].result
+  })
+}

--- a/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python/python-regress-14037.py
+++ b/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python/python-regress-14037.py
@@ -1,0 +1,21 @@
+import pulumi
+import json
+import pulumi_aws as aws
+import pulumi_random as random
+
+data = [
+    "bob",
+    "john",
+    "carl",
+]
+user = []
+for range in [{"key": k, "value": v} for [k, v] in enumerate(data)]:
+    user.append(random.RandomPassword(f"user-{range['key']}", length=16))
+db_users = []
+for range in [{"key": k, "value": v} for [k, v] in enumerate(data)]:
+    db_users.append(aws.secretsmanager.SecretVersion(f"dbUsers-{range['key']}",
+        secret_id="mySecret",
+        secret_string=user[range["value"]].result.apply(lambda result: json.dumps({
+            "username": range["value"],
+            "password": result,
+        }))))


### PR DESCRIPTION
# Description

Fixes #14037 so that the program generation no longer panics

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
