### PR TITLE
Fix index out of range in get-mapping

### DIFF
--- a/changelog/pending/20231006--cli-package--fix-a-panic-in-get-mapping-when-not-passing-a-provider-name.yaml
+++ b/changelog/pending/20231006--cli-package--fix-a-panic-in-get-mapping-when-not-passing-a-provider-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Fix a panic in get-mapping when not passing a provider name.

--- a/pkg/cmd/pulumi/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/package_extract_mapping.go
@@ -36,7 +36,10 @@ func newExtractMappingCommand() *cobra.Command {
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			source := args[1]
-			provider := args[2]
+			var provider string
+			if len(args) > 2 {
+				provider = args[2]
+			}
 
 			p, err := providerFromSource(source)
 			if err != nil {


### PR DESCRIPTION
Small bug fix in get-mapping. We added the optional arg of provider name a while ago, but didn't actually make it optional. If you didn't pass it the cli panic'd with an index out of range.