### PR TITLE
add refresh option for up in NodeJS automation API

### DIFF
--- a/changelog/pending/20231021--auto-nodejs--add-refresh-option-for-up.yaml
+++ b/changelog/pending/20231021--auto-nodejs--add-refresh-option-for-up.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add `refresh` option for `up`

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -165,6 +165,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.expectNoChanges) {
                 args.push("--expect-no-changes");
             }
+            if (opts.refresh) {
+                args.push("--refresh");
+            }
             if (opts.diff) {
                 args.push("--diff");
             }
@@ -867,6 +870,10 @@ export interface UpOptions extends GlobalOpts {
     parallel?: number;
     message?: string;
     expectNoChanges?: boolean;
+    /**
+     * Refresh the state of the stack's resources before this update.
+     */
+    refresh?: boolean;
     diff?: boolean;
     replace?: string[];
     policyPacks?: string[];


### PR DESCRIPTION
# Description

Adding the `refresh` option to `up` in the NodeJS automation API

Mirror of this PR adding support for `refresh` in `preview` (https://github.com/pulumi/pulumi/issues/12740)
