### PR TITLE
fix panic when we have a nil object

### DIFF
--- a/changelog/pending/20231024--cli-config--dont-crash-on-empty-config-values.yaml
+++ b/changelog/pending/20231024--cli-config--dont-crash-on-empty-config-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Don't crash on empty config values

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -547,6 +547,8 @@ func (c object) toDecryptedPropertyValue(decrypter Decrypter) resource.PropertyV
 			values[resource.PropertyKey(k)] = v.toDecryptedPropertyValue(decrypter)
 		}
 		prop = resource.NewObjectProperty(values)
+	case nil:
+		prop = resource.NewNullProperty()
 	default:
 		contract.Failf("unexpected value type %T", v)
 	}

--- a/sdk/go/common/resource/config/object_test.go
+++ b/sdk/go/common/resource/config/object_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/sdk/go/common/resource/config/object_test.go
+++ b/sdk/go/common/resource/config/object_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	// Test that an empty object can be converted to a property value
+	// without error.
+	o := object{}
+	crypter := nopCrypter{}
+	v := o.toDecryptedPropertyValue(crypter)
+	assert.Equal(t, resource.NewNullProperty(), v)
+}


### PR DESCRIPTION
In some cases we construct a nil object, which isn't handled properly when we convert it into a property value.  This is likely related to https://github.com/pulumi/pulumi/issues/14146, where we started allowing such objects as a fix for a similar, but separate issue.

Fixes #14325

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
