### PR TITLE
[go] add list all stacks operation within an access token's scope

### DIFF
--- a/changelog/pending/20231110--auto-go--addes-pulumi-stack-ls-all-json-command-to-go-auto-api.yaml
+++ b/changelog/pending/20231110--auto-go--addes-pulumi-stack-ls-all-json-command-to-go-auto-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Addes `pulumi stack ls --all --json` command to go auto api

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -518,8 +518,30 @@ func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string, opts
 // ListStacks returns all Stacks created under the current Project.
 // This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
 func (l *LocalWorkspace) ListStacks(ctx context.Context) ([]StackSummary, error) {
+	return l.listStacks(ctx, false)
+}
+
+// ListStacks returns all Stacks created under the scope of the current Pulumi Access Token (PAT).
+// This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+func (l *LocalWorkspace) ListAllStacks(ctx context.Context) ([]StackSummary, error) {
+	return l.listStacks(ctx, true)
+}
+
+// ListStacks returns all Stacks created under the current Project or
+//
+//	all stacks under the scope of the current Pulumi Access Token (PAT).
+//
+// This queries underlying backend and may return stacks not
+//
+//	present in the Workspace (as Pulumi.<stack>.yaml files).
+func (l *LocalWorkspace) listStacks(ctx context.Context, listAll bool) ([]StackSummary, error) {
 	var stacks []StackSummary
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "ls", "--json")
+	args := []string{"stack", "ls", "--json"}
+	if listAll {
+		args = append(args, "--all")
+	}
+
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return stacks, newAutoError(fmt.Errorf("could not list stacks: %w", err), stdout, stderr, errCode)
 	}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2950,32 +2950,11 @@ func TestListAllStacksFunction(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	createStack := func(ctx context.Context, project string) Stack {
-		opts := []LocalWorkspaceOption{
-			SecretsProvider("passphrase"),
-			EnvVars(map[string]string{
-				"PULUMI_CONFIG_PASSPHRASE": "password",
-			}),
-		}
-
-		name := randomStackName()
-		sName := FullyQualifiedStackName(pulumiOrg, project, name)
-
-		// initialize
-		pDir := filepath.Join(".", "test", project)
-		s, err := NewStackLocalSource(ctx, sName, pDir, opts...)
-		if err != nil {
-			t.Errorf("failed to initialize stack, err: %v", err)
-			t.FailNow()
-		}
-
-		return s
-	}
 
 	// it's possible we will encounter additional stacks across other projects, however,
 	// we will validate we can see these two stacks across different projects
-	s1 := createStack(ctx, "testproj")
-	s2 := createStack(ctx, "correct_project")
+	s1 := newListStacksSource(ctx, t, "testproj")
+	s2 := newListStacksSource(ctx, t, "correct_project")
 
 	ws, err := NewLocalWorkspace(ctx)
 	if err != nil {

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -117,6 +117,9 @@ type Workspace interface {
 	// ListStacks returns all Stacks created under the current Project.
 	// This queries underlying backend and may return stacks not present in the Workspace.
 	ListStacks(context.Context) ([]StackSummary, error)
+	// ListStacks returns all Stacks created under the scope of the current Pulumi Access Token.
+	// This queries underlying backend and may return stacks not present in the Workspace.
+	ListAllStacks(context.Context) ([]StackSummary, error)
 	// InstallPlugin acquires the plugin matching the specified name and version.
 	InstallPlugin(context.Context, string, string) error
 	// InstallPluginFromServer acquires the plugin matching the specified name and version.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Add a automation api method that executes `pulumi stack ls -a` to return all stacks within the scope of a given access token.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
