### PR TITLE
Move language check from installPlugin to installPlugins

### DIFF
--- a/changelog/pending/20231005--engine--engine-will-now-error-earlier-if-a-deployment-needs-a-bundled-plugin-that-is-missing.yaml
+++ b/changelog/pending/20231005--engine--engine-will-now-error-earlier-if-a-deployment-needs-a-bundled-plugin-that-is-missing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine will now error earlier if a deployment needs a bundled plugin that is missing.

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -203,16 +203,26 @@ func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
 			continue
 		}
 
+		if workspace.IsPluginBundled(plug.Kind, plug.Name) {
+			return fmt.Errorf(
+				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed."+
+					" Reinstall Pulumi via your package manager or install script",
+				plug.Name,
+				plug.Kind,
+			)
+		}
+
+		info := plug // don't close over the loop induction variable
+
 		// If DISABLE_AUTOMATIC_PLUGIN_ACQUISITION is set just add an error to the error group and continue.
 		if env.DisableAutomaticPluginAcquisition.Value() {
 			installTasks.Go(func() error {
-				return fmt.Errorf("plugin %s %s not installed", plug.Name, plug.Version)
+				return fmt.Errorf("plugin %s %s not installed", info.Name, info.Version)
 			})
 			continue
 		}
 
 		// Launch an install task asynchronously and add it to the current error group.
-		info := plug // don't close over the loop induction variable
 		installTasks.Go(func() error {
 			logging.V(preparePluginLog).Infof(
 				"ensurePluginsAreInstalled(): plugin %s %s not installed, doing install", info.Name, info.Version)
@@ -234,11 +244,6 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins pluginSet, kinds pl
 // installPlugin installs a plugin from the given backend client.
 func installPlugin(ctx context.Context, plugin workspace.PluginSpec) error {
 	logging.V(preparePluginLog).Infof("installPlugin(%s, %s): beginning install", plugin.Name, plugin.Version)
-	if plugin.Kind == workspace.LanguagePlugin {
-		logging.V(preparePluginLog).Infof(
-			"installPlugin(%s, %s): is a language plugin, skipping install", plugin.Name, plugin.Version)
-		return nil
-	}
 
 	// If we don't have a version yet try and call GetLatestVersion to fill it in
 	if plugin.Version == nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As part of looking into abstracting away the plugin checks for engine tests, I noticed we have two _very_ similar methods for install plugins. The main difference was that in `installPlugin` we skipped the install if the plugin was a language plugin.

This isn't the ideal behaviour, so I've moved that check up into `installPlugins` and checked for "bundleness" not just being a language plugin and made it an error (similar error to what people get if they try and `pulumi plugin install language dotnet`).

So now if the engine wants to use a plugin that should be bundled but it's missing we'll just error out the deployment.

A follow up PR will look at merging `InstallPlugin` and `installPlugin` into one method.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
