### PR TITLE
codegen/go: output correct array type

### DIFF
--- a/changelog/pending/20231020--programgen-go--fix-codegen-to-correctly-output-pulumi-array-instead-of-pulumi-anyarray.yaml
+++ b/changelog/pending/20231020--programgen-go--fix-codegen-to-correctly-output-pulumi-array-instead-of-pulumi-anyarray.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix codegen to correctly output pulumi.Array instead of pulumi.AnyArray

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -556,9 +556,15 @@ func (pkg *pkgContext) argsTypeImpl(t schema.Type) (result string) {
 		return pkg.resolveEnumType(t)
 	case *schema.ArrayType:
 		en := pkg.argsTypeImpl(t.ElementType)
+		if en == "pulumi.Any" {
+			en = strings.TrimSuffix(en, "Any")
+		}
 		return strings.TrimSuffix(en, "Args") + "Array"
 	case *schema.MapType:
 		en := pkg.argsTypeImpl(t.ElementType)
+		if en == "pulumi.Any" {
+			en = strings.TrimSuffix(en, "Any")
+		}
 		return strings.TrimSuffix(en, "Args") + "Map"
 	case *schema.ObjectType:
 		return pkg.resolveObjectType(t)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -859,12 +859,18 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 	case *model.MapType:
 		valType := g.argumentTypeName(nil, destType.ElementType, isInput)
 		if isInput {
+			if Title(valType) == "pulumi.Any" {
+				return "pulumi.Map"
+			}
 			return fmt.Sprintf("pulumi.%sMap", Title(valType))
 		}
 		return fmt.Sprintf("map[string]%s", valType)
 	case *model.ListType:
 		argTypeName := g.argumentTypeName(nil, destType.ElementType, isInput)
 		if strings.HasPrefix(argTypeName, "pulumi.") && argTypeName != "pulumi.Resource" {
+			if argTypeName == "pulumi.Any" {
+				return "pulumi.Array"
+			}
 			return fmt.Sprintf("%sArray", argTypeName)
 		}
 		return fmt.Sprintf("[]%s", argTypeName)
@@ -890,6 +896,9 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 		if elmType != nil {
 			argTypeName := g.argumentTypeName(nil, elmType, isInput)
 			if strings.HasPrefix(argTypeName, "pulumi.") && argTypeName != "pulumi.Resource" {
+				if argTypeName == "pulumi.Any" {
+					return "pulumi.Array"
+				}
 				return fmt.Sprintf("%sArray", argTypeName)
 			}
 			return fmt.Sprintf("[]%s", argTypeName)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -139,7 +139,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Azure Native",
 		SkipCompile: codegen.NewStringSet("go", "nodejs", "dotnet"),
 		// Blocked on go:
-		//   TODO[pulumi/pulumi#8072]
 		//   TODO[pulumi/pulumi#8073]
 		//   TODO[pulumi/pulumi#8074]
 		// Blocked on nodejs:

--- a/pkg/codegen/testing/test/testdata/azure-native-pp/go/azure-native.go
+++ b/pkg/codegen/testing/test/testdata/azure-native-pp/go/azure-native.go
@@ -29,7 +29,7 @@ func main() {
 			DeliveryPolicy: &cdn.EndpointPropertiesUpdateParametersDeliveryPolicyArgs{
 				Rules: []cdn.DeliveryRuleArgs{
 					{
-						Actions: pulumi.AnyArray{
+						Actions: pulumi.Array{
 							{
 								Name: "CacheExpiration",
 								Parameters: {
@@ -58,7 +58,7 @@ func main() {
 								},
 							},
 						},
-						Conditions: pulumi.AnyArray{
+						Conditions: pulumi.Array{
 							{
 								Name: "RemoteAddress",
 								Parameters: {


### PR DESCRIPTION
Currently for an array of objects, codegen for Go outputs a `pulumi.AnyArray` type.  However that does not exist.  Make sure it always outputs the correct `pulumi.Array` type.

While there give Maps the same treatment, as `pulumi.AnyMap` also doesn't exist.

Fixes #https://github.com/pulumi/pulumi/issues/8072

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
