### PR TITLE
Actually disable plugin acquisition

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -71,7 +71,7 @@ env:
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   PULUMI_TEST_PYTHON_SHARED_VENV: "true"
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
-  DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
+  PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
   PYTHON: python
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -123,15 +123,14 @@ func getDocsForPackage(pkg *Package) []doc {
 	return allDocs
 }
 
+//nolint:paralleltest // needs to set plugin acquisition env var
 func TestParseAndRenderDocs(t *testing.T) {
-	t.Parallel()
-
 	files, err := os.ReadDir(testdataPath)
 	if err != nil {
 		t.Fatalf("could not read test data: %v", err)
 	}
 
-	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
+	//nolint:paralleltest // needs to set plugin acquisition env var
 	for _, f := range files {
 		f := f
 		if filepath.Ext(f.Name()) != ".json" || strings.Contains(f.Name(), "awsx") {
@@ -139,7 +138,7 @@ func TestParseAndRenderDocs(t *testing.T) {
 		}
 
 		t.Run(f.Name(), func(t *testing.T) {
-			t.Parallel()
+			t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 			path := filepath.Join(testdataPath, f.Name())
 			contents, err := os.ReadFile(path)

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -335,9 +335,8 @@ func TestEnums(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // needs to set plugin acquisition env var
 func TestImportResourceRef(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name       string
 		schemaFile string
@@ -397,10 +396,11 @@ func TestImportResourceRef(t *testing.T) {
 			},
 		},
 	}
+	//nolint:paralleltest // needs to set plugin acquisition env var
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 			// Read in, decode, and import the schema.
 			schemaBytes, err := os.ReadFile(

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -68,7 +68,8 @@ func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, 
 	}
 
 	wrapper := func(stream io.ReadCloser, size int64) io.ReadCloser {
-		log(diag.Info, fmt.Sprintf("Downloading provider: %s", pluginSpec.Name))
+		// Log at info but to stderr so we don't pollute stdout for commands like `package get-schema`
+		log(diag.Infoerr, fmt.Sprintf("Downloading provider: %s", pluginSpec.Name))
 		return stream
 	}
 

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -763,7 +763,11 @@ func TestConstructProviderGo(t *testing.T) {
 }
 
 func TestGetResourceGo(t *testing.T) {
+	// This uses the random plugin so needs to be able to download it
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel: true,
 		Dependencies: []string{
 			"github.com/pulumi/pulumi/sdk/v3",
 		},

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -258,9 +259,10 @@ func TestPackageGetSchema(t *testing.T) {
 	bindSchema(schemaJSON)
 
 	// Now try to get the schema from the path to the binary
+	pulumiHome, err := workspace.GetPulumiHomeDir()
+	require.NoError(t, err)
 	binaryPath := filepath.Join(
-		os.Getenv("HOME"),
-		".pulumi",
+		pulumiHome,
 		"plugins",
 		"resource-random-v4.13.0",
 		"pulumi-resource-random")

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -217,9 +217,6 @@ func TestLanguageGenerateSmoke(t *testing.T) {
 
 //nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetSchema(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping because it gets rate limited in CI")
-	}
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 	removeRandomFromLocalPlugins := func() {
@@ -272,10 +269,6 @@ func TestPackageGetSchema(t *testing.T) {
 
 //nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetMapping(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping because it gets rate limited in CI")
-	}
-
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 	removeRandomFromLocalPlugins := func() {
@@ -327,10 +320,6 @@ func TestLanguageImportSmoke(t *testing.T) {
 //
 //nolint:paralleltest // changes env vars and plugin cache
 func TestConvertDisableAutomaticPluginAcquisition(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping because it gets rate limited in CI")
-	}
-
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -217,6 +217,8 @@ func TestLanguageGenerateSmoke(t *testing.T) {
 
 //nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetSchema(t *testing.T) {
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 	removeRandomFromLocalPlugins := func() {
@@ -269,6 +271,8 @@ func TestPackageGetSchema(t *testing.T) {
 
 //nolint:paralleltest // disabled parallel because we change the plugins cache
 func TestPackageGetMapping(t *testing.T) {
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)
 	removeRandomFromLocalPlugins := func() {
@@ -294,6 +298,8 @@ func TestPackageGetMapping(t *testing.T) {
 //
 //nolint:paralleltest // pulumi new is not parallel safe
 func TestLanguageImportSmoke(t *testing.T) {
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -30,6 +30,9 @@ var Languages = map[string]string{
 //
 //nolint:paralleltest // pulumi new is not parallel safe
 func TestLanguageNewSmoke(t *testing.T) {
+	// make sure we can download needed plugins
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Turns out in https://github.com/pulumi/pulumi/pull/14104 we typo'd the environment variable name, missing the "PULUMI_" prefix at the start.

This change fixes that, and the resulting fall out of tests running with automatic plugin downloads being disabled by default.
One test it made sense to actually check with and without the envvar set. All the others I've just made sure the envvar is falsy so they can fetch the plugins they want to.

I've also un-skipped the tests that had been disabled due to always hitting the rate limits. Hopefully now we should be hitting github less often to allow these to pass consistently. 