### PR TITLE
NodeJS now accepts unknown resource IDs for read resource

### DIFF
--- a/changelog/pending/20231019--sdk-nodejs--nodejs-now-supports-unknown-resource-ids.yaml
+++ b/changelog/pending/20231019--sdk-nodejs--nodejs-now-supports-unknown-resource-ids.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Nodejs now supports unknown resource IDs.

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -244,13 +244,13 @@ export function readResource(
     opts: ResourceOptions,
     sourcePosition?: SourcePosition,
 ): void {
-    const id: Input<ID> | undefined = opts.id;
-    if (!id) {
+    if (!opts.id) {
         throw new Error("Cannot read resource whose options are lacking an ID value");
     }
+    const id: Promise<Input<ID>> = output(opts.id).promise(true);
 
     const label = `resource:${name}[${t}]#...`;
-    log.debug(`Reading resource: id=${Output.isInstance(id) ? "Output<T>" : id}, t=${t}, name=${name}`);
+    log.debug(`Reading resource: t=${t}, name=${name}`);
 
     const monitor = getMonitor();
     const resopAsync = prepareResource(label, res, parent, true, false, props, opts);
@@ -258,7 +258,7 @@ export function readResource(
     const preallocError = new Error();
     debuggablePromise(
         resopAsync.then(async (resop) => {
-            const resolvedID = await serializeProperty(label, id, new Set(), { keepOutputValues: false });
+            const resolvedID = await serializeProperty(label, await id, new Set(), { keepOutputValues: false });
             log.debug(
                 `ReadResource RPC prepared: id=${resolvedID}, t=${t}, name=${name}` +
                     (excessiveDebugOutput ? `, obj=${JSON.stringify(resop.serializedProps)}` : ``),

--- a/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
@@ -10,7 +10,7 @@ let inputs = {
     d: undefined,
 };
 
-let res = new pulumi.CustomResource("test:read:resource", "foo", inputs, { id: "abc123" });
+let res = new pulumi.CustomResource("test:read:resource", "foo", inputs, { id: pulumi.secret("abc123") });
 res.id.apply((id) => assert.strictEqual(id, "abc123"));
 res.urn.apply((urn) => assert.strictEqual(urn, "test:read:resource::foo"));
 res.a.apply((a) => assert.strictEqual(a, inputs.a)); // same as input


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11719 

NodeJS now accepts unknown resource IDs for read resource.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
