### PR TITLE
Allow anything in resource names

### DIFF
--- a/changelog/pending/20231026--engine--engine-now-correctly-handles-any-resource-name.yaml
+++ b/changelog/pending/20231026--engine--engine-now-correctly-handles-any-resource-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine now correctly handles any resource name.

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -107,7 +107,7 @@ func TestGetStackResourceOutputs(t *testing.T) {
 //
 
 func testURN(typ, name string) resource.URN {
-	return resource.NewURN("test", "test", "", tokens.Type(typ), tokens.QName(name))
+	return resource.NewURN("test", "test", "", tokens.Type(typ), name)
 }
 
 func deleteState(typ, name string, outs resource.PropertyMap) *resource.State {

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -308,7 +308,7 @@ func (data *resourceRowData) ColorizedColumns() []string {
 		// If we don't have a URN yet, mock parent it to the global stack.
 		urn = resource.DefaultRootStackURN(data.display.stack.Q(), data.display.proj)
 	}
-	name := string(urn.Name())
+	name := urn.Name()
 	typ := urn.Type().DisplayName()
 
 	done := data.IsDone()

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -57,26 +57,26 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 			p := e.Payload().(engine.DiagEventPayload)
 			resourceName := ""
 			if p.URN != "" {
-				resourceName = string(p.URN.Name())
+				resourceName = p.URN.Name()
 			}
 			PrintfWithWatchPrefix(time.Now(), resourceName,
 				"%s", renderDiffDiagEvent(p, opts))
 		case engine.ResourcePreEvent:
 			p := e.Payload().(engine.ResourcePreEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
+				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
 					"%s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		case engine.ResourceOutputsEvent:
 			p := e.Payload().(engine.ResourceOutputsEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
+				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
 					"done %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		case engine.ResourceOperationFailed:
 			p := e.Payload().(engine.ResourceOperationFailedPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
+				PrintfWithWatchPrefix(time.Now(), p.Metadata.URN.Name(),
 					"failed %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
 			}
 		default:

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -120,12 +120,12 @@ func TestGetLogsForTargetWithNoSnapshot(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func makeUntypedDeployment(name tokens.QName, phrase, state string) (*apitype.UntypedDeployment, error) {
+func makeUntypedDeployment(name string, phrase, state string) (*apitype.UntypedDeployment, error) {
 	return makeUntypedDeploymentTimestamp(name, phrase, state, nil, nil)
 }
 
 func makeUntypedDeploymentTimestamp(
-	name tokens.QName,
+	name string,
 	phrase, state string,
 	created, modified *time.Time,
 ) (*apitype.UntypedDeployment, error) {

--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -250,7 +250,7 @@ func TestParseImportFileSameName(t *testing.T) {
 	}
 	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
-	resourceNames := map[tokens.QName]struct{}{}
+	resourceNames := map[string]struct{}{}
 	for _, imp := range imports {
 		_, exists := resourceNames[imp.Name]
 		assert.False(t, exists, "name %s should not have been seen already", imp.Name)
@@ -258,7 +258,7 @@ func TestParseImportFileSameName(t *testing.T) {
 	}
 
 	// Check expected names are present.
-	for _, name := range []tokens.QName{"thing", "thing_1"} {
+	for _, name := range []string{"thing", "thing_1"} {
 		_, exists := resourceNames[name]
 		assert.True(t, exists, "expected resource with name '%v' to be in the imports", name)
 	}
@@ -290,7 +290,7 @@ func TestParseImportFileRenameNoClash(t *testing.T) {
 	}
 	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
-	resourceNames := map[tokens.QName]struct{}{}
+	resourceNames := map[string]struct{}{}
 	// Check resource names are unique.
 	for _, imp := range imports {
 		_, exists := resourceNames[imp.Name]
@@ -299,7 +299,7 @@ func TestParseImportFileRenameNoClash(t *testing.T) {
 	}
 
 	// Check expected names are present.
-	for _, name := range []tokens.QName{"thing", "thing_1", "thing_2"} {
+	for _, name := range []string{"thing", "thing_1", "thing_2"} {
 		_, exists := resourceNames[name]
 		assert.True(t, exists, "expected resource with name '%v' to be in the imports", name)
 	}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -322,7 +322,7 @@ func renderTree(snap *deploy.Snapshot, showURNs, showIDs bool) ([]cmdutil.TableR
 }
 
 func renderResourceRow(res *resource.State, prefix, infoPrefix string, showURN, showID bool) cmdutil.TableRow {
-	columns := []string{prefix + string(res.Type), string(res.URN.Name())}
+	columns := []string{prefix + string(res.Type), res.URN.Name()}
 	additionalInfo := ""
 
 	// If the ID and/or URN is requested, show it on the following line.  It would be nice to do

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -185,7 +185,7 @@ func (vertex *dependencyVertex) Data() interface{} {
 
 func (vertex *dependencyVertex) Label() string {
 	if shortNodeName {
-		return string(vertex.resource.URN.Name())
+		return vertex.resource.URN.Name()
 	}
 	return string(vertex.resource.URN)
 }

--- a/pkg/cmd/pulumi/state_rename_test.go
+++ b/pkg/cmd/pulumi/state_rename_test.go
@@ -62,7 +62,7 @@ func TestRenameProvider(t *testing.T) {
 	// Check that the snapshot contains the renamed provider as `our-provider`.
 	for _, res := range snap.Resources {
 		if res.ID == prov.ID {
-			assert.Equal(t, "our-provider", res.URN.Name().String())
+			assert.Equal(t, "our-provider", res.URN.Name())
 		}
 	}
 }
@@ -153,7 +153,7 @@ func TestStateRename_updatesChildren(t *testing.T) {
 	for _, res := range snap.Resources {
 		if res.URN == child {
 			sawChild = true
-			assert.Equal(t, "new-parent", res.Parent.Name().String())
+			assert.Equal(t, "new-parent", res.Parent.Name())
 		}
 	}
 	assert.True(t, sawChild, "child resource not found in snapshot")

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -87,7 +87,7 @@ func generateComplexTestDependencyGraph(
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		register := func(urn resource.URN, provider string, inputs resource.PropertyMap) resource.ID {
-			_, id, _, err := monitor.RegisterResource(urn.Type(), string(urn.Name()), true, deploytest.ResourceOptions{
+			_, id, _, err := monitor.RegisterResource(urn.Type(), urn.Name(), true, deploytest.ResourceOptions{
 				Provider: provider,
 				Inputs:   inputs,
 			})

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -271,7 +271,7 @@ func TestSingleResourceDefaultProviderGolangTransformations(t *testing.T) {
 				}
 				if res.URN.Name() == "res2Child" {
 					foundRes2Child = true
-					assert.Equal(t, res.Parent.Name(), tokens.QName("res2"))
+					assert.Equal(t, res.Parent.Name(), "res2")
 					assert.Equal(t, res.Type, tokens.Type("pkgA:m:typA"))
 					assert.Contains(t, res.AdditionalSecretOutputs, resource.PropertyKey("output"))
 					assert.Contains(t, res.AdditionalSecretOutputs, resource.PropertyKey("output2"))
@@ -289,7 +289,7 @@ func TestSingleResourceDefaultProviderGolangTransformations(t *testing.T) {
 				// result should be "baz".
 				if res.URN.Name() == "res4Child" {
 					foundRes4Child = true
-					assert.Equal(t, res.Parent.Name(), tokens.QName("res4"))
+					assert.Equal(t, res.Parent.Name(), "res4")
 					assert.Equal(t, "baz", res.Inputs["foo"].StringValue())
 				}
 			}

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -811,7 +811,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 								continue
 							}
 
-							switch entry.Step.URN().Name().String() {
+							switch entry.Step.URN().Name() {
 							case resName, resBName:
 								assert.Equal(t, expectedStep, entry.Step.Op())
 							}
@@ -833,11 +833,11 @@ func TestDefaultProviderDiff(t *testing.T) {
 	for _, res := range snap.Resources {
 		switch {
 		case providers.IsDefaultProvider(res.URN):
-			assert.Equal(t, "default", res.URN.Name().String())
-		case res.URN.Name().String() == resName || res.URN.Name().String() == resBName:
+			assert.Equal(t, "default", res.URN.Name())
+		case res.URN.Name() == resName || res.URN.Name() == resBName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default", provRef.URN().Name().String())
+			assert.Equal(t, "default", provRef.URN().Name())
 		}
 	}
 
@@ -852,11 +852,11 @@ func TestDefaultProviderDiff(t *testing.T) {
 	for _, res := range snap.Resources {
 		switch {
 		case providers.IsDefaultProvider(res.URN):
-			assert.Equal(t, "default_0_17_10", res.URN.Name().String())
-		case res.URN.Name().String() == resName || res.URN.Name().String() == resBName:
+			assert.Equal(t, "default_0_17_10", res.URN.Name())
+		case res.URN.Name() == resName || res.URN.Name() == resBName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default_0_17_10", provRef.URN().Name().String())
+			assert.Equal(t, "default_0_17_10", provRef.URN().Name())
 		}
 	}
 
@@ -868,15 +868,15 @@ func TestDefaultProviderDiff(t *testing.T) {
 	for _, res := range snap.Resources {
 		switch {
 		case providers.IsDefaultProvider(res.URN):
-			assert.True(t, res.URN.Name().String() == "default_0_17_11" || res.URN.Name().String() == "default_0_17_12")
-		case res.URN.Name().String() == resName:
+			assert.True(t, res.URN.Name() == "default_0_17_11" || res.URN.Name() == "default_0_17_12")
+		case res.URN.Name() == resName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default_0_17_11", provRef.URN().Name().String())
-		case res.URN.Name().String() == resBName:
+			assert.Equal(t, "default_0_17_11", provRef.URN().Name())
+		case res.URN.Name() == resBName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default_0_17_12", provRef.URN().Name().String())
+			assert.Equal(t, "default_0_17_12", provRef.URN().Name())
 		}
 	}
 }
@@ -938,7 +938,7 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 								continue
 							}
 
-							switch entry.Step.URN().Name().String() {
+							switch entry.Step.URN().Name() {
 							case resName:
 								assert.Subset(t, expectedSteps, []display.StepOp{entry.Step.Op()})
 							case resBName:
@@ -961,11 +961,11 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 	for _, res := range snap.Resources {
 		switch {
 		case providers.IsDefaultProvider(res.URN):
-			assert.Equal(t, "default", res.URN.Name().String())
-		case res.URN.Name().String() == resName || res.URN.Name().String() == resBName:
+			assert.Equal(t, "default", res.URN.Name())
+		case res.URN.Name() == resName || res.URN.Name() == resBName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default", provRef.URN().Name().String())
+			assert.Equal(t, "default", provRef.URN().Name())
 		}
 	}
 
@@ -975,15 +975,15 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 	for _, res := range snap.Resources {
 		switch {
 		case providers.IsDefaultProvider(res.URN):
-			assert.True(t, res.URN.Name().String() == "default_0_17_10" || res.URN.Name().String() == "default_0_17_11")
-		case res.URN.Name().String() == resName:
+			assert.True(t, res.URN.Name() == "default_0_17_10" || res.URN.Name() == "default_0_17_11")
+		case res.URN.Name() == resName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default_0_17_10", provRef.URN().Name().String())
-		case res.URN.Name().String() == resBName:
+			assert.Equal(t, "default_0_17_10", provRef.URN().Name())
+		case res.URN.Name() == resBName:
 			provRef, err := providers.ParseReference(res.Provider)
 			assert.NoError(t, err)
-			assert.Equal(t, "default_0_17_11", provRef.URN().Name().String())
+			assert.Equal(t, "default_0_17_11", provRef.URN().Name())
 		}
 	}
 }

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -62,21 +62,21 @@ func TestParallelRefresh(t *testing.T) {
 	snap := p.Run(t, nil)
 
 	assert.Len(t, snap.Resources, 5)
-	assert.Equal(t, string(snap.Resources[0].URN.Name()), "default") // provider
-	assert.Equal(t, string(snap.Resources[1].URN.Name()), "resA")
-	assert.Equal(t, string(snap.Resources[2].URN.Name()), "resB")
-	assert.Equal(t, string(snap.Resources[3].URN.Name()), "resC")
-	assert.Equal(t, string(snap.Resources[4].URN.Name()), "resD")
+	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
+	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
+	assert.Equal(t, snap.Resources[3].URN.Name(), "resC")
+	assert.Equal(t, snap.Resources[4].URN.Name(), "resD")
 
 	p.Steps = []TestStep{{Op: Refresh}}
 	snap = p.Run(t, snap)
 
 	assert.Len(t, snap.Resources, 5)
-	assert.Equal(t, string(snap.Resources[0].URN.Name()), "default") // provider
-	assert.Equal(t, string(snap.Resources[1].URN.Name()), "resA")
-	assert.Equal(t, string(snap.Resources[2].URN.Name()), "resB")
-	assert.Equal(t, string(snap.Resources[3].URN.Name()), "resC")
-	assert.Equal(t, string(snap.Resources[4].URN.Name()), "resD")
+	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
+	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, snap.Resources[2].URN.Name(), "resB")
+	assert.Equal(t, snap.Resources[3].URN.Name(), "resC")
+	assert.Equal(t, snap.Resources[4].URN.Name(), "resD")
 }
 
 func TestExternalRefresh(t *testing.T) {
@@ -106,8 +106,8 @@ func TestExternalRefresh(t *testing.T) {
 	// The read should place "resA" in the snapshot with the "External" bit set.
 	snap := p.Run(t, nil)
 	assert.Len(t, snap.Resources, 2)
-	assert.Equal(t, string(snap.Resources[0].URN.Name()), "default") // provider
-	assert.Equal(t, string(snap.Resources[1].URN.Name()), "resA")
+	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
+	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.True(t, snap.Resources[1].External)
 
 	p = &TestPlan{
@@ -118,8 +118,8 @@ func TestExternalRefresh(t *testing.T) {
 	snap = p.Run(t, snap)
 	// A refresh should leave "resA" as it is in the snapshot. The External bit should still be set.
 	assert.Len(t, snap.Resources, 2)
-	assert.Equal(t, string(snap.Resources[0].URN.Name()), "default") // provider
-	assert.Equal(t, string(snap.Resources[1].URN.Name()), "resA")
+	assert.Equal(t, snap.Resources[0].URN.Name(), "default") // provider
+	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
 	assert.True(t, snap.Resources[1].External)
 }
 

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -263,7 +263,7 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 			if !targetDependents {
 				// We should only perform updates on the entries we have targeted.
 				for _, target := range p.Options.Targets.Literals() {
-					assert.Contains(t, targets, target.Name().String())
+					assert.Contains(t, targets, target.Name())
 				}
 			} else {
 				// We expect to find at least one other resource updates.
@@ -274,8 +274,8 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 				found := false
 				updateList := []string{}
 				for target := range updated {
-					updateList = append(updateList, target.Name().String())
-					if !contains(targets, target.Name().String()) {
+					updateList = append(updateList, target.Name())
+					if !contains(targets, target.Name()) {
 						found = true
 					}
 				}
@@ -793,7 +793,7 @@ func generateParentedTestDependencyGraph(t *testing.T, p *TestPlan) (
 			register := func(urn, parent resource.URN) resource.ID {
 				_, id, _, err := monitor.RegisterResource(
 					urn.Type(),
-					string(urn.Name()),
+					urn.Name(),
 					urn.Type() != resTypeComponent,
 					deploytest.ResourceOptions{
 						Inputs: nil,

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -221,7 +221,7 @@ func (p *TestPlan) NewURN(typ tokens.Type, name string, parent resource.URN) res
 	if parent != "" {
 		pt = parent.QualifiedType()
 	}
-	return resource.NewURN(stack.Q(), project, pt, typ, tokens.QName(name))
+	return resource.NewURN(stack.Q(), project, pt, typ, name)
 }
 
 func (p *TestPlan) NewProviderURN(pkg tokens.Package, name string, parent resource.URN) resource.URN {

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1276,7 +1276,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 						return result, nil, nil
 					}
 
-					name, err := resource.NewUniqueHex(urn.Name().String(), 8, 512)
+					name, err := resource.NewUniqueHex(urn.Name(), 8, 512)
 					assert.NoError(t, err)
 
 					result := news.Copy()
@@ -1476,7 +1476,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 						if name, has := olds["name"]; has {
 							news["name"] = name
 						} else {
-							name, err := resource.NewUniqueName(randomSeed, urn.Name().String(), -1, -1, nil)
+							name, err := resource.NewUniqueName(randomSeed, urn.Name(), -1, -1, nil)
 							assert.NoError(t, err)
 							generatedName = resource.NewStringProperty(name)
 							news["name"] = generatedName

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -77,9 +77,9 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 
 	typ, name := state.URN.Type(), state.URN.Name()
 	return &model.Block{
-		Tokens: syntax.NewBlockTokens("resource", string(name), string(typ)),
+		Tokens: syntax.NewBlockTokens("resource", name, string(typ)),
 		Type:   "resource",
-		Labels: []string{string(name), string(typ)},
+		Labels: []string{name, string(typ)},
 		Body: &model.Body{
 			Items: items,
 		},

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -209,7 +209,7 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 	}
 	return &resource.State{
 		Type:     token,
-		URN:      resource.NewURN("stack", "project", parentType, token, tokens.QName(r.Name())),
+		URN:      resource.NewURN("stack", "project", parentType, token, r.Name()),
 		Custom:   true,
 		Inputs:   inputs,
 		Parent:   parent,

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -65,7 +65,7 @@ func (ops *cloudOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 		// We get the aws:lambda/function:Function child and request it's logs, parsing out the
 		// user-visible content from those logs to project into our own log output, but leaving out
 		// explicit Lambda metadata.
-		name := string(state.URN.Name())
+		name := state.URN.Name()
 		serverlessFunction, ok := ops.component.GetChild(awsLambdaFunctionTypeName, name)
 		if !ok {
 			logging.V(6).Infof("Child resource (type %v, name %v) not found", awsLambdaFunctionTypeName, name)
@@ -94,7 +94,7 @@ func (ops *cloudOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 		// centrally archived into the log collector. As a result, we will combine reading these logs with reading the
 		// live Lambda logs from individual functions, de-duplicating the results, to piece together the full set of
 		// logs.
-		name := string(state.URN.Name())
+		name := state.URN.Name()
 		serverlessFunction, ok := ops.component.GetChild(awsLambdaFunctionTypeName, name)
 		if !ok {
 			logging.V(6).Infof("Child resource (type %v, name %v) not found", awsLambdaFunctionTypeName, name)
@@ -142,7 +142,7 @@ func (ops *cloudOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 		// Both Services and Tasks track a log group, which we can directly query for logs.  These logs are only
 		// populated by user code within containers, so we can safely project these logs back unmodified.
 		urn := state.URN
-		name := string(urn.Name())
+		name := urn.Name()
 		logGroup, ok := ops.component.GetChild(awsLogGroupTypeName, name)
 		if !ok {
 			logging.V(6).Infof("Child resource (type %v, name %v) not found", awsLogGroupTypeName, name)

--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -115,7 +115,7 @@ func (r *Resource) GetChild(typ string, name string) (*Resource, bool) {
 		if childURN.Stack() == r.Stack &&
 			childURN.Project() == r.Project &&
 			childURN.Type() == tokens.Type(typ) &&
-			childURN.Name() == tokens.QName(name) {
+			childURN.Name() == name {
 			return childResource, true
 		}
 	}
@@ -245,11 +245,11 @@ func (ops *resourceOperations) matchesResourceFilter(filter *ResourceFilter) boo
 		// The filter matched the full URN
 		return true
 	}
-	if string(*filter) == string(urn.Type())+"::"+string(urn.Name()) {
+	if string(*filter) == string(urn.Type())+"::"+urn.Name() {
 		// The filter matched the '<type>::<name>' part of the URN
 		return true
 	}
-	if tokens.QName(*filter) == urn.Name() {
+	if string(*filter) == urn.Name() {
 		// The filter matched the '<name>' part of the URN
 		return true
 	}

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -173,7 +173,7 @@ func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
 	}, resource.StatusOK, nil
 }
 
-func (p *builtinProvider) Construct(info plugin.ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN,
+func (p *builtinProvider) Construct(info plugin.ConstructInfo, typ tokens.Type, name string, parent resource.URN,
 	inputs resource.PropertyMap, options plugin.ConstructOptions,
 ) (plugin.ConstructResult, error) {
 	return plugin.ConstructResult{}, errors.New("builtin resources may not be constructed")

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -539,7 +539,7 @@ func (d *Deployment) GetProvider(ref providers.Reference) (plugin.Provider, bool
 
 // generateURN generates a resource's URN from its parent, type, and name under the scope of the deployment's stack and
 // project.
-func (d *Deployment) generateURN(parent resource.URN, ty tokens.Type, name tokens.QName) resource.URN {
+func (d *Deployment) generateURN(parent resource.URN, ty tokens.Type, name string) resource.URN {
 	// Use the resource goal state name to produce a globally unique URN.
 	parentType := tokens.Type("")
 	if parent != "" && parent.Type() != resource.RootStackType {

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -16,7 +16,7 @@ func newResource(name string) *resource.State {
 	ty := tokens.Type("test")
 	return &resource.State{
 		Type:    ty,
-		URN:     resource.NewURN(tokens.QName("teststack"), tokens.PackageName("pkg"), ty, ty, tokens.QName(name)),
+		URN:     resource.NewURN(tokens.QName("teststack"), tokens.PackageName("pkg"), ty, ty, name),
 		Inputs:  make(resource.PropertyMap),
 		Outputs: make(resource.PropertyMap),
 	}

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -195,7 +195,7 @@ func (prov *Provider) Read(urn resource.URN, id resource.ID,
 	return prov.ReadF(urn, id, inputs, state)
 }
 
-func (prov *Provider) Construct(info plugin.ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN,
+func (prov *Provider) Construct(info plugin.ConstructInfo, typ tokens.Type, name string, parent resource.URN,
 	inputs resource.PropertyMap, options plugin.ConstructOptions,
 ) (plugin.ConstructResult, error) {
 	if prov.ConstructF == nil {
@@ -205,7 +205,7 @@ func (prov *Provider) Construct(info plugin.ConstructInfo, typ tokens.Type, name
 	if err != nil {
 		return plugin.ConstructResult{}, err
 	}
-	return prov.ConstructF(monitor, string(typ), string(name), parent, inputs, info, options)
+	return prov.ConstructF(monitor, string(typ), name, parent, inputs, info, options)
 }
 
 func (prov *Provider) Invoke(tok tokens.ModuleMember,

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -33,7 +33,7 @@ import (
 // An Import specifies a resource to import.
 type Import struct {
 	Type              tokens.Type       // The type token for the resource. Required.
-	Name              tokens.QName      // The name of the resource. Required.
+	Name              string            // The name of the resource. Required.
 	ID                resource.ID       // The ID of the resource. Required.
 	Parent            resource.URN      // The parent of the resource, if any.
 	Provider          resource.URN      // The specific provider to use for the resource, if any.
@@ -174,7 +174,7 @@ func (i *importer) getOrCreateStackResource(ctx context.Context) (resource.URN, 
 
 	projectName, stackName := i.deployment.source.Project(), i.deployment.target.Name
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
-	urn := resource.NewURN(stackName.Q(), projectName, "", typ, tokens.QName(name))
+	urn := resource.NewURN(stackName.Q(), projectName, "", typ, name)
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
 		nil, false, nil, nil, nil, "", false, "", nil, nil, "")
 	// TODO(seqnum) should stacks be created with 1? When do they ever get recreated/replaced?

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -108,7 +108,7 @@ type GoalPlan struct {
 	// the type of resource.
 	Type tokens.Type
 	// the name for the resource's URN.
-	Name tokens.QName
+	Name string
 	// true if this resource is custom, managed by a plugin.
 	Custom bool
 	// the resource's checked input properties we expect to change.

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -83,7 +83,7 @@ func (p ProviderRequest) PluginChecksums() map[string][]byte {
 //
 // If a version is not provided, "default" is returned. Otherwise, Name returns a name starting with "default" and
 // followed by a QName-legal representation of the semantic version of the requested provider.
-func (p ProviderRequest) Name() tokens.QName {
+func (p ProviderRequest) Name() string {
 	base := "default"
 	if v := p.version; v != nil {
 		// QNames are forbidden to contain dashes, so we construct a string here using the semantic
@@ -101,9 +101,10 @@ func (p ProviderRequest) Name() tokens.QName {
 		base += "_" + tokens.IntoQName(url).String()
 	}
 
-	// This thing that we generated must be a QName.
+	// This thing that we generated must be a QName, the engine doesn't actually care but it probably helps
+	// down the line if we keep these names simple.
 	contract.Assertf(tokens.IsQName(base), "generated provider name %q is not a QName", base)
-	return tokens.QName(base)
+	return base
 }
 
 // String returns a string representation of this request. This string is suitable for use as a hash key.

--- a/pkg/resource/deploy/providers/provider_test.go
+++ b/pkg/resource/deploy/providers/provider_test.go
@@ -5,15 +5,13 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 func TestProviderRequestNameNil(t *testing.T) {
 	t.Parallel()
 
 	req := NewProviderRequest(nil, "pkg", "", nil)
-	assert.Equal(t, tokens.QName("default"), req.Name())
+	assert.Equal(t, "default", req.Name())
 	assert.Equal(t, "pkg", req.String())
 }
 
@@ -22,7 +20,7 @@ func TestProviderRequestNameNoPre(t *testing.T) {
 
 	ver := semver.MustParse("0.18.1")
 	req := NewProviderRequest(&ver, "pkg", "", nil)
-	assert.Equal(t, "default_0_18_1", req.Name().String())
+	assert.Equal(t, "default_0_18_1", req.Name())
 	assert.Equal(t, "pkg-0.18.1", req.String())
 }
 
@@ -31,7 +29,7 @@ func TestProviderRequestNameDev(t *testing.T) {
 
 	ver := semver.MustParse("0.17.7-dev.1555435978+gb7030aa4.dirty")
 	req := NewProviderRequest(&ver, "pkg", "", nil)
-	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty", req.Name().String())
+	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty", req.Name())
 	assert.Equal(t, "pkg-0.17.7-dev.1555435978+gb7030aa4.dirty", req.String())
 }
 
@@ -40,7 +38,7 @@ func TestProviderRequestNameNoPreURL(t *testing.T) {
 
 	ver := semver.MustParse("0.18.1")
 	req := NewProviderRequest(&ver, "pkg", "pulumi.com/pkg", nil)
-	assert.Equal(t, "default_0_18_1_pulumi.com/pkg", req.Name().String())
+	assert.Equal(t, "default_0_18_1_pulumi.com/pkg", req.Name())
 	assert.Equal(t, "pkg-0.18.1-pulumi.com/pkg", req.String())
 }
 
@@ -49,7 +47,7 @@ func TestProviderRequestNameDevURL(t *testing.T) {
 
 	ver := semver.MustParse("0.17.7-dev.1555435978+gb7030aa4.dirty")
 	req := NewProviderRequest(&ver, "pkg", "company.com/artifact-storage/pkg", nil)
-	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty_company.com/artifact-storage/pkg", req.Name().String())
+	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty_company.com/artifact-storage/pkg", req.Name())
 	assert.Equal(t, "pkg-0.17.7-dev.1555435978+gb7030aa4.dirty-company.com/artifact-storage/pkg", req.String())
 }
 
@@ -58,5 +56,5 @@ func TestProviderRequestCanonicalizeURL(t *testing.T) {
 
 	req := NewProviderRequest(nil, "pkg", "company.com/", nil)
 	assert.Equal(t, "company.com", req.PluginDownloadURL())
-	assert.Equal(t, "default_company.com", req.Name().String())
+	assert.Equal(t, "default_company.com", req.Name())
 }

--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -48,7 +48,7 @@ func IsProviderType(typ tokens.Type) bool {
 
 // IsDefaultProvider returns true if this URN refers to a default Pulumi provider.
 func IsDefaultProvider(urn resource.URN) bool {
-	return IsProviderType(urn.Type()) && strings.HasPrefix(urn.Name().String(), "default")
+	return IsProviderType(urn.Type()) && strings.HasPrefix(urn.Name(), "default")
 }
 
 // MakeProviderType returns the provider type token for the given package.
@@ -104,7 +104,7 @@ func (r Reference) String() string {
 const denyDefaultProviderID resource.ID = "denydefaultprovider"
 
 // DenyDefaultProvider represent a default provider that cannot be created.
-func NewDenyDefaultProvider(name tokens.QName) Reference {
+func NewDenyDefaultProvider(name string) Reference {
 	return mustNewReference(
 		resource.NewURN("denied", "denied", "denied", "pulumi:providers:denied", name),
 		denyDefaultProviderID)
@@ -119,7 +119,7 @@ func NewDenyDefaultProvider(name tokens.QName) Reference {
 // Panics if called on a provider that is not a DenyDefaultProvider.
 func GetDeniedDefaultProviderPkg(ref Reference) string {
 	contract.Requiref(IsDenyDefaultsProvider(ref), "ref", "must be a DenyDefaultProvider, got %v", ref)
-	return ref.URN().Name().String()
+	return ref.URN().Name()
 }
 
 func IsDenyDefaultsProvider(ref Reference) bool {

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -571,7 +571,7 @@ func (r *Registry) Read(urn resource.URN, id resource.ID,
 	return plugin.ReadResult{}, resource.StatusUnknown, errors.New("provider resources may not be read")
 }
 
-func (r *Registry) Construct(info plugin.ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN,
+func (r *Registry) Construct(info plugin.ConstructInfo, typ tokens.Type, name string, parent resource.URN,
 	inputs resource.PropertyMap, options plugin.ConstructOptions,
 ) (plugin.ConstructResult, error) {
 	return plugin.ConstructResult{}, errors.New("provider resources may not be constructed")

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -242,7 +242,7 @@ func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.Pro
 
 func newProviderState(pkg, name, id string, delete bool, inputs resource.PropertyMap) *resource.State {
 	typ := MakeProviderType(tokens.Package(pkg))
-	urn := resource.NewURN("test", "test", "", typ, tokens.QName(name))
+	urn := resource.NewURN("test", "test", "", typ, name)
 	if inputs == nil {
 		inputs = resource.PropertyMap{}
 	}
@@ -778,10 +778,10 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 			defer wg.Done()
 
 			typ := MakeProviderType("pkgA")
-			providerURN := resource.NewURN("test", "test", "", typ, tokens.QName(fmt.Sprintf("p%d", i)))
+			providerURN := resource.NewURN("test", "test", "", typ, fmt.Sprintf("p%d", i))
 
 			for j := 0; j < 1000; j++ {
-				aliasURN := resource.NewURN("test", "test", "", typ, tokens.QName(fmt.Sprintf("p%d_%d", i, j)))
+				aliasURN := resource.NewURN("test", "test", "", typ, fmt.Sprintf("p%d_%d", i, j))
 				r.RegisterAlias(providerURN, aliasURN)
 			}
 

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -109,7 +109,7 @@ type ReadResourceEvent interface {
 	// ID is the requested ID of this read.
 	ID() resource.ID
 	// Name is the requested name of this read.
-	Name() tokens.QName
+	Name() string
 	// Type is type of the resource being read.
 	Type() tokens.Type
 	// Provider is a reference to the provider instance to use for this read.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -389,7 +389,7 @@ func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (provide
 	}
 	if denyCreation {
 		logging.V(5).Infof("denied default provider request for package %s", req)
-		return providers.NewDenyDefaultProvider(tokens.QName(string(req.Package().Name()))), nil
+		return providers.NewDenyDefaultProvider(string(req.Package().Name())), nil
 	}
 
 	// Have we loaded this provider before? Use the existing reference, if so.
@@ -958,7 +958,7 @@ func (rm *resmon) ReadResource(ctx context.Context,
 		return nil, rpcerror.New(codes.InvalidArgument, err.Error())
 	}
 
-	name := tokens.QName(req.GetName())
+	name := req.GetName()
 	parent, err := resource.ParseOptionalURN(req.GetParent())
 	if err != nil {
 		return nil, rpcerror.New(codes.InvalidArgument, fmt.Sprintf("invalid parent URN: %s", err))
@@ -1178,7 +1178,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	req *pulumirpc.RegisterResourceRequest,
 ) (*pulumirpc.RegisterResourceResponse, error) {
 	// Communicate the type, name, and object information to the iterator that is awaiting us.
-	name := tokens.QName(req.GetName())
+	name := req.GetName()
 	custom := req.GetCustom()
 	remote := req.GetRemote()
 	parent, err := resource.ParseOptionalURN(req.GetParent())
@@ -1722,7 +1722,7 @@ func (g *registerResourceOutputsEvent) Done() {
 
 type readResourceEvent struct {
 	id                      resource.ID
-	name                    tokens.QName
+	name                    string
 	baseType                tokens.Type
 	provider                string
 	parent                  resource.URN
@@ -1738,7 +1738,7 @@ var _ ReadResourceEvent = (*readResourceEvent)(nil)
 func (g *readResourceEvent) event() {}
 
 func (g *readResourceEvent) ID() resource.ID                  { return g.id }
-func (g *readResourceEvent) Name() tokens.QName               { return g.name }
+func (g *readResourceEvent) Name() string                     { return g.name }
 func (g *readResourceEvent) Type() tokens.Type                { return g.baseType }
 func (g *readResourceEvent) Provider() string                 { return g.provider }
 func (g *readResourceEvent) Parent() resource.URN             { return g.parent }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -170,7 +170,7 @@ func (sg *stepGenerator) bailDaig(diag *diag.Diag, args ...interface{}) error {
 
 // generateURN generates a URN for a new resource and confirms we haven't seen it before in this deployment.
 func (sg *stepGenerator) generateURN(
-	parent resource.URN, ty tokens.Type, name tokens.QName,
+	parent resource.URN, ty tokens.Type, name string,
 ) (resource.URN, error) {
 	// Generate a URN for this new resource, confirm we haven't seen it before in this deployment.
 	urn := sg.deployment.generateURN(parent, ty, name)
@@ -365,7 +365,7 @@ func (sg *stepGenerator) collapseAliasToUrn(goal *resource.Goal, alias resource.
 
 	n := alias.Name
 	if n == "" {
-		n = string(goal.Name)
+		n = goal.Name
 	}
 	t := alias.Type
 	if t == "" {
@@ -403,7 +403,7 @@ func (sg *stepGenerator) collapseAliasToUrn(goal *resource.Goal, alias resource.
 // from the name of the parent, and the parent name changed.
 func (sg *stepGenerator) inheritedChildAlias(
 	childType tokens.Type,
-	childName, parentName tokens.QName,
+	childName, parentName string,
 	parentAlias resource.URN,
 ) resource.URN {
 	// If the child name has the parent name as a prefix, then we make the assumption that
@@ -420,10 +420,8 @@ func (sg *stepGenerator) inheritedChildAlias(
 	// * childAlias: "urn:pulumi:stackname::projectname::aws:s3/bucket:Bucket::app-function"
 
 	aliasName := childName
-	if strings.HasPrefix(childName.String(), parentName.String()) {
-		aliasName = tokens.QName(
-			parentAlias.Name().String() +
-				strings.TrimPrefix(childName.String(), parentName.String()))
+	if strings.HasPrefix(childName, parentName) {
+		aliasName = parentAlias.Name() + strings.TrimPrefix(childName, parentName)
 	}
 	return resource.NewURN(
 		sg.deployment.Target().Name.Q(),

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -167,7 +167,7 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.StackName, newProject tok
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want
 		// to rename the name portion as well.
 		if u.QualifiedType() == "pulumi:pulumi:Stack" {
-			return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), tokens.QName(project)+"-"+newName.Q())
+			return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), string(tokens.QName(project)+"-"+newName.Q()))
 		}
 
 		return resource.NewURN(tokens.QName(newName.String()), project, "", u.QualifiedType(), u.Name())

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -43,7 +43,7 @@ func NewResource(name string, provider *resource.State, deps ...resource.URN) *r
 	t := tokens.Type("a:b:c")
 	return &resource.State{
 		Type:         t,
-		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		URN:          resource.NewURN("test", "test", "", t, name),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},
 		Dependencies: deps,
@@ -55,7 +55,7 @@ func NewProviderResource(pkg, name, id string, deps ...resource.URN) *resource.S
 	t := providers.MakeProviderType(tokens.Package(pkg))
 	return &resource.State{
 		Type:         t,
-		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		URN:          resource.NewURN("test", "test", "", t, name),
 		ID:           resource.ID(id),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -15,7 +15,7 @@ func NewProviderResource(pkg, name, id string, deps ...resource.URN) *resource.S
 	t := providers.MakeProviderType(tokens.Package(pkg))
 	return &resource.State{
 		Type:         t,
-		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		URN:          resource.NewURN("test", "test", "", t, name),
 		ID:           resource.ID(id),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},
@@ -36,7 +36,7 @@ func NewResource(name string, provider *resource.State, deps ...resource.URN) *r
 	t := tokens.Type("test:test:test")
 	return &resource.State{
 		Type:         t,
-		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		URN:          resource.NewURN("test", "test", "", t, name),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},
 		Dependencies: deps,

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -46,7 +46,7 @@ func TestDeploymentSerialization(t *testing.T) {
 			tokens.PackageName("resource/test"),
 			tokens.Type(""),
 			tokens.Type("Test"),
-			tokens.QName("resource-x"),
+			"resource-x",
 		),
 		true,
 		false,

--- a/sdk/go/common/apitype/plan.go
+++ b/sdk/go/common/apitype/plan.go
@@ -23,7 +23,7 @@ type GoalV1 struct {
 	// the type of resource.
 	Type tokens.Type `json:"type"`
 	// the name for the resource's URN.
-	Name tokens.QName `json:"name"`
+	Name string `json:"name"`
 	// true if this resource is custom, managed by a plugin.
 	Custom bool `json:"custom"`
 	// the resource properties that will be changed.

--- a/sdk/go/common/resource/plugin/analyzer.go
+++ b/sdk/go/common/resource/plugin/analyzer.go
@@ -51,7 +51,7 @@ type Analyzer interface {
 type AnalyzerResource struct {
 	URN        resource.URN
 	Type       tokens.Type
-	Name       tokens.QName
+	Name       string
 	Properties resource.PropertyMap
 	Options    AnalyzerResourceOptions
 	Provider   *AnalyzerProviderResource
@@ -80,7 +80,7 @@ type AnalyzerResourceOptions struct {
 type AnalyzerProviderResource struct {
 	URN        resource.URN
 	Type       tokens.Type
-	Name       tokens.QName
+	Name       string
 	Properties resource.PropertyMap
 }
 

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -186,7 +186,7 @@ func (a *analyzer) Analyze(r AnalyzerResource) ([]AnalyzeDiagnostic, error) {
 	resp, err := a.client.Analyze(a.ctx.Request(), &pulumirpc.AnalyzeRequest{
 		Urn:        string(urn),
 		Type:       string(t),
-		Name:       string(name),
+		Name:       name,
 		Properties: mprops,
 		Options:    marshalResourceOptions(r.Options),
 		Provider:   provider,
@@ -243,7 +243,7 @@ func (a *analyzer) AnalyzeStack(resources []AnalyzerStackResource) ([]AnalyzeDia
 		protoResources[idx] = &pulumirpc.AnalyzerResource{
 			Urn:                  string(resource.URN),
 			Type:                 string(resource.Type),
-			Name:                 string(resource.Name),
+			Name:                 resource.Name,
 			Properties:           props,
 			Options:              marshalResourceOptions(resource.Options),
 			Provider:             provider,
@@ -300,7 +300,7 @@ func (a *analyzer) Remediate(r AnalyzerResource) ([]Remediation, error) {
 	resp, err := a.client.Remediate(a.ctx.Request(), &pulumirpc.AnalyzeRequest{
 		Urn:        string(urn),
 		Type:       string(t),
-		Name:       string(name),
+		Name:       name,
 		Properties: mprops,
 		Options:    marshalResourceOptions(r.Options),
 		Provider:   provider,
@@ -546,7 +546,7 @@ func marshalProvider(provider *AnalyzerProviderResource) (*pulumirpc.AnalyzerPro
 	return &pulumirpc.AnalyzerProviderResource{
 		Urn:        string(provider.URN),
 		Type:       string(provider.Type),
-		Name:       string(provider.Name),
+		Name:       provider.Name,
 		Properties: props,
 	}, nil
 }

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -77,7 +77,7 @@ type Provider interface {
 		inputs, outputs resource.PropertyMap, timeout float64) (resource.Status, error)
 
 	// Construct creates a new component resource.
-	Construct(info ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN, inputs resource.PropertyMap,
+	Construct(info ConstructInfo, typ tokens.Type, name string, parent resource.URN, inputs resource.PropertyMap,
 		options ConstructOptions) (ConstructResult, error)
 
 	// Invoke dynamically executes a built-in function in the provider.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1337,7 +1337,7 @@ func (p *provider) Delete(urn resource.URN, id resource.ID, oldInputs, oldOutput
 
 // Construct creates a new component resource from the given type, name, parent, options, and inputs, and returns
 // its URN and outputs.
-func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN,
+func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name string, parent resource.URN,
 	inputs resource.PropertyMap, options ConstructOptions,
 ) (ConstructResult, error) {
 	contract.Assertf(typ != "", "Construct requires a type")
@@ -1420,7 +1420,7 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QN
 		Parallel:                int32(info.Parallel),
 		MonitorEndpoint:         info.MonitorAddress,
 		Type:                    string(typ),
-		Name:                    string(name),
+		Name:                    name,
 		Parent:                  string(parent),
 		Inputs:                  minputs,
 		Protect:                 options.Protect,

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -431,7 +431,7 @@ func (p *providerServer) Delete(ctx context.Context, req *pulumirpc.DeleteReques
 func (p *providerServer) Construct(ctx context.Context,
 	req *pulumirpc.ConstructRequest,
 ) (*pulumirpc.ConstructResponse, error) {
-	typ, name, parent := tokens.Type(req.GetType()), tokens.QName(req.GetName()), resource.URN(req.GetParent())
+	typ, name, parent := tokens.Type(req.GetType()), req.GetName(), resource.URN(req.GetParent())
 
 	inputs, err := UnmarshalProperties(req.GetInputs(), p.unmarshalOptions("inputs"))
 	if err != nil {

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -78,7 +78,7 @@ func (p *UnimplementedProvider) Delete(urn resource.URN, id resource.ID, oldInpu
 	return resource.StatusUnknown, status.Error(codes.Unimplemented, "Delete is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN, inputs resource.PropertyMap, options ConstructOptions) (ConstructResult, error) {
+func (p *UnimplementedProvider) Construct(info ConstructInfo, typ tokens.Type, name string, parent resource.URN, inputs resource.PropertyMap, options ConstructOptions) (ConstructResult, error) {
 	return ConstructResult{}, status.Error(codes.Unimplemented, "Construct is not yet implemented")
 }
 

--- a/sdk/go/common/resource/resource_goal.go
+++ b/sdk/go/common/resource/resource_goal.go
@@ -22,7 +22,7 @@ import (
 // a program, however if Output is true, it represents a more complete, post-deployment view of the state.
 type Goal struct {
 	Type                    tokens.Type           // the type of resource.
-	Name                    tokens.QName          // the name for the resource's URN.
+	Name                    string                // the name for the resource's URN.
 	Custom                  bool                  // true if this resource is custom, managed by a plugin.
 	Properties              PropertyMap           // the resource's property state.
 	Parent                  URN                   // an optional parent URN for this resource.
@@ -47,7 +47,7 @@ type Goal struct {
 }
 
 // NewGoal allocates a new resource goal state.
-func NewGoal(t tokens.Type, name tokens.QName, custom bool, props PropertyMap,
+func NewGoal(t tokens.Type, name string, custom bool, props PropertyMap,
 	parent URN, protect bool, dependencies []URN, provider string, initErrors []string,
 	propertyDependencies map[PropertyKey][]URN, deleteBeforeReplace *bool, ignoreChanges []string,
 	additionalSecretOutputs []PropertyKey, aliases []Alias, id ID, customTimeouts *CustomTimeouts,

--- a/sdk/go/common/resource/stack.go
+++ b/sdk/go/common/resource/stack.go
@@ -23,5 +23,5 @@ const RootStackType tokens.Type = "pulumi:pulumi:Stack"
 
 // DefaultRootStackURN constructs a default root stack URN for the given stack and project.
 func DefaultRootStackURN(stack tokens.QName, proj tokens.PackageName) URN {
-	return NewURN(stack, proj, "", RootStackType, tokens.QName(string(proj)+"-"+string(stack)))
+	return NewURN(stack, proj, "", RootStackType, string(proj)+"-"+string(stack))
 }

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -135,7 +135,7 @@ func urnGenerator(ctx *StackContext) *rapid.Generator[resource.URN] {
 		projectName := tokens.PackageName(projectNameGenerator.Draw(t, "project name"))
 		parentType := TypeGenerator().Draw(t, "parent type")
 		resourceType := TypeGenerator().Draw(t, "resource type")
-		resourceName := tokens.QName(rapid.StringMatching(`^((:[^:])[^:]*)*:?$`).Draw(t, "resource name"))
+		resourceName := rapid.StringMatching(`^((:[^:])[^:]*)*:?$`).Draw(t, "resource name")
 		return resource.NewURN(stackName, projectName, parentType, resourceType, resourceName)
 	})
 }

--- a/sdk/go/common/resource/urn_test.go
+++ b/sdk/go/common/resource/urn_test.go
@@ -29,7 +29,7 @@ func TestURNRoundTripping(t *testing.T) {
 	proj := tokens.PackageName("foo/bar/baz")
 	parentType := tokens.Type("")
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
-	name := tokens.QName("a-swell-resource")
+	name := "a-swell-resource"
 	urn := NewURN(stack, proj, parentType, typ, name)
 	assert.Equal(t, stack, urn.Stack())
 	assert.Equal(t, proj, urn.Project())
@@ -45,11 +45,42 @@ func TestURNRoundTripping2(t *testing.T) {
 	proj := tokens.PackageName("foo/bar/baz")
 	parentType := tokens.Type("parent$type")
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
-	name := tokens.QName("a-swell-resource")
+	name := "a-swell-resource"
 	urn := NewURN(stack, proj, parentType, typ, name)
 	assert.Equal(t, stack, urn.Stack())
 	assert.Equal(t, proj, urn.Project())
 	assert.Equal(t, tokens.Type("parent$type$bang:boom/fizzle:MajorResource"), urn.QualifiedType())
 	assert.Equal(t, typ, urn.Type())
 	assert.Equal(t, name, urn.Name())
+}
+
+func TestURNRoundTripping3(t *testing.T) {
+	t.Parallel()
+
+	stack := tokens.QName("stck")
+	proj := tokens.PackageName("foo/bar/baz")
+	parentType := tokens.Type("parent$type")
+	typ := tokens.Type("bang:boom/fizzle:MajorResource")
+	name := "a-swell-resource::with_awkward$names"
+	urn := NewURN(stack, proj, parentType, typ, name)
+	assert.Equal(t, stack, urn.Stack())
+	assert.Equal(t, proj, urn.Project())
+	assert.Equal(t, tokens.Type("parent$type$bang:boom/fizzle:MajorResource"), urn.QualifiedType())
+	assert.Equal(t, typ, urn.Type())
+	assert.Equal(t, name, urn.Name())
+}
+
+func TestIsValid(t *testing.T) {
+	t.Parallel()
+
+	goodUrns := []string{
+		"urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+		"urn:pulumi:stack-name::project-name::my:customtype$aws:s3/bucket:Bucket::bob",
+		"urn:pulumi:stack::project::type::",
+		"urn:pulumi:stack::project::type::some really ::^&\n*():: crazy name",
+	}
+	for _, str := range goodUrns {
+		urn := URN(str)
+		assert.True(t, urn.IsValid(), "IsValid expected to be true: %v", urn)
+	}
 }

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1126,7 +1126,7 @@ func (ctx *Context) collapseAliases(aliases []Alias, t, name string, parent Reso
 					return nil, fmt.Errorf("error collapsing alias to URN: %w", err)
 				}
 				inheritedAlias := urn.ApplyT(func(urn URN) URNOutput {
-					aliasedChildName := string(resource.URN(urn).Name())
+					aliasedChildName := resource.URN(urn).Name()
 					aliasedChildType := string(resource.URN(urn).Type())
 					return inheritedChildAlias(aliasedChildName, parent.getName(), aliasedChildType, project, stack, parentAlias)
 				}).ApplyT(func(urn interface{}) URN {

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -77,7 +77,7 @@ func (m *mockMonitor) newURN(parent, typ, name string) string {
 	}
 
 	return string(resource.NewURN(tokens.QName(m.stack), tokens.PackageName(m.project), parentType, tokens.Type(typ),
-		tokens.QName(name)))
+		name))
 }
 
 func (m *mockMonitor) SupportsFeature(ctx context.Context, in *pulumirpc.SupportsFeatureRequest,

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -1764,7 +1764,7 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 				tokens.PackageName(ctx.Project()),
 				"", // parent
 				tokens.Type(typ),
-				tokens.QName(name),
+				name,
 			)
 
 			snap, err := NewResourceOptions(opts)

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -478,7 +478,7 @@ func unmarshalResourceReference(ctx *Context, ref resource.ResourceReference) (R
 		}
 	}
 
-	resName := ref.URN.Name().String()
+	resName := ref.URN.Name()
 	resType := ref.URN.Type()
 
 	isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -823,15 +823,19 @@ func testConstructProviderPropagation(t *testing.T, lang string, deps []string) 
 		Quick:      true,
 		NoParallel: true, // already called by tests
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			gotProviders := make(map[tokens.QName]tokens.QName) // resource name => provider name
+			gotProviders := make(map[string]string) // resource name => provider name
 
 			for _, res := range stackInfo.Deployment.Resources {
 				if res.URN.Type() == "testprovider:index:Random" {
-					gotProviders[res.URN.Name()] = resource.URN(res.Provider).Name()
+					ref, err := providers.ParseReference(res.Provider)
+					assert.NoError(t, err)
+					if err == nil {
+						gotProviders[res.URN.Name()] = ref.URN().Name()
+					}
 				}
 			}
 
-			assert.Equal(t, map[tokens.QName]tokens.QName{
+			assert.Equal(t, map[string]string{
 				"uses_default":       "default",
 				"uses_provider":      "explicit",
 				"uses_providers":     "explicit",
@@ -850,7 +854,7 @@ func testConstructResourceOptions(t *testing.T, dir string, deps []string) {
 	runComponentSetup(t, testDir)
 
 	validate := func(t *testing.T, resources []apitype.ResourceV3) {
-		urns := make(map[tokens.QName]resource.URN) // name => URN
+		urns := make(map[string]resource.URN) // name => URN
 		for _, res := range resources {
 			urns[res.URN.Name()] = res.URN
 		}

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -380,7 +380,7 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 					var hasExpectedResource bool
 					var result string
 					for _, res := range stackInfo.Deployment.Resources {
-						if res.URN.Name().String() == "myrandom" {
+						if res.URN.Name() == "myrandom" {
 							hasExpectedResource = true
 							result = res.Outputs["result"].(string)
 							assert.Equal(t, float64(10), res.Inputs["length"])

--- a/tests/integration/targets/targets_test.go
+++ b/tests/integration/targets/targets_test.go
@@ -81,7 +81,7 @@ func TestDeleteManyTargets(t *testing.T) {
 
 	// Create a handy mkURN func to create URNs for dynamic resources in this project/stack.
 	resourceType := tokens.Type("pulumi-nodejs:dynamic:Resource")
-	mkURNStr := func(resourceName tokens.QName, parentType tokens.Type) string {
+	mkURNStr := func(resourceName string, parentType tokens.Type) string {
 		return string(resource.NewURN(
 			tokens.QName(stackName), tokens.PackageName(projName), parentType, resourceType, resourceName))
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Fixes https://github.com/pulumi/pulumi/issues/13968.
Fixes https://github.com/pulumi/pulumi/issues/8949.

This requires changing the parsing of URN's slightly, it is _very_ likely that
providers will need to update to handle URNs like this correctly.

This changes resource names to be `string` not `QName`. We never
validated this before and it turns out that users have put all manner of
text for resource names so we just updating the system to correctly
reflect that.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
