### PR TITLE
feat: Add support for language specific settings for resources

### DIFF
--- a/changelog/pending/20231022--sdkgen-dotnet--added-support-for-language-specific-settings-for-resources-and-support-for-overriding-resource-name-in-dotnet-codegen.yaml
+++ b/changelog/pending/20231022--sdkgen-dotnet--added-support-for-language-specific-settings-for-resources-and-support-for-overriding-resource-name-in-dotnet-codegen.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/dotnet
+  description: Added support for language specific settings for resources and support for overriding resource name in dotnet codegen

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -443,7 +443,7 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 		if typ != "" {
 			typ += "."
 		}
-		return typ + tokenToName(t.Token)
+		return typ + resourceName(t.Resource)
 	case *schema.TokenType:
 		// Use the underlying type for now.
 		if t.UnderlyingType != nil {
@@ -2504,7 +2504,7 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 			lr := LanguageResource{
 				Resource: r,
 				Package:  namespaceName(info.Namespaces, modName),
-				Name:     tokenToName(r.Token),
+				Name:     resourceName(r),
 			}
 			resources[r.Token] = lr
 		}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -190,6 +190,13 @@ func resourceName(r *schema.Resource) string {
 	if r.IsProvider {
 		return "Provider"
 	}
+
+	if val1, ok := r.Language["csharp"]; ok {
+		val2, ok := val1.(CSharpResourceInfo)
+		contract.Assertf(ok, "dotnet specific settings for resources should be of type CSharpResourceInfo")
+		return Title(val2.Name)
+	}
+
 	return tokenToName(r.Token)
 }
 

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -935,6 +935,14 @@ func (g *generator) resourceTypeName(r *pcl.Resource) string {
 	pkg, module, member, diags := r.DecomposeToken()
 	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
 
+	if r.Schema != nil {
+		if val1, ok := r.Schema.Language["csharp"]; ok {
+			val2, ok := val1.(CSharpResourceInfo)
+			contract.Assertf(ok, "dotnet specific settings for resources should be of type CSharpResourceInfo")
+			member = val2.Name
+		}
+	}
+
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)
 

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -25,6 +25,11 @@ type CSharpPropertyInfo struct {
 	Name string `json:"name,omitempty"`
 }
 
+// CSharpResourceInfo represents the C# language-specific info for a resource.
+type CSharpResourceInfo struct {
+	Name string `json:"name,omitempty"`
+}
+
 // CSharpPackageInfo represents the C# language-specific info for a package.
 type CSharpPackageInfo struct {
 	PackageReferences      map[string]string `json:"packageReferences,omitempty"`
@@ -76,7 +81,11 @@ func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMess
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.
 func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
-	return raw, nil
+	var info CSharpResourceInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 // ImportFunctionSpec decodes language-specific metadata associated with a Function.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -438,7 +438,7 @@ func (r *Resource) ReplaceOnChanges() (changes [][]*Property, err []error) {
 		}
 	}
 	for i, e := range err {
-		err[i] = fmt.Errorf("Failed to genereate full `ReplaceOnChanges`: %w", e)
+		err[i] = fmt.Errorf("failed to genereate full `ReplaceOnChanges`: %w", e)
 	}
 	return changes, err
 }
@@ -465,7 +465,7 @@ func replaceOnChangesType(t Type, stack *map[string]struct{}) ([][]*Property, []
 
 				delete(*stack, p.Type.String())
 			} else {
-				err = append(err, fmt.Errorf("Found recursive object %q", p.Name))
+				err = append(err, fmt.Errorf("found recursive object %q", p.Name))
 			}
 		}
 		// We don't want to emit errors where replaceOnChanges is not used.
@@ -1116,11 +1116,6 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 		}
 	}
 
-	lang, err := marshalLanguage(r.Language)
-	if err != nil {
-		return ResourceSpec{}, err
-	}
-
 	return ResourceSpec{
 		ObjectTypeSpec:     object,
 		InputProperties:    inputs,
@@ -1130,7 +1125,6 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 		DeprecationMessage: r.DeprecationMessage,
 		IsComponent:        r.IsComponent,
 		Methods:            methods,
-		Language:           lang,
 	}, nil
 }
 
