### PR TITLE
build resourcedocsgen from registry

### DIFF
--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -106,6 +106,12 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
           repository: pulumi/docs
           path: docs
+      - name: Check out registry
+        uses: actions/checkout@v2
+        with:
+          repository: pulumi/registry
+          path: registry
+
 
       - name: Regenerate resource docs
         id: regenerate-resource-docs
@@ -113,23 +119,28 @@ jobs:
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           BRANCH_NAME="${GITHUB_ACTOR}/${PR_NUMBER}-test-generator-changes"
 
+          pushd registry/tools/resourcedocsgen
+
+          go mod edit -replace github.com/pulumi/pulumi/pkg/v3=../../../pulumi/pkg
+          go mod edit -replace github.com/pulumi/pulumi/sdk/v3=../../../pulumi/sdk
+
+          go mod tidy
+
+          if [ -z "${GOPATH:-}" ]; then
+            echo "GOPATH is empty. Defaulting to ${HOME}/go"
+            GOPATH="${HOME}/go"
+          fi
+          go build -o "${GOPATH}/bin/resourcedocsgen" .
+          export PATH="${GOPATH}/bin/":$PATH
+
+          popd
+
           # If generating docs for more providers here, be sure to update
           # the description of the draft PR that is opened in the next step.
           pushd docs
 
-          pushd tools/resourcedocsgen
-          go mod edit -replace github.com/pulumi/pulumi/pkg/v3=../../../pulumi/pkg
-          go mod edit -replace github.com/pulumi/pulumi/sdk/v3=../../../pulumi/sdk
-          popd
-
           ./scripts/gen_resource_docs.sh aws true v5.42.0
           ./scripts/gen_resource_docs.sh kubernetes true
-
-          # Undo the changes to the go.mod and go.sum files since we don't want the PR
-          # to contain local overrides or the PR build in docs repo would fail.
-          pushd tools/resourcedocsgen
-          git checkout .
-          popd
 
           popd
 

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -55,7 +55,7 @@ jobs:
     needs: [matrix]
     # Verify that the event is not triggered by a fork since forks cannot
     # access secrets other than the default GITHUB_TOKEN. Specifically,
-    # this workflow relies on the secret PULUMI_BOT_GH_PAT_DOCS to create a
+    # this workflow relies on the secret PULUMI_BOT_TOKEN to create a
     # draft PR in the docs repo.
     env:
       GOPATH: ${{ github.workspace }}
@@ -85,25 +85,25 @@ jobs:
         with:
           path: pulumi
           ref: ${{ inputs.ref }}
-          token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out pulumi-aws
         uses: actions/checkout@v2
         with:
           repository: pulumi/pulumi-aws
           path: pulumi-aws
-          token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out pulumi-kubernetes
         uses: actions/checkout@v2
         with:
           repository: pulumi/pulumi-kubernetes
           path: pulumi-kubernetes
-          token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out docs
         uses: actions/checkout@v2
         with:
           # Use the PAT and not the default GITHUB_TOKEN since we want to create a branch
           # in this workflow and push it to a remote that is NOT the current repo, i.e. pulumi/pulumi.
-          token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
           repository: pulumi/docs
           path: docs
       - name: Check out registry
@@ -156,7 +156,7 @@ jobs:
           # docs repo. Using a fork repo to raise the PR would also cause the `on: pull_request` workflow
           # to trigger, but currently Pulumify in the docs repo does not run for forks, but we want it to
           # generate the preview link.
-          token: ${{ secrets.PULUMI_BOT_GH_PAT_DOCS }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
           path: docs
           committer: Pulumi Bot <bot@pulumi.com>
           author: Pulumi Bot <bot@pulumi.com>


### PR DESCRIPTION
resourcedocsgen has been remved from the pulumi/docs repo in https://github.com/pulumi/docs/pull/10009, so now the related CI build fails.  Get it from the pulumi/registry repository instead, where it lives now.

Note that this requires https://github.com/pulumi/docs/pull/10053 to be merged first to update the script to no longer try to build the tool.

I'm not sure why the CI job didn't break earlier, the first time I noticed it being broken was in https://github.com/pulumi/pulumi/pull/14156.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
