### PR TITLE
Support 'key.[index]' in property paths

### DIFF
--- a/changelog/pending/20231030--engine--fix-parsing-of-property-paths-such-as-root-1-being-returned-from-providers.yaml
+++ b/changelog/pending/20231030--engine--fix-parsing-of-property-paths-such-as-root-1-being-returned-from-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix parsing of property paths such as "root.[1]" being returned from providers.

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1253,7 +1253,6 @@ func TestSetFail(t *testing.T) {
 		{Key: "my:root["},
 		{Key: `my:root["nested]`},
 		{Key: "my:root.array[abc]"},
-		{Key: "my:root.[1]"},
 
 		// First path component must be a string.
 		{Key: `my:[""]`},

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // PropertyPath represents a path to a nested property. The path may be composed of strings (which access properties
@@ -60,8 +61,12 @@ func ParsePropertyPath(path string) (PropertyPath, error) {
 		switch path[0] {
 		case '.':
 			path = path[1:]
-			if len(path) > 0 && path[0] == '[' {
-				return nil, errors.New("expected property name after '.'")
+			if len(path) == 0 {
+				return nil, errors.New("expected property path to end with a name or index")
+			}
+			if path[0] == '[' {
+				// We tolerate a '.' followed by a '[', which is not strictly legal, but is common from old providers.
+				logging.V(10).Infof("property path '%s' contains a '.' followed by a '['; this is not strictly legal", path)
 			}
 		case '[':
 			// If the character following the '[' is a '"', parse a string key.

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -133,6 +133,19 @@ func TestPropertyPath(t *testing.T) {
 			PropertyPath{"root key with a .", 1},
 			`["root key with a ."][1]`,
 		},
+		// The following two cases are regressions for https://github.com/pulumi/pulumi/issues/14439. Ideally
+		// these would be a syntax error, but it seems providers have been emitting paths of this style and so
+		// we need to keep supporting them.
+		{
+			`root.array.[1]`,
+			PropertyPath{"root", "array", 1},
+			`root.array[1]`,
+		},
+		{
+			`root.["key with a ."]`,
+			PropertyPath{"root", "key with a ."},
+			`root["key with a ."]`,
+		},
 	}
 
 	for _, c := range cases {
@@ -214,7 +227,7 @@ func TestPropertyPath(t *testing.T) {
 		`root["nested]`,
 		`root."double".nest`,
 		"root.array[abc]",
-		"root.[1]",
+		"root.",
 
 		// Missing values
 		"root[1]",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -494,7 +494,6 @@ func TestConfigPaths(t *testing.T) {
 		"root[",
 		`root["nested]`,
 		"root.array[abc]",
-		"root.[0]",
 
 		// First path segment must be a non-empty string.
 		`[""]`,


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14439.

Ideally we would treat this as an error, but it seems providers are building property paths of this format so we need to keep supporting it.

It is at least now tested, and clearly linked back to this issue so we don't inadvertantly remove support for it in the future.

Yet another element of the system that could be tightened up in a V4 release.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
