### PR TITLE
Fix issue calling nonexistent `_configure` method on external types

### DIFF
--- a/changelog/pending/20231023--sdkgen-python--fix-issue-calling-nonexistent-_configure-method-on-external-types.yaml
+++ b/changelog/pending/20231023--sdkgen-python--fix-issue-calling-nonexistent-_configure-method-on-external-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fix issue calling nonexistent `_configure` method on external types

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
@@ -114,7 +114,7 @@ class Component(pulumi.ComponentResource):
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
             __props__.__dict__["eni_config"] = eni_config
-            if pod is not None and not isinstance(pod, pulumi_kubernetes.core.v1.PodArgs):
+            if pod is not None and not isinstance(pod, pulumi_kubernetes.core.v1.PodArgs) and hasattr(pulumi_kubernetes.core.v1.PodArgs, '_configure'):
                 pod = pod or {}
                 def _setter(key, value):
                     pod[key] = value

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -94,7 +94,7 @@ class IamResource(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = IamResourceArgs.__new__(IamResourceArgs)
 
-            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs):
+            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs) and hasattr(pulumi_google_native.iam.v1.AuditConfigArgs, '_configure'):
                 config = config or {}
                 def _setter(key, value):
                     config[key] = value

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -94,7 +94,7 @@ class IamResource(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = IamResourceArgs.__new__(IamResourceArgs)
 
-            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs):
+            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs) and hasattr(pulumi_google_native.iam.v1.AuditConfigArgs, '_configure'):
                 config = config or {}
                 def _setter(key, value):
                     config[key] = value

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -186,7 +186,7 @@ class Component(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
-            if metadata is not None and not isinstance(metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs):
+            if metadata is not None and not isinstance(metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs) and hasattr(pulumi_kubernetes.meta.v1.ObjectMetaArgs, '_configure'):
                 metadata = metadata or {}
                 def _setter(key, value):
                     metadata[key] = value
@@ -194,7 +194,7 @@ class Component(pulumi.CustomResource):
             __props__.__dict__["metadata"] = metadata
             __props__.__dict__["metadata_array"] = metadata_array
             __props__.__dict__["metadata_map"] = metadata_map
-            if required_metadata is not None and not isinstance(required_metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs):
+            if required_metadata is not None and not isinstance(required_metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs) and hasattr(pulumi_kubernetes.meta.v1.ObjectMetaArgs, '_configure'):
                 required_metadata = required_metadata or {}
                 def _setter(key, value):
                     required_metadata[key] = value


### PR DESCRIPTION
We recently added the ability to assign default values for nested types in generated Python SDKs, when the nested types are passed as dicts. We do so by calling a new static `_configure` method on the input type, to assign default values.

The problem is that we're emitting calls to `_configure` for external types, and such types may not have been upgraded yet to the latest codegen, so they may not have a static `_configure` method yet.

This change makes it so that `_configure` is only called for external types that have a `_configure`, via a runtime `hasattr` check.

Fixes #14316