### PR TITLE
Update help text for `pulumi state delete`

### DIFF
--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -41,8 +41,8 @@ func newStateDeleteCommand() *cobra.Command {
 This command deletes a resource from a stack's state, as long as it is safe to do so. The resource is specified
 by its Pulumi URN. If the URN is omitted, this command will prompt for it.
 
-Resources can't be deleted if there exist other resources that depend on it or are parented to it. Protected resources
-will not be deleted unless it is specifically requested using the --force flag.
+Resources can't be deleted if other resources depend on it or are parented to it. Protected resources
+will not be deleted unless specifically requested using the --force flag.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
 


### PR DESCRIPTION
ericrudder 
> @dixler can we make this:
> Resources can't be deleted if other resources depend on it or are parented to it. Protected resources
will not be deleted unless specifically requested using the --force flag.

https://github.com/pulumi/home/pull/2164/files/ffdbe00b62f2fe8c0077ab83e3258eb1687fb769..1867fffa90253f58f1f57b40ad9f6780d9aa6396#r1357277045