### PR TITLE
Fix TestPackageGetSchema for Windows

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -266,6 +267,9 @@ func TestPackageGetSchema(t *testing.T) {
 		"plugins",
 		"resource-random-v4.13.0",
 		"pulumi-resource-random")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
 
 	schemaJSON, _ = e.RunCommand("pulumi", "package", "get-schema", binaryPath)
 	bindSchema(schemaJSON)


### PR DESCRIPTION
Path needs ".exe" added on Windows.