### PR TITLE
tighten up parsing of property path to avoid accepting typos

### DIFF
--- a/changelog/pending/20231016--cli--tightened-the-parser-for-property-paths-to-be-less-prone-to-typos.yaml
+++ b/changelog/pending/20231016--cli--tightened-the-parser-for-property-paths-to-be-less-prone-to-typos.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Tightened the parser for property paths to be less prone to typos

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1252,6 +1252,7 @@ func TestSetFail(t *testing.T) {
 		{Key: "my:root["},
 		{Key: `my:root["nested]`},
 		{Key: "my:root.array[abc]"},
+		{Key: "my:root.[1]"},
 
 		// First path component must be a string.
 		{Key: `my:[""]`},

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -53,6 +53,9 @@ func ParsePropertyPath(path string) (PropertyPath, error) {
 	// pathIndex := '[' ( [0-9]+ | '"' ('\' '"' | [^"] )+ '"' ']'
 	// path := { pathElement | pathIndex }
 	var elements []interface{}
+	if len(path) > 0 && path[0] == '.' {
+		return nil, errors.New("expected property path to start with a name or index")
+	}
 	for len(path) > 0 {
 		switch path[0] {
 		case '.':

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -49,13 +49,17 @@ type PropertyPath []interface{}
 func ParsePropertyPath(path string) (PropertyPath, error) {
 	// We interpret the grammar above a little loosely in order to keep things simple. Specifically, we will accept
 	// something close to the following:
-	// pathElement := { '.' } ( '[' ( [0-9]+ | '"' ('\' '"' | [^"] )+ '"' ']' | [a-zA-Z_$][a-zA-Z0-9_$] )
-	// path := { pathElement }
+	// pathElement := { '.' } [a-zA-Z_$][a-zA-Z0-9_$]
+	// pathIndex := '[' ( [0-9]+ | '"' ('\' '"' | [^"] )+ '"' ']'
+	// path := { pathElement | pathIndex }
 	var elements []interface{}
 	for len(path) > 0 {
 		switch path[0] {
 		case '.':
 			path = path[1:]
+			if len(path) > 0 && path[0] == '[' {
+				return nil, errors.New("expected property name after '.'")
+			}
 		case '[':
 			// If the character following the '[' is a '"', parse a string key.
 			var pathElement interface{}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -500,7 +500,7 @@ func TestConfigPaths(t *testing.T) {
 		`[""]`,
 		"[0]",
 		".foo",
-		".[0],
+		".[0]",
 
 		// Index out of range.
 		"names[-1]",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -499,6 +499,8 @@ func TestConfigPaths(t *testing.T) {
 		// First path segment must be a non-empty string.
 		`[""]`,
 		"[0]",
+		".foo",
+		".[0],
 
 		// Index out of range.
 		"names[-1]",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -494,6 +494,7 @@ func TestConfigPaths(t *testing.T) {
 		"root[",
 		`root["nested]`,
 		"root.array[abc]",
+		"root.[0]",
 
 		// First path segment must be a non-empty string.
 		`[""]`,


### PR DESCRIPTION
The key "my:root.[1]" used to not be accepted, because the `.` before the index is invalid.  However through https://github.com/pulumi/pulumi/pull/13814/files#r1320306140 and subsequently https://github.com/pulumi/pulumi/pull/14149, the parsing was loosened.

Presumably we were never checking this at the right level in the first place, and we only accidentally refused to parse it.  Fix this by tightening the conditions when parsing the property path.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
