### PR TITLE
Add google-protobuf types

### DIFF
--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -18,10 +18,11 @@ import * as dynamic from "../../dynamic";
 import * as rpc from "../../runtime/rpc";
 import { version } from "../../version";
 
+import * as anyproto from "google-protobuf/google/protobuf/any_pb";
+import * as emptyproto from "google-protobuf/google/protobuf/empty_pb";
+import * as structproto from "google-protobuf/google/protobuf/struct_pb";
+
 const requireFromString = require("require-from-string");
-const anyproto = require("google-protobuf/google/protobuf/any_pb.js");
-const emptyproto = require("google-protobuf/google/protobuf/empty_pb.js");
-const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 const provproto = require("../../proto/provider_pb.js");
 const provrpc = require("../../proto/provider_grpc_pb.js");
 const plugproto = require("../../proto/plugin_pb.js");

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -46,6 +46,7 @@
         "@types/semver": "^5.5.0",
         "@types/sinon": "^10.0.13",
         "@types/split2": "^2.1.6",
+        "@types/google-protobuf": "^3.15.5",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
         "eslint": "^7.32.0",

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -19,14 +19,15 @@ import { Provider } from "./provider";
 import * as log from "../log";
 import { Inputs, Output, output } from "../output";
 import * as resource from "../resource";
-import * as settings from "../runtime/settings";
-import * as rpc from "../runtime/rpc";
 import * as config from "../runtime/config";
+import * as rpc from "../runtime/rpc";
+import * as settings from "../runtime/settings";
 import { parseArgs } from "./internals";
 
-const anyproto = require("google-protobuf/google/protobuf/any_pb.js");
-const emptyproto = require("google-protobuf/google/protobuf/empty_pb.js");
-const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
+import * as anyproto from "google-protobuf/google/protobuf/any_pb";
+import * as emptyproto from "google-protobuf/google/protobuf/empty_pb";
+import * as structproto from "google-protobuf/google/protobuf/struct_pb";
+
 const provproto = require("../proto/provider_pb.js");
 const provrpc = require("../proto/provider_grpc_pb.js");
 const plugproto = require("../proto/plugin_pb.js");

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -15,9 +15,10 @@
 import { deserializeProperties, serializeProperties } from "./rpc";
 import { getProject, getStack, setMockOptions } from "./settings";
 
+import * as structproto from "google-protobuf/google/protobuf/struct_pb";
+
 const provproto = require("../proto/provider_pb.js");
 const resproto = require("../proto/resource_pb.js");
-const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 
 /**
  * MockResourceArgs is used to construct a newResource Mock.
@@ -110,7 +111,7 @@ export interface Mocks {
 }
 
 export class MockMonitor {
-    readonly resources = new Map<string, { urn: string; id: string | undefined; state: any }>();
+    readonly resources = new Map<string, { urn: string; id: string | null; state: any }>();
 
     constructor(readonly mocks: Mocks) {}
 
@@ -171,7 +172,7 @@ export class MockMonitor {
             const urn = this.newUrn(req.getParent(), req.getType(), req.getName());
             const serializedState = await serializeProperties("", result.state);
 
-            this.resources.set(urn, { urn, id: result.id, state: serializedState });
+            this.resources.set(urn, { urn, id: result.id ?? null, state: serializedState });
 
             const response = new resproto.ReadResourceResponse();
             response.setUrn(urn);
@@ -196,7 +197,7 @@ export class MockMonitor {
             const urn = this.newUrn(req.getParent(), req.getType(), req.getName());
             const serializedState = await serializeProperties("", result.state);
 
-            this.resources.set(urn, { urn, id: result.id, state: serializedState });
+            this.resources.set(urn, { urn, id: result.id ?? null, state: serializedState });
 
             const response = new resproto.RegisterResourceResponse();
             response.setUrn(urn);

--- a/sdk/nodejs/tests/provider.spec.ts
+++ b/sdk/nodejs/tests/provider.spec.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 import * as pulumi from "..";
 import * as internals from "../provider/internals";
 
-const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
+import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 
 class TestResource extends pulumi.CustomResource {
     constructor(name: string, opts?: pulumi.CustomResourceOptions) {

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -20,10 +20,11 @@ import { platformIndependentEOL } from "../../constants";
 
 import * as grpc from "@grpc/grpc-js";
 
+import * as gempty from "google-protobuf/google/protobuf/empty_pb";
+import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
+
 const enginerpc = require("../../../proto/engine_grpc_pb.js");
 const engineproto = require("../../../proto/engine_pb.js");
-const gempty = require("google-protobuf/google/protobuf/empty_pb.js");
-const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
 const langrpc = require("../../../proto/language_grpc_pb.js");
 const langproto = require("../../../proto/language_pb.js");
 const resrpc = require("../../../proto/resource_grpc_pb.js");
@@ -294,7 +295,6 @@ describe("rpc", () => {
                     }
                     default:
                         assert.fail(`Unrecognized resource type ${t}`);
-                        throw new Error();
                 }
                 return {
                     urn: makeUrn(t, name),
@@ -560,7 +560,6 @@ describe("rpc", () => {
                         return;
                     default:
                         assert.fail("unexpected message: " + message);
-                        break;
                 }
             },
         },

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -25,7 +25,7 @@ import {
     secret,
 } from "../../index";
 
-const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
+import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 
 class TestComponentResource extends ComponentResource {
     constructor(name: string, opts?: ResourceOptions) {

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -619,6 +619,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
+"@types/google-protobuf@^3.15.5":
+  version "3.15.9"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.9.tgz#a983fc4bc35acb2b84a824d2ec8107d084e8603f"
+  integrity sha512-l51aVJnCNNMBkmSUQddSStXinB2qSXqfrmY9zkdcE9sqPzDneQ3BGg/hu7LfeOCUeGHOu+Rly89YhuDhvbmmPw==
+
 "@types/ini@^1.3.31":
   version "1.3.31"
   resolved "https://registry.yarnpkg.com/@types/ini/-/ini-1.3.31.tgz#c78541a187bd88d5c73e990711c9d85214800d1b"


### PR DESCRIPTION
Adds "@types/google-protobuf" to the nodesdk and changes `requires` to plain imports.