### PR TITLE
[sdkgen/python] Fix calling `_configure` with an Output value

### DIFF
--- a/changelog/pending/20231024--sdkgen-python--fix-calling-_configure-with-an-output-value.yaml
+++ b/changelog/pending/20231024--sdkgen-python--fix-calling-_configure-with-an-output-value.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fix calling `_configure` with an Output value

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/outputs.py
@@ -35,7 +35,7 @@ class CompositePathResponse(dict):
              _setter: Callable[[Any, Any], None],
              order: Optional[str] = None,
              path: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if order is not None:
@@ -96,7 +96,7 @@ class IndexingPolicyResponse(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              composite_indexes: Optional[Sequence[Sequence['outputs.CompositePathResponse']]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if composite_indexes is None and 'compositeIndexes' in kwargs:
             composite_indexes = kwargs['compositeIndexes']
@@ -145,7 +145,7 @@ class SqlContainerGetPropertiesResponseResource(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              indexing_policy: Optional['outputs.IndexingPolicyResponse'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if indexing_policy is None and 'indexingPolicy' in kwargs:
             indexing_policy = kwargs['indexingPolicy']

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
@@ -22,7 +22,7 @@ class SqlResourceSqlContainerArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/provider.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instance/instance.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instance/instance.py
@@ -29,7 +29,7 @@ class InstanceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              boot_disk: Optional[pulumi.Input['_compute.instancebootdisk.InstanceBootDiskArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if boot_disk is None and 'bootDisk' in kwargs:
             boot_disk = kwargs['bootDisk']
@@ -69,7 +69,7 @@ class _InstanceState:
     def _configure(
              _setter: Callable[[Any, Any], None],
              boot_disk: Optional[pulumi.Input['_compute.instancebootdisk.InstanceBootDiskArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if boot_disk is None and 'bootDisk' in kwargs:
             boot_disk = kwargs['bootDisk']
@@ -144,11 +144,7 @@ class Instance(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = InstanceArgs.__new__(InstanceArgs)
 
-            if boot_disk is not None and not isinstance(boot_disk, _compute.instancebootdisk.InstanceBootDiskArgs):
-                boot_disk = boot_disk or {}
-                def _setter(key, value):
-                    boot_disk[key] = value
-                _compute.instancebootdisk.InstanceBootDiskArgs._configure(_setter, **boot_disk)
+            boot_disk = _utilities.configure(boot_disk, _compute.instancebootdisk.InstanceBootDiskArgs, True)
             if boot_disk is None and not opts.urn:
                 raise TypeError("Missing required property 'boot_disk'")
             __props__.__dict__["boot_disk"] = boot_disk

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/_inputs.py
@@ -31,7 +31,7 @@ class InstanceBootDiskArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              initialize_params: Optional[pulumi.Input['_compute.instancebootdiskinitializeparams.InstanceBootDiskInitializeParamsArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if initialize_params is None and 'initializeParams' in kwargs:
             initialize_params = kwargs['initializeParams']

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/outputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdisk/outputs.py
@@ -48,7 +48,7 @@ class InstanceBootDisk(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              initialize_params: Optional['_compute.instancebootdiskinitializeparams.outputs.InstanceBootDiskInitializeParams'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if initialize_params is None and 'initializeParams' in kwargs:
             initialize_params = kwargs['initializeParams']

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/_inputs.py
@@ -36,7 +36,7 @@ class InstanceBootDiskInitializeParamsArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              image_name: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if image_name is None and 'imageName' in kwargs:
             image_name = kwargs['imageName']

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/compute/instancebootdiskinitializeparams/outputs.py
@@ -53,7 +53,7 @@ class InstanceBootDiskInitializeParams(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              image_name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if image_name is None and 'imageName' in kwargs:
             image_name = kwargs['imageName']

--- a/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/provider.py
+++ b/pkg/codegen/testing/test/testdata/configure-prop-names/python/pulumi_gcp/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_inputs.py
@@ -25,7 +25,7 @@ class TopLevelArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              buzz: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if buzz is not None:

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/outputs.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/outputs.py
@@ -25,7 +25,7 @@ class TopLevel(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              buzz: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if buzz is not None:

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/provider.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/foo_encrypted_bar_class.py
@@ -21,7 +21,7 @@ class FOOEncryptedBarClassArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -28,7 +28,7 @@ class ModuleResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              thing: Optional[pulumi.Input['_root_inputs.TopLevelArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if thing is not None:
@@ -93,11 +93,7 @@ class ModuleResource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ModuleResourceArgs.__new__(ModuleResourceArgs)
 
-            if thing is not None and not isinstance(thing, _root_inputs.TopLevelArgs):
-                thing = thing or {}
-                def _setter(key, value):
-                    thing[key] = value
-                _root_inputs.TopLevelArgs._configure(_setter, **thing)
+            thing = _utilities.configure(thing, _root_inputs.TopLevelArgs, True)
             __props__.__dict__["thing"] = thing
         super(ModuleResource, __self__).__init__(
             'foo-bar:submodule1:ModuleResource',

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
@@ -35,7 +35,7 @@ class ContainerArgs:
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/outputs.py
@@ -35,7 +35,7 @@ class Container(dict):
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -32,7 +32,7 @@ class NurseryArgs:
              _setter: Callable[[Any, Any], None],
              varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if varieties is None:
             raise TypeError("Missing 'varieties' argument")

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -42,7 +42,7 @@ class RubberTreeArgs:
              container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
              size: Optional[pulumi.Input['TreeSize']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if diameter is None:
@@ -123,7 +123,7 @@ class _RubberTreeState:
     def _configure(
              _setter: Callable[[Any, Any], None],
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if farm is None:
@@ -198,11 +198,7 @@ class RubberTree(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            if container is not None and not isinstance(container, _root_inputs.ContainerArgs):
-                container = container or {}
-                def _setter(key, value):
-                    container[key] = value
-                _root_inputs.ContainerArgs._configure(_setter, **container)
+            container = _utilities.configure(container, _root_inputs.ContainerArgs, True)
             __props__.__dict__["container"] = container
             if diameter is None:
                 diameter = 6

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
@@ -35,7 +35,7 @@ class ContainerArgs:
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/outputs.py
@@ -35,7 +35,7 @@ class Container(dict):
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -32,7 +32,7 @@ class NurseryArgs:
              _setter: Callable[[Any, Any], None],
              varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if varieties is None:
             raise TypeError("Missing 'varieties' argument")

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -42,7 +42,7 @@ class RubberTreeArgs:
              container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
              size: Optional[pulumi.Input['TreeSize']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if diameter is None:
@@ -123,7 +123,7 @@ class _RubberTreeState:
     def _configure(
              _setter: Callable[[Any, Any], None],
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if farm is None:
@@ -198,11 +198,7 @@ class RubberTree(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            if container is not None and not isinstance(container, _root_inputs.ContainerArgs):
-                container = container or {}
-                def _setter(key, value):
-                    container[key] = value
-                _root_inputs.ContainerArgs._configure(_setter, **container)
+            container = _utilities.configure(container, _root_inputs.ContainerArgs, True)
             __props__.__dict__["container"] = container
             if diameter is None:
                 diameter = 6

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/component.py
@@ -31,7 +31,7 @@ class ComponentArgs:
              _setter: Callable[[Any, Any], None],
              eni_config: Optional[pulumi.Input[Mapping[str, pulumi.Input['_crd_k8s_amazonaws_com.v1alpha1.ENIConfigSpecArgs']]]] = None,
              pod: Optional[pulumi.Input['pulumi_kubernetes.core.v1.PodArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if eni_config is None and 'eniConfig' in kwargs:
             eni_config = kwargs['eniConfig']
@@ -114,11 +114,7 @@ class Component(pulumi.ComponentResource):
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
             __props__.__dict__["eni_config"] = eni_config
-            if pod is not None and not isinstance(pod, pulumi_kubernetes.core.v1.PodArgs) and hasattr(pulumi_kubernetes.core.v1.PodArgs, '_configure'):
-                pod = pod or {}
-                def _setter(key, value):
-                    pod[key] = value
-                pulumi_kubernetes.core.v1.PodArgs._configure(_setter, **pod)
+            pod = _utilities.configure(pod, pulumi_kubernetes.core.v1.PodArgs, True)
             __props__.__dict__["pod"] = pod
         super(Component, __self__).__init__(
             'foo:index:Component',

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/_inputs.py
@@ -28,7 +28,7 @@ class ENIConfigSpecArgs:
              _setter: Callable[[Any, Any], None],
              security_groups: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
              subnet: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if security_groups is None and 'securityGroups' in kwargs:
             security_groups = kwargs['securityGroups']

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/crd_k8s_amazonaws_com/v1alpha1/outputs.py
@@ -45,7 +45,7 @@ class ENIConfigSpec(dict):
              _setter: Callable[[Any, Any], None],
              security_groups: Optional[Sequence[str]] = None,
              subnet: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if security_groups is None and 'securityGroups' in kwargs:
             security_groups = kwargs['securityGroups']

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/gcp/gke/outputs.py
@@ -46,7 +46,7 @@ class NodePoolAutoscaling(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              location_policy: Optional['pulumi_google_native.container.v1.NodePoolAutoscalingLocationPolicy'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if location_policy is None and 'locationPolicy' in kwargs:
             location_policy = kwargs['locationPolicy']

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -27,7 +27,7 @@ class IamResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[pulumi.Input['pulumi_google_native.iam.v1.AuditConfigArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -94,11 +94,7 @@ class IamResource(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = IamResourceArgs.__new__(IamResourceArgs)
 
-            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs) and hasattr(pulumi_google_native.iam.v1.AuditConfigArgs, '_configure'):
-                config = config or {}
-                def _setter(key, value):
-                    config[key] = value
-                pulumi_google_native.iam.v1.AuditConfigArgs._configure(_setter, **config)
+            config = _utilities.configure(config, pulumi_google_native.iam.v1.AuditConfigArgs, True)
             __props__.__dict__["config"] = config
         super(IamResource, __self__).__init__(
             'example:myModule:IamResource',

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/replicated_bucket.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/replicated_bucket.py
@@ -29,7 +29,7 @@ class ReplicatedBucketArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              destination_region: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if destination_region is None and 'destinationRegion' in kwargs:
             destination_region = kwargs['destinationRegion']

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -27,7 +27,7 @@ class IamResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[pulumi.Input['pulumi_google_native.iam.v1.AuditConfigArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -94,11 +94,7 @@ class IamResource(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = IamResourceArgs.__new__(IamResourceArgs)
 
-            if config is not None and not isinstance(config, pulumi_google_native.iam.v1.AuditConfigArgs) and hasattr(pulumi_google_native.iam.v1.AuditConfigArgs, '_configure'):
-                config = config or {}
-                def _setter(key, value):
-                    config[key] = value
-                pulumi_google_native.iam.v1.AuditConfigArgs._configure(_setter, **config)
+            config = _utilities.configure(config, pulumi_google_native.iam.v1.AuditConfigArgs, True)
             __props__.__dict__["config"] = config
         super(IamResource, __self__).__init__(
             'example:myModule:IamResource',

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
@@ -31,7 +31,7 @@ class ComponentArgs:
              _setter: Callable[[Any, Any], None],
              local_enum: Optional[pulumi.Input['local.MyEnum']] = None,
              remote_enum: Optional[pulumi.Input['pulumi_google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if local_enum is None and 'localEnum' in kwargs:
             local_enum = kwargs['localEnum']

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -30,7 +30,7 @@ class TrailArgs:
              _setter: Callable[[Any, Any], None],
              advanced_event_selectors: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]] = None,
              trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if advanced_event_selectors is None and 'advancedEventSelectors' in kwargs:
             advanced_event_selectors = kwargs['advancedEventSelectors']

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
@@ -44,7 +44,7 @@ class PetArgs:
              name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
              name_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
              name_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_name is None and 'requiredName' in kwargs:
             required_name = kwargs['requiredName']

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -31,7 +31,7 @@ class CatArgs:
              _setter: Callable[[Any, Any], None],
              age: Optional[pulumi.Input[int]] = None,
              pet: Optional[pulumi.Input['PetArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if age is not None:
@@ -110,11 +110,7 @@ class Cat(pulumi.CustomResource):
             __props__ = CatArgs.__new__(CatArgs)
 
             __props__.__dict__["age"] = age
-            if pet is not None and not isinstance(pet, PetArgs):
-                pet = pet or {}
-                def _setter(key, value):
-                    pet[key] = value
-                PetArgs._configure(_setter, **pet)
+            pet = _utilities.configure(pet, PetArgs, True)
             __props__.__dict__["pet"] = pet
             __props__.__dict__["name"] = None
         super(Cat, __self__).__init__(

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -43,7 +43,7 @@ class ComponentArgs:
              metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
              metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
              metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_metadata is None and 'requiredMetadata' in kwargs:
             required_metadata = kwargs['requiredMetadata']
@@ -186,19 +186,11 @@ class Component(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
-            if metadata is not None and not isinstance(metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs) and hasattr(pulumi_kubernetes.meta.v1.ObjectMetaArgs, '_configure'):
-                metadata = metadata or {}
-                def _setter(key, value):
-                    metadata[key] = value
-                pulumi_kubernetes.meta.v1.ObjectMetaArgs._configure(_setter, **metadata)
+            metadata = _utilities.configure(metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs, True)
             __props__.__dict__["metadata"] = metadata
             __props__.__dict__["metadata_array"] = metadata_array
             __props__.__dict__["metadata_map"] = metadata_map
-            if required_metadata is not None and not isinstance(required_metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs) and hasattr(pulumi_kubernetes.meta.v1.ObjectMetaArgs, '_configure'):
-                required_metadata = required_metadata or {}
-                def _setter(key, value):
-                    required_metadata[key] = value
-                pulumi_kubernetes.meta.v1.ObjectMetaArgs._configure(_setter, **required_metadata)
+            required_metadata = _utilities.configure(required_metadata, pulumi_kubernetes.meta.v1.ObjectMetaArgs, True)
             if required_metadata is None and not opts.urn:
                 raise TypeError("Missing required property 'required_metadata'")
             __props__.__dict__["required_metadata"] = required_metadata

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -22,7 +22,7 @@ class WorkloadArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/provider.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -28,7 +28,7 @@ class RegistryGeoReplicationArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              resource_group: Optional[pulumi.Input['pulumi_azure_native.resources.ResourceGroup']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if resource_group is None and 'resourceGroup' in kwargs:
             resource_group = kwargs['resourceGroup']

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/foo.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/foo.py
@@ -22,7 +22,7 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/outputs.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/outputs.py
@@ -42,7 +42,7 @@ class Bar(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              has_a_hyphen: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if has_a_hyphen is None and 'has-a-hyphen' in kwargs:
             has_a_hyphen = kwargs['has-a-hyphen']

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/provider.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/main_component.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/main_component.py
@@ -21,7 +21,7 @@ class MainComponentArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component.py
@@ -31,7 +31,7 @@ class ComponentArgs:
              _setter: Callable[[Any, Any], None],
              local: Optional[pulumi.Input['Component2']] = None,
              main: Optional[pulumi.Input['MainComponent']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if local is not None:

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component2.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component2.py
@@ -21,7 +21,7 @@ class Component2Args:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource.py
@@ -21,7 +21,7 @@ class ResourceArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource_input.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource_input.py
@@ -21,7 +21,7 @@ class ResourceInputArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -26,7 +26,7 @@ class ResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              baz: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if baz is not None:

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/provider.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -26,7 +26,7 @@ class ResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              bar: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_inputs.py
@@ -38,7 +38,7 @@ class ConfigurationFilters:
              _setter: Callable[[Any, Any], None],
              hierarchy_information: Optional['HierarchyInformation'] = None,
              filterable_property: Optional[Sequence['FilterableProperty']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if hierarchy_information is None and 'hierarchyInformation' in kwargs:
             hierarchy_information = kwargs['hierarchyInformation']
@@ -100,7 +100,7 @@ class CustomerSubscriptionDetails:
              quota_id: Optional[str] = None,
              location_placement_id: Optional[str] = None,
              registered_features: Optional[Sequence['CustomerSubscriptionRegisteredFeatures']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if quota_id is None and 'quotaId' in kwargs:
             quota_id = kwargs['quotaId']
@@ -174,7 +174,7 @@ class CustomerSubscriptionRegisteredFeatures:
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
              state: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:
@@ -227,7 +227,7 @@ class FilterableProperty:
              _setter: Callable[[Any, Any], None],
              supported_values: Optional[Sequence[str]] = None,
              type: Optional[Union[str, 'SupportedFilterTypes']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if supported_values is None and 'supportedValues' in kwargs:
             supported_values = kwargs['supportedValues']
@@ -292,7 +292,7 @@ class HierarchyInformation:
              product_family_name: Optional[str] = None,
              product_line_name: Optional[str] = None,
              product_name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if configuration_name is None and 'configurationName' in kwargs:
             configuration_name = kwargs['configurationName']

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
@@ -57,7 +57,7 @@ class AvailabilityInformationResponse(dict):
              availability_stage: Optional[str] = None,
              disabled_reason: Optional[str] = None,
              disabled_reason_message: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if availability_stage is None and 'availabilityStage' in kwargs:
             availability_stage = kwargs['availabilityStage']
@@ -132,7 +132,7 @@ class BillingMeterDetailsResponse(dict):
              meter_details: Optional[Any] = None,
              metering_type: Optional[str] = None,
              name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if frequency is None:
             raise TypeError("Missing 'frequency' argument")
@@ -236,7 +236,7 @@ class ConfigurationResponse(dict):
              hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
              image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
              specifications: Optional[Sequence['outputs.SpecificationResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
@@ -375,7 +375,7 @@ class CostInformationResponse(dict):
              _setter: Callable[[Any, Any], None],
              billing_info_url: Optional[str] = None,
              billing_meter_details: Optional[Sequence['outputs.BillingMeterDetailsResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if billing_info_url is None and 'billingInfoUrl' in kwargs:
             billing_info_url = kwargs['billingInfoUrl']
@@ -445,7 +445,7 @@ class DescriptionResponse(dict):
              links: Optional[Sequence['outputs.LinkResponse']] = None,
              long_description: Optional[str] = None,
              short_description: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if attributes is None:
             raise TypeError("Missing 'attributes' argument")
@@ -565,7 +565,7 @@ class DimensionsResponse(dict):
              weight: Optional[float] = None,
              weight_unit: Optional[str] = None,
              width: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if depth is None:
             raise TypeError("Missing 'depth' argument")
@@ -674,7 +674,7 @@ class FilterablePropertyResponse(dict):
              _setter: Callable[[Any, Any], None],
              supported_values: Optional[Sequence[str]] = None,
              type: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if supported_values is None and 'supportedValues' in kwargs:
             supported_values = kwargs['supportedValues']
@@ -734,7 +734,7 @@ class HierarchyInformationResponse(dict):
              product_family_name: Optional[str] = None,
              product_line_name: Optional[str] = None,
              product_name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if configuration_name is None and 'configurationName' in kwargs:
             configuration_name = kwargs['configurationName']
@@ -810,7 +810,7 @@ class ImageInformationResponse(dict):
              _setter: Callable[[Any, Any], None],
              image_type: Optional[str] = None,
              image_url: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if image_type is None and 'imageType' in kwargs:
             image_type = kwargs['imageType']
@@ -864,7 +864,7 @@ class LinkResponse(dict):
              _setter: Callable[[Any, Any], None],
              link_type: Optional[str] = None,
              link_url: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if link_type is None and 'linkType' in kwargs:
             link_type = kwargs['linkType']
@@ -927,7 +927,7 @@ class Pav2MeterDetailsResponse(dict):
              charging_type: Optional[str] = None,
              meter_guid: Optional[str] = None,
              multiplier: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if billing_type is None and 'billingType' in kwargs:
             billing_type = kwargs['billingType']
@@ -1030,7 +1030,7 @@ class ProductFamilyResponse(dict):
              hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
              image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
              product_lines: Optional[Sequence['outputs.ProductLineResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
@@ -1184,7 +1184,7 @@ class ProductLineResponse(dict):
              hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
              image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
              products: Optional[Sequence['outputs.ProductResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
@@ -1336,7 +1336,7 @@ class ProductResponse(dict):
              filterable_properties: Optional[Sequence['outputs.FilterablePropertyResponse']] = None,
              hierarchy_information: Optional['outputs.HierarchyInformationResponse'] = None,
              image_information: Optional[Sequence['outputs.ImageInformationResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if availability_information is None and 'availabilityInformation' in kwargs:
             availability_information = kwargs['availabilityInformation']
@@ -1481,7 +1481,7 @@ class PurchaseMeterDetailsResponse(dict):
              product_id: Optional[str] = None,
              sku_id: Optional[str] = None,
              term_id: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if billing_type is None and 'billingType' in kwargs:
             billing_type = kwargs['billingType']
@@ -1586,7 +1586,7 @@ class SpecificationResponse(dict):
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
              value: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if name is None:
             raise TypeError("Missing 'name' argument")

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_inputs.py
@@ -28,7 +28,7 @@ class GetAmiIdsFilterArgs:
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
              values: Optional[Sequence[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if name is None:
             raise TypeError("Missing 'name' argument")

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/outputs.py
@@ -45,7 +45,7 @@ class StorageAccountKeyResponseResult(dict):
              key_name: Optional[str] = None,
              permissions: Optional[str] = None,
              value: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if creation_time is None and 'creationTime' in kwargs:
             creation_time = kwargs['creationTime']
@@ -113,7 +113,7 @@ class GetAmiIdsFilterResult(dict):
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
              values: Optional[Sequence[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if name is None:
             raise TypeError("Missing 'name' argument")

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_inputs.py
@@ -29,7 +29,7 @@ class BastionShareableLink:
     def _configure(
              _setter: Callable[[Any, Any], None],
              vm: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if vm is None:
             raise TypeError("Missing 'vm' argument")

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/outputs.py
@@ -52,7 +52,7 @@ class SsisEnvironmentReferenceResponse(dict):
              environment_name: Optional[str] = None,
              id: Optional[float] = None,
              reference_type: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if environment_folder_name is None and 'environmentFolderName' in kwargs:
             environment_folder_name = kwargs['environmentFolderName']
@@ -143,7 +143,7 @@ class SsisEnvironmentResponse(dict):
              id: Optional[float] = None,
              name: Optional[str] = None,
              variables: Optional[Sequence['outputs.SsisVariableResponse']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if type is None:
             raise TypeError("Missing 'type' argument")
@@ -244,7 +244,7 @@ class SsisFolderResponse(dict):
              description: Optional[str] = None,
              id: Optional[float] = None,
              name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if type is None:
             raise TypeError("Missing 'type' argument")
@@ -339,7 +339,7 @@ class SsisPackageResponse(dict):
              parameters: Optional[Sequence['outputs.SsisParameterResponse']] = None,
              project_id: Optional[float] = None,
              project_version: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if type is None:
             raise TypeError("Missing 'type' argument")
@@ -495,7 +495,7 @@ class SsisParameterResponse(dict):
              value_set: Optional[bool] = None,
              value_type: Optional[str] = None,
              variable: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if data_type is None and 'dataType' in kwargs:
             data_type = kwargs['dataType']
@@ -680,7 +680,7 @@ class SsisProjectResponse(dict):
              name: Optional[str] = None,
              parameters: Optional[Sequence['outputs.SsisParameterResponse']] = None,
              version: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if type is None:
             raise TypeError("Missing 'type' argument")
@@ -814,7 +814,7 @@ class SsisVariableResponse(dict):
              sensitive: Optional[bool] = None,
              sensitive_value: Optional[str] = None,
              value: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if data_type is None and 'dataType' in kwargs:
             data_type = kwargs['dataType']
@@ -924,7 +924,7 @@ class StorageAccountKeyResponse(dict):
              key_name: Optional[str] = None,
              permissions: Optional[str] = None,
              value: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if creation_time is None and 'creationTime' in kwargs:
             creation_time = kwargs['creationTime']

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -75,7 +75,7 @@ class ModuleResourceArgs:
              plain_optional_const: Optional[str] = None,
              plain_optional_number: Optional[float] = None,
              plain_optional_string: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if plain_required_bool is None:

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
@@ -43,7 +43,7 @@ class HelmReleaseSettings:
              required_arg: Optional[str] = None,
              driver: Optional[str] = None,
              plugins_path: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
@@ -123,7 +123,7 @@ class HelmReleaseSettingsArgs:
              required_arg: Optional[pulumi.Input[str]] = None,
              driver: Optional[pulumi.Input[str]] = None,
              plugins_path: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
@@ -202,7 +202,7 @@ class KubeClientSettingsArgs:
              burst: Optional[pulumi.Input[int]] = None,
              qps: Optional[pulumi.Input[float]] = None,
              rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
@@ -286,7 +286,7 @@ class LayeredTypeArgs:
              plain_other: Optional['HelmReleaseSettingsArgs'] = None,
              question: Optional[pulumi.Input[str]] = None,
              recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if other is None:
             raise TypeError("Missing 'other' argument")
@@ -398,7 +398,7 @@ class TypArgs:
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              mod2: Optional[pulumi.Input['_mod2.TypArgs']] = None,
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
@@ -40,7 +40,7 @@ class FooArgs:
              argument: Optional[str] = None,
              kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              settings: Optional[pulumi.Input['LayeredTypeArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if backup_kube_client_settings is None and 'backupKubeClientSettings' in kwargs:
             backup_kube_client_settings = kwargs['backupKubeClientSettings']
@@ -164,25 +164,13 @@ class Foo(pulumi.CustomResource):
             __props__ = FooArgs.__new__(FooArgs)
 
             __props__.__dict__["argument"] = argument
-            if backup_kube_client_settings is not None and not isinstance(backup_kube_client_settings, KubeClientSettingsArgs):
-                backup_kube_client_settings = backup_kube_client_settings or {}
-                def _setter(key, value):
-                    backup_kube_client_settings[key] = value
-                KubeClientSettingsArgs._configure(_setter, **backup_kube_client_settings)
+            backup_kube_client_settings = _utilities.configure(backup_kube_client_settings, KubeClientSettingsArgs, True)
             if backup_kube_client_settings is None and not opts.urn:
                 raise TypeError("Missing required property 'backup_kube_client_settings'")
             __props__.__dict__["backup_kube_client_settings"] = backup_kube_client_settings
-            if kube_client_settings is not None and not isinstance(kube_client_settings, KubeClientSettingsArgs):
-                kube_client_settings = kube_client_settings or {}
-                def _setter(key, value):
-                    kube_client_settings[key] = value
-                KubeClientSettingsArgs._configure(_setter, **kube_client_settings)
+            kube_client_settings = _utilities.configure(kube_client_settings, KubeClientSettingsArgs, True)
             __props__.__dict__["kube_client_settings"] = kube_client_settings
-            if settings is not None and not isinstance(settings, LayeredTypeArgs):
-                settings = settings or {}
-                def _setter(key, value):
-                    settings[key] = value
-                LayeredTypeArgs._configure(_setter, **settings)
+            settings = _utilities.configure(settings, LayeredTypeArgs, True)
             __props__.__dict__["settings"] = settings
             __props__.__dict__["default_kube_client_settings"] = None
         super(Foo, __self__).__init__(

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
@@ -28,7 +28,7 @@ class TypArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if val is None:

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
@@ -32,7 +32,7 @@ class TypArgs:
              _setter: Callable[[Any, Any], None],
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
@@ -32,7 +32,7 @@ class ModuleTestArgs:
              _setter: Callable[[Any, Any], None],
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              val: Optional[pulumi.Input['TypArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:
@@ -110,17 +110,9 @@ class ModuleTest(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ModuleTestArgs.__new__(ModuleTestArgs)
 
-            if mod1 is not None and not isinstance(mod1, _mod1.TypArgs):
-                mod1 = mod1 or {}
-                def _setter(key, value):
-                    mod1[key] = value
-                _mod1.TypArgs._configure(_setter, **mod1)
+            mod1 = _utilities.configure(mod1, _mod1.TypArgs, True)
             __props__.__dict__["mod1"] = mod1
-            if val is not None and not isinstance(val, TypArgs):
-                val = val or {}
-                def _setter(key, value):
-                    val[key] = value
-                TypArgs._configure(_setter, **val)
+            val = _utilities.configure(val, TypArgs, True)
             __props__.__dict__["val"] = val
         super(ModuleTest, __self__).__init__(
             'example:index:moduleTest',

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/outputs.py
@@ -57,7 +57,7 @@ class KubeClientSettings(dict):
              burst: Optional[int] = None,
              qps: Optional[float] = None,
              rec_test: Optional['outputs.KubeClientSettings'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -28,7 +28,7 @@ class ProviderArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if helm_release_settings is None and 'helmReleaseSettings' in kwargs:
             helm_release_settings = kwargs['helmReleaseSettings']
@@ -101,11 +101,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            if helm_release_settings is not None and not isinstance(helm_release_settings, HelmReleaseSettingsArgs):
-                helm_release_settings = helm_release_settings or {}
-                def _setter(key, value):
-                    helm_release_settings[key] = value
-                HelmReleaseSettingsArgs._configure(_setter, **helm_release_settings)
+            helm_release_settings = _utilities.configure(helm_release_settings, HelmReleaseSettingsArgs, True)
             __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings).apply(pulumi.runtime.to_json) if helm_release_settings is not None else None
         super(Provider, __self__).__init__(
             'example',

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
@@ -43,7 +43,7 @@ class HelmReleaseSettings:
              required_arg: Optional[str] = None,
              driver: Optional[str] = None,
              plugins_path: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
@@ -123,7 +123,7 @@ class HelmReleaseSettingsArgs:
              required_arg: Optional[pulumi.Input[str]] = None,
              driver: Optional[pulumi.Input[str]] = None,
              plugins_path: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if required_arg is None and 'requiredArg' in kwargs:
             required_arg = kwargs['requiredArg']
@@ -202,7 +202,7 @@ class KubeClientSettingsArgs:
              burst: Optional[pulumi.Input[int]] = None,
              qps: Optional[pulumi.Input[float]] = None,
              rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']
@@ -286,7 +286,7 @@ class LayeredTypeArgs:
              plain_other: Optional['HelmReleaseSettingsArgs'] = None,
              question: Optional[pulumi.Input[str]] = None,
              recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if other is None:
             raise TypeError("Missing 'other' argument")
@@ -398,7 +398,7 @@ class TypArgs:
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              mod2: Optional[pulumi.Input['_mod2.TypArgs']] = None,
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -40,7 +40,7 @@ class FooArgs:
              argument: Optional[str] = None,
              kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
              settings: Optional[pulumi.Input['LayeredTypeArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if backup_kube_client_settings is None and 'backupKubeClientSettings' in kwargs:
             backup_kube_client_settings = kwargs['backupKubeClientSettings']
@@ -164,25 +164,13 @@ class Foo(pulumi.CustomResource):
             __props__ = FooArgs.__new__(FooArgs)
 
             __props__.__dict__["argument"] = argument
-            if backup_kube_client_settings is not None and not isinstance(backup_kube_client_settings, KubeClientSettingsArgs):
-                backup_kube_client_settings = backup_kube_client_settings or {}
-                def _setter(key, value):
-                    backup_kube_client_settings[key] = value
-                KubeClientSettingsArgs._configure(_setter, **backup_kube_client_settings)
+            backup_kube_client_settings = _utilities.configure(backup_kube_client_settings, KubeClientSettingsArgs, True)
             if backup_kube_client_settings is None and not opts.urn:
                 raise TypeError("Missing required property 'backup_kube_client_settings'")
             __props__.__dict__["backup_kube_client_settings"] = backup_kube_client_settings
-            if kube_client_settings is not None and not isinstance(kube_client_settings, KubeClientSettingsArgs):
-                kube_client_settings = kube_client_settings or {}
-                def _setter(key, value):
-                    kube_client_settings[key] = value
-                KubeClientSettingsArgs._configure(_setter, **kube_client_settings)
+            kube_client_settings = _utilities.configure(kube_client_settings, KubeClientSettingsArgs, True)
             __props__.__dict__["kube_client_settings"] = kube_client_settings
-            if settings is not None and not isinstance(settings, LayeredTypeArgs):
-                settings = settings or {}
-                def _setter(key, value):
-                    settings[key] = value
-                LayeredTypeArgs._configure(_setter, **settings)
+            settings = _utilities.configure(settings, LayeredTypeArgs, True)
             __props__.__dict__["settings"] = settings
             __props__.__dict__["default_kube_client_settings"] = None
         super(Foo, __self__).__init__(

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
@@ -28,7 +28,7 @@ class TypArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if val is None:

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
@@ -32,7 +32,7 @@ class TypArgs:
              _setter: Callable[[Any, Any], None],
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              val: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -32,7 +32,7 @@ class ModuleTestArgs:
              _setter: Callable[[Any, Any], None],
              mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
              val: Optional[pulumi.Input['TypArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if mod1 is not None:
@@ -110,17 +110,9 @@ class ModuleTest(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ModuleTestArgs.__new__(ModuleTestArgs)
 
-            if mod1 is not None and not isinstance(mod1, _mod1.TypArgs):
-                mod1 = mod1 or {}
-                def _setter(key, value):
-                    mod1[key] = value
-                _mod1.TypArgs._configure(_setter, **mod1)
+            mod1 = _utilities.configure(mod1, _mod1.TypArgs, True)
             __props__.__dict__["mod1"] = mod1
-            if val is not None and not isinstance(val, TypArgs):
-                val = val or {}
-                def _setter(key, value):
-                    val[key] = value
-                TypArgs._configure(_setter, **val)
+            val = _utilities.configure(val, TypArgs, True)
             __props__.__dict__["val"] = val
         super(ModuleTest, __self__).__init__(
             'example:index:moduleTest',

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/outputs.py
@@ -57,7 +57,7 @@ class KubeClientSettings(dict):
              burst: Optional[int] = None,
              qps: Optional[float] = None,
              rec_test: Optional['outputs.KubeClientSettings'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if rec_test is None and 'recTest' in kwargs:
             rec_test = kwargs['recTest']

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -28,7 +28,7 @@ class ProviderArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if helm_release_settings is None and 'helmReleaseSettings' in kwargs:
             helm_release_settings = kwargs['helmReleaseSettings']
@@ -101,11 +101,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            if helm_release_settings is not None and not isinstance(helm_release_settings, HelmReleaseSettingsArgs):
-                helm_release_settings = helm_release_settings or {}
-                def _setter(key, value):
-                    helm_release_settings[key] = value
-                HelmReleaseSettingsArgs._configure(_setter, **helm_release_settings)
+            helm_release_settings = _utilities.configure(helm_release_settings, HelmReleaseSettingsArgs, True)
             __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings).apply(pulumi.runtime.to_json) if helm_release_settings is not None else None
         super(Provider, __self__).__init__(
             'example',

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
@@ -25,7 +25,7 @@ class FooArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              a: Optional[pulumi.Input[bool]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if a is not None:

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -32,7 +32,7 @@ class StaticPageArgs:
              _setter: Callable[[Any, Any], None],
              index_content: Optional[pulumi.Input[str]] = None,
              foo: Optional['FooArgs'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if index_content is None and 'indexContent' in kwargs:
             index_content = kwargs['indexContent']
@@ -119,11 +119,7 @@ class StaticPage(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = StaticPageArgs.__new__(StaticPageArgs)
 
-            if foo is not None and not isinstance(foo, FooArgs):
-                foo = foo or {}
-                def _setter(key, value):
-                    foo[key] = value
-                FooArgs._configure(_setter, **foo)
+            foo = _utilities.configure(foo, FooArgs, False)
             __props__.__dict__["foo"] = foo
             if index_content is None and not opts.urn:
                 raise TypeError("Missing required property 'index_content'")

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/_inputs.py
@@ -28,7 +28,7 @@ class SandwichArgs:
              _setter: Callable[[Any, Any], None],
              bread: Optional[pulumi.Input[str]] = None,
              veggies: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bread is not None:

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/outputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/outputs.py
@@ -28,7 +28,7 @@ class Sandwich(dict):
              _setter: Callable[[Any, Any], None],
              bread: Optional[str] = None,
              veggies: Optional[Sequence[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bread is not None:

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/outputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/outputs.py
@@ -29,7 +29,7 @@ class Child(dict):
              _setter: Callable[[Any, Any], None],
              age: Optional[int] = None,
              name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if age is not None:

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -33,7 +33,7 @@ class ProviderArgs:
              _setter: Callable[[Any, Any], None],
              favorite_color: Optional[pulumi.Input[Union[str, 'Color']]] = None,
              secret_sandwiches: Optional[pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if favorite_color is None and 'favoriteColor' in kwargs:
             favorite_color = kwargs['favoriteColor']

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/submod/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/submod/provider.py
@@ -26,7 +26,7 @@ class ProviderArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              a: Optional[bool] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if a is not None:

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/outputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/outputs.py
@@ -20,7 +20,7 @@ class GetCustomDbRolesResult(dict):
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_inputs.py
@@ -35,7 +35,7 @@ class ContainerArgs:
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if size is None:

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/outputs.py
@@ -35,7 +35,7 @@ class Container(dict):
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if size is None:

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -42,7 +42,7 @@ class RubberTreeArgs:
              container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
              size: Optional[pulumi.Input['TreeSize']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if diameter is not None:
@@ -147,7 +147,7 @@ class _RubberTreeState:
     def _configure(
              _setter: Callable[[Any, Any], None],
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if farm is None:
@@ -222,11 +222,7 @@ class RubberTree(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            if container is not None and not isinstance(container, _root_inputs.ContainerArgs):
-                container = container or {}
-                def _setter(key, value):
-                    container[key] = value
-                _root_inputs.ContainerArgs._configure(_setter, **container)
+            container = _utilities.configure(container, _root_inputs.ContainerArgs, True)
             __props__.__dict__["container"] = container
             if diameter is None:
                 diameter = 6

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
@@ -28,7 +28,7 @@ class ProviderCertmanagerArgs:
              _setter: Callable[[Any, Any], None],
              mtls_cert_pem: Optional[pulumi.Input[str]] = None,
              mtls_key_pem: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if mtls_cert_pem is None:
             raise TypeError("Missing 'mtls_cert_pem' argument")

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
@@ -27,7 +27,7 @@ class ProviderArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              certmanager: Optional[pulumi.Input['ProviderCertmanagerArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if certmanager is not None:
@@ -92,11 +92,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            if certmanager is not None and not isinstance(certmanager, ProviderCertmanagerArgs):
-                certmanager = certmanager or {}
-                def _setter(key, value):
-                    certmanager[key] = value
-                ProviderCertmanagerArgs._configure(_setter, **certmanager)
+            certmanager = _utilities.configure(certmanager, ProviderCertmanagerArgs, True)
             __props__.__dict__["certmanager"] = pulumi.Output.from_input(certmanager).apply(pulumi.runtime.to_json) if certmanager is not None else None
         super(Provider, __self__).__init__(
             'foo',

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/_inputs.py
@@ -25,7 +25,7 @@ class GetPolicyDocumentStatementArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              actions: Optional[Sequence[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if actions is not None:

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/outputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/outputs.py
@@ -25,7 +25,7 @@ class GetPolicyDocumentStatementResult(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              actions: Optional[Sequence[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if actions is not None:

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/cat.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/cat.py
@@ -23,7 +23,7 @@ class CatArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/dog.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/dog.py
@@ -21,7 +21,7 @@ class DogArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/god.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/god.py
@@ -22,7 +22,7 @@ class GodArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/no_recursive.py
@@ -22,7 +22,7 @@ class NoRecursiveArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/outputs.py
@@ -37,7 +37,7 @@ class Chew(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              owner: Optional['Dog'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if owner is not None:
@@ -73,7 +73,7 @@ class Laser(dict):
              animal: Optional['Cat'] = None,
              batteries: Optional[bool] = None,
              light: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if animal is not None:
@@ -111,7 +111,7 @@ class Rec(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              rec1: Optional['outputs.Rec'] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if rec1 is not None:
@@ -147,7 +147,7 @@ class Toy(dict):
              associated: Optional['outputs.Toy'] = None,
              color: Optional[str] = None,
              wear: Optional[float] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if associated is not None:

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/toy_store.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/toy_store.py
@@ -24,7 +24,7 @@ class ToyStoreArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
@@ -25,7 +25,7 @@ class PetArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/outputs.py
@@ -25,7 +25,7 @@ class Pet(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -31,7 +31,7 @@ class PersonArgs:
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
              pets: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -26,7 +26,7 @@ class PetInitArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_inputs.py
@@ -25,7 +25,7 @@ class PetArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/outputs.py
@@ -25,7 +25,7 @@ class Pet(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
@@ -31,7 +31,7 @@ class PersonArgs:
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
              pets: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
@@ -26,7 +26,7 @@ class PetInitArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              name: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if name is not None:

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
@@ -21,7 +21,7 @@ class RecArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_inputs.py
@@ -25,7 +25,7 @@ class ConfigArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/outputs.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/outputs.py
@@ -25,7 +25,7 @@ class Config(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/resource.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/resource.py
@@ -43,7 +43,7 @@ class ResourceArgs:
              foo: Optional[pulumi.Input[str]] = None,
              foo_array: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
              foo_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if config is None:
             raise TypeError("Missing 'config' argument")
@@ -187,11 +187,7 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
-            if config is not None and not isinstance(config, ConfigArgs):
-                config = config or {}
-                def _setter(key, value):
-                    config[key] = value
-                ConfigArgs._configure(_setter, **config)
+            config = _utilities.configure(config, ConfigArgs, True)
             if config is None and not opts.urn:
                 raise TypeError("Missing required property 'config'")
             __props__.__dict__["config"] = None if config is None else pulumi.Output.secret(config)

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
@@ -35,7 +35,7 @@ class ContainerArgs:
              brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
              color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
              material: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
@@ -35,7 +35,7 @@ class Container(dict):
              brightness: Optional['ContainerBrightness'] = None,
              color: Optional[str] = None,
              material: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if size is None:
             raise TypeError("Missing 'size' argument")

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -32,7 +32,7 @@ class NurseryArgs:
              _setter: Callable[[Any, Any], None],
              varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
              sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if varieties is None:
             raise TypeError("Missing 'varieties' argument")

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -42,7 +42,7 @@ class RubberTreeArgs:
              container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
              size: Optional[pulumi.Input['TreeSize']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if diameter is None:
@@ -123,7 +123,7 @@ class _RubberTreeState:
     def _configure(
              _setter: Callable[[Any, Any], None],
              farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if farm is None:
@@ -198,11 +198,7 @@ class RubberTree(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            if container is not None and not isinstance(container, _root_inputs.ContainerArgs):
-                container = container or {}
-                def _setter(key, value):
-                    container[key] = value
-                _root_inputs.ContainerArgs._configure(_setter, **container)
+            container = _utilities.configure(container, _root_inputs.ContainerArgs, True)
             __props__.__dict__["container"] = container
             if diameter is None:
                 diameter = 6

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -21,7 +21,7 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
@@ -23,7 +23,7 @@ class FooArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/nested/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/nested/_inputs.py
@@ -28,7 +28,7 @@ class Baz:
              _setter: Callable[[Any, Any], None],
              hello: Optional[str] = None,
              world: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if hello is not None:

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_inputs.py
@@ -40,7 +40,7 @@ class FooArgs:
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -52,7 +52,7 @@ class ComponentArgs:
              d: Optional[int] = None,
              f: Optional[str] = None,
              foo: Optional[pulumi.Input['FooArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")
@@ -230,11 +230,7 @@ class Component(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'a'")
             __props__.__dict__["a"] = a
             __props__.__dict__["b"] = b
-            if bar is not None and not isinstance(bar, FooArgs):
-                bar = bar or {}
-                def _setter(key, value):
-                    bar[key] = value
-                FooArgs._configure(_setter, **bar)
+            bar = _utilities.configure(bar, FooArgs, False)
             __props__.__dict__["bar"] = bar
             __props__.__dict__["baz"] = baz
             if c is None and not opts.urn:
@@ -245,11 +241,7 @@ class Component(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'e'")
             __props__.__dict__["e"] = e
             __props__.__dict__["f"] = f
-            if foo is not None and not isinstance(foo, FooArgs):
-                foo = foo or {}
-                def _setter(key, value):
-                    foo[key] = value
-                FooArgs._configure(_setter, **foo)
+            foo = _utilities.configure(foo, FooArgs, True)
             __props__.__dict__["foo"] = foo
         super(Component, __self__).__init__(
             'example::Component',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/outputs.py
@@ -40,7 +40,7 @@ class Foo(dict):
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
@@ -41,7 +41,7 @@ class Foo:
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")
@@ -142,7 +142,7 @@ class FooArgs:
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -55,7 +55,7 @@ class ComponentArgs:
              d: Optional[int] = None,
              f: Optional[str] = None,
              foo: Optional[pulumi.Input['FooArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")
@@ -248,11 +248,7 @@ class Component(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'a'")
             __props__.__dict__["a"] = a
             __props__.__dict__["b"] = b
-            if bar is not None and not isinstance(bar, FooArgs):
-                bar = bar or {}
-                def _setter(key, value):
-                    bar[key] = value
-                FooArgs._configure(_setter, **bar)
+            bar = _utilities.configure(bar, FooArgs, False)
             __props__.__dict__["bar"] = bar
             __props__.__dict__["baz"] = baz
             __props__.__dict__["baz_map"] = baz_map
@@ -264,11 +260,7 @@ class Component(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'e'")
             __props__.__dict__["e"] = e
             __props__.__dict__["f"] = f
-            if foo is not None and not isinstance(foo, FooArgs):
-                foo = foo or {}
-                def _setter(key, value):
-                    foo[key] = value
-                FooArgs._configure(_setter, **foo)
+            foo = _utilities.configure(foo, FooArgs, True)
             __props__.__dict__["foo"] = foo
         super(Component, __self__).__init__(
             'example::Component',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
@@ -40,7 +40,7 @@ class Foo(dict):
              b: Optional[bool] = None,
              d: Optional[int] = None,
              f: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if a is None:
             raise TypeError("Missing 'a' argument")

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -27,7 +27,7 @@ class OtherResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input['Resource']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -26,7 +26,7 @@ class ResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              bar: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -29,7 +29,7 @@ class ConfigMapArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -60,7 +60,7 @@ class ObjectWithNodeOptionalInputsArgs:
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input[str]] = None,
              bar: Optional[pulumi.Input[int]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if foo is None:
             raise TypeError("Missing 'foo' argument")
@@ -116,7 +116,7 @@ class ObjectArgs:
              foo: Optional[pulumi.Input['Resource']] = None,
              others: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
              still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
@@ -196,7 +196,7 @@ class SomeOtherObjectArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              baz: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if baz is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return "example.com/download"

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -27,7 +27,7 @@ class BarResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input['Resource']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -27,7 +27,7 @@ class FooResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input['Resource']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -27,7 +27,7 @@ class OtherResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input['Resource']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/outputs.py
@@ -30,7 +30,7 @@ class ConfigMap(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -87,7 +87,7 @@ class Object(dict):
              foo: Optional['Resource'] = None,
              others: Optional[Sequence[Sequence['outputs.SomeOtherObject']]] = None,
              still_others: Optional[Mapping[str, Sequence['outputs.SomeOtherObject']]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
@@ -150,7 +150,7 @@ class ObjectWithNodeOptionalInputs(dict):
              _setter: Callable[[Any, Any], None],
              foo: Optional[str] = None,
              bar: Optional[int] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if foo is None:
             raise TypeError("Missing 'foo' argument")
@@ -182,7 +182,7 @@ class SomeOtherObject(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              baz: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if baz is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -26,7 +26,7 @@ class ResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              bar: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -35,7 +35,7 @@ class TypeUsesArgs:
              bar: Optional[pulumi.Input['SomeOtherObjectArgs']] = None,
              baz: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']] = None,
              foo: Optional[pulumi.Input['ObjectArgs']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:
@@ -126,23 +126,11 @@ class TypeUses(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = TypeUsesArgs.__new__(TypeUsesArgs)
 
-            if bar is not None and not isinstance(bar, SomeOtherObjectArgs):
-                bar = bar or {}
-                def _setter(key, value):
-                    bar[key] = value
-                SomeOtherObjectArgs._configure(_setter, **bar)
+            bar = _utilities.configure(bar, SomeOtherObjectArgs, True)
             __props__.__dict__["bar"] = bar
-            if baz is not None and not isinstance(baz, ObjectWithNodeOptionalInputsArgs):
-                baz = baz or {}
-                def _setter(key, value):
-                    baz[key] = value
-                ObjectWithNodeOptionalInputsArgs._configure(_setter, **baz)
+            baz = _utilities.configure(baz, ObjectWithNodeOptionalInputsArgs, True)
             __props__.__dict__["baz"] = baz
-            if foo is not None and not isinstance(foo, ObjectArgs):
-                foo = foo or {}
-                def _setter(key, value):
-                    foo[key] = value
-                ObjectArgs._configure(_setter, **foo)
+            foo = _utilities.configure(foo, ObjectArgs, True)
             __props__.__dict__["foo"] = foo
         super(TypeUses, __self__).__init__(
             'example::TypeUses',

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -30,7 +30,7 @@ class ConfigMapArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -61,7 +61,7 @@ class ObjectWithNodeOptionalInputsArgs:
              _setter: Callable[[Any, Any], None],
              foo: Optional[pulumi.Input[str]] = None,
              bar: Optional[pulumi.Input[int]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if foo is None:
             raise TypeError("Missing 'foo' argument")
@@ -117,7 +117,7 @@ class ObjectArgs:
              foo: Optional[pulumi.Input['Resource']] = None,
              others: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
              still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
@@ -197,7 +197,7 @@ class SomeOtherObjectArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              baz: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if baz is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -246,5 +246,24 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     return (lambda _: lifted_func)
 
+
+def configure(val, cls: type, input: bool):
+    def _apply(v):
+        if isinstance(v, typing.Mapping):
+            def _setter(key, value):
+                v[key] = value
+            cls._configure(_setter, **v)
+        return v
+
+    # Check that cls has a static _configure method. External classes may
+    # not have it if it was generated with older codegen.
+    if hasattr(cls, "_configure"):
+        if isinstance(val, typing.Mapping):
+            return _apply(val)
+        elif input and val is not None and not isinstance(val, cls):
+            return pulumi.Output.from_input(val).apply(_apply)
+
+    return val
+
 def get_plugin_download_url():
 	return None

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -30,7 +30,7 @@ class OtherResourceArgs:
              _setter: Callable[[Any, Any], None],
              bar: Optional[Sequence[pulumi.Input[str]]] = None,
              foo: Optional[pulumi.Input['Resource']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/outputs.py
@@ -32,7 +32,7 @@ class ConfigMap(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              config: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if config is not None:
@@ -89,7 +89,7 @@ class Object(dict):
              foo: Optional['Resource'] = None,
              others: Optional[Sequence[Sequence['outputs.SomeOtherObject']]] = None,
              still_others: Optional[Mapping[str, Sequence['outputs.SomeOtherObject']]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if still_others is None and 'stillOthers' in kwargs:
             still_others = kwargs['stillOthers']
@@ -152,7 +152,7 @@ class ObjectWithNodeOptionalInputs(dict):
              _setter: Callable[[Any, Any], None],
              foo: Optional[str] = None,
              bar: Optional[int] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if foo is None:
             raise TypeError("Missing 'foo' argument")
@@ -184,7 +184,7 @@ class OutputOnlyObjectType(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              foo: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if foo is not None:
@@ -208,7 +208,7 @@ class SomeOtherObject(dict):
     def _configure(
              _setter: Callable[[Any, Any], None],
              baz: Optional[str] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if baz is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/provider.py
@@ -21,7 +21,7 @@ class ProviderArgs:
     @staticmethod
     def _configure(
              _setter: Callable[[Any, Any], None],
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         pass
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
@@ -26,7 +26,7 @@ class ResourceArgs:
     def _configure(
              _setter: Callable[[Any, Any], None],
              bar: Optional[pulumi.Input[str]] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -39,7 +39,7 @@ class TypeUsesArgs:
              baz: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']] = None,
              foo: Optional[pulumi.Input['ObjectArgs']] = None,
              qux: Optional[pulumi.Input['RubberTreeVariety']] = None,
-             opts: Optional[pulumi.ResourceOptions]=None,
+             opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
 
         if bar is not None:
@@ -143,23 +143,11 @@ class TypeUses(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = TypeUsesArgs.__new__(TypeUsesArgs)
 
-            if bar is not None and not isinstance(bar, SomeOtherObjectArgs):
-                bar = bar or {}
-                def _setter(key, value):
-                    bar[key] = value
-                SomeOtherObjectArgs._configure(_setter, **bar)
+            bar = _utilities.configure(bar, SomeOtherObjectArgs, True)
             __props__.__dict__["bar"] = bar
-            if baz is not None and not isinstance(baz, ObjectWithNodeOptionalInputsArgs):
-                baz = baz or {}
-                def _setter(key, value):
-                    baz[key] = value
-                ObjectWithNodeOptionalInputsArgs._configure(_setter, **baz)
+            baz = _utilities.configure(baz, ObjectWithNodeOptionalInputsArgs, True)
             __props__.__dict__["baz"] = baz
-            if foo is not None and not isinstance(foo, ObjectArgs):
-                foo = foo or {}
-                def _setter(key, value):
-                    foo[key] = value
-                ObjectArgs._configure(_setter, **foo)
+            foo = _utilities.configure(foo, ObjectArgs, True)
             __props__.__dict__["foo"] = foo
             __props__.__dict__["qux"] = qux
             __props__.__dict__["alpha"] = None


### PR DESCRIPTION
We recently added the ability to assign default values for nested types in generated Python SDKs, when the nested types are passed as dicts. We do so by calling a new static `_configure` method on the input type, to assign default values.

This wasn't working correctly if the value was an `Output[T]` or `Awaitable[T]`. This change fixes the code to call `_configure` inside an `apply`, if needed.

Since the boilerplate code was getting bigger, moved it into a `configure` helper method in `_utilities.py`.

Fixes #14320