### PR TITLE
Validate component type tokens in RegisterResource

### DIFF
--- a/changelog/pending/20231030--engine--the-engine-will-validate-that-component-resource-type-tokens-do-not-contain-invalid-characters.yaml
+++ b/changelog/pending/20231030--engine--the-engine-will-validate-that-component-resource-type-tokens-do-not-contain-invalid-characters.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: The engine will validate that component resource type tokens do not contain invalid characters.

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -1351,7 +1351,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 		"foo": "bar",
 	})
 	createA := func(monitor *deploytest.ResourceMonitor) {
-		_, _, _, err := monitor.RegisterResource("prog::myType", "resA", false, deploytest.ResourceOptions{
+		_, _, _, err := monitor.RegisterResource("prog:index:myType", "resA", false, deploytest.ResourceOptions{
 			Inputs: insA,
 		})
 		assert.NoError(t, err)
@@ -1374,7 +1374,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 1)
-	assert.Equal(t, tokens.Type("prog::myType"), snap.Resources[0].Type)
+	assert.Equal(t, tokens.Type("prog:index:myType"), snap.Resources[0].Type)
 	assert.False(t, snap.Resources[0].Custom)
 
 	// Now update A from a component to custom with an alias
@@ -1383,7 +1383,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 			Inputs: insA,
 			Aliases: []resource.Alias{
 				{
-					Type: "prog::myType",
+					Type: "prog:index:myType",
 				},
 			},
 		})
@@ -1400,7 +1400,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 
 	// Now update A back to a component (with an alias)
 	createA = func(monitor *deploytest.ResourceMonitor) {
-		_, _, _, err := monitor.RegisterResource("prog::myType", "resA", false, deploytest.ResourceOptions{
+		_, _, _, err := monitor.RegisterResource("prog:index:myType", "resA", false, deploytest.ResourceOptions{
 			Inputs: insA,
 			Aliases: []resource.Alias{
 				{
@@ -1416,7 +1416,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 	assert.NotNil(t, snap)
 	// Back to one because the provider should have been cleaned up as well
 	assert.Len(t, snap.Resources, 1)
-	assert.Equal(t, tokens.Type("prog::myType"), snap.Resources[0].Type)
+	assert.Equal(t, tokens.Type("prog:index:myType"), snap.Resources[0].Type)
 	assert.False(t, snap.Resources[0].Custom)
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This adds some basic validation to ensure users don't try to use "$" or "::" in component resource type names, both of these will cause serious issues with URN parsing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
