### PR TITLE
Support disable plugin acquisition in deployments, and use for tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -70,6 +70,8 @@ env:
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   PULUMI_TEST_PYTHON_SHARED_VENV: "true"
+  # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
+  DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
   PYTHON: python
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2

--- a/changelog/pending/20231005--engine--disable_automatic_plugin_acquisition-is-respected-for-deployment-operations-now.yaml
+++ b/changelog/pending/20231005--engine--disable_automatic_plugin_acquisition-is-respected-for-deployment-operations-now.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: DISABLE_AUTOMATIC_PLUGIN_ACQUISITION is respected for deployment operations now.

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -199,6 +200,14 @@ func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(
 				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version)
+			continue
+		}
+
+		// If DISABLE_AUTOMATIC_PLUGIN_ACQUISITION is set just add an error to the error group and continue.
+		if env.DisableAutomaticPluginAcquisition.Value() {
+			installTasks.Go(func() error {
+				return fmt.Errorf("plugin %s %s not installed", plug.Name, plug.Version)
+			})
 			continue
 		}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Missed this in the initial PR for https://github.com/pulumi/pulumi/pull/14083. This stops the deployment engine trying to install missing plugins on startup.

We're also using this for CI tests for now because deploytest tries to auto install providers that don't really exist (like pkgA). Long term we'll abstract out that code so deploytest can fake the plugin cache.

Fixes #14106

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
