### PR TITLE
[auto/nodejs] Remove SxS check that's no longer needed

### DIFF
--- a/changelog/pending/20231010--auto-nodejs--remove-unneeded-sxs-check-for-inline-programs.yaml
+++ b/changelog/pending/20231010--auto-nodejs--remove-unneeded-sxs-check-for-inline-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Remove unneeded SxS check for inline programs

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -37,10 +37,6 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
 
     constructor(program: () => Promise<T>) {
         this.program = program;
-
-        // set a bit in runtime settings to indicate that we're running in inline mode.
-        // this allows us to detect and fail fast for side by side pulumi scenarios.
-        settings.setInline();
     }
 
     onPulumiExit(hasError: boolean) {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -856,37 +856,6 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
-    it(`detects inline programs with side by side pulumi and throws an error`, async () => {
-        const program = async () => {
-            // clear pulumi/pulumi from require cache
-            delete require.cache[require.resolve("../../runtime")];
-            delete require.cache[require.resolve("../../runtime/config")];
-            delete require.cache[require.resolve("../../runtime/settings")];
-            // load up a fresh instance of pulumi
-            const p1 = require("../../runtime/settings");
-            // do some work that happens to observe runtime options with the new instance
-            p1.monitorSupportsSecrets();
-            return {
-                // export an output from originally pulumi causing settings to be observed again (boom).
-                test: output("original_pulumi"),
-            };
-        };
-        const projectName = "inline_node_sxs";
-        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
-        const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
-
-        // pulumi up
-        await assert.rejects(stack.up(), (err: Error) => {
-            return err.stack!.indexOf("Detected multiple versions of '@pulumi/pulumi'") >= 0;
-        });
-
-        // pulumi destroy
-        const destroyRes = await stack.destroy();
-        assert.strictEqual(destroyRes.summary.kind, "destroy");
-        assert.strictEqual(destroyRes.summary.result, "succeeded");
-
-        await stack.workspace.removeStack(stackName);
-    });
     it(`sets pulumi version`, async () => {
         const ws = await LocalWorkspace.create({});
         assert(ws.pulumiVersion);


### PR DESCRIPTION
This change removes the SxS check in the Node.js Automation API since it's blocking a customer scenario and isn't needed anymore now that #5449 has been addressed with #10568.

The check was originally added in #7349 to provide a helpful error message when multiple versions of `@pulumi/pulumi` were used with inline programs, which could cause clashes with global state. Since then, we've changed how state is stored to allow parallel execution of multiple inline programs with #10568. However, the SxS checks were not removed as part of that change.

A customer recently hit the error associated with the SxS check. They are creating a Next.js program that runs Pulumi operations as inline programs. Next.js ends up loading modules multiple times in a way that confuses the SxS checker, causing the error to be thrown, even though it wouldn't have been a problem.

Fixes #14128