### PR TITLE
Reuse provider instances where possible

### DIFF
--- a/changelog/pending/20231009--engine--engine-is-now-more-efficent-about-starting-up-provider-processes-generally-saving-at-least-one-process-startup-per-deployment.yaml
+++ b/changelog/pending/20231009--engine--engine-is-now-more-efficent-about-starting-up-provider-processes-generally-saving-at-least-one-process-startup-per-deployment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine is now more efficent about starting up provider processes, generally saving at least one process startup per deployment.

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -25,8 +25,10 @@ import (
 func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 	t.Parallel()
 
+	startupCount := 0
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			startupCount++
 			return &deploytest.Provider{}, nil
 		}),
 	}
@@ -43,6 +45,10 @@ func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 		Steps:   MakeBasicLifecycleSteps(t, 2),
 	}
 	p.Run(t, nil)
+
+	// We should have started the provider 10 times, twice for each of the steps in the basic lifecycle (one preview,
+	// one up), but zero for the last refresh step where the provider is not needed.
+	assert.Equal(t, 10, startupCount)
 }
 
 func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {

--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -32,6 +32,11 @@ import (
 // performing a preview).
 const UnknownID = plugin.UnknownStringValue
 
+// UnconfiguredID is a distinguished token used to indicate that a provider doesn't yet have an ID because it hasn't
+// been configured yet. This should never be returned back to SDKs by the engine but is used for internal tracking so we
+// maximally reuse provider instances but only configure them once.
+const UnconfiguredID = "unconfigured"
+
 // IsProviderType returns true if the supplied type token refers to a Pulumi provider.
 func IsProviderType(typ tokens.Type) bool {
 	// Tokens without a module member are definitely not provider types.

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -334,8 +334,8 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 		return nil, failures, err
 	}
 
-	// Create a provider reference using the URN and the unknown ID and register the provider.
-	r.setProvider(mustNewReference(urn, UnknownID), provider)
+	// Create a provider reference using the URN and the unconfigured ID and register the provider.
+	r.setProvider(mustNewReference(urn, UnconfiguredID), provider)
 
 	return inputs, nil, nil
 }
@@ -362,10 +362,10 @@ func (r *Registry) Diff(urn resource.URN, id resource.ID, oldInputs, oldOutputs,
 	logging.V(7).Infof("%s: executing (#oldInputs=%d#oldOutputs=%d,#newInputs=%d)",
 		label, len(oldInputs), len(oldOutputs), len(newInputs))
 
-	// Create a reference using the URN and the unknown ID and fetch the provider.
-	provider, ok := r.GetProvider(mustNewReference(urn, UnknownID))
+	// Create a reference using the URN and the unconfigured ID and fetch the provider.
+	provider, ok := r.GetProvider(mustNewReference(urn, UnconfiguredID))
 	if !ok {
-		// If the provider was not found in the registry under its URN and the Unknown ID, then it must have not have
+		// If the provider was not found in the registry under its URN and the unconfigured ID, then it must have not have
 		// been subject to a call to `Check`. This can happen when we are diffing a provider's inputs as part of
 		// evaluating the fanout of a delete-before-replace operation. In this case, we can just use the old provider
 		// (which we should have loaded during diff search), and we will not unload it.
@@ -419,25 +419,34 @@ func (r *Registry) Same(res *resource.State) error {
 		return nil
 	}
 
-	providerPkg := GetProviderPackage(urn.Type())
+	// We may have started this provider up for Check/Diff, but then decided to Same it, if so we can just
+	// reuse that instance, but as we're now configuring it remove the unconfigured ID from the provider map
+	// so nothing else tries to use it.
+	provider, ok := r.deleteProvider(mustNewReference(urn, UnconfiguredID))
+	if !ok {
+		// Else we need to load it fresh
+		providerPkg := GetProviderPackage(urn.Type())
 
-	// Parse the provider version, then load, configure, and register the provider.
-	version, err := GetProviderVersion(res.Inputs)
-	if err != nil {
-		return fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+		// Parse the provider version, then load, configure, and register the provider.
+		version, err := GetProviderVersion(res.Inputs)
+		if err != nil {
+			return fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		downloadURL, err := GetProviderDownloadURL(res.Inputs)
+		if err != nil {
+			return fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		// TODO: We should thread checksums through here.
+		provider, err = loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
+		if err != nil {
+			return fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		if provider == nil {
+			return fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
+		}
 	}
-	downloadURL, err := GetProviderDownloadURL(res.Inputs)
-	if err != nil {
-		return fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
-	}
-	// TODO: We should thread checksums through here.
-	provider, err := loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
-	if err != nil {
-		return fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
-	}
-	if provider == nil {
-		return fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
-	}
+	contract.Assertf(provider != nil, "provider must not be nil")
+
 	if err := provider.Configure(res.Inputs); err != nil {
 		closeErr := r.host.CloseProvider(provider)
 		contract.IgnoreError(closeErr)
@@ -451,7 +460,7 @@ func (r *Registry) Same(res *resource.State) error {
 	return nil
 }
 
-// Create coonfigures the provider with the given URN using the indicated configuration, assigns it an ID, and
+// Create configures the provider with the given URN using the indicated configuration, assigns it an ID, and
 // registers it under the assigned (URN, ID).
 //
 // The provider must have been loaded by a prior call to Check.
@@ -461,15 +470,43 @@ func (r *Registry) Create(urn resource.URN, news resource.PropertyMap, timeout f
 	label := fmt.Sprintf("%s.Create(%s)", r.label(), urn)
 	logging.V(7).Infof("%s executing (#news=%v)", label, len(news))
 
-	// Fetch the unconfigured provider, configure it, and register it under a new ID.
-	provider, ok := r.GetProvider(mustNewReference(urn, UnknownID))
-	contract.Assertf(ok, "'Check' must be called before 'Create' (%v)", urn)
+	// Fetch the unconfigured provider, configure it, and register it under a new ID. We remove the
+	// unconfigured ID from the provider map so nothing else tries to use and re-configure this instance.
+	provider, ok := r.deleteProvider(mustNewReference(urn, UnconfiguredID))
+	if !ok {
+		// The unconfigured provider may have been Same'd after Check and this provider could be a replacement create.
+		// In which case we need to start up a fresh copy.
+
+		providerPkg := GetProviderPackage(urn.Type())
+
+		// Parse the provider version, then load, configure, and register the provider.
+		version, err := GetProviderVersion(news)
+		if err != nil {
+			return "", nil, resource.StatusUnknown,
+				fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		downloadURL, err := GetProviderDownloadURL(news)
+		if err != nil {
+			return "", nil, resource.StatusUnknown,
+				fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		// TODO: We should thread checksums through here.
+		provider, err = loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
+		if err != nil {
+			return "", nil, resource.StatusUnknown,
+				fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
+		}
+		if provider == nil {
+			return "", nil, resource.StatusUnknown,
+				fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
+		}
+	}
 
 	if err := provider.Configure(news); err != nil {
 		return "", nil, resource.StatusOK, err
 	}
 
-	var id resource.ID
+	id := resource.ID(UnknownID)
 	if !preview {
 		// generate a new uuid
 		uuid, err := uuid.NewV4()
@@ -496,8 +533,9 @@ func (r *Registry) Update(urn resource.URN, id resource.ID,
 	logging.V(7).Infof("%s: executing (#oldInputs=%d#oldOutputs=%d,#newInputs=%d)",
 		label, len(oldInputs), len(oldOutputs), len(newInputs))
 
-	// Fetch the unconfigured provider and configure it.
-	provider, ok := r.GetProvider(mustNewReference(urn, UnknownID))
+	// Fetch the unconfigured provider, configure it, and register it under a new ID. We remove the
+	// unconfigured ID from the provider map so nothing else tries to use and re-configure this instance.
+	provider, ok := r.deleteProvider(mustNewReference(urn, UnconfiguredID))
 	contract.Assertf(ok, "'Check' and 'Diff' must be called before 'Update' (%v)", urn)
 
 	if err := provider.Configure(newInputs); err != nil {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -446,7 +446,7 @@ func TestCRUD(t *testing.T) {
 		assert.Empty(t, failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
-		p, ok := r.GetProvider(Reference{urn: urn, id: UnknownID})
+		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
 		assert.True(t, ok)
 		assert.False(t, p.(*testProvider).configured)
 
@@ -454,6 +454,7 @@ func TestCRUD(t *testing.T) {
 		id, outs, status, err := r.Create(urn, inputs, timeout, false)
 		assert.NoError(t, err)
 		assert.NotEqual(t, "", id)
+		assert.NotEqual(t, UnconfiguredID, id)
 		assert.NotEqual(t, UnknownID, id)
 		assert.Equal(t, resource.PropertyMap{}, outs)
 		assert.Equal(t, resource.StatusOK, status)
@@ -481,7 +482,7 @@ func TestCRUD(t *testing.T) {
 		assert.Empty(t, failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
-		p, ok := r.GetProvider(Reference{urn: urn, id: UnknownID})
+		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
 		assert.True(t, ok)
 		assert.False(t, p == old)
 		assert.False(t, p.(*testProvider).configured)
@@ -599,7 +600,7 @@ func TestCRUDPreview(t *testing.T) {
 		assert.Empty(t, failures)
 
 		// The provider should not be configured: configuration will occur during the previewed Create.
-		p, ok := r.GetProvider(Reference{urn: urn, id: UnknownID})
+		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
 		assert.True(t, ok)
 		assert.False(t, p.(*testProvider).configured)
 	}
@@ -620,7 +621,7 @@ func TestCRUDPreview(t *testing.T) {
 		assert.Empty(t, failures)
 
 		// The provider should remain unconfigured.
-		p, ok := r.GetProvider(Reference{urn: urn, id: UnknownID})
+		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
 		assert.True(t, ok)
 		assert.False(t, p == old)
 		assert.False(t, p.(*testProvider).configured)
@@ -653,7 +654,7 @@ func TestCRUDPreview(t *testing.T) {
 		assert.Empty(t, failures)
 
 		// The provider should remain unconfigured.
-		p, ok := r.GetProvider(Reference{urn: urn, id: UnknownID})
+		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
 		assert.True(t, ok)
 		assert.False(t, p == old)
 		assert.False(t, p.(*testProvider).configured)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -120,6 +120,7 @@ func newProviderEvent(pkg, name string, inputs resource.PropertyMap, parent reso
 	}
 	goal := &resource.Goal{
 		Type:       providers.MakeProviderType(tokens.Package(pkg)),
+		ID:         "id",
 		Name:       tokens.QName(name),
 		Custom:     true,
 		Properties: inputs,
@@ -682,7 +683,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 				case RegisterResourceEvent:
 					urn := newURN(event.Goal().Type, string(event.Goal().Name), event.Goal().Parent)
 					event.Done(&RegisterResult{
-						State: resource.NewState(event.Goal().Type, urn, true, false, event.Goal().ID, event.Goal().Properties,
+						State: resource.NewState(event.Goal().Type, urn, true, false, "id", event.Goal().Properties,
 							resource.PropertyMap{}, event.Goal().Parent, false, false, event.Goal().Dependencies, nil,
 							event.Goal().Provider, nil, false, nil, nil, nil, "", false, "", nil, nil, ""),
 					})
@@ -896,12 +897,16 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 				switch ev := ev.(type) {
 				case RegisterResourceEvent:
 					goal := ev.Goal()
+					id := goal.ID
+					if id == "" {
+						id = "id"
+					}
 					ev.Done(&RegisterResult{
 						State: &resource.State{
 							Type:         goal.Type,
 							URN:          newURN(goal.Type, string(goal.Name), goal.Parent),
 							Custom:       goal.Custom,
-							ID:           goal.ID,
+							ID:           id,
 							Inputs:       goal.Properties,
 							Parent:       goal.Parent,
 							Dependencies: goal.Dependencies,

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -225,15 +225,19 @@ func newQueryResourceMonitor(
 				providerRegErrChan <- err
 				return
 			}
-			_, _, _, err = reg.Create(urn, inputs, 9999, false)
+			id, _, _, err := reg.Create(urn, inputs, 9999, false)
 			if err != nil {
 				providerRegErrChan <- err
 				return
 			}
 
+			contract.Assertf(id != "", "expected non-empty provider ID")
+			contract.Assertf(id != providers.UnknownID, "expected non-unknown provider ID")
+
 			e.done <- &RegisterResult{State: &resource.State{
 				Type: e.goal.Type,
 				URN:  urn,
+				ID:   id,
 			}}
 		}
 	}()

--- a/tests/integration/query/step1/package.json
+++ b/tests/integration/query/step1/package.json
@@ -1,8 +1,6 @@
 {
     "name": "steps",
     "license": "Apache-2.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
     "devDependencies": {
         "typescript": "^3.0.0"
     },


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13987.

This reworks the registry to better track provider instances such that we can reuse unconfigured instances between Creates, Updates, and Sames.

When we allocate a provider instance in the registry for a Check call we save it with the special id "unconfigured". This value should never make its way back to program SDKs, it's purely an internal value for the engine.

When we do a Create, Update or Same we look to see if there's an unconfigured provider to use and if so configures that one, else it starts up a fresh one. (N.B. Update we can assume there will always be an unconfigured one from the Check call before).

This has also fixed registry Create to use the ID `UnknownID` rather than `""`, have added some contract assertions to check that and fixed up some test fallout because of that (the tests had been getting away with leaving ID blank before).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
