### PR TITLE
Fix PropertyPaths generated by NewDetailedDiffFromObjectDiff

### DIFF
--- a/changelog/pending/20231025--engine--fix-generation-of-property-paths-in-diff.yaml
+++ b/changelog/pending/20231025--engine--fix-generation-of-property-paths-in-diff.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix generation of property paths in diff.

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -243,16 +242,15 @@ func NewDetailedDiffFromObjectDiff(diff *resource.ObjectDiff, inputDiff bool) ma
 		return map[string]PropertyDiff{}
 	}
 	out := map[string]PropertyDiff{}
-	objectDiffToDetailedDiff("", diff, inputDiff, out)
+	objectDiffToDetailedDiff(nil, diff, inputDiff, out)
 	return out
 }
 
-func objectDiffToDetailedDiff(prefix string, diff *resource.ObjectDiff, inputDiff bool, acc map[string]PropertyDiff) {
-	getPrefix := func(k resource.PropertyKey) string {
-		if prefix == "" {
-			return string(k)
-		}
-		return fmt.Sprintf("%s.%s", prefix, string(k))
+func objectDiffToDetailedDiff(
+	prefix resource.PropertyPath, diff *resource.ObjectDiff, inputDiff bool, acc map[string]PropertyDiff,
+) {
+	getPrefix := func(k resource.PropertyKey) resource.PropertyPath {
+		return append(prefix, string(k))
 	}
 
 	for k, vd := range diff.Updates {
@@ -262,29 +260,35 @@ func objectDiffToDetailedDiff(prefix string, diff *resource.ObjectDiff, inputDif
 
 	for k := range diff.Adds {
 		nestedPrefix := getPrefix(k)
-		acc[nestedPrefix] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
+		acc[nestedPrefix.String()] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
 	}
 
 	for k := range diff.Deletes {
 		nestedPrefix := getPrefix(k)
-		acc[nestedPrefix] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
+		acc[nestedPrefix.String()] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
 	}
 }
 
-func arrayDiffToDetailedDiff(prefix string, d *resource.ArrayDiff, inputDiff bool, acc map[string]PropertyDiff) {
-	nestedPrefix := func(i int) string { return fmt.Sprintf("%s[%d]", prefix, i) }
+func arrayDiffToDetailedDiff(
+	prefix resource.PropertyPath, d *resource.ArrayDiff, inputDiff bool, acc map[string]PropertyDiff,
+) {
+	nestedPrefix := func(i int) resource.PropertyPath {
+		return append(prefix, i)
+	}
 	for i, vd := range d.Updates {
 		valueDiffToDetailedDiff(nestedPrefix(i), vd, inputDiff, acc)
 	}
 	for i := range d.Adds {
-		acc[nestedPrefix(i)] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
+		acc[nestedPrefix(i).String()] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
 	}
 	for i := range d.Deletes {
-		acc[nestedPrefix(i)] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
+		acc[nestedPrefix(i).String()] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
 	}
 }
 
-func valueDiffToDetailedDiff(prefix string, vd resource.ValueDiff, inputDiff bool, acc map[string]PropertyDiff) {
+func valueDiffToDetailedDiff(
+	prefix resource.PropertyPath, vd resource.ValueDiff, inputDiff bool, acc map[string]PropertyDiff,
+) {
 	if vd.Object != nil {
 		objectDiffToDetailedDiff(prefix, vd.Object, inputDiff, acc)
 	} else if vd.Array != nil {
@@ -292,11 +296,11 @@ func valueDiffToDetailedDiff(prefix string, vd resource.ValueDiff, inputDiff boo
 	} else {
 		switch {
 		case vd.Old.V == nil && vd.New.V != nil:
-			acc[prefix] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
+			acc[prefix.String()] = PropertyDiff{Kind: DiffAdd, InputDiff: inputDiff}
 		case vd.Old.V != nil && vd.New.V == nil:
-			acc[prefix] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
+			acc[prefix.String()] = PropertyDiff{Kind: DiffDelete, InputDiff: inputDiff}
 		default:
-			acc[prefix] = PropertyDiff{Kind: DiffUpdate, InputDiff: inputDiff}
+			acc[prefix.String()] = PropertyDiff{Kind: DiffUpdate, InputDiff: inputDiff}
 		}
 	}
 }

--- a/sdk/go/common/resource/plugin/provider_test.go
+++ b/sdk/go/common/resource/plugin/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDetailedDiff(t *testing.T) {
@@ -131,3 +132,97 @@ func TestNewDetailedDiff(t *testing.T) {
 
 // Assert that UnimplementedProvider implements Provider
 var _ = Provider((*UnimplementedProvider)(nil))
+
+// Regression test for https://github.com/pulumi/pulumi/issues/14335.
+// Ensure that NewDetailedDiffFromObjectDiff builds correct keys.
+func TestNewDetailedDiffFromObjectDiff(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		diff          *resource.ObjectDiff
+		inputDiff     bool
+		expected      map[string]PropertyDiff
+		expectedPaths map[string]resource.PropertyPath
+	}{
+		"simple add": {
+			diff: &resource.ObjectDiff{
+				Adds: resource.PropertyMap{
+					"a": resource.NewPropertyValue(1),
+				},
+			},
+			expected: map[string]PropertyDiff{
+				"a": {Kind: DiffAdd},
+			},
+			expectedPaths: map[string]resource.PropertyPath{
+				"a": {"a"},
+			},
+		},
+		"simple update": {
+			diff: &resource.ObjectDiff{
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"a": *resource.NewPropertyValue(1).Diff(resource.NewPropertyValue(2)),
+				},
+			},
+			expected: map[string]PropertyDiff{
+				"a": {Kind: DiffUpdate},
+			},
+			expectedPaths: map[string]resource.PropertyPath{
+				"a": {"a"},
+			},
+		},
+		"nested update": {
+			diff: &resource.ObjectDiff{
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"a": *resource.NewObjectProperty(resource.PropertyMap{
+						"b": resource.NewPropertyValue(1),
+					}).Diff(resource.NewObjectProperty(resource.PropertyMap{
+						"b": resource.NewPropertyValue(2),
+					})),
+				},
+			},
+			expected: map[string]PropertyDiff{
+				"a.b": {Kind: DiffUpdate},
+			},
+			expectedPaths: map[string]resource.PropertyPath{
+				"a.b": {"a", "b"},
+			},
+		},
+		"nested update with quoted keys": {
+			diff: &resource.ObjectDiff{
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"a": *resource.NewObjectProperty(resource.PropertyMap{
+						"b.c":          resource.NewPropertyValue(1),
+						`"quoted key"`: resource.NewPropertyValue(2),
+					}).Diff(resource.NewObjectProperty(resource.PropertyMap{
+						"b.c":          resource.NewPropertyValue(2),
+						`"quoted key"`: resource.NewPropertyValue(3),
+					})),
+				},
+			},
+			expected: map[string]PropertyDiff{
+				`a["\"quoted key\""]`: {Kind: DiffUpdate},
+				`a["b.c"]`:            {Kind: DiffUpdate},
+			},
+			expectedPaths: map[string]resource.PropertyPath{
+				`a["\"quoted key\""]`: {"a", `"quoted key"`},
+				`a["b.c"]`:            {"a", "b.c"},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := NewDetailedDiffFromObjectDiff(tt.diff, tt.inputDiff)
+			assert.Equal(t, tt.expected, result)
+
+			for k := range result {
+				path, err := resource.ParsePropertyPath(k)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedPaths[k], path)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14335.

This was incorrectly building property keys by just splicing "." inbetween every key. This was incorrect for keys which required quoting (e.g. those with "." in the key itself, or other special characters).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
