### PR TITLE
Fix panic in whoami

### DIFF
--- a/changelog/pending/20231005--cli--fix-a-panic-in-whoami-with-tokens-missing-expected-information.yaml
+++ b/changelog/pending/20231005--cli--fix-a-panic-in-whoami-with-tokens-missing-expected-information.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic in `whoami` with tokens missing expected information.

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
@@ -109,11 +108,10 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 		fmt.Fprintf(cmd.Stdout, "Organizations: %s\n", strings.Join(orgs, ", "))
 		fmt.Fprintf(cmd.Stdout, "Backend URL: %s\n", b.URL())
 		if tokenInfo != nil {
-			var tokenType string
+			tokenType := "unknown"
 			if tokenInfo.Team != "" {
 				tokenType = fmt.Sprintf("team: %s", tokenInfo.Team)
-			} else {
-				contract.Assertf(tokenInfo.Organization != "", "token must have an organization or team")
+			} else if tokenInfo.Organization != "" {
 				tokenType = fmt.Sprintf("organization: %s", tokenInfo.Organization)
 			}
 			fmt.Fprintf(cmd.Stdout, "Token type: %s\n", tokenType)

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -126,7 +126,7 @@ type Account struct {
 	TokenInformation *TokenInformation `json:"tokenInformation,omitempty"`
 }
 
-// Information about the token that was used to authenticate the current user. One of Team or Organization
+// Information about the token that was used to authenticate the current user. One (or none) of Team or Organization
 // will be set, but not both.
 type TokenInformation struct {
 	Name         string `json:"name"`                   // The name of the token.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14109.

Fixes a panic where the service sends a token without an organization or team.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
