### PR TITLE
[auto/nodejs] Add support for the path option for config operations

### DIFF
--- a/changelog/pending/20231021--auto-nodejs--add-support-for-the-path-option-for-config-operations.yaml
+++ b/changelog/pending/20231021--auto-nodejs--add-support-for-the-path-option-for-config-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add support for the path option for config operations

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -450,9 +450,15 @@ export class LocalWorkspace implements Workspace {
      *
      * @param stackName The stack to read config from
      * @param key The key to use for the config lookup
+     * @param path The key contains a path to a property in a map or list to get
      */
-    async getConfig(stackName: string, key: string): Promise<ConfigValue> {
-        const result = await this.runPulumiCmd(["config", "get", key, "--json", "--stack", stackName]);
+    async getConfig(stackName: string, key: string, path?: boolean): Promise<ConfigValue> {
+        const args = ["config", "get"];
+        if (path) {
+            args.push("--path");
+        }
+        args.push(key, "--json", "--stack", stackName);
+        const result = await this.runPulumiCmd(args);
         return JSON.parse(result.stdout);
     }
     /**
@@ -472,33 +478,33 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to operate on
      * @param key The config key to set
      * @param value The value to set
+     * @param path The key contains a path to a property in a map or list to set
      */
-    async setConfig(stackName: string, key: string, value: ConfigValue): Promise<void> {
+    async setConfig(stackName: string, key: string, value: ConfigValue, path?: boolean): Promise<void> {
+        const args = ["config", "set"];
+        if (path) {
+            args.push("--path");
+        }
         const secretArg = value.secret ? "--secret" : "--plaintext";
-        await this.runPulumiCmd([
-            "config",
-            "set",
-            key,
-            "--stack",
-            stackName,
-            secretArg,
-            "--non-interactive",
-            "--",
-            value.value,
-        ]);
+        args.push(key, "--stack", stackName, secretArg, "--non-interactive", "--", value.value);
+        await this.runPulumiCmd(args);
     }
     /**
      * Sets all values in the provided config map for the specified stack name.
      * LocalWorkspace writes the config to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
      *
      * @param stackName The stack to operate on
-     * @param config The `ConfigMap` to upsert against the existing config.
+     * @param config The `ConfigMap` to upsert against the existing config
+     * @param path The keys contain a path to a property in a map or list to set
      */
-    async setAllConfig(stackName: string, config: ConfigMap): Promise<void> {
-        let args = ["config", "set-all", "--stack", stackName];
+    async setAllConfig(stackName: string, config: ConfigMap, path?: boolean): Promise<void> {
+        const args = ["config", "set-all", "--stack", stackName];
+        if (path) {
+            args.push("--path");
+        }
         for (const [key, value] of Object.entries(config)) {
             const secretArg = value.secret ? "--secret" : "--plaintext";
-            args = [...args, secretArg, `${key}=${value.value}`];
+            args.push(secretArg, `${key}=${value.value}`);
         }
 
         await this.runPulumiCmd(args);
@@ -509,9 +515,14 @@ export class LocalWorkspace implements Workspace {
      *
      * @param stackName The stack to operate on
      * @param key The config key to remove
+     * @param path The key contains a path to a property in a map or list to remove
      */
-    async removeConfig(stackName: string, key: string): Promise<void> {
-        await this.runPulumiCmd(["config", "rm", key, "--stack", stackName]);
+    async removeConfig(stackName: string, key: string, path?: boolean): Promise<void> {
+        const args = ["config", "rm", key, "--stack", stackName];
+        if (path) {
+            args.push("--path");
+        }
+        await this.runPulumiCmd(args);
     }
     /**
      *
@@ -520,9 +531,15 @@ export class LocalWorkspace implements Workspace {
      *
      * @param stackName The stack to operate on
      * @param keys The list of keys to remove from the underlying config
+     * @param path The keys contain a path to a property in a map or list to remove
      */
-    async removeAllConfig(stackName: string, keys: string[]): Promise<void> {
-        await this.runPulumiCmd(["config", "rm-all", "--stack", stackName, ...keys]);
+    async removeAllConfig(stackName: string, keys: string[], path?: boolean): Promise<void> {
+        const args = ["config", "rm-all", "--stack", stackName];
+        if (path) {
+            args.push("--path");
+        }
+        args.push(...keys);
+        await this.runPulumiCmd(args);
     }
     /**
      * Gets and sets the config map used with the last update for Stack matching stack name.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -14,7 +14,7 @@
 
 import * as fs from "fs";
 import * as os from "os";
-import * as path from "path";
+import * as pathlib from "path";
 import * as readline from "readline";
 import * as upath from "upath";
 
@@ -531,9 +531,10 @@ Event: ${line}\n${e.toString()}`);
      * Returns the config value associated with the specified key.
      *
      * @param key The key to use for the config lookup
+     * @param path The key contains a path to a property in a map or list to get
      */
-    async getConfig(key: string): Promise<ConfigValue> {
-        return this.workspace.getConfig(this.name, key);
+    async getConfig(key: string, path?: boolean): Promise<ConfigValue> {
+        return this.workspace.getConfig(this.name, key, path);
     }
     /**
      * Returns the full config map associated with the stack in the Workspace.
@@ -546,33 +547,37 @@ Event: ${line}\n${e.toString()}`);
      *
      * @param key The key to set.
      * @param value The config value to set.
+     * @param path The key contains a path to a property in a map or list to set.
      */
-    async setConfig(key: string, value: ConfigValue): Promise<void> {
-        return this.workspace.setConfig(this.name, key, value);
+    async setConfig(key: string, value: ConfigValue, path?: boolean): Promise<void> {
+        return this.workspace.setConfig(this.name, key, value, path);
     }
     /**
      * Sets all specified config values on the stack in the associated Workspace.
      *
      * @param config The map of config key-value pairs to set.
+     * @param path The keys contain a path to a property in a map or list to set.
      */
-    async setAllConfig(config: ConfigMap): Promise<void> {
-        return this.workspace.setAllConfig(this.name, config);
+    async setAllConfig(config: ConfigMap, path?: boolean): Promise<void> {
+        return this.workspace.setAllConfig(this.name, config, path);
     }
     /**
      * Removes the specified config key from the Stack in the associated Workspace.
      *
      * @param key The config key to remove.
+     * @param path The key contains a path to a property in a map or list to remove.
      */
-    async removeConfig(key: string): Promise<void> {
-        return this.workspace.removeConfig(this.name, key);
+    async removeConfig(key: string, path?: boolean): Promise<void> {
+        return this.workspace.removeConfig(this.name, key, path);
     }
     /**
      * Removes the specified config keys from the Stack in the associated Workspace.
      *
      * @param keys The config keys to remove.
+     * @param path The keys contain a path to a property in a map or list to remove.
      */
-    async removeAllConfig(keys: string[]): Promise<void> {
-        return this.workspace.removeAllConfig(this.name, keys);
+    async removeAllConfig(keys: string[], path?: boolean): Promise<void> {
+        return this.workspace.removeAllConfig(this.name, keys, path);
     }
     /**
      * Gets and sets the config map used with the last update.
@@ -977,12 +982,12 @@ const cleanUp = async (logFile?: string, rl?: ReadlineResult) => {
         // remove the logfile
         if (fs.rm) {
             // remove with Node JS 15.X+
-            fs.rm(path.dirname(logFile), { recursive: true }, () => {
+            fs.rm(pathlib.dirname(logFile), { recursive: true }, () => {
                 return;
             });
         } else {
             // remove with Node JS 14.X
-            fs.rmdir(path.dirname(logFile), { recursive: true }, () => {
+            fs.rmdir(pathlib.dirname(logFile), { recursive: true }, () => {
                 return;
             });
         }

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -97,8 +97,9 @@ export interface Workspace {
      *
      * @param stackName The stack to read config from
      * @param key The key to use for the config lookup
+     * @param path The key contains a path to a property in a map or list to get
      */
-    getConfig(stackName: string, key: string): Promise<ConfigValue>;
+    getConfig(stackName: string, key: string, path?: boolean): Promise<ConfigValue>;
     /**
      * Returns the config map for the specified stack name, scoped to the current Workspace.
      *
@@ -111,30 +112,34 @@ export interface Workspace {
      * @param stackName The stack to operate on
      * @param key The config key to set
      * @param value The value to set
+     * @param path The key contains a path to a property in a map or list to set
      */
-    setConfig(stackName: string, key: string, value: ConfigValue): Promise<void>;
+    setConfig(stackName: string, key: string, value: ConfigValue, path?: boolean): Promise<void>;
     /**
      * Sets all values in the provided config map for the specified stack name.
      *
      * @param stackName The stack to operate on
-     * @param config The `ConfigMap` to upsert against the existing config.
+     * @param config The `ConfigMap` to upsert against the existing config
+     * @param path The keys contain a path to a property in a map or list to set
      */
-    setAllConfig(stackName: string, config: ConfigMap): Promise<void>;
+    setAllConfig(stackName: string, config: ConfigMap, path?: boolean): Promise<void>;
     /**
      * Removes the specified key-value pair on the provided stack name.
      *
      * @param stackName The stack to operate on
      * @param key The config key to remove
+     * @param path The key contains a path to a property in a map or list to remove
      */
-    removeConfig(stackName: string, key: string): Promise<void>;
+    removeConfig(stackName: string, key: string, path?: boolean): Promise<void>;
     /**
      *
      * Removes all values in the provided key list for the specified stack name.
      *
      * @param stackName The stack to operate on
      * @param keys The list of keys to remove from the underlying config
+     * @param path The keys contain a path to a property in a map or list to remove
      */
-    removeAllConfig(stackName: string, keys: string[]): Promise<void>;
+    removeAllConfig(stackName: string, keys: string[], path?: boolean): Promise<void>;
     /**
      * Gets and sets the config map used with the last update for Stack matching stack name.
      *


### PR DESCRIPTION
Add support for the `--path` flag for config operations in Node.js Automation API.

Part of https://github.com/pulumi/pulumi/issues/5506
Related: https://github.com/pulumi/pulumi/pull/12265
Related: https://github.com/pulumi/pulumi/pull/13052
Related: https://github.com/pulumi/pulumi-dotnet/pull/191