### PR TITLE
Adds remote .zip archive support to `pulumi new`

### DIFF
--- a/changelog/pending/20231031--cli-new--adds-support-for-remote-zip-archive-templates-to-pulumi-new.yaml
+++ b/changelog/pending/20231031--cli-new--adds-support-for-remote-zip-archive-templates-to-pulumi-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Adds support for remote zip archive templates to pulumi new

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -284,6 +284,9 @@ func isTemplateFileOrDirectory(templateNamePathOrURL string) bool {
 func RetrieveTemplates(templateNamePathOrURL string, offline bool,
 	templateKind TemplateKind,
 ) (TemplateRepository, error) {
+	if isZIPTemplateURL(templateNamePathOrURL) {
+		return retrieveZIPTemplates(templateNamePathOrURL)
+	}
 	if IsTemplateURL(templateNamePathOrURL) {
 		return retrieveURLTemplates(templateNamePathOrURL, offline, templateKind)
 	}

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -72,13 +72,6 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string) (string, er
 		return "", err
 	}
 	packageRequest.Header.Set("Accept", "application/zip")
-	requestQuery := packageRequest.URL.Query()
-	for key, values := range templateURL.Query() {
-		for _, value := range values {
-			requestQuery.Add(key, value)
-		}
-	}
-	packageRequest.URL.RawQuery = requestQuery.Encode()
 	packageResponse, err := http.DefaultClient.Do(packageRequest)
 	if err != nil {
 		return "", err

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -1,0 +1,115 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Sanitize archive file pathing from "G305: Zip Slip vulnerability"
+func sanitizeArchivePath(d, t string) (v string, err error) {
+	v = filepath.Join(d, t)
+	if strings.HasPrefix(v, filepath.Clean(d)) {
+		return v, nil
+	}
+
+	return "", fmt.Errorf("%s: %s", "content filepath is tainted", t)
+}
+
+func isZIPTemplateURL(templateNamePathOrURL string) bool {
+	parsedURL, _ := url.Parse(templateNamePathOrURL)
+	return parsedURL.Path != "" && strings.HasSuffix(parsedURL.Path, ".zip")
+}
+
+func retrieveZIPTemplates(templateURL string) (TemplateRepository, error) {
+	var err error
+	// Create a temp dir.
+	var temp string
+	if temp, err = os.MkdirTemp("", "pulumi-template-"); err != nil {
+		return TemplateRepository{}, err
+	}
+
+	parsedURL, err := url.Parse(strings.ReplaceAll(templateURL, ".zip", ""))
+	if err != nil {
+		return TemplateRepository{}, err
+	}
+
+	var fullPath string
+	if fullPath, err = RetrieveZIPTemplateFolder(parsedURL, temp); err != nil {
+		return TemplateRepository{}, fmt.Errorf("failed to retrieve zip archive: %w", err)
+	}
+
+	return TemplateRepository{
+		Root:         temp,
+		SubDirectory: fullPath,
+		ShouldDelete: true,
+	}, nil
+}
+
+func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string) (string, error) {
+	packageRequest, err := http.NewRequest(http.MethodGet, templateURL.String(), bytes.NewReader([]byte{}))
+	if err != nil {
+		return "", err
+	}
+	packageRequest.Header.Set("Accept", "application/zip")
+	requestQuery := packageRequest.URL.Query()
+	for key, values := range templateURL.Query() {
+		for _, value := range values {
+			requestQuery.Add(key, value)
+		}
+	}
+	packageRequest.URL.RawQuery = requestQuery.Encode()
+	packageResponse, err := http.DefaultClient.Do(packageRequest)
+	if err != nil {
+		return "", err
+	}
+	packageResponseBody, err := io.ReadAll(packageResponse.Body)
+	if err != nil {
+		return "", err
+	}
+	archive, err := zip.NewReader(bytes.NewReader(packageResponseBody), int64(len(packageResponseBody)))
+	if err != nil {
+		return "", err
+	}
+	for _, file := range archive.File {
+		filePath, err := sanitizeArchivePath(tempDir, file.Name)
+		if err != nil {
+			return "", err
+		}
+		fileReader, err := file.Open()
+		if err != nil {
+			return "", err
+		}
+		defer fileReader.Close()
+		destinationFile, err := os.Create(filePath)
+		if err != nil {
+			return "", err
+		}
+		defer destinationFile.Close()
+		_, err = io.Copy(destinationFile, fileReader) // #nosec G110
+		if err != nil {
+			return "", err
+		}
+	}
+	return tempDir, nil
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi.ai/issues/363

This change introduces a new accepted suffix to `pulumi new` HTTP arguments - `.zip`.

When a URL of the form `http[s]://<url>.zip` is provided to `pulumi new`, we send a GET request to `<url>` (without the .zip suffix) with the `accept` header set to `application/zip`. It is then up to whatever is hosted at that location to correctly return a binary zip archive in its response.

We then parse that response in memory and write each file to a tempdir as we do with current templates, which can then be picked up by the standard `pulumi new` templating logic.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
