### PR TITLE
Track actual error in StepExecutor

### DIFF
--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -131,7 +131,7 @@ func (i *importer) executeParallel(ctx context.Context, steps ...Step) bool {
 
 func (i *importer) wait(ctx context.Context, token completionToken) bool {
 	token.Wait(ctx)
-	return ctx.Err() == nil && !i.executor.Errored()
+	return ctx.Err() == nil && i.executor.Errored() == nil
 }
 
 func (i *importer) registerExistingResources(ctx context.Context) bool {

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -95,9 +95,11 @@ type stepExecutor struct {
 	workers        sync.WaitGroup     // WaitGroup tracking the worker goroutines that are owned by this step executor.
 	incomingChains chan incomingChain // Incoming chains that we are to execute
 
-	ctx      context.Context    // cancellation context for the current deployment.
-	cancel   context.CancelFunc // CancelFunc that cancels the above context.
-	sawError atomic.Value       // atomic boolean indicating whether or not the step excecutor saw that there was an error.
+	ctx    context.Context    // cancellation context for the current deployment.
+	cancel context.CancelFunc // CancelFunc that cancels the above context.
+
+	// atomic error indicating an error seen by the step executor, if multiple errors are seen this will only hold one.
+	sawError atomic.Value
 }
 
 //
@@ -218,7 +220,7 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 			outErr := fmt.Errorf("resource complete event returned an error: %w", eventerr)
 			diagMsg := diag.RawMessage(reg.URN(), outErr.Error())
 			se.deployment.Diag().Errorf(diagMsg)
-			se.cancelDueToError()
+			se.cancelDueToError(eventerr)
 			return nil
 		}
 	}
@@ -227,8 +229,12 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 }
 
 // Errored returns whether or not this step executor saw a step whose execution ended in failure.
-func (se *stepExecutor) Errored() bool {
-	return se.sawError.Load().(bool)
+func (se *stepExecutor) Errored() error {
+	err := se.sawError.Load()
+	if err == nil {
+		return nil
+	}
+	return err.(error)
 }
 
 // SignalCompletion signals to the stepExecutor that there are no more chains left to execute. All worker
@@ -271,7 +277,7 @@ func (se *stepExecutor) executeChain(workerID int, chain chain) {
 
 		if err != nil {
 			se.log(workerID, "step %v on %v failed, signalling cancellation", step.Op(), step.URN())
-			se.cancelDueToError()
+			se.cancelDueToError(err)
 			if err != errStepApplyFailed {
 				// Step application errors are recorded by the OnResourceStepPost callback. This is confusing,
 				// but it means that at this level we shouldn't be logging any errors that came from there.
@@ -286,8 +292,8 @@ func (se *stepExecutor) executeChain(workerID int, chain chain) {
 	}
 }
 
-func (se *stepExecutor) cancelDueToError() {
-	se.sawError.Store(true)
+func (se *stepExecutor) cancelDueToError(err error) {
+	se.sawError.Store(err)
 	if !se.continueOnError {
 		se.cancel()
 	}
@@ -493,8 +499,6 @@ func newStepExecutor(ctx context.Context, cancel context.CancelFunc, deployment 
 		ctx:             ctx,
 		cancel:          cancel,
 	}
-
-	exec.sawError.Store(false)
 
 	// If we're being asked to run as parallel as possible, spawn a single worker that launches chain executions
 	// asynchronously.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This results in much nicer errors being bubbled up to tests. User UX is not changed by this because these errors are always wrapped into Bails and so not shown to users.

We should make a similar change for step generator errors.