### PR TITLE
Use the yaml converter plugin rather than Eject

### DIFF
--- a/changelog/pending/20231028--cli--the-cli-now-uses-the-yaml-converter-plugin-rather-than-yaml-convert-logic-linked-in.yaml
+++ b/changelog/pending/20231028--cli--the-cli-now-uses-the-yaml-converter-plugin-rather-than-yaml-convert-logic-linked-in.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: The CLI now uses the yaml converter plugin rather than yaml convert logic linked in.

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -15,6 +15,10 @@
 package util
 
 import (
+	"runtime/debug"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -63,6 +67,32 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
 		for _, plugin := range pulumiversePlugins {
 			if spec.Name == plugin {
 				spec.PluginDownloadURL = "github://api.github.com/pulumiverse"
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// SetKnownPluginVersion sets the Version for the given PluginSpec if it's a known plugin.
+// Returns true if it filled in the version.
+func SetKnownPluginVersion(spec *workspace.PluginSpec) bool {
+	// If the version is already set don't touch it
+	if spec.Version != nil {
+		return false
+	}
+
+	if spec.Kind == workspace.ConverterPlugin && spec.Name == "yaml" {
+		// By default use the version of yaml we've linked to. N.B. This has to be tested manually because
+		// ReadBuildInfo doesn't return anything in test builds (https://github.com/golang/go/issues/33976).
+		info, ok := debug.ReadBuildInfo()
+		contract.Assertf(ok, "expected to be able to read build info")
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/pulumi/pulumi-yaml" {
+				v, err := semver.ParseTolerant(dep.Version)
+				contract.AssertNoErrorf(err, "expected to be able to parse version for yaml got %q", dep.Version)
+				spec.Version = &v
 				return true
 			}
 		}

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -59,6 +59,7 @@ func (err *InstallPluginError) Unwrap() error {
 
 func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, msg string)) (*semver.Version, error) {
 	util.SetKnownPluginDownloadURL(&pluginSpec)
+	util.SetKnownPluginVersion(&pluginSpec)
 	if pluginSpec.Version == nil {
 		var err error
 		pluginSpec.Version, err = pluginSpec.GetLatestVersion()

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -59,8 +59,11 @@ func TestLanguageNewSmoke(t *testing.T) {
 }
 
 // Quick sanity tests that YAML convert works.
+//
+//nolint:paralleltest // sets envvars
 func TestYamlConvertSmoke(t *testing.T) {
-	t.Parallel()
+	// make sure we can download the yaml converter plugin
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 	e := ptesting.NewEnvironment(t)
 	defer deleteIfNotFailed(e)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We add some hooks to ensure we always use the version of pulumi-converter-yaml that matches the version of yaml we've linked the CLI to, this preserves the behaviour we have today that eject code matches the gen code.

At some point it will make sense to decouple these and often just default to the the latest converter instead.

This unlinks one part of the yaml codebase from the cli. We still need to do codegen and docgen, but this at least means breaking changes can be made to the eject interface without breaking the build because of the circular dependency cycle.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works - Covered by `TestYamlConvertSmoke`
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
