### PR TITLE
Add a span for plugin startup/launch time

### DIFF
--- a/changelog/pending/20231006--auto--added-a-tracing-span-for-plugin-launch.yaml
+++ b/changelog/pending/20231006--auto--added-a-tracing-span-for-plugin-launch.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto
+  description: Added a tracing span for plugin launch

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -181,16 +181,19 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 			}
 			argstr += arg
 		}
-		logging.V(9).Infof("Launching plugin '%v' from '%v' with args: %v", prefix, bin, argstr)
+		logging.V(9).Infof("newPlugin(): Launching plugin '%v' from '%v' with args: %v", prefix, bin, argstr)
 	}
 
-	// Create a root span for the operation
-	opts := []opentracing.StartSpanOption{}
+	// Create a span for the plugin initialization
+	opts := []opentracing.StartSpanOption{
+		opentracing.Tag{Key: "prefix", Value: prefix},
+		opentracing.Tag{Key: "bin", Value: bin},
+		opentracing.Tag{Key: "pulumi-decorator", Value: prefix + ":" + bin},
+	}
 	if ctx != nil && ctx.tracingSpan != nil {
 		opts = append(opts, opentracing.ChildOf(ctx.tracingSpan.Context()))
 	}
-	opts = append(opts, opentracing.Tag{Key: "pulumi-decorator", Value: prefix + ":" + bin})
-	tracingSpan := opentracing.StartSpan("LaunchPlugin", opts...)
+	tracingSpan := opentracing.StartSpan("newPlugin", opts...)
 	defer tracingSpan.Finish()
 
 	// Try to execute the binary.

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -189,7 +189,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 	if ctx != nil && ctx.tracingSpan != nil {
 		opts = append(opts, opentracing.ChildOf(ctx.tracingSpan.Context()))
 	}
-	opts = append(opts, opentracing.Tag{Key: "pulumi-decorator", Value: prefix})
+	opts = append(opts, opentracing.Tag{Key: "pulumi-decorator", Value: prefix + ":" + bin})
 	tracingSpan := opentracing.StartSpan("LaunchPlugin", opts...)
 	defer tracingSpan.Finish()
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds a tracing span that covers the time spent waiting for a plugin to initialize.  This will make it easier to distinguish how much provider initialization time is contributing to overall pulumi command duration.

Fixes https://github.com/pulumi/pulumi/issues/13986 (Traces from within the provider plugins are tracked in separate issues)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
It's pretty difficult to test this method independently without some refactoring. Since this change is diagnostic only, I lean toward adding without test to avoid dragging in a potentially complicated restructuring, but open to suggestions.
 
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
