### PR TITLE
Fix _configure to accept fallback property names correctly

### DIFF
--- a/changelog/pending/20231018--sdkgen-python--fix-_configure-failing-due-to-required-args-mismatch.yaml
+++ b/changelog/pending/20231018--sdkgen-python--fix-_configure-failing-due-to-required-args-mismatch.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fix `_configure` failing due to required args mismatch.

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -366,7 +366,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "configure-prop-names",
 		Description: "Checks that python _configure handles camelcased and snakecased prop names correctly",
-		Skip:        allLanguages.Except(python),
+		Skip:        allLanguages.Except("python/any"),
 	},
 }
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
@@ -98,7 +98,7 @@ class IndexingPolicyResponse(dict):
              composite_indexes: Optional[Sequence[Sequence['outputs.CompositePathResponse']]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'compositeIndexes' in kwargs:
+        if composite_indexes is None and 'compositeIndexes' in kwargs:
             composite_indexes = kwargs['compositeIndexes']
 
         if composite_indexes is not None:
@@ -147,7 +147,7 @@ class SqlContainerGetPropertiesResponseResource(dict):
              indexing_policy: Optional['outputs.IndexingPolicyResponse'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'indexingPolicy' in kwargs:
+        if indexing_policy is None and 'indexingPolicy' in kwargs:
             indexing_policy = kwargs['indexingPolicy']
 
         if indexing_policy is not None:

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python-extras/tests/test_codegen.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python-extras/tests/test_codegen.py
@@ -38,17 +38,48 @@ class MyMocks(pulumi.runtime.Mocks):
 
         :param MockResourceArgs args.
         """
-        assert args.inputs['bootDisk']['initializeParams']['image'] == "debian-cloud/debian-11"
+        assert args.inputs['bootDisk']['initializeParams']['imageName'] == "debian-cloud/debian-11"
         return 'foo', args.inputs
 
 @pulumi.runtime.test
 def test_func_with_default_value(my_mocks):
     compute.instance.Instance(
-        "instance-old",
+        "instance-1",
         boot_disk={
             "initializeParams": {
-                "image": "debian-cloud/debian-11",
+                "imageName": "debian-cloud/debian-11",
             },
         },
     )
+    compute.instance.Instance(
+        "instance-2",
+        boot_disk={
+            "initialize_params": {
+                "image_name": "debian-cloud/debian-11",
+            },
+        },
+    )
+    compute.instance.Instance(
+        "instance-3",
+        boot_disk={
+            "initializeParams": {
+                "image_name": "debian-cloud/debian-11",
+            },
+        },
+    )
+    compute.instance.Instance(
+        "instance-4",
+        boot_disk={
+            "initialize_params": {
+                "imageName": "debian-cloud/debian-11",
+            },
+        },
+    )
+    with pytest.raises(TypeError):
+        # Check that this fails as it is missing "initialize_params".
+        compute.instance.Instance(
+            "will-fail",
+            boot_disk={},
+        )
+
 

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instance/instance.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instance/instance.py
@@ -28,11 +28,13 @@ class InstanceArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             boot_disk: pulumi.Input['_compute.instancebootdisk.InstanceBootDiskArgs'],
+             boot_disk: Optional[pulumi.Input['_compute.instancebootdisk.InstanceBootDiskArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'bootDisk' in kwargs:
+        if boot_disk is None and 'bootDisk' in kwargs:
             boot_disk = kwargs['bootDisk']
+        if boot_disk is None:
+            raise TypeError("Missing 'boot_disk' argument")
 
         _setter("boot_disk", boot_disk)
 
@@ -69,7 +71,7 @@ class _InstanceState:
              boot_disk: Optional[pulumi.Input['_compute.instancebootdisk.InstanceBootDiskArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'bootDisk' in kwargs:
+        if boot_disk is None and 'bootDisk' in kwargs:
             boot_disk = kwargs['bootDisk']
 
         if boot_disk is not None:

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
@@ -17,7 +17,7 @@ __all__ = [
 @pulumi.input_type
 class InstanceBootDiskArgs:
     def __init__(__self__, *,
-                 initialize_params: Optional[pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']] = None):
+                 initialize_params: pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']):
         """
         :param pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs'] initialize_params: Parameters for a new disk that will be created
                alongside the new instance. Either `initialize_params` or `source` must be set.
@@ -33,15 +33,16 @@ class InstanceBootDiskArgs:
              initialize_params: Optional[pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'initializeParams' in kwargs:
+        if initialize_params is None and 'initializeParams' in kwargs:
             initialize_params = kwargs['initializeParams']
+        if initialize_params is None:
+            raise TypeError("Missing 'initialize_params' argument")
 
-        if initialize_params is not None:
-            _setter("initialize_params", initialize_params)
+        _setter("initialize_params", initialize_params)
 
     @property
     @pulumi.getter(name="initializeParams")
-    def initialize_params(self) -> Optional[pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']]:
+    def initialize_params(self) -> pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']:
         """
         Parameters for a new disk that will be created
         alongside the new instance. Either `initialize_params` or `source` must be set.
@@ -50,7 +51,7 @@ class InstanceBootDiskArgs:
         return pulumi.get(self, "initialize_params")
 
     @initialize_params.setter
-    def initialize_params(self, value: Optional[pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']]):
+    def initialize_params(self, value: pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']):
         pulumi.set(self, "initialize_params", value)
 
 

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/outputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/outputs.py
@@ -34,7 +34,7 @@ class InstanceBootDisk(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 initialize_params: Optional['_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams'] = None):
+                 initialize_params: '_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams'):
         """
         :param '_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs' initialize_params: Parameters for a new disk that will be created
                alongside the new instance. Either `initialize_params` or `source` must be set.
@@ -50,15 +50,16 @@ class InstanceBootDisk(dict):
              initialize_params: Optional['_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'initializeParams' in kwargs:
+        if initialize_params is None and 'initializeParams' in kwargs:
             initialize_params = kwargs['initializeParams']
+        if initialize_params is None:
+            raise TypeError("Missing 'initialize_params' argument")
 
-        if initialize_params is not None:
-            _setter("initialize_params", initialize_params)
+        _setter("initialize_params", initialize_params)
 
     @property
     @pulumi.getter(name="initializeParams")
-    def initialize_params(self) -> Optional['_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams']:
+    def initialize_params(self) -> '_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams':
         """
         Parameters for a new disk that will be created
         alongside the new instance. Either `initialize_params` or `source` must be set.

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
@@ -16,9 +16,9 @@ __all__ = [
 @pulumi.input_type
 class InstanceBootDiskInitializeParamsArgs:
     def __init__(__self__, *,
-                 image: Optional[pulumi.Input[str]] = None):
+                 image_name: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[str] image: The image from which to initialize this disk. This can be
+        :param pulumi.Input[str] image_name: The image from which to initialize this disk. This can be
                one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
                `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
                `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
@@ -30,23 +30,23 @@ class InstanceBootDiskInitializeParamsArgs:
         """
         InstanceBootDiskInitializeParamsArgs._configure(
             lambda key, value: pulumi.set(__self__, key, value),
-            image=image,
+            image_name=image_name,
         )
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             image: Optional[pulumi.Input[str]] = None,
+             image_name: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'image' in kwargs:
-            image = kwargs['image']
+        if image_name is None and 'imageName' in kwargs:
+            image_name = kwargs['imageName']
 
-        if image is not None:
-            _setter("image", image)
+        if image_name is not None:
+            _setter("image_name", image_name)
 
     @property
-    @pulumi.getter
-    def image(self) -> Optional[pulumi.Input[str]]:
+    @pulumi.getter(name="imageName")
+    def image_name(self) -> Optional[pulumi.Input[str]]:
         """
         The image from which to initialize this disk. This can be
         one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
@@ -58,10 +58,10 @@ class InstanceBootDiskInitializeParamsArgs:
         For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
         These images can be referred by family name here.
         """
-        return pulumi.get(self, "image")
+        return pulumi.get(self, "image_name")
 
-    @image.setter
-    def image(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "image", value)
+    @image_name.setter
+    def image_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "image_name", value)
 
 

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
@@ -15,10 +15,27 @@ __all__ = [
 
 @pulumi.output_type
 class InstanceBootDiskInitializeParams(dict):
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "imageName":
+            suggest = "image_name"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in InstanceBootDiskInitializeParams. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        InstanceBootDiskInitializeParams.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        InstanceBootDiskInitializeParams.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
-                 image: Optional[str] = None):
+                 image_name: Optional[str] = None):
         """
-        :param str image: The image from which to initialize this disk. This can be
+        :param str image_name: The image from which to initialize this disk. This can be
                one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
                `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
                `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
@@ -30,23 +47,23 @@ class InstanceBootDiskInitializeParams(dict):
         """
         InstanceBootDiskInitializeParams._configure(
             lambda key, value: pulumi.set(__self__, key, value),
-            image=image,
+            image_name=image_name,
         )
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             image: Optional[str] = None,
+             image_name: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'image' in kwargs:
-            image = kwargs['image']
+        if image_name is None and 'imageName' in kwargs:
+            image_name = kwargs['imageName']
 
-        if image is not None:
-            _setter("image", image)
+        if image_name is not None:
+            _setter("image_name", image_name)
 
     @property
-    @pulumi.getter
-    def image(self) -> Optional[str]:
+    @pulumi.getter(name="imageName")
+    def image_name(self) -> Optional[str]:
         """
         The image from which to initialize this disk. This can be
         one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
@@ -58,6 +75,6 @@ class InstanceBootDiskInitializeParams(dict):
         For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
         These images can be referred by family name here.
         """
-        return pulumi.get(self, "image")
+        return pulumi.get(self, "image_name")
 
 

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/schema.json
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/schema.json
@@ -10,6 +10,9 @@
                     "willReplaceOnChanges": true
                 }
             },
+            "required": [
+                "initializeParams"
+            ],
             "type": "object",
             "language": {
                 "nodejs": {
@@ -21,7 +24,7 @@
         },
         "gcp:compute/InstanceBootDiskInitializeParams:InstanceBootDiskInitializeParams": {
             "properties": {
-                "image": {
+                "imageName": {
                     "type": "string",
                     "description": "The image from which to initialize this disk. This can be\none of: the image's `self_link`, `projects/{project}/global/images/{image}`,\n`projects/{project}/global/images/family/{family}`, `global/images/{image}`,\n`global/images/family/{family}`, `family/{family}`, `{project}/{family}`,\n`{project}/{image}`, `{family}`, or `{image}`. If referred by family, the\nimages names must include the family name. If they don't, use the\n[gcp.compute.Image data source](https://www.terraform.io/docs/providers/google/d/compute_image.html).\nFor instance, the image `centos-6-v20180104` includes its family name `centos-6`.\nThese images can be referred by family name here.\n",
                     "willReplaceOnChanges": true
@@ -31,7 +34,7 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "image"
+                        "imageName"
                     ]
                 }
             }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
@@ -31,12 +31,14 @@ class ContainerArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: pulumi.Input['ContainerSize'],
+             size: Optional[pulumi.Input['ContainerSize']] = None,
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/outputs.py
@@ -31,12 +31,14 @@ class Container(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: 'ContainerSize',
+             size: Optional['ContainerSize'] = None,
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -30,10 +30,12 @@ class NurseryArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
+             varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if varieties is None:
+            raise TypeError("Missing 'varieties' argument")
 
         _setter("varieties", varieties)
         if sizes is not None:

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
@@ -31,12 +31,14 @@ class ContainerArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: pulumi.Input['ContainerSize'],
+             size: Optional[pulumi.Input['ContainerSize']] = None,
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/outputs.py
@@ -31,12 +31,14 @@ class Container(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: 'ContainerSize',
+             size: Optional['ContainerSize'] = None,
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -30,10 +30,12 @@ class NurseryArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
+             varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if varieties is None:
+            raise TypeError("Missing 'varieties' argument")
 
         _setter("varieties", varieties)
         if sizes is not None:

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
@@ -33,7 +33,7 @@ class ComponentArgs:
              pod: Optional[pulumi.Input['pulumi_kubernetes.core.v1.PodArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'eniConfig' in kwargs:
+        if eni_config is None and 'eniConfig' in kwargs:
             eni_config = kwargs['eniConfig']
 
         if eni_config is not None:

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
@@ -30,7 +30,7 @@ class ENIConfigSpecArgs:
              subnet: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'securityGroups' in kwargs:
+        if security_groups is None and 'securityGroups' in kwargs:
             security_groups = kwargs['securityGroups']
 
         if security_groups is not None:

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
@@ -47,7 +47,7 @@ class ENIConfigSpec(dict):
              subnet: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'securityGroups' in kwargs:
+        if security_groups is None and 'securityGroups' in kwargs:
             security_groups = kwargs['securityGroups']
 
         if security_groups is not None:

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
@@ -48,7 +48,7 @@ class NodePoolAutoscaling(dict):
              location_policy: Optional['pulumi_google_native.container.v1.NodePoolAutoscalingLocationPolicy'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'locationPolicy' in kwargs:
+        if location_policy is None and 'locationPolicy' in kwargs:
             location_policy = kwargs['locationPolicy']
 
         if location_policy is not None:

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/replicated_bucket.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/replicated_bucket.py
@@ -28,11 +28,13 @@ class ReplicatedBucketArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             destination_region: pulumi.Input[str],
+             destination_region: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'destinationRegion' in kwargs:
+        if destination_region is None and 'destinationRegion' in kwargs:
             destination_region = kwargs['destinationRegion']
+        if destination_region is None:
+            raise TypeError("Missing 'destination_region' argument")
 
         _setter("destination_region", destination_region)
 

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
@@ -33,9 +33,9 @@ class ComponentArgs:
              remote_enum: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'localEnum' in kwargs:
+        if local_enum is None and 'localEnum' in kwargs:
             local_enum = kwargs['localEnum']
-        if 'remoteEnum' in kwargs:
+        if remote_enum is None and 'remoteEnum' in kwargs:
             remote_enum = kwargs['remoteEnum']
 
         if local_enum is not None:

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -32,7 +32,7 @@ class TrailArgs:
              trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'advancedEventSelectors' in kwargs:
+        if advanced_event_selectors is None and 'advancedEventSelectors' in kwargs:
             advanced_event_selectors = kwargs['advancedEventSelectors']
 
         if advanced_event_selectors is not None:

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
@@ -37,24 +37,30 @@ class PetArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_name: pulumi.Input['pulumi_random.RandomPet'],
-             required_name_array: pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]],
-             required_name_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]],
+             required_name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
+             required_name_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
+             required_name_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None,
              age: Optional[pulumi.Input[int]] = None,
              name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
              name_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
              name_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredName' in kwargs:
+        if required_name is None and 'requiredName' in kwargs:
             required_name = kwargs['requiredName']
-        if 'requiredNameArray' in kwargs:
+        if required_name is None:
+            raise TypeError("Missing 'required_name' argument")
+        if required_name_array is None and 'requiredNameArray' in kwargs:
             required_name_array = kwargs['requiredNameArray']
-        if 'requiredNameMap' in kwargs:
+        if required_name_array is None:
+            raise TypeError("Missing 'required_name_array' argument")
+        if required_name_map is None and 'requiredNameMap' in kwargs:
             required_name_map = kwargs['requiredNameMap']
-        if 'nameArray' in kwargs:
+        if required_name_map is None:
+            raise TypeError("Missing 'required_name_map' argument")
+        if name_array is None and 'nameArray' in kwargs:
             name_array = kwargs['nameArray']
-        if 'nameMap' in kwargs:
+        if name_map is None and 'nameMap' in kwargs:
             name_map = kwargs['nameMap']
 
         _setter("required_name", required_name)

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -37,23 +37,29 @@ class ComponentArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_metadata: pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs'],
-             required_metadata_array: pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
-             required_metadata_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
+             required_metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
+             required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
+             required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
              metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
              metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
              metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredMetadata' in kwargs:
+        if required_metadata is None and 'requiredMetadata' in kwargs:
             required_metadata = kwargs['requiredMetadata']
-        if 'requiredMetadataArray' in kwargs:
+        if required_metadata is None:
+            raise TypeError("Missing 'required_metadata' argument")
+        if required_metadata_array is None and 'requiredMetadataArray' in kwargs:
             required_metadata_array = kwargs['requiredMetadataArray']
-        if 'requiredMetadataMap' in kwargs:
+        if required_metadata_array is None:
+            raise TypeError("Missing 'required_metadata_array' argument")
+        if required_metadata_map is None and 'requiredMetadataMap' in kwargs:
             required_metadata_map = kwargs['requiredMetadataMap']
-        if 'metadataArray' in kwargs:
+        if required_metadata_map is None:
+            raise TypeError("Missing 'required_metadata_map' argument")
+        if metadata_array is None and 'metadataArray' in kwargs:
             metadata_array = kwargs['metadataArray']
-        if 'metadataMap' in kwargs:
+        if metadata_map is None and 'metadataMap' in kwargs:
             metadata_map = kwargs['metadataMap']
 
         _setter("required_metadata", required_metadata)

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -27,11 +27,13 @@ class RegistryGeoReplicationArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             resource_group: pulumi.Input['pulumi_azure_native.resources.ResourceGroup'],
+             resource_group: Optional[pulumi.Input['pulumi_azure_native.resources.ResourceGroup']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'resourceGroup' in kwargs:
+        if resource_group is None and 'resourceGroup' in kwargs:
             resource_group = kwargs['resourceGroup']
+        if resource_group is None:
+            raise TypeError("Missing 'resource_group' argument")
 
         _setter("resource_group", resource_group)
 

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/outputs.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/outputs.py
@@ -44,7 +44,7 @@ class Bar(dict):
              has_a_hyphen: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'has-a-hyphen' in kwargs:
+        if has_a_hyphen is None and 'has-a-hyphen' in kwargs:
             has_a_hyphen = kwargs['has-a-hyphen']
 
         if has_a_hyphen is not None:

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
@@ -36,13 +36,15 @@ class ConfigurationFilters:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             hierarchy_information: 'HierarchyInformation',
+             hierarchy_information: Optional['HierarchyInformation'] = None,
              filterable_property: Optional[Sequence['FilterableProperty']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'hierarchyInformation' in kwargs:
+        if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
-        if 'filterableProperty' in kwargs:
+        if hierarchy_information is None:
+            raise TypeError("Missing 'hierarchy_information' argument")
+        if filterable_property is None and 'filterableProperty' in kwargs:
             filterable_property = kwargs['filterableProperty']
 
         _setter("hierarchy_information", hierarchy_information)
@@ -95,16 +97,18 @@ class CustomerSubscriptionDetails:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             quota_id: str,
+             quota_id: Optional[str] = None,
              location_placement_id: Optional[str] = None,
              registered_features: Optional[Sequence['CustomerSubscriptionRegisteredFeatures']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'quotaId' in kwargs:
+        if quota_id is None and 'quotaId' in kwargs:
             quota_id = kwargs['quotaId']
-        if 'locationPlacementId' in kwargs:
+        if quota_id is None:
+            raise TypeError("Missing 'quota_id' argument")
+        if location_placement_id is None and 'locationPlacementId' in kwargs:
             location_placement_id = kwargs['locationPlacementId']
-        if 'registeredFeatures' in kwargs:
+        if registered_features is None and 'registeredFeatures' in kwargs:
             registered_features = kwargs['registeredFeatures']
 
         _setter("quota_id", quota_id)
@@ -221,12 +225,16 @@ class FilterableProperty:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             supported_values: Sequence[str],
-             type: Union[str, 'SupportedFilterTypes'],
+             supported_values: Optional[Sequence[str]] = None,
+             type: Optional[Union[str, 'SupportedFilterTypes']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'supportedValues' in kwargs:
+        if supported_values is None and 'supportedValues' in kwargs:
             supported_values = kwargs['supportedValues']
+        if supported_values is None:
+            raise TypeError("Missing 'supported_values' argument")
+        if type is None:
+            raise TypeError("Missing 'type' argument")
 
         _setter("supported_values", supported_values)
         _setter("type", type)
@@ -286,13 +294,13 @@ class HierarchyInformation:
              product_name: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'configurationName' in kwargs:
+        if configuration_name is None and 'configurationName' in kwargs:
             configuration_name = kwargs['configurationName']
-        if 'productFamilyName' in kwargs:
+        if product_family_name is None and 'productFamilyName' in kwargs:
             product_family_name = kwargs['productFamilyName']
-        if 'productLineName' in kwargs:
+        if product_line_name is None and 'productLineName' in kwargs:
             product_line_name = kwargs['productLineName']
-        if 'productName' in kwargs:
+        if product_name is None and 'productName' in kwargs:
             product_name = kwargs['productName']
 
         if configuration_name is not None:

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
@@ -54,17 +54,23 @@ class AvailabilityInformationResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             availability_stage: str,
-             disabled_reason: str,
-             disabled_reason_message: str,
+             availability_stage: Optional[str] = None,
+             disabled_reason: Optional[str] = None,
+             disabled_reason_message: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'availabilityStage' in kwargs:
+        if availability_stage is None and 'availabilityStage' in kwargs:
             availability_stage = kwargs['availabilityStage']
-        if 'disabledReason' in kwargs:
+        if availability_stage is None:
+            raise TypeError("Missing 'availability_stage' argument")
+        if disabled_reason is None and 'disabledReason' in kwargs:
             disabled_reason = kwargs['disabledReason']
-        if 'disabledReasonMessage' in kwargs:
+        if disabled_reason is None:
+            raise TypeError("Missing 'disabled_reason' argument")
+        if disabled_reason_message is None and 'disabledReasonMessage' in kwargs:
             disabled_reason_message = kwargs['disabledReasonMessage']
+        if disabled_reason_message is None:
+            raise TypeError("Missing 'disabled_reason_message' argument")
 
         _setter("availability_stage", availability_stage)
         _setter("disabled_reason", disabled_reason)
@@ -122,16 +128,24 @@ class BillingMeterDetailsResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             frequency: str,
-             meter_details: Any,
-             metering_type: str,
-             name: str,
+             frequency: Optional[str] = None,
+             meter_details: Optional[Any] = None,
+             metering_type: Optional[str] = None,
+             name: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'meterDetails' in kwargs:
+        if frequency is None:
+            raise TypeError("Missing 'frequency' argument")
+        if meter_details is None and 'meterDetails' in kwargs:
             meter_details = kwargs['meterDetails']
-        if 'meteringType' in kwargs:
+        if meter_details is None:
+            raise TypeError("Missing 'meter_details' argument")
+        if metering_type is None and 'meteringType' in kwargs:
             metering_type = kwargs['meteringType']
+        if metering_type is None:
+            raise TypeError("Missing 'metering_type' argument")
+        if name is None:
+            raise TypeError("Missing 'name' argument")
 
         _setter("frequency", frequency)
         _setter("meter_details", meter_details)
@@ -213,29 +227,47 @@ class ConfigurationResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             availability_information: 'outputs.AvailabilityInformationResponse',
-             cost_information: 'outputs.CostInformationResponse',
-             description: 'outputs.DescriptionResponse',
-             dimensions: 'outputs.DimensionsResponse',
-             display_name: str,
-             filterable_properties: Sequence['outputs.FilterablePropertyResponse'],
-             hierarchy_information: 'outputs.HierarchyInformationResponse',
-             image_information: Sequence['outputs.ImageInformationResponse'],
-             specifications: Sequence['outputs.SpecificationResponse'],
+             availability_information: Optional['outputs.AvailabilityInformationResponse'] = None,
+             cost_information: Optional['outputs.CostInformationResponse'] = None,
+             description: Optional['outputs.DescriptionResponse'] = None,
+             dimensions: Optional['outputs.DimensionsResponse'] = None,
+             display_name: Optional[str] = None,
+             filterable_properties: Optional[Sequence['outputs.FilterablePropertyResponse']] = None,
+             hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
+             image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
+             specifications: Optional[Sequence['outputs.SpecificationResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'availabilityInformation' in kwargs:
+        if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
-        if 'costInformation' in kwargs:
+        if availability_information is None:
+            raise TypeError("Missing 'availability_information' argument")
+        if cost_information is None and 'costInformation' in kwargs:
             cost_information = kwargs['costInformation']
-        if 'displayName' in kwargs:
+        if cost_information is None:
+            raise TypeError("Missing 'cost_information' argument")
+        if description is None:
+            raise TypeError("Missing 'description' argument")
+        if dimensions is None:
+            raise TypeError("Missing 'dimensions' argument")
+        if display_name is None and 'displayName' in kwargs:
             display_name = kwargs['displayName']
-        if 'filterableProperties' in kwargs:
+        if display_name is None:
+            raise TypeError("Missing 'display_name' argument")
+        if filterable_properties is None and 'filterableProperties' in kwargs:
             filterable_properties = kwargs['filterableProperties']
-        if 'hierarchyInformation' in kwargs:
+        if filterable_properties is None:
+            raise TypeError("Missing 'filterable_properties' argument")
+        if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
-        if 'imageInformation' in kwargs:
+        if hierarchy_information is None:
+            raise TypeError("Missing 'hierarchy_information' argument")
+        if image_information is None and 'imageInformation' in kwargs:
             image_information = kwargs['imageInformation']
+        if image_information is None:
+            raise TypeError("Missing 'image_information' argument")
+        if specifications is None:
+            raise TypeError("Missing 'specifications' argument")
 
         _setter("availability_information", availability_information)
         _setter("cost_information", cost_information)
@@ -341,14 +373,18 @@ class CostInformationResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             billing_info_url: str,
-             billing_meter_details: Sequence['outputs.BillingMeterDetailsResponse'],
+             billing_info_url: Optional[str] = None,
+             billing_meter_details: Optional[Sequence['outputs.BillingMeterDetailsResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'billingInfoUrl' in kwargs:
+        if billing_info_url is None and 'billingInfoUrl' in kwargs:
             billing_info_url = kwargs['billingInfoUrl']
-        if 'billingMeterDetails' in kwargs:
+        if billing_info_url is None:
+            raise TypeError("Missing 'billing_info_url' argument")
+        if billing_meter_details is None and 'billingMeterDetails' in kwargs:
             billing_meter_details = kwargs['billingMeterDetails']
+        if billing_meter_details is None:
+            raise TypeError("Missing 'billing_meter_details' argument")
 
         _setter("billing_info_url", billing_info_url)
         _setter("billing_meter_details", billing_meter_details)
@@ -403,20 +439,32 @@ class DescriptionResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             attributes: Sequence[str],
-             description_type: str,
-             keywords: Sequence[str],
-             links: Sequence['outputs.LinkResponse'],
-             long_description: str,
-             short_description: str,
+             attributes: Optional[Sequence[str]] = None,
+             description_type: Optional[str] = None,
+             keywords: Optional[Sequence[str]] = None,
+             links: Optional[Sequence['outputs.LinkResponse']] = None,
+             long_description: Optional[str] = None,
+             short_description: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'descriptionType' in kwargs:
+        if attributes is None:
+            raise TypeError("Missing 'attributes' argument")
+        if description_type is None and 'descriptionType' in kwargs:
             description_type = kwargs['descriptionType']
-        if 'longDescription' in kwargs:
+        if description_type is None:
+            raise TypeError("Missing 'description_type' argument")
+        if keywords is None:
+            raise TypeError("Missing 'keywords' argument")
+        if links is None:
+            raise TypeError("Missing 'links' argument")
+        if long_description is None and 'longDescription' in kwargs:
             long_description = kwargs['longDescription']
-        if 'shortDescription' in kwargs:
+        if long_description is None:
+            raise TypeError("Missing 'long_description' argument")
+        if short_description is None and 'shortDescription' in kwargs:
             short_description = kwargs['shortDescription']
+        if short_description is None:
+            raise TypeError("Missing 'short_description' argument")
 
         _setter("attributes", attributes)
         _setter("description_type", description_type)
@@ -510,19 +558,33 @@ class DimensionsResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             depth: float,
-             height: float,
-             length: float,
-             length_height_unit: str,
-             weight: float,
-             weight_unit: str,
-             width: float,
+             depth: Optional[float] = None,
+             height: Optional[float] = None,
+             length: Optional[float] = None,
+             length_height_unit: Optional[str] = None,
+             weight: Optional[float] = None,
+             weight_unit: Optional[str] = None,
+             width: Optional[float] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'lengthHeightUnit' in kwargs:
+        if depth is None:
+            raise TypeError("Missing 'depth' argument")
+        if height is None:
+            raise TypeError("Missing 'height' argument")
+        if length is None:
+            raise TypeError("Missing 'length' argument")
+        if length_height_unit is None and 'lengthHeightUnit' in kwargs:
             length_height_unit = kwargs['lengthHeightUnit']
-        if 'weightUnit' in kwargs:
+        if length_height_unit is None:
+            raise TypeError("Missing 'length_height_unit' argument")
+        if weight is None:
+            raise TypeError("Missing 'weight' argument")
+        if weight_unit is None and 'weightUnit' in kwargs:
             weight_unit = kwargs['weightUnit']
+        if weight_unit is None:
+            raise TypeError("Missing 'weight_unit' argument")
+        if width is None:
+            raise TypeError("Missing 'width' argument")
 
         _setter("depth", depth)
         _setter("height", height)
@@ -610,12 +672,16 @@ class FilterablePropertyResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             supported_values: Sequence[str],
-             type: str,
+             supported_values: Optional[Sequence[str]] = None,
+             type: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'supportedValues' in kwargs:
+        if supported_values is None and 'supportedValues' in kwargs:
             supported_values = kwargs['supportedValues']
+        if supported_values is None:
+            raise TypeError("Missing 'supported_values' argument")
+        if type is None:
+            raise TypeError("Missing 'type' argument")
 
         _setter("supported_values", supported_values)
         _setter("type", type)
@@ -670,13 +736,13 @@ class HierarchyInformationResponse(dict):
              product_name: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'configurationName' in kwargs:
+        if configuration_name is None and 'configurationName' in kwargs:
             configuration_name = kwargs['configurationName']
-        if 'productFamilyName' in kwargs:
+        if product_family_name is None and 'productFamilyName' in kwargs:
             product_family_name = kwargs['productFamilyName']
-        if 'productLineName' in kwargs:
+        if product_line_name is None and 'productLineName' in kwargs:
             product_line_name = kwargs['productLineName']
-        if 'productName' in kwargs:
+        if product_name is None and 'productName' in kwargs:
             product_name = kwargs['productName']
 
         if configuration_name is not None:
@@ -742,14 +808,18 @@ class ImageInformationResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             image_type: str,
-             image_url: str,
+             image_type: Optional[str] = None,
+             image_url: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'imageType' in kwargs:
+        if image_type is None and 'imageType' in kwargs:
             image_type = kwargs['imageType']
-        if 'imageUrl' in kwargs:
+        if image_type is None:
+            raise TypeError("Missing 'image_type' argument")
+        if image_url is None and 'imageUrl' in kwargs:
             image_url = kwargs['imageUrl']
+        if image_url is None:
+            raise TypeError("Missing 'image_url' argument")
 
         _setter("image_type", image_type)
         _setter("image_url", image_url)
@@ -792,14 +862,18 @@ class LinkResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             link_type: str,
-             link_url: str,
+             link_type: Optional[str] = None,
+             link_url: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'linkType' in kwargs:
+        if link_type is None and 'linkType' in kwargs:
             link_type = kwargs['linkType']
-        if 'linkUrl' in kwargs:
+        if link_type is None:
+            raise TypeError("Missing 'link_type' argument")
+        if link_url is None and 'linkUrl' in kwargs:
             link_url = kwargs['linkUrl']
+        if link_url is None:
+            raise TypeError("Missing 'link_url' argument")
 
         _setter("link_type", link_type)
         _setter("link_url", link_url)
@@ -849,18 +923,26 @@ class Pav2MeterDetailsResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             billing_type: str,
-             charging_type: str,
-             meter_guid: str,
-             multiplier: float,
+             billing_type: Optional[str] = None,
+             charging_type: Optional[str] = None,
+             meter_guid: Optional[str] = None,
+             multiplier: Optional[float] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'billingType' in kwargs:
+        if billing_type is None and 'billingType' in kwargs:
             billing_type = kwargs['billingType']
-        if 'chargingType' in kwargs:
+        if billing_type is None:
+            raise TypeError("Missing 'billing_type' argument")
+        if charging_type is None and 'chargingType' in kwargs:
             charging_type = kwargs['chargingType']
-        if 'meterGuid' in kwargs:
+        if charging_type is None:
+            raise TypeError("Missing 'charging_type' argument")
+        if meter_guid is None and 'meterGuid' in kwargs:
             meter_guid = kwargs['meterGuid']
+        if meter_guid is None:
+            raise TypeError("Missing 'meter_guid' argument")
+        if multiplier is None:
+            raise TypeError("Missing 'multiplier' argument")
 
         _setter("billing_type", 'Pav2')
         _setter("charging_type", charging_type)
@@ -940,30 +1022,46 @@ class ProductFamilyResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             availability_information: 'outputs.AvailabilityInformationResponse',
-             cost_information: 'outputs.CostInformationResponse',
-             description: 'outputs.DescriptionResponse',
-             display_name: str,
-             filterable_properties: Sequence['outputs.FilterablePropertyResponse'],
-             hierarchy_information: 'outputs.HierarchyInformationResponse',
-             image_information: Sequence['outputs.ImageInformationResponse'],
-             product_lines: Sequence['outputs.ProductLineResponse'],
+             availability_information: Optional['outputs.AvailabilityInformationResponse'] = None,
+             cost_information: Optional['outputs.CostInformationResponse'] = None,
+             description: Optional['outputs.DescriptionResponse'] = None,
+             display_name: Optional[str] = None,
+             filterable_properties: Optional[Sequence['outputs.FilterablePropertyResponse']] = None,
+             hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
+             image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
+             product_lines: Optional[Sequence['outputs.ProductLineResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'availabilityInformation' in kwargs:
+        if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
-        if 'costInformation' in kwargs:
+        if availability_information is None:
+            raise TypeError("Missing 'availability_information' argument")
+        if cost_information is None and 'costInformation' in kwargs:
             cost_information = kwargs['costInformation']
-        if 'displayName' in kwargs:
+        if cost_information is None:
+            raise TypeError("Missing 'cost_information' argument")
+        if description is None:
+            raise TypeError("Missing 'description' argument")
+        if display_name is None and 'displayName' in kwargs:
             display_name = kwargs['displayName']
-        if 'filterableProperties' in kwargs:
+        if display_name is None:
+            raise TypeError("Missing 'display_name' argument")
+        if filterable_properties is None and 'filterableProperties' in kwargs:
             filterable_properties = kwargs['filterableProperties']
-        if 'hierarchyInformation' in kwargs:
+        if filterable_properties is None:
+            raise TypeError("Missing 'filterable_properties' argument")
+        if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
-        if 'imageInformation' in kwargs:
+        if hierarchy_information is None:
+            raise TypeError("Missing 'hierarchy_information' argument")
+        if image_information is None and 'imageInformation' in kwargs:
             image_information = kwargs['imageInformation']
-        if 'productLines' in kwargs:
+        if image_information is None:
+            raise TypeError("Missing 'image_information' argument")
+        if product_lines is None and 'productLines' in kwargs:
             product_lines = kwargs['productLines']
+        if product_lines is None:
+            raise TypeError("Missing 'product_lines' argument")
 
         _setter("availability_information", availability_information)
         _setter("cost_information", cost_information)
@@ -1078,28 +1176,44 @@ class ProductLineResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             availability_information: 'outputs.AvailabilityInformationResponse',
-             cost_information: 'outputs.CostInformationResponse',
-             description: 'outputs.DescriptionResponse',
-             display_name: str,
-             filterable_properties: Sequence['outputs.FilterablePropertyResponse'],
-             hierarchy_information: 'outputs.HierarchyInformationResponse',
-             image_information: Sequence['outputs.ImageInformationResponse'],
-             products: Sequence['outputs.ProductResponse'],
+             availability_information: Optional['outputs.AvailabilityInformationResponse'] = None,
+             cost_information: Optional['outputs.CostInformationResponse'] = None,
+             description: Optional['outputs.DescriptionResponse'] = None,
+             display_name: Optional[str] = None,
+             filterable_properties: Optional[Sequence['outputs.FilterablePropertyResponse']] = None,
+             hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
+             image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
+             products: Optional[Sequence['outputs.ProductResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'availabilityInformation' in kwargs:
+        if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
-        if 'costInformation' in kwargs:
+        if availability_information is None:
+            raise TypeError("Missing 'availability_information' argument")
+        if cost_information is None and 'costInformation' in kwargs:
             cost_information = kwargs['costInformation']
-        if 'displayName' in kwargs:
+        if cost_information is None:
+            raise TypeError("Missing 'cost_information' argument")
+        if description is None:
+            raise TypeError("Missing 'description' argument")
+        if display_name is None and 'displayName' in kwargs:
             display_name = kwargs['displayName']
-        if 'filterableProperties' in kwargs:
+        if display_name is None:
+            raise TypeError("Missing 'display_name' argument")
+        if filterable_properties is None and 'filterableProperties' in kwargs:
             filterable_properties = kwargs['filterableProperties']
-        if 'hierarchyInformation' in kwargs:
+        if filterable_properties is None:
+            raise TypeError("Missing 'filterable_properties' argument")
+        if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
-        if 'imageInformation' in kwargs:
+        if hierarchy_information is None:
+            raise TypeError("Missing 'hierarchy_information' argument")
+        if image_information is None and 'imageInformation' in kwargs:
             image_information = kwargs['imageInformation']
+        if image_information is None:
+            raise TypeError("Missing 'image_information' argument")
+        if products is None:
+            raise TypeError("Missing 'products' argument")
 
         _setter("availability_information", availability_information)
         _setter("cost_information", cost_information)
@@ -1214,28 +1328,44 @@ class ProductResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             availability_information: 'outputs.AvailabilityInformationResponse',
-             configurations: Sequence['outputs.ConfigurationResponse'],
-             cost_information: 'outputs.CostInformationResponse',
-             description: 'outputs.DescriptionResponse',
-             display_name: str,
-             filterable_properties: Sequence['outputs.FilterablePropertyResponse'],
-             hierarchy_information: 'outputs.HierarchyInformationResponse',
-             image_information: Sequence['outputs.ImageInformationResponse'],
+             availability_information: Optional['outputs.AvailabilityInformationResponse'] = None,
+             configurations: Optional[Sequence['outputs.ConfigurationResponse']] = None,
+             cost_information: Optional['outputs.CostInformationResponse'] = None,
+             description: Optional['outputs.DescriptionResponse'] = None,
+             display_name: Optional[str] = None,
+             filterable_properties: Optional[Sequence['outputs.FilterablePropertyResponse']] = None,
+             hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
+             image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'availabilityInformation' in kwargs:
+        if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
-        if 'costInformation' in kwargs:
+        if availability_information is None:
+            raise TypeError("Missing 'availability_information' argument")
+        if configurations is None:
+            raise TypeError("Missing 'configurations' argument")
+        if cost_information is None and 'costInformation' in kwargs:
             cost_information = kwargs['costInformation']
-        if 'displayName' in kwargs:
+        if cost_information is None:
+            raise TypeError("Missing 'cost_information' argument")
+        if description is None:
+            raise TypeError("Missing 'description' argument")
+        if display_name is None and 'displayName' in kwargs:
             display_name = kwargs['displayName']
-        if 'filterableProperties' in kwargs:
+        if display_name is None:
+            raise TypeError("Missing 'display_name' argument")
+        if filterable_properties is None and 'filterableProperties' in kwargs:
             filterable_properties = kwargs['filterableProperties']
-        if 'hierarchyInformation' in kwargs:
+        if filterable_properties is None:
+            raise TypeError("Missing 'filterable_properties' argument")
+        if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
-        if 'imageInformation' in kwargs:
+        if hierarchy_information is None:
+            raise TypeError("Missing 'hierarchy_information' argument")
+        if image_information is None and 'imageInformation' in kwargs:
             image_information = kwargs['imageInformation']
+        if image_information is None:
+            raise TypeError("Missing 'image_information' argument")
 
         _setter("availability_information", availability_information)
         _setter("configurations", configurations)
@@ -1345,24 +1475,36 @@ class PurchaseMeterDetailsResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             billing_type: str,
-             charging_type: str,
-             multiplier: float,
-             product_id: str,
-             sku_id: str,
-             term_id: str,
+             billing_type: Optional[str] = None,
+             charging_type: Optional[str] = None,
+             multiplier: Optional[float] = None,
+             product_id: Optional[str] = None,
+             sku_id: Optional[str] = None,
+             term_id: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'billingType' in kwargs:
+        if billing_type is None and 'billingType' in kwargs:
             billing_type = kwargs['billingType']
-        if 'chargingType' in kwargs:
+        if billing_type is None:
+            raise TypeError("Missing 'billing_type' argument")
+        if charging_type is None and 'chargingType' in kwargs:
             charging_type = kwargs['chargingType']
-        if 'productId' in kwargs:
+        if charging_type is None:
+            raise TypeError("Missing 'charging_type' argument")
+        if multiplier is None:
+            raise TypeError("Missing 'multiplier' argument")
+        if product_id is None and 'productId' in kwargs:
             product_id = kwargs['productId']
-        if 'skuId' in kwargs:
+        if product_id is None:
+            raise TypeError("Missing 'product_id' argument")
+        if sku_id is None and 'skuId' in kwargs:
             sku_id = kwargs['skuId']
-        if 'termId' in kwargs:
+        if sku_id is None:
+            raise TypeError("Missing 'sku_id' argument")
+        if term_id is None and 'termId' in kwargs:
             term_id = kwargs['termId']
+        if term_id is None:
+            raise TypeError("Missing 'term_id' argument")
 
         _setter("billing_type", 'Purchase')
         _setter("charging_type", charging_type)
@@ -1442,10 +1584,14 @@ class SpecificationResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             name: str,
-             value: str,
+             name: Optional[str] = None,
+             value: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if name is None:
+            raise TypeError("Missing 'name' argument")
+        if value is None:
+            raise TypeError("Missing 'value' argument")
 
         _setter("name", name)
         _setter("value", value)

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
@@ -26,10 +26,14 @@ class GetAmiIdsFilterArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             name: str,
-             values: Sequence[str],
+             name: Optional[str] = None,
+             values: Optional[Sequence[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if name is None:
+            raise TypeError("Missing 'name' argument")
+        if values is None:
+            raise TypeError("Missing 'values' argument")
 
         _setter("name", name)
         _setter("values", values)

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
@@ -41,16 +41,24 @@ class StorageAccountKeyResponseResult(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             creation_time: str,
-             key_name: str,
-             permissions: str,
-             value: str,
+             creation_time: Optional[str] = None,
+             key_name: Optional[str] = None,
+             permissions: Optional[str] = None,
+             value: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'creationTime' in kwargs:
+        if creation_time is None and 'creationTime' in kwargs:
             creation_time = kwargs['creationTime']
-        if 'keyName' in kwargs:
+        if creation_time is None:
+            raise TypeError("Missing 'creation_time' argument")
+        if key_name is None and 'keyName' in kwargs:
             key_name = kwargs['keyName']
+        if key_name is None:
+            raise TypeError("Missing 'key_name' argument")
+        if permissions is None:
+            raise TypeError("Missing 'permissions' argument")
+        if value is None:
+            raise TypeError("Missing 'value' argument")
 
         _setter("creation_time", creation_time)
         _setter("key_name", key_name)
@@ -103,10 +111,14 @@ class GetAmiIdsFilterResult(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             name: str,
-             values: Sequence[str],
+             name: Optional[str] = None,
+             values: Optional[Sequence[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if name is None:
+            raise TypeError("Missing 'name' argument")
+        if values is None:
+            raise TypeError("Missing 'values' argument")
 
         _setter("name", name)
         _setter("values", values)

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_inputs.py
@@ -28,9 +28,11 @@ class BastionShareableLink:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             vm: str,
+             vm: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if vm is None:
+            raise TypeError("Missing 'vm' argument")
 
         _setter("vm", vm)
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/outputs.py
@@ -54,11 +54,11 @@ class SsisEnvironmentReferenceResponse(dict):
              reference_type: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'environmentFolderName' in kwargs:
+        if environment_folder_name is None and 'environmentFolderName' in kwargs:
             environment_folder_name = kwargs['environmentFolderName']
-        if 'environmentName' in kwargs:
+        if environment_name is None and 'environmentName' in kwargs:
             environment_name = kwargs['environmentName']
-        if 'referenceType' in kwargs:
+        if reference_type is None and 'referenceType' in kwargs:
             reference_type = kwargs['referenceType']
 
         if environment_folder_name is not None:
@@ -137,7 +137,7 @@ class SsisEnvironmentResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             type: str,
+             type: Optional[str] = None,
              description: Optional[str] = None,
              folder_id: Optional[float] = None,
              id: Optional[float] = None,
@@ -145,7 +145,9 @@ class SsisEnvironmentResponse(dict):
              variables: Optional[Sequence['outputs.SsisVariableResponse']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'folderId' in kwargs:
+        if type is None:
+            raise TypeError("Missing 'type' argument")
+        if folder_id is None and 'folderId' in kwargs:
             folder_id = kwargs['folderId']
 
         _setter("type", 'Environment')
@@ -238,12 +240,14 @@ class SsisFolderResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             type: str,
+             type: Optional[str] = None,
              description: Optional[str] = None,
              id: Optional[float] = None,
              name: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if type is None:
+            raise TypeError("Missing 'type' argument")
 
         _setter("type", 'Folder')
         if description is not None:
@@ -327,7 +331,7 @@ class SsisPackageResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             type: str,
+             type: Optional[str] = None,
              description: Optional[str] = None,
              folder_id: Optional[float] = None,
              id: Optional[float] = None,
@@ -337,11 +341,13 @@ class SsisPackageResponse(dict):
              project_version: Optional[float] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'folderId' in kwargs:
+        if type is None:
+            raise TypeError("Missing 'type' argument")
+        if folder_id is None and 'folderId' in kwargs:
             folder_id = kwargs['folderId']
-        if 'projectId' in kwargs:
+        if project_id is None and 'projectId' in kwargs:
             project_id = kwargs['projectId']
-        if 'projectVersion' in kwargs:
+        if project_version is None and 'projectVersion' in kwargs:
             project_version = kwargs['projectVersion']
 
         _setter("type", 'Package')
@@ -491,17 +497,17 @@ class SsisParameterResponse(dict):
              variable: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'dataType' in kwargs:
+        if data_type is None and 'dataType' in kwargs:
             data_type = kwargs['dataType']
-        if 'defaultValue' in kwargs:
+        if default_value is None and 'defaultValue' in kwargs:
             default_value = kwargs['defaultValue']
-        if 'designDefaultValue' in kwargs:
+        if design_default_value is None and 'designDefaultValue' in kwargs:
             design_default_value = kwargs['designDefaultValue']
-        if 'sensitiveDefaultValue' in kwargs:
+        if sensitive_default_value is None and 'sensitiveDefaultValue' in kwargs:
             sensitive_default_value = kwargs['sensitiveDefaultValue']
-        if 'valueSet' in kwargs:
+        if value_set is None and 'valueSet' in kwargs:
             value_set = kwargs['valueSet']
-        if 'valueType' in kwargs:
+        if value_type is None and 'valueType' in kwargs:
             value_type = kwargs['valueType']
 
         if data_type is not None:
@@ -666,7 +672,7 @@ class SsisProjectResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             type: str,
+             type: Optional[str] = None,
              description: Optional[str] = None,
              environment_refs: Optional[Sequence['outputs.SsisEnvironmentReferenceResponse']] = None,
              folder_id: Optional[float] = None,
@@ -676,9 +682,11 @@ class SsisProjectResponse(dict):
              version: Optional[float] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'environmentRefs' in kwargs:
+        if type is None:
+            raise TypeError("Missing 'type' argument")
+        if environment_refs is None and 'environmentRefs' in kwargs:
             environment_refs = kwargs['environmentRefs']
-        if 'folderId' in kwargs:
+        if folder_id is None and 'folderId' in kwargs:
             folder_id = kwargs['folderId']
 
         _setter("type", 'Project')
@@ -808,9 +816,9 @@ class SsisVariableResponse(dict):
              value: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'dataType' in kwargs:
+        if data_type is None and 'dataType' in kwargs:
             data_type = kwargs['dataType']
-        if 'sensitiveValue' in kwargs:
+        if sensitive_value is None and 'sensitiveValue' in kwargs:
             sensitive_value = kwargs['sensitiveValue']
 
         if data_type is not None:
@@ -912,16 +920,24 @@ class StorageAccountKeyResponse(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             creation_time: str,
-             key_name: str,
-             permissions: str,
-             value: str,
+             creation_time: Optional[str] = None,
+             key_name: Optional[str] = None,
+             permissions: Optional[str] = None,
+             value: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'creationTime' in kwargs:
+        if creation_time is None and 'creationTime' in kwargs:
             creation_time = kwargs['creationTime']
-        if 'keyName' in kwargs:
+        if creation_time is None:
+            raise TypeError("Missing 'creation_time' argument")
+        if key_name is None and 'keyName' in kwargs:
             key_name = kwargs['keyName']
+        if key_name is None:
+            raise TypeError("Missing 'key_name' argument")
+        if permissions is None:
+            raise TypeError("Missing 'permissions' argument")
+        if value is None:
+            raise TypeError("Missing 'value' argument")
 
         _setter("creation_time", creation_time)
         _setter("key_name", key_name)

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
@@ -40,14 +40,16 @@ class HelmReleaseSettings:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_arg: str,
+             required_arg: Optional[str] = None,
              driver: Optional[str] = None,
              plugins_path: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredArg' in kwargs:
+        if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
-        if 'pluginsPath' in kwargs:
+        if required_arg is None:
+            raise TypeError("Missing 'required_arg' argument")
+        if plugins_path is None and 'pluginsPath' in kwargs:
             plugins_path = kwargs['pluginsPath']
 
         _setter("required_arg", required_arg)
@@ -118,14 +120,16 @@ class HelmReleaseSettingsArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_arg: pulumi.Input[str],
+             required_arg: Optional[pulumi.Input[str]] = None,
              driver: Optional[pulumi.Input[str]] = None,
              plugins_path: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredArg' in kwargs:
+        if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
-        if 'pluginsPath' in kwargs:
+        if required_arg is None:
+            raise TypeError("Missing 'required_arg' argument")
+        if plugins_path is None and 'pluginsPath' in kwargs:
             plugins_path = kwargs['pluginsPath']
 
         _setter("required_arg", required_arg)
@@ -200,7 +204,7 @@ class KubeClientSettingsArgs:
              rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'recTest' in kwargs:
+        if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
 
         if burst is None:
@@ -276,7 +280,7 @@ class LayeredTypeArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             other: pulumi.Input['HelmReleaseSettingsArgs'],
+             other: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
              thinker: Optional[pulumi.Input[str]] = None,
              answer: Optional[pulumi.Input[float]] = None,
              plain_other: Optional['HelmReleaseSettingsArgs'] = None,
@@ -284,7 +288,9 @@ class LayeredTypeArgs:
              recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'plainOther' in kwargs:
+        if other is None:
+            raise TypeError("Missing 'other' argument")
+        if plain_other is None and 'plainOther' in kwargs:
             plain_other = kwargs['plainOther']
 
         _setter("other", other)

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
@@ -36,15 +36,17 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             backup_kube_client_settings: pulumi.Input['KubeClientSettingsArgs'],
+             backup_kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              argument: Optional[str] = None,
              kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              settings: Optional[pulumi.Input['LayeredTypeArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'backupKubeClientSettings' in kwargs:
+        if backup_kube_client_settings is None and 'backupKubeClientSettings' in kwargs:
             backup_kube_client_settings = kwargs['backupKubeClientSettings']
-        if 'kubeClientSettings' in kwargs:
+        if backup_kube_client_settings is None:
+            raise TypeError("Missing 'backup_kube_client_settings' argument")
+        if kube_client_settings is None and 'kubeClientSettings' in kwargs:
             kube_client_settings = kwargs['kubeClientSettings']
 
         _setter("backup_kube_client_settings", backup_kube_client_settings)

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/outputs.py
@@ -59,7 +59,7 @@ class KubeClientSettings(dict):
              rec_test: Optional['outputs.KubeClientSettings'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'recTest' in kwargs:
+        if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
 
         if burst is None:

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -30,7 +30,7 @@ class ProviderArgs:
              helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'helmReleaseSettings' in kwargs:
+        if helm_release_settings is None and 'helmReleaseSettings' in kwargs:
             helm_release_settings = kwargs['helmReleaseSettings']
 
         if helm_release_settings is not None:

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
@@ -40,14 +40,16 @@ class HelmReleaseSettings:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_arg: str,
+             required_arg: Optional[str] = None,
              driver: Optional[str] = None,
              plugins_path: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredArg' in kwargs:
+        if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
-        if 'pluginsPath' in kwargs:
+        if required_arg is None:
+            raise TypeError("Missing 'required_arg' argument")
+        if plugins_path is None and 'pluginsPath' in kwargs:
             plugins_path = kwargs['pluginsPath']
 
         _setter("required_arg", required_arg)
@@ -118,14 +120,16 @@ class HelmReleaseSettingsArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             required_arg: pulumi.Input[str],
+             required_arg: Optional[pulumi.Input[str]] = None,
              driver: Optional[pulumi.Input[str]] = None,
              plugins_path: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'requiredArg' in kwargs:
+        if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
-        if 'pluginsPath' in kwargs:
+        if required_arg is None:
+            raise TypeError("Missing 'required_arg' argument")
+        if plugins_path is None and 'pluginsPath' in kwargs:
             plugins_path = kwargs['pluginsPath']
 
         _setter("required_arg", required_arg)
@@ -200,7 +204,7 @@ class KubeClientSettingsArgs:
              rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'recTest' in kwargs:
+        if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
 
         if burst is None:
@@ -276,7 +280,7 @@ class LayeredTypeArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             other: pulumi.Input['HelmReleaseSettingsArgs'],
+             other: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
              thinker: Optional[pulumi.Input[str]] = None,
              answer: Optional[pulumi.Input[float]] = None,
              plain_other: Optional['HelmReleaseSettingsArgs'] = None,
@@ -284,7 +288,9 @@ class LayeredTypeArgs:
              recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'plainOther' in kwargs:
+        if other is None:
+            raise TypeError("Missing 'other' argument")
+        if plain_other is None and 'plainOther' in kwargs:
             plain_other = kwargs['plainOther']
 
         _setter("other", other)

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -36,15 +36,17 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             backup_kube_client_settings: pulumi.Input['KubeClientSettingsArgs'],
+             backup_kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              argument: Optional[str] = None,
              kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              settings: Optional[pulumi.Input['LayeredTypeArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'backupKubeClientSettings' in kwargs:
+        if backup_kube_client_settings is None and 'backupKubeClientSettings' in kwargs:
             backup_kube_client_settings = kwargs['backupKubeClientSettings']
-        if 'kubeClientSettings' in kwargs:
+        if backup_kube_client_settings is None:
+            raise TypeError("Missing 'backup_kube_client_settings' argument")
+        if kube_client_settings is None and 'kubeClientSettings' in kwargs:
             kube_client_settings = kwargs['kubeClientSettings']
 
         _setter("backup_kube_client_settings", backup_kube_client_settings)

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/outputs.py
@@ -59,7 +59,7 @@ class KubeClientSettings(dict):
              rec_test: Optional['outputs.KubeClientSettings'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'recTest' in kwargs:
+        if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
 
         if burst is None:

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -30,7 +30,7 @@ class ProviderArgs:
              helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'helmReleaseSettings' in kwargs:
+        if helm_release_settings is None and 'helmReleaseSettings' in kwargs:
             helm_release_settings = kwargs['helmReleaseSettings']
 
         if helm_release_settings is not None:

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -30,12 +30,14 @@ class StaticPageArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             index_content: pulumi.Input[str],
+             index_content: Optional[pulumi.Input[str]] = None,
              foo: Optional['FooArgs'] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'indexContent' in kwargs:
+        if index_content is None and 'indexContent' in kwargs:
             index_content = kwargs['indexContent']
+        if index_content is None:
+            raise TypeError("Missing 'index_content' argument")
 
         _setter("index_content", index_content)
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -35,9 +35,9 @@ class ProviderArgs:
              secret_sandwiches: Optional[pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'favoriteColor' in kwargs:
+        if favorite_color is None and 'favoriteColor' in kwargs:
             favorite_color = kwargs['favoriteColor']
-        if 'secretSandwiches' in kwargs:
+        if secret_sandwiches is None and 'secretSandwiches' in kwargs:
             secret_sandwiches = kwargs['secretSandwiches']
 
         if favorite_color is None:

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
@@ -26,10 +26,14 @@ class ProviderCertmanagerArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             mtls_cert_pem: pulumi.Input[str],
-             mtls_key_pem: pulumi.Input[str],
+             mtls_cert_pem: Optional[pulumi.Input[str]] = None,
+             mtls_key_pem: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if mtls_cert_pem is None:
+            raise TypeError("Missing 'mtls_cert_pem' argument")
+        if mtls_key_pem is None:
+            raise TypeError("Missing 'mtls_key_pem' argument")
 
         _setter("mtls_cert_pem", mtls_cert_pem)
         _setter("mtls_key_pem", mtls_key_pem)

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/resource.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/resource.py
@@ -37,22 +37,34 @@ class ResourceArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             config: pulumi.Input['ConfigArgs'],
-             config_array: pulumi.Input[Sequence[pulumi.Input['ConfigArgs']]],
-             config_map: pulumi.Input[Mapping[str, pulumi.Input['ConfigArgs']]],
-             foo: pulumi.Input[str],
-             foo_array: pulumi.Input[Sequence[pulumi.Input[str]]],
-             foo_map: pulumi.Input[Mapping[str, pulumi.Input[str]]],
+             config: Optional[pulumi.Input['ConfigArgs']] = None,
+             config_array: Optional[pulumi.Input[Sequence[pulumi.Input['ConfigArgs']]]] = None,
+             config_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['ConfigArgs']]]] = None,
+             foo: Optional[pulumi.Input[str]] = None,
+             foo_array: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+             foo_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'configArray' in kwargs:
+        if config is None:
+            raise TypeError("Missing 'config' argument")
+        if config_array is None and 'configArray' in kwargs:
             config_array = kwargs['configArray']
-        if 'configMap' in kwargs:
+        if config_array is None:
+            raise TypeError("Missing 'config_array' argument")
+        if config_map is None and 'configMap' in kwargs:
             config_map = kwargs['configMap']
-        if 'fooArray' in kwargs:
+        if config_map is None:
+            raise TypeError("Missing 'config_map' argument")
+        if foo is None:
+            raise TypeError("Missing 'foo' argument")
+        if foo_array is None and 'fooArray' in kwargs:
             foo_array = kwargs['fooArray']
-        if 'fooMap' in kwargs:
+        if foo_array is None:
+            raise TypeError("Missing 'foo_array' argument")
+        if foo_map is None and 'fooMap' in kwargs:
             foo_map = kwargs['fooMap']
+        if foo_map is None:
+            raise TypeError("Missing 'foo_map' argument")
 
         _setter("config", config)
         _setter("config_array", config_array)

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
@@ -31,12 +31,14 @@ class ContainerArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: pulumi.Input['ContainerSize'],
+             size: Optional[pulumi.Input['ContainerSize']] = None,
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
@@ -31,12 +31,14 @@ class Container(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             size: 'ContainerSize',
+             size: Optional['ContainerSize'] = None,
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if size is None:
+            raise TypeError("Missing 'size' argument")
 
         _setter("size", size)
         if brightness is None:

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -30,10 +30,12 @@ class NurseryArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
+             varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if varieties is None:
+            raise TypeError("Missing 'varieties' argument")
 
         _setter("varieties", varieties)
         if sizes is not None:

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
@@ -34,14 +34,20 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -43,9 +43,9 @@ class ComponentArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              bar: Optional['FooArgs'] = None,
              baz: Optional[Sequence[pulumi.Input['FooArgs']]] = None,
@@ -54,6 +54,12 @@ class ComponentArgs:
              foo: Optional[pulumi.Input['FooArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
@@ -34,14 +34,20 @@ class Foo(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
@@ -35,14 +35,20 @@ class Foo:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)
@@ -130,14 +136,20 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -45,9 +45,9 @@ class ComponentArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              bar: Optional['FooArgs'] = None,
              baz: Optional[Sequence[pulumi.Input['FooArgs']]] = None,
@@ -57,7 +57,13 @@ class ComponentArgs:
              foo: Optional[pulumi.Input['FooArgs']] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'bazMap' in kwargs:
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
+        if baz_map is None and 'bazMap' in kwargs:
             baz_map = kwargs['bazMap']
 
         _setter("a", a)

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
@@ -34,14 +34,20 @@ class Foo(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             a: bool,
-             c: int,
-             e: str,
+             a: Optional[bool] = None,
+             c: Optional[int] = None,
+             e: Optional[str] = None,
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if a is None:
+            raise TypeError("Missing 'a' argument")
+        if c is None:
+            raise TypeError("Missing 'c' argument")
+        if e is None:
+            raise TypeError("Missing 'e' argument")
 
         _setter("a", a)
         _setter("c", c)

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -58,10 +58,12 @@ class ObjectWithNodeOptionalInputsArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             foo: pulumi.Input[str],
+             foo: Optional[pulumi.Input[str]] = None,
              bar: Optional[pulumi.Input[int]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if foo is None:
+            raise TypeError("Missing 'foo' argument")
 
         _setter("foo", foo)
         if bar is not None:
@@ -116,7 +118,7 @@ class ObjectArgs:
              still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'stillOthers' in kwargs:
+        if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/outputs.py
@@ -89,7 +89,7 @@ class Object(dict):
              still_others: Optional[Mapping[str, Sequence['outputs.SomeOtherObject']]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'stillOthers' in kwargs:
+        if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
 
         if bar is not None:
@@ -148,10 +148,12 @@ class ObjectWithNodeOptionalInputs(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             foo: str,
+             foo: Optional[str] = None,
              bar: Optional[int] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if foo is None:
+            raise TypeError("Missing 'foo' argument")
 
         _setter("foo", foo)
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -59,10 +59,12 @@ class ObjectWithNodeOptionalInputsArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             foo: pulumi.Input[str],
+             foo: Optional[pulumi.Input[str]] = None,
              bar: Optional[pulumi.Input[int]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if foo is None:
+            raise TypeError("Missing 'foo' argument")
 
         _setter("foo", foo)
         if bar is not None:
@@ -117,7 +119,7 @@ class ObjectArgs:
              still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'stillOthers' in kwargs:
+        if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/outputs.py
@@ -91,7 +91,7 @@ class Object(dict):
              still_others: Optional[Mapping[str, Sequence['outputs.SomeOtherObject']]] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
-        if 'stillOthers' in kwargs:
+        if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
 
         if bar is not None:
@@ -150,10 +150,12 @@ class ObjectWithNodeOptionalInputs(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             foo: str,
+             foo: Optional[str] = None,
              bar: Optional[int] = None,
              opts: Optional[pulumi.ResourceOptions]=None,
              **kwargs):
+        if foo is None:
+            raise TypeError("Missing 'foo' argument")
 
         _setter("foo", foo)
         if bar is not None:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14274

Given a property of imageName, Python resource args can receive the
property as image_name or imageName. When provided imageName, the
required argument is provided as imageName, the required image_name
argument is not provided and the _configure call fails.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
