### PR TITLE
Bump homebrew with pulumi's fork instead of pulumi-bot's

### DIFF
--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -18,6 +18,7 @@ jobs:
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
+          org: pulumi
           token: ${{secrets.PULUMI_BOT_TOKEN}}
           formula: pulumi
           tag: v${{env.VERSION}}

--- a/changelog/pending/20231030--ci--bump-homebrew-using-pulumis-fork-instead-of-pulumi-bots.yaml
+++ b/changelog/pending/20231030--ci--bump-homebrew-using-pulumis-fork-instead-of-pulumi-bots.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Bump homebrew using pulumi's fork instead of pulumi-bot's


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The pulumi-bot fine-grained token is scoped to the Pulumi org, therefore the repositories it interacts with need to belong to pulumi.

This action was attempting to fork/clone the homebrew repo with the pulumi-bot user as its owner. It should use the pulumi org instead.

I've confirmed that I'm able to fork the repo with this token:

```
❯ gh repo fork --clone homebrew/homebrew-core --org pulumi
✓ Created fork pulumi/homebrew-core
```

Fixes #14412

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
