### PR TITLE
add debugging info to smoke test

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -314,6 +314,7 @@ jobs:
       - name: run tests
         id: test
         run: ${{ inputs.test-command }}
+        shell: bash
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi

--- a/pkg/cmd/pulumi/package_extract_schema.go
+++ b/pkg/cmd/pulumi/package_extract_schema.go
@@ -51,6 +51,7 @@ func newExtractSchemaCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			fmt.Println("I made a change here")
 			if len(bytes) != n {
 				return fmt.Errorf("only wrote %d/%d bytes of the schema", len(bytes), n)
 			}

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -172,6 +172,8 @@ def run_list_tests(pkg_dir: str, tags: List[str]) -> List[str]:
     # $ go test -tags all --list ./tests/integration
     # no Go files in /home/friel/c/github.com/pulumi/pulumi
     # ```
+    print("# test list", tags)
+    print("# pkgdir", pkg_dir)
     try:
         cmd = sp.run(
             ["go", "test", "-tags", " ".join(tags), "--list", "."],

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -254,18 +254,18 @@ func TestPackageGetSchema(t *testing.T) {
 
 	// try again using a specific version
 	removeRandomFromLocalPlugins()
-	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", "random@4.13.0")
-	require.NoError(t, err)
+	schemaJSON, stderr = e.RunCommand("pulumi", "package", "get-schema", "random@4.13.0")
+	fmt.Println(stderr)
 	bindSchema(schemaJSON)
 
 	// Now that the random provider is installed, run the command again without removing random from plugins
-	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", "random")
-	require.NoError(t, err)
+	schemaJSON, stderr = e.RunCommand("pulumi", "package", "get-schema", "random")
+	fmt.Println(stderr)
 	bindSchema(schemaJSON)
 
 	// Now try to get the schema from the path to the binary
-	pulumiHome, err := workspace.GetPulumiHomeDir()
-	require.NoError(t, err)
+	pulumiHome, stderr := workspace.GetPulumiHomeDir()
+	fmt.Println(stderr)
 	binaryPath := filepath.Join(
 		pulumiHome,
 		"plugins",

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -241,15 +241,15 @@ func TestPackageGetSchema(t *testing.T) {
 	// Make sure the random provider is not installed locally
 	// So that we can test the `package get-schema` command works if the plugin
 	// is not installed locally on first run.
-	out, err := e.RunCommand("pulumi", "plugin", "ls")
-	require.NoError(t, err)
+	out, stderr := e.RunCommand("pulumi", "plugin", "ls")
+	fmt.Println(stderr)
 	if strings.Contains(out, "random  resource") {
 		removeRandomFromLocalPlugins()
 	}
 
 	// get the schema and bind it
-	schemaJSON, err := e.RunCommand("pulumi", "package", "get-schema", "random")
-	require.NoError(t, err)
+	schemaJSON, stderr := e.RunCommand("pulumi", "package", "get-schema", "random")
+	fmt.Println(stderr)
 	bindSchema(schemaJSON)
 
 	// try again using a specific version
@@ -273,15 +273,14 @@ func TestPackageGetSchema(t *testing.T) {
 		"pulumi-resource-random")
 
 	// TODO: remove this, it's for debugging only.
-	entries, err := os.ReadDir(pulumiHome)
-	require.NoError(t, err)
+	entries, _ := os.ReadDir(pulumiHome)
 
 	for _, e := range entries {
 		fmt.Println(e.Name())
 	}
 
-	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", binaryPath)
-	require.NoError(t, err)
+	schemaJSON, stderr = e.RunCommand("pulumi", "package", "get-schema", binaryPath)
+	fmt.Println(stderr)
 	bindSchema(schemaJSON)
 }
 

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -264,8 +264,9 @@ func TestPackageGetSchema(t *testing.T) {
 	bindSchema(schemaJSON)
 
 	// Now try to get the schema from the path to the binary
-	pulumiHome, stderr := workspace.GetPulumiHomeDir()
-	fmt.Println(stderr)
+	pulumiHome, err := workspace.GetPulumiHomeDir()
+	assert.NoError(t, err)
+	fmt.Println(pulumiHome)
 	binaryPath := filepath.Join(
 		pulumiHome,
 		"plugins",

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -240,22 +241,26 @@ func TestPackageGetSchema(t *testing.T) {
 	// Make sure the random provider is not installed locally
 	// So that we can test the `package get-schema` command works if the plugin
 	// is not installed locally on first run.
-	out, _ := e.RunCommand("pulumi", "plugin", "ls")
+	out, err := e.RunCommand("pulumi", "plugin", "ls")
+	require.NoError(t, err)
 	if strings.Contains(out, "random  resource") {
 		removeRandomFromLocalPlugins()
 	}
 
 	// get the schema and bind it
-	schemaJSON, _ := e.RunCommand("pulumi", "package", "get-schema", "random")
+	schemaJSON, err := e.RunCommand("pulumi", "package", "get-schema", "random")
+	require.NoError(t, err)
 	bindSchema(schemaJSON)
 
 	// try again using a specific version
 	removeRandomFromLocalPlugins()
-	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", "random@4.13.0")
+	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", "random@4.13.0")
+	require.NoError(t, err)
 	bindSchema(schemaJSON)
 
 	// Now that the random provider is installed, run the command again without removing random from plugins
-	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", "random")
+	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", "random")
+	require.NoError(t, err)
 	bindSchema(schemaJSON)
 
 	// Now try to get the schema from the path to the binary
@@ -267,7 +272,16 @@ func TestPackageGetSchema(t *testing.T) {
 		"resource-random-v4.13.0",
 		"pulumi-resource-random")
 
-	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", binaryPath)
+	// TODO: remove this, it's for debugging only.
+	entries, err := os.ReadDir(pulumiHome)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		fmt.Println(e.Name())
+	}
+
+	schemaJSON, err = e.RunCommand("pulumi", "package", "get-schema", binaryPath)
+	require.NoError(t, err)
 	bindSchema(schemaJSON)
 }
 


### PR DESCRIPTION
# Description

Add some debugging info to the smoke test to try and figure out what's happening in https://github.com/pulumi/pulumi/issues/14292.  Unfortunately there doesn't seem to be a way to run the action manually, so we'll have to merge this to trigger the CI run, but should undo at least the `fmt.Println`'s once we figured out what's going on with the flaky test.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
