### PR TITLE
Mark diff as an input diff when auto-diffing in the step generator

### DIFF
--- a/changelog/pending/20231016--engine--fix-automatic-diffs-comparing-against-output-instead-of-input-properties.yaml
+++ b/changelog/pending/20231016--engine--fix-automatic-diffs-comparing-against-output-instead-of-input-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix automatic diffs comparing against output instead of input properties.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1482,7 +1482,7 @@ func TestReplaceOnChanges(t *testing.T) {
 			if diff == nil {
 				return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 			}
-			detailedDiff := plugin.NewDetailedDiffFromObjectDiff(diff)
+			detailedDiff := plugin.NewDetailedDiffFromObjectDiff(diff, false)
 			changedKeys := diff.ChangedKeys()
 
 			return plugin.DiffResult{
@@ -3263,7 +3263,7 @@ func TestEventSecrets(t *testing.T) {
 					if diff == nil {
 						return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 					}
-					detailedDiff := plugin.NewDetailedDiffFromObjectDiff(diff)
+					detailedDiff := plugin.NewDetailedDiffFromObjectDiff(diff, false)
 					changedKeys := diff.ChangedKeys()
 
 					return plugin.DiffResult{
@@ -4380,4 +4380,69 @@ func TestProviderChecksums(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 0)
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/14040, ensure the step generators automatic
+// diff is tagged as an input diff.
+func TestAutomaticDiff(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	inputs := resource.PropertyMap{
+		"foo": resource.NewNumberProperty(1),
+	}
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs: inputs,
+		})
+		assert.NoError(t, err)
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &TestPlan{
+		Options: TestUpdateOptions{HostF: hostF},
+	}
+	resURN := p.NewURN("pkgA:m:typA", "resA", "")
+
+	// Run the initial update.
+	project := p.GetProject()
+	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NoError(t, err)
+
+	// Change the inputs and run again
+	inputs = resource.PropertyMap{
+		"foo": resource.NewNumberProperty(2),
+	}
+	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
+		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
+			events []Event, err error,
+		) error {
+			found := false
+			for _, e := range events {
+				if e.Type == ResourcePreEvent {
+					p := e.Payload().(ResourcePreEventPayload).Metadata
+					if p.URN == resURN {
+						// Should find an update op with the diff set to an input diff
+						assert.Equal(t, deploy.OpUpdate, p.Op)
+						assert.Equal(t, []resource.PropertyKey{"foo"}, p.Diffs)
+						assert.Equal(t, map[string]plugin.PropertyDiff{
+							"foo": {
+								Kind:      plugin.DiffUpdate,
+								InputDiff: true,
+							},
+						}, p.DetailedDiff)
+						found = true
+					}
+				}
+			}
+			assert.True(t, found)
+			return err
+		})
+	assert.NoError(t, err)
 }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1617,7 +1617,7 @@ func diffResource(urn resource.URN, id resource.ID, oldInputs, oldOutputs,
 		if tmp.AnyChanges() {
 			diff.Changes = plugin.DiffSome
 			diff.ChangedKeys = tmp.ChangedKeys()
-			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp /* inputDiff*/, true)
+			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp, true /* inputDiff */)
 		} else {
 			diff.Changes = plugin.DiffNone
 		}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1617,7 +1617,7 @@ func diffResource(urn resource.URN, id resource.ID, oldInputs, oldOutputs,
 		if tmp.AnyChanges() {
 			diff.Changes = plugin.DiffSome
 			diff.ChangedKeys = tmp.ChangedKeys()
-			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp)
+			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp /* inputDiff*/, true)
 		} else {
 			diff.Changes = plugin.DiffNone
 		}

--- a/sdk/go/common/resource/plugin/provider_test.go
+++ b/sdk/go/common/resource/plugin/provider_test.go
@@ -123,7 +123,7 @@ func TestNewDetailedDiff(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := NewDetailedDiffFromObjectDiff(c.diff)
+			actual := NewDetailedDiffFromObjectDiff(c.diff, false)
 			assert.Equal(t, c.expected, actual)
 		})
 	}


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Fixes https://github.com/pulumi/pulumi/issues/14040

When a provider returns `DiffUnknown` the step generator calculates a simple diff based on the old and new inputs.

We were not correctly marking that this is an input diff, and so when reconstructing objects from the detailed diff later in `TranslateDetailedDiff` we we're looking at the old output properties rather than the old input properties.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
