### PR TITLE
Support {NAME} in plugin download url

### DIFF
--- a/changelog/pending/20231028--engine--support-name-in-http-plugin-download-urls.yaml
+++ b/changelog/pending/20231028--engine--support-name-in-http-plugin-download-urls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Support {NAME} in http plugin download URLs.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -538,9 +538,10 @@ func (source *httpSource) GetLatestVersion(
 	return nil, errors.New("GetLatestVersion is not supported for plugins from http sources")
 }
 
-func interpolateURL(serverURL string, version semver.Version, os, arch string) string {
-	// Expectation is the URL is already encoded, so we need to encode the {}'s in the replacement strings.
+func interpolateURL(serverURL string, name string, version semver.Version, os, arch string) string {
+	// Expectation is the URL is already escaped, so we need to escape the {}'s in the replacement strings.
 	replacer := strings.NewReplacer(
+		"$%7BNAME%7D", url.QueryEscape(name),
 		"$%7BVERSION%7D", url.QueryEscape(version.String()),
 		"$%7BOS%7D", url.QueryEscape(os),
 		"$%7BARCH%7D", url.QueryEscape(arch))
@@ -551,7 +552,7 @@ func (source *httpSource) Download(
 	version semver.Version, opSy string, arch string,
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error),
 ) (io.ReadCloser, int64, error) {
-	serverURL := interpolateURL(source.url, version, opSy, arch)
+	serverURL := interpolateURL(source.url, source.name, version, opSy, arch)
 	serverURL = strings.TrimSuffix(serverURL, "/")
 	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
 

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -369,17 +369,18 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Custom https URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
 		spec := PluginSpec{
-			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name/v${VERSION}/${OS}/${ARCH}/",
-			Name:              "mockdl",
-			Version:           &version,
-			Kind:              PluginKind("resource"),
+			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/" +
+				"package-name/${NAME}/v${VERSION}/${OS}/${ARCH}/",
+			Name:    "mockdl",
+			Version: &version,
+			Kind:    PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
 				"https://customurl.jfrog.io/artifactory/pulumi-packages/"+
-					"package-name/v4.32.0/darwin/amd64/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
+					"package-name/mockdl/v4.32.0/darwin/amd64/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Allows `${NAME}` in the download url template string. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
