### PR TITLE
ignore unexpected types instead of erroring out

### DIFF
--- a/changelog/pending/20231010--cli--ignore-unexpected-types-instead-of-erroring-out.yaml
+++ b/changelog/pending/20231010--cli--ignore-unexpected-types-instead-of-erroring-out.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: ignore unexpected types instead of erroring out

--- a/changelog/pending/20231010--cli--ignore-unexpected-types-instead-of-erroring-out.yaml
+++ b/changelog/pending/20231010--cli--ignore-unexpected-types-instead-of-erroring-out.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli
-  description: ignore unexpected types instead of erroring out
+  description: allow unmarshalling nil as a config value.

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -115,6 +115,8 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 			vs[k] = pv
 		}
 		return NewPlaintext(vs), nil
+	case nil:
+		return Plaintext{}, nil
 	default:
 		contract.Failf("unexpected value of type %T", v)
 		return Plaintext{}, nil

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -461,6 +462,8 @@ func unmarshalObject(v any) (object, error) {
 		return newObject(v), nil
 	case string:
 		return newObject(v), nil
+	case time.Time:
+		return newObject(v.String()), nil
 	case map[string]any:
 		if ok, ciphertext := isSecureValue(v); ok {
 			return newSecureObject(ciphertext), nil

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -118,7 +118,8 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 	case nil:
 		return Plaintext{}, nil
 	default:
-		return Plaintext{}, errors.New(fmt.Sprintf("unrepresentable type: %T", v))
+		contract.Failf("unexpected value of type %T", v)
+		return Plaintext{}, nil
 	}
 }
 
@@ -492,7 +493,8 @@ func unmarshalObject(v any) (object, error) {
 	case nil:
 		return object{}, nil
 	default:
-		return object{}, errors.New(fmt.Sprintf("unrepresentable type: %T", v))
+		contract.Failf("unexpected wire type %T", v)
+		return object{}, nil
 	}
 }
 

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -115,8 +115,10 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 			vs[k] = pv
 		}
 		return NewPlaintext(vs), nil
-	default:
+	case nil:
 		return Plaintext{}, nil
+	default:
+		return Plaintext{}, errors.New(fmt.Sprintf("unrepresentable type: %T", v))
 	}
 }
 
@@ -487,8 +489,10 @@ func unmarshalObject(v any) (object, error) {
 			a[i] = sv
 		}
 		return newObject(a), nil
-	default:
+	case nil:
 		return object{}, nil
+	default:
+		return object{}, errors.New(fmt.Sprintf("unrepresentable type: %T", v))
 	}
 }
 

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -115,8 +115,6 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 			vs[k] = pv
 		}
 		return NewPlaintext(vs), nil
-	case nil:
-		return Plaintext{}, nil
 	default:
 		contract.Failf("unexpected value of type %T", v)
 		return Plaintext{}, nil

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -116,7 +116,6 @@ func (c object) decrypt(ctx context.Context, path resource.PropertyPath, decrypt
 		}
 		return NewPlaintext(vs), nil
 	default:
-		contract.Failf("unexpected value of type %T", v)
 		return Plaintext{}, nil
 	}
 }
@@ -489,7 +488,6 @@ func unmarshalObject(v any) (object, error) {
 		}
 		return newObject(a), nil
 	default:
-		contract.Failf("unexpected wire type %T", v)
 		return object{}, nil
 	}
 }

--- a/sdk/go/common/workspace/loaders_test.go
+++ b/sdk/go/common/workspace/loaders_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshallNil(t *testing.T) {
+	t.Parallel()
+	modifiedProjectStack := []byte(`
+config:
+  aws:region: us-east-1
+  aws:id:
+    -
+`)
+
+	marshaller, err := marshallerForPath(".yaml")
+	require.NoError(t, err)
+	var projectStack ProjectStack
+	err = marshaller.Unmarshal(modifiedProjectStack, &projectStack)
+	assert.NoError(t, err)
+}

--- a/sdk/go/common/workspace/loaders_test.go
+++ b/sdk/go/common/workspace/loaders_test.go
@@ -40,3 +40,20 @@ config:
 	_, err = projectStack.Config.Decrypt(config.Base64Crypter)
 	assert.NoError(t, err)
 }
+
+func TestUnmarshalTime(t *testing.T) {
+	t.Parallel()
+	modifiedProjectStack := []byte(`
+config:
+  aws:region: us-east-1
+  aws:time: 2020-01-01T00:00:00Z
+`)
+	marshaller, err := marshallerForPath(".yaml")
+	require.NoError(t, err)
+	var projectStack ProjectStack
+	err = marshaller.Unmarshal(modifiedProjectStack, &projectStack)
+	assert.NoError(t, err)
+
+	_, err = projectStack.Config.Decrypt(config.Base64Crypter)
+	assert.NoError(t, err)
+}

--- a/sdk/go/common/workspace/loaders_test.go
+++ b/sdk/go/common/workspace/loaders_test.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,5 +35,8 @@ config:
 	require.NoError(t, err)
 	var projectStack ProjectStack
 	err = marshaller.Unmarshal(modifiedProjectStack, &projectStack)
+	assert.NoError(t, err)
+
+	_, err = projectStack.Config.Decrypt(config.Base64Crypter)
 	assert.NoError(t, err)
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -494,7 +494,6 @@ func TestConfigPaths(t *testing.T) {
 		"root[",
 		`root["nested]`,
 		"root.array[abc]",
-		"root.[1]",
 
 		// First path segment must be a non-empty string.
 		`[""]`,


### PR DESCRIPTION
Before #13814, when we encountered unexpected types in a yaml file, we ignored them.  However that PR changed that, and we end up panicing, e.g. in case we have a config like the following:

```
config:
  aws:region: us-east-1
  aws:id:
    -
```

Fix that by getting the old behaviour of ignoring this error back.

Fixes #14146 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