@@ -1551,8 +1545,6 @@ type ResourceSpec struct {
 	IsComponent bool `json:"isComponent,omitempty" yaml:"isComponent,omitempty"`
 	// Methods maps method names to functions in this schema.
 	Methods map[string]string `json:"methods,omitempty" yaml:"methods,omitempty"`
-	// Language specifies additional language-specific data about the function.
-	Language map[string]RawMessage `json:"language,omitempty" yaml:"language,omitempty"`
 }
 
 // ReturnTypeSpec is either ObjectTypeSpec or TypeSpec.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1116,6 +1116,11 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 		}
 	}
 
+	lang, err := marshalLanguage(r.Language)
+	if err != nil {
+		return ResourceSpec{}, err
+	}
+
 	return ResourceSpec{
 		ObjectTypeSpec:     object,
 		InputProperties:    inputs,
@@ -1125,6 +1130,7 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 		DeprecationMessage: r.DeprecationMessage,
 		IsComponent:        r.IsComponent,
 		Methods:            methods,
+		Language:           lang,
 	}, nil
 }
 
@@ -1545,6 +1551,8 @@ type ResourceSpec struct {
 	IsComponent bool `json:"isComponent,omitempty" yaml:"isComponent,omitempty"`
 	// Methods maps method names to functions in this schema.
 	Methods map[string]string `json:"methods,omitempty" yaml:"methods,omitempty"`
+	// Language specifies additional language-specific data about the function.
+	Language map[string]RawMessage `json:"language,omitempty" yaml:"language,omitempty"`
 }
 
 // ReturnTypeSpec is either ObjectTypeSpec or TypeSpec.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -438,7 +438,7 @@ func (r *Resource) ReplaceOnChanges() (changes [][]*Property, err []error) {
 		}
 	}
 	for i, e := range err {
-		err[i] = fmt.Errorf("failed to genereate full `ReplaceOnChanges`: %w", e)
+		err[i] = fmt.Errorf("Failed to genereate full `ReplaceOnChanges`: %w", e)
 	}
 	return changes, err
 }
@@ -465,7 +465,7 @@ func replaceOnChangesType(t Type, stack *map[string]struct{}) ([][]*Property, []
 
 				delete(*stack, p.Type.String())
 			} else {
-				err = append(err, fmt.Errorf("found recursive object %q", p.Name))
+				err = append(err, fmt.Errorf("Found recursive object %q", p.Name))
 			}
 		}
 		// We don't want to emit errors where replaceOnChanges is not used.

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1075,6 +1075,58 @@ func TestBindDefaultInt(t *testing.T) {
 	}
 }
 
+func TestMarshalResourceWithLanguageSettings(t *testing.T) {
+	t.Parallel()
+
+	prop := &Property{
+		Name: "prop1",
+		Language: map[string]interface{}{
+			"csharp": map[string]string{
+				"name": "CSharpProp1",
+			},
+		},
+		Type: stringType,
+	}
+	r := Resource{
+		Token: "xyz:index:resource",
+		Properties: []*Property{
+			prop,
+		},
+		Language: map[string]interface{}{
+			"csharp": map[string]string{
+				"name": "CSharpResource",
+			},
+		},
+	}
+	p := Package{
+		Name:        "xyz",
+		DisplayName: "xyz package",
+		Version: &semver.Version{
+			Major: 0,
+			Minor: 0,
+			Patch: 0,
+		},
+		Provider: &Resource{
+			IsProvider: true,
+			Token:      "provider",
+		},
+		Resources: []*Resource{
+			&r,
+		},
+	}
+	pspec, err := p.MarshalSpec()
+	assert.NoError(t, err)
+	res, ok := pspec.Resources[r.Token]
+	assert.True(t, ok)
+	assert.Contains(t, res.Language, "csharp")
+	assert.IsType(t, RawMessage{}, res.Language["csharp"])
+
+	prspec, ok := res.Properties[prop.Name]
+	assert.True(t, ok)
+	assert.Contains(t, prspec.Language, "csharp")
+	assert.IsType(t, RawMessage{}, prspec.Language["csharp"])
+}
+
 func TestFunctionSpecToJSONAndYAMLTurnaround(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR contains changes to support language specific settings for resources. This PR is a prerequisite to resolve a corresponding [bug](https://github.com/pulumi/pulumi-terraform-bridge/issues/1460) in the Terraform Bridge.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1460

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
