### PR TITLE
Fix recursive fixups in JavaScript protobuf generation

### DIFF
--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -5,7 +5,7 @@
 452332392 1755 proto/build-container/scripts/install-protobuf-tools.sh
 745180271 1066 proto/build-container/scripts/install-python.sh
 2099022623 1282 proto/build-container/scripts/utils.sh
-1879768646 6203 proto/generate.sh
+3305499434 6629 proto/generate.sh
 1574098198 4061 proto/google/protobuf/status.proto
 1405145341 1741 proto/pulumi/alias.proto
 4283367129 10425 proto/pulumi/analyzer.proto

--- a/sdk/nodejs/proto/alias_pb.js
+++ b/sdk/nodejs/proto/alias_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.Alias', null, global);
 goog.exportSymbol('proto.pulumirpc.Alias.AliasCase', null, global);

--- a/sdk/nodejs/proto/analyzer_pb.js
+++ b/sdk/nodejs/proto/analyzer_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var pulumi_plugin_pb = require('./plugin_pb.js');
 goog.object.extend(proto, pulumi_plugin_pb);

--- a/sdk/nodejs/proto/codegen/hcl_pb.js
+++ b/sdk/nodejs/proto/codegen/hcl_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.codegen.Diagnostic', null, global);
 goog.exportSymbol('proto.pulumirpc.codegen.DiagnosticSeverity', null, global);

--- a/sdk/nodejs/proto/codegen/loader_grpc_pb.js
+++ b/sdk/nodejs/proto/codegen/loader_grpc_pb.js
@@ -17,7 +17,7 @@
 //
 'use strict';
 var grpc = require('@grpc/grpc-js');
-var pulumi_codegen_loader_pb = require('../../pulumi/codegen/loader_pb.js');
+var pulumi_codegen_loader_pb = require('../codegen/loader_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');
 

--- a/sdk/nodejs/proto/codegen/loader_pb.js
+++ b/sdk/nodejs/proto/codegen/loader_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);

--- a/sdk/nodejs/proto/codegen/mapper_grpc_pb.js
+++ b/sdk/nodejs/proto/codegen/mapper_grpc_pb.js
@@ -17,7 +17,7 @@
 //
 'use strict';
 var grpc = require('@grpc/grpc-js');
-var pulumi_codegen_mapper_pb = require('../../pulumi/codegen/mapper_pb.js');
+var pulumi_codegen_mapper_pb = require('../codegen/mapper_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');
 

--- a/sdk/nodejs/proto/codegen/mapper_pb.js
+++ b/sdk/nodejs/proto/codegen/mapper_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);

--- a/sdk/nodejs/proto/converter_pb.js
+++ b/sdk/nodejs/proto/converter_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var pulumi_codegen_hcl_pb = require('./codegen/hcl_pb.js');
 goog.object.extend(proto, pulumi_codegen_hcl_pb);

--- a/sdk/nodejs/proto/engine_pb.js
+++ b/sdk/nodejs/proto/engine_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);

--- a/sdk/nodejs/proto/errors_pb.js
+++ b/sdk/nodejs/proto/errors_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.ErrorCause', null, global);
 /**

--- a/sdk/nodejs/proto/language_pb.js
+++ b/sdk/nodejs/proto/language_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var pulumi_codegen_hcl_pb = require('./codegen/hcl_pb.js');
 goog.object.extend(proto, pulumi_codegen_hcl_pb);

--- a/sdk/nodejs/proto/plugin_pb.js
+++ b/sdk/nodejs/proto/plugin_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.PluginAttach', null, global);
 goog.exportSymbol('proto.pulumirpc.PluginDependency', null, global);

--- a/sdk/nodejs/proto/provider_pb.js
+++ b/sdk/nodejs/proto/provider_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var pulumi_plugin_pb = require('./plugin_pb.js');
 goog.object.extend(proto, pulumi_plugin_pb);

--- a/sdk/nodejs/proto/resource_pb.js
+++ b/sdk/nodejs/proto/resource_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);

--- a/sdk/nodejs/proto/source_pb.js
+++ b/sdk/nodejs/proto/source_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.SourcePosition', null, global);
 /**

--- a/sdk/nodejs/proto/testing/language_grpc_pb.js
+++ b/sdk/nodejs/proto/testing/language_grpc_pb.js
@@ -17,7 +17,7 @@
 //
 'use strict';
 var grpc = require('@grpc/grpc-js');
-var pulumi_testing_language_pb = require('../../pulumi/testing/language_pb.js');
+var pulumi_testing_language_pb = require('../testing/language_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 
 function serialize_pulumirpc_testing_GetLanguageTestsRequest(arg) {

--- a/sdk/nodejs/proto/testing/language_pb.js
+++ b/sdk/nodejs/proto/testing/language_pb.js
@@ -13,7 +13,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);
+var proto = { pulumirpc: { codegen: { }, testing: { } } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 goog.object.extend(proto, google_protobuf_empty_pb);


### PR DESCRIPTION
The proto/generate.sh script was trying to do some sed based fixups to the generated javascript files but wasn't correctly fixing up nested files.