### PR TITLE
[Test] Eager cancelation for ProgramTester

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -184,8 +184,6 @@ type ProgramTestOptions struct {
 	// ExpectRefreshChanges may be set to true if a test is expected to have changes yielded by an immediate refresh.
 	// This could occur, for example, is a resource's state is constantly changing outside of Pulumi (e.g., timestamps).
 	ExpectRefreshChanges bool
-	// ExpectTestFailure is true if we should continue with steps after a test failure.
-	ExpectTestFailure bool
 	// RetryFailedSteps indicates that failed updates, refreshes, and destroys should be retried after a brief
 	// intermission. A maximum of 3 retries will be attempted.
 	RetryFailedSteps bool
@@ -1160,7 +1158,7 @@ func (pt *ProgramTester) TestLifeCyclePrepare() error {
 }
 
 func (pt *ProgramTester) checkTestFailure() error {
-	if !pt.opts.ExpectTestFailure && pt.t.Failed() {
+	if pt.t.Failed() {
 		pt.t.Logf("Canceling further steps due to test failure")
 		return ErrTestFailed
 	}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -68,7 +68,7 @@ const (
 
 const windowsOS = "windows"
 
-var ErrTestCanceled = errors.New("test canceled")
+var ErrTestFailed = errors.New("test failed")
 
 // RuntimeValidationStackInfo contains details related to the stack that runtime validation logic may want to use.
 type RuntimeValidationStackInfo struct {
@@ -796,7 +796,7 @@ func ProgramTest(t *testing.T, opts *ProgramTestOptions) {
 	prepareProgram(t, opts)
 	pt := newProgramTester(t, opts)
 	err := pt.TestLifeCycleInitAndDestroy()
-	if !errors.Is(err, ErrTestCanceled) {
+	if !errors.Is(err, ErrTestFailed) {
 		assert.NoError(t, err)
 	}
 }
@@ -1162,7 +1162,7 @@ func (pt *ProgramTester) TestLifeCyclePrepare() error {
 func (pt *ProgramTester) checkTestFailure() error {
 	if !pt.opts.ExpectTestFailure && pt.t.Failed() {
 		pt.t.Logf("Canceling further steps due to test failure")
-		return ErrTestCanceled
+		return ErrTestFailed
 	}
 	return nil
 }

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -68,6 +68,8 @@ const (
 
 const windowsOS = "windows"
 
+var ErrTestCanceled = errors.New("test canceled")
+
 // RuntimeValidationStackInfo contains details related to the stack that runtime validation logic may want to use.
 type RuntimeValidationStackInfo struct {
 	StackName    tokens.QName
@@ -182,6 +184,8 @@ type ProgramTestOptions struct {
 	// ExpectRefreshChanges may be set to true if a test is expected to have changes yielded by an immediate refresh.
 	// This could occur, for example, is a resource's state is constantly changing outside of Pulumi (e.g., timestamps).
 	ExpectRefreshChanges bool
+	// ExpectTestFailure is true if we should continue with steps after a test failure.
+	ExpectTestFailure bool
 	// RetryFailedSteps indicates that failed updates, refreshes, and destroys should be retried after a brief
 	// intermission. A maximum of 3 retries will be attempted.
 	RetryFailedSteps bool
@@ -792,7 +796,9 @@ func ProgramTest(t *testing.T, opts *ProgramTestOptions) {
 	prepareProgram(t, opts)
 	pt := newProgramTester(t, opts)
 	err := pt.TestLifeCycleInitAndDestroy()
-	assert.NoError(t, err)
+	if !errors.Is(err, ErrTestCanceled) {
+		assert.NoError(t, err)
+	}
 }
 
 // ProgramTestManualLifeCycle returns a ProgramTester than must be manually controlled in terms of its lifecycle
@@ -1153,6 +1159,14 @@ func (pt *ProgramTester) TestLifeCyclePrepare() error {
 	return err
 }
 
+func (pt *ProgramTester) checkTestFailure() error {
+	if !pt.opts.ExpectTestFailure && pt.t.Failed() {
+		pt.t.Logf("Canceling further steps due to test failure")
+		return ErrTestCanceled
+	}
+	return nil
+}
+
 // TestCleanUp cleans up the temporary directory that a test used
 func (pt *ProgramTester) TestCleanUp() {
 	testFinished := pt.TestFinished
@@ -1438,6 +1452,10 @@ func (pt *ProgramTester) exportImport(dir string) error {
 		}
 		pt.t.Logf("Calling ExportStateValidator")
 		f(pt.t, bytes)
+
+		if err := pt.checkTestFailure(); err != nil {
+			return err
+		}
 	}
 
 	return pt.runPulumiCommand("pulumi-stack-import", importCmd, dir, false)
@@ -1724,7 +1742,8 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	pt.t.Log("Performing extra runtime validation.")
 	extraRuntimeValidation(pt.t, stackInfo)
 	pt.t.Log("Extra runtime validation complete.")
-	return nil
+
+	return pt.checkTestFailure()
 }
 
 func (pt *ProgramTester) readUpdateEventLog() ([]apitype.EngineEvent, error) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR changes the behavior of `ProgramTester` in `pkg/testing/integration` package, to detect test failures more eagerly and then to skip remaining steps. Specifically it checks whether the test been marked as failed by a validation function (as defined by [`t.Failed()`](https://pkg.go.dev/testing#T.Failed)).

The rationale is that, for most integration tests, each step assumes that the previous step was successful. It is simply noisy to continue with the subsequent steps. A workaround is to call `t.FailNow()` in the validation function (or use `require`).

An option is provided `ExpectTestFailure` to continue with steps after test failure (as is the current behavior).

There exists an option `ExpectFailures` to continue with steps after a pulumi deployment failure.  I took such failures to be orthogonal to test failure.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->

## Example
Here's a snippet of output in the event that a validation function marks the test as failed (e.g. using an assertion).
```
    ...
    /Users/eronwright/Pulumi/pulumi/tests/examples/program.go:1742: Performing extra runtime validation.
    /Users/eronwright/Pulumi/pulumi/tests/examples/examples_test.go:44:
                Error Trace:    ...
                Error:          Expected nil, but got ...
                Test:           TestAccMinimal
    /Users/eronwright/Pulumi/pulumi/tests/examples/program.go:1744: Extra runtime validation complete.
    /Users/eronwright/Pulumi/pulumi/tests/examples/program.go:1164: Canceling further steps due to test failure
    /Users/eronwright/Pulumi/pulumi/tests/examples/program.go:1349: Destroying stack
    ...
    /Users/eronwright/Pulumi/pulumi/tests/examples/program.go:1365: Test failed, retaining stack '...'
--- FAIL: TestAccMinimal (5.61s)
```

