### PR TITLE
[pcl/binder] Fixes panic when binding the signature of output-versioned invokes without arguments

### DIFF
--- a/changelog/pending/20231012--programgen--fixes-panic-when-binding-the-signature-of-output-versioned-invokes-without-input-arguments.yaml
+++ b/changelog/pending/20231012--programgen--fixes-panic-when-binding-the-signature-of-output-versioned-invokes-without-input-arguments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fixes panic when binding the signature of output-versioned invokes without input arguments 

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -255,8 +255,13 @@ func (b *binder) outputVersionSignature(fn *schema.Function) (model.StaticFuncti
 		return model.StaticFunctionSignature{}, fmt.Errorf("Function %s does not have an Output version", fn.Token)
 	}
 
-	// Given `fn.NeedsOutputVersion()==true`, can assume `fn.Inputs != nil`, `fn.ReturnType != nil`.
-	argsType := b.schemaTypeToType(fn.Inputs.InputShape)
+	// Given `fn.NeedsOutputVersion()==true` `fn.ReturnType != nil`.
+	var argsType model.Type
+	if fn.Inputs != nil {
+		argsType = b.schemaTypeToType(fn.Inputs.InputShape)
+	} else {
+		argsType = model.NewObjectType(map[string]model.Type{})
+	}
 	returnType := b.schemaTypeToType(fn.ReturnType)
 	return b.makeSignature(argsType, model.NewOutputType(returnType)), nil
 }


### PR DESCRIPTION
# Description

Fixes #14231 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
