### PR TITLE
fix: Invalid namespace delimiter in dotnet codegen

### DIFF
--- a/changelog/pending/20231020--programgen-dotnet--fixes-invalid-namespace-delemiter-in-dotnet-codegen.yaml
+++ b/changelog/pending/20231020--programgen-dotnet--fixes-invalid-namespace-delemiter-in-dotnet-codegen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Fixes invalid namespace delemiter in dotnet codegen

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -114,7 +115,7 @@ func namespaceName(namespaces map[string]string, name string) string {
 	if ns, ok := namespaces[name]; ok {
 		return ns
 	}
-	names := strings.Split(name, "-")
+	names := strings.Split(name, tokens.QNameDelimiter)
 	for i, name := range names {
 		names[i] = Title(name)
 	}

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -114,3 +114,10 @@ func TestGenerateTypeNames(t *testing.T) {
 		}
 	})
 }
+
+func TestParseNamespaces(t *testing.T) {
+	t.Parallel()
+
+	ns := namespaceName(map[string]string{}, "ns1/ns2/item")
+	assert.Equal(t, "Ns1Ns2Item", ns)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR fixes an in issue in the dotnet codegen where an invalid character is used to parse namespaces.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
