### PR TITLE
use v3 of setup-dotnet instead of a specific SHA

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -165,7 +165,7 @@ jobs:
           cache: pip
           cache-dependency-path: sdk/python/requirements.txt
       - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
           dotnet-quality: ga

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: ${{ fromJson(needs.matrix.outputs.version-set).python }}
       - name: Set up DotNet
-        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ fromJson(needs.matrix.outputs.version-set).dotnet }}
           dotnet-quality: ga


### PR DESCRIPTION
# Description

The specific SHA seems to be failing to download sometimes today.  Try to update it to the latest v3 version to see if that works better.

This seems likely an issue that's currently going on with the GitHub infrastructure, but it seems to me that we don't need to pin this version anyway, and we can get the latest fixes for the action this way. 
