### PR TITLE
Allow importing a parent and child resource at the same time

### DIFF
--- a/changelog/pending/20231031--engine--import-can-now-import-a-parent-resource-in-the-same-deployment-as-a-child-resource.yaml
+++ b/changelog/pending/20231031--engine--import-can-now-import-a-parent-resource-in-the-same-deployment-as-a-child-resource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: `import` can now import a parent resource in the same deployment as a child resource.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1001,7 +1001,8 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			return resource.StatusOK, nil, fmt.Errorf("resource '%v' already exists", s.new.URN)
 		}
 		if s.new.Parent.Type() != resource.RootStackType {
-			if _, ok := s.deployment.olds[s.new.Parent]; !ok {
+			_, ok := s.deployment.news.get(s.new.Parent)
+			if !ok {
 				return resource.StatusOK, nil, fmt.Errorf("unknown parent '%v' for resource '%v'",
 					s.new.Parent, s.new.URN)
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Allow `pulumi import` to import one resource and then use that resource as a parent for another imported resource.

Currently parents can only refer to resources that already exist in the deployment meaning if you want to do this today you have to do two imports.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
