### PR TITLE
Allow `import` to create empty component resources

### DIFF
--- a/changelog/pending/20231031--engine--import-can-now-create-empty-component-resource-to-use-as-the-parent-of-other-imported-resources.yaml
+++ b/changelog/pending/20231031--engine--import-can-now-create-empty-component-resource-to-use-as-the-parent-of-other-imported-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: `import` can now create empty component resource to use as the parent of other imported resources.

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -944,3 +944,149 @@ func TestImportIntoParent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, snap.Resources, 4)
 }
+
+func TestImportComponent(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(version int) ([]byte, error) {
+					return []byte(importSchema), nil
+				},
+				DiffF: diffImportResource,
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool,
+				) (resource.ID, resource.PropertyMap, resource.Status, error) {
+					return "", nil, resource.StatusUnknown, fmt.Errorf("not implemented")
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap,
+				) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{
+						Inputs: resource.PropertyMap{
+							"foo":  resource.NewStringProperty("bar"),
+							"frob": resource.NewNumberProperty(1),
+						},
+						Outputs: resource.PropertyMap{
+							"foo":  resource.NewStringProperty("bar"),
+							"frob": resource.NewNumberProperty(1),
+						},
+					}, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(nil)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &TestPlan{
+		Options: TestUpdateOptions{HostF: hostF},
+	}
+
+	// Run the initial import.
+	project := p.GetProject()
+	snap, err := ImportOp([]deploy.Import{
+		{
+			Type:      "my-component",
+			Name:      "comp",
+			Component: true,
+		},
+		{
+			Type:   "pkgA:m:typA",
+			Name:   "resB",
+			ID:     "imported-id",
+			Parent: p.NewURN("my-component", "comp", ""),
+		},
+	}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, snap.Resources, 4)
+
+	// Ensure that the resource 2 is the component.
+	comp := snap.Resources[2]
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::my-component::comp"), comp.URN)
+	// Ensure it's marked as a component.
+	assert.False(t, comp.Custom, "expected component resource to not be marked as custom")
+
+	// Ensure resource 3 is the custom resource
+	custom := snap.Resources[3]
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::my-component$pkgA:m:typA::resB"), custom.URN)
+	// Ensure it's marked as custom.
+	assert.True(t, custom.Custom, "expected custom resource to be marked as custom")
+}
+
+func TestImportRemoteComponent(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("mlc", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(version int) ([]byte, error) {
+					return []byte(importSchema), nil
+				},
+				DiffF: diffImportResource,
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool,
+				) (resource.ID, resource.PropertyMap, resource.Status, error) {
+					return "", nil, resource.StatusUnknown, fmt.Errorf("not implemented")
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap,
+				) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{
+						Inputs: resource.PropertyMap{
+							"foo":  resource.NewStringProperty("bar"),
+							"frob": resource.NewNumberProperty(1),
+						},
+						Outputs: resource.PropertyMap{
+							"foo":  resource.NewStringProperty("bar"),
+							"frob": resource.NewNumberProperty(1),
+						},
+					}, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(nil)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &TestPlan{
+		Options: TestUpdateOptions{HostF: hostF},
+	}
+
+	// Run the initial import.
+	project := p.GetProject()
+	snap, err := ImportOp([]deploy.Import{
+		{
+			Type:      "mlc:index:Component",
+			Name:      "comp",
+			Component: true,
+			Remote:    true,
+		},
+		{
+			Type:   "pkgA:m:typA",
+			Name:   "resB",
+			ID:     "imported-id",
+			Parent: p.NewURN("mlc:index:Component", "comp", ""),
+		},
+	}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, snap.Resources, 5)
+
+	// Ensure that the resource 3 is the component.
+	comp := snap.Resources[3]
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::mlc:index:Component::comp"), comp.URN)
+	// Ensure it's marked as a component.
+	assert.False(t, comp.Custom, "expected component resource to not be marked as custom")
+
+	// Ensure resource 4 is the custom resource
+	custom := snap.Resources[4]
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::mlc:index:Component$pkgA:m:typA::resB"), custom.URN)
+	// Ensure it's marked as custom.
+	assert.True(t, custom.Custom, "expected custom resource to be marked as custom")
+}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -42,6 +42,11 @@ type Import struct {
 	PluginChecksums   map[string][]byte // The provider checksums to use for the resource, if any.
 	Protect           bool              // Whether to mark the resource as protected after import
 	Properties        []string          // Which properties to include (Defaults to required properties)
+
+	// True if this import should create an empty component resource. ID must not be set if this is used.
+	Component bool
+	// True if this is a remote component resource. Component must be true if this is true.
+	Remote bool
 }
 
 // ImportOptions controls the import process.
@@ -190,6 +195,11 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 	defaultProviderRequests := slice.Prealloc[providers.ProviderRequest](len(i.deployment.imports))
 	defaultProviders := map[resource.URN]struct{}{}
 	for _, imp := range i.deployment.imports {
+		if imp.Component && !imp.Remote {
+			// Skip local component resources, they don't have providers.
+			continue
+		}
+
 		if imp.Provider != "" {
 			// If the provider for this import exists, map its URN to its provider reference. If it does not exist,
 			// the import step will issue an appropriate error or errors.
@@ -345,36 +355,69 @@ func (i *importer) importResources(ctx context.Context) error {
 			}
 		}
 
+		// If the resource already exists and the ID matches the ID to import, then Same this resource. If the ID does
+		// not match, the step itself will issue an error.
+		if old, ok := i.deployment.olds[urn]; ok {
+			oldID := old.ID
+			if old.ImportID != "" {
+				oldID = old.ImportID
+			}
+			if oldID == imp.ID {
+				// Clear the ID because Same asserts that the new state has no ID.
+				new := *old
+				new.ID = ""
+				// Set a dummy goal so the resource is tracked as managed.
+				i.deployment.goals.set(old.URN, &resource.Goal{})
+				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, &new))
+				continue
+			}
+		}
+
 		providerURN := imp.Provider
-		if providerURN == "" {
+		if providerURN == "" && (!imp.Component || imp.Remote) {
 			req := providers.NewProviderRequest(imp.Version, imp.Type.Package(), imp.PluginDownloadURL, imp.PluginChecksums)
 			typ, name := providers.MakeProviderType(req.Package()), req.Name()
 			providerURN = i.deployment.generateURN("", typ, name)
 		}
 
-		// Fetch the provider reference for this import. All provider URNs should be mapped.
-		provider, ok := urnToReference[providerURN]
-		contract.Assertf(ok, "provider reference for URN %v not found", providerURN)
-
-		// If we have a plan for this resource we need to feed the saved seed to Check to remove non-determinism
-		var randomSeed []byte
-		if i.deployment.plan != nil {
-			if resourcePlan, ok := i.deployment.plan.ResourcePlans[urn]; ok {
-				randomSeed = resourcePlan.Seed
-			}
-		} else {
-			randomSeed = make([]byte, 32)
-			n, err := cryptorand.Read(randomSeed)
-			contract.AssertNoErrorf(err, "could not read random bytes")
-			contract.Assertf(n == len(randomSeed), "read %d random bytes, expected %d", n, len(randomSeed))
+		var provider string
+		if providerURN != "" {
+			// Fetch the provider reference for this import. All provider URNs should be mapped.
+			provider, ok = urnToReference[providerURN]
+			contract.Assertf(ok, "provider reference for URN %v not found", providerURN)
 		}
 
-		// Create the new desired state. Note that the resource is protected.
-		new := resource.NewState(urn.Type(), urn, true, false, imp.ID, resource.PropertyMap{}, nil, parent, imp.Protect,
+		// Create the new desired state. Note that the resource is protected. Provider might be "" at this point.
+		new := resource.NewState(
+			urn.Type(), urn, !imp.Component, false, imp.ID, resource.PropertyMap{}, nil, parent, imp.Protect,
 			false, nil, nil, provider, nil, false, nil, nil, nil, "", false, "", nil, nil, "")
 		// Set a dummy goal so the resource is tracked as managed.
 		i.deployment.goals.set(urn, &resource.Goal{})
-		steps = append(steps, newImportDeploymentStep(i.deployment, new, randomSeed))
+
+		if imp.Component {
+			if imp.Remote {
+				contract.Assertf(ok, "provider reference for URN %v not found", providerURN)
+			}
+
+			steps = append(steps, newImportDeploymentStep(i.deployment, new, nil))
+		} else {
+			contract.Assertf(ok, "provider reference for URN %v not found", providerURN)
+
+			// If we have a plan for this resource we need to feed the saved seed to Check to remove non-determinism
+			var randomSeed []byte
+			if i.deployment.plan != nil {
+				if resourcePlan, ok := i.deployment.plan.ResourcePlans[urn]; ok {
+					randomSeed = resourcePlan.Seed
+				}
+			} else {
+				randomSeed = make([]byte, 32)
+				n, err := cryptorand.Read(randomSeed)
+				contract.AssertNoErrorf(err, "could not read random bytes")
+				contract.Assertf(n == len(randomSeed), "read %d random bytes, expected %d", n, len(randomSeed))
+			}
+
+			steps = append(steps, newImportDeploymentStep(i.deployment, new, randomSeed))
+		}
 	}
 
 	// We've created all the steps above but we need to execute them in parallel batches which don't depend on each other

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -956,12 +956,10 @@ func NewImportReplacementStep(deployment *Deployment, reg RegisterResourceEvent,
 func newImportDeploymentStep(deployment *Deployment, new *resource.State, randomSeed []byte) Step {
 	contract.Requiref(new != nil, "new", "must not be nil")
 	contract.Requiref(new.URN != "", "new", "must have a URN")
-	contract.Requiref(new.ID != "", "new", "must have an ID")
-	contract.Requiref(new.Custom, "new", "must be a custom resource")
+	contract.Requiref(!new.Custom || new.ID != "", "new", "must have an ID")
 	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
 	contract.Requiref(!new.External, "new", "must not be external")
-
-	contract.Requiref(randomSeed != nil, "randomSeed", "must not be nil")
+	contract.Requiref(!new.Custom || randomSeed != nil, "randomSeed", "must not be nil")
 
 	return &ImportStep{
 		deployment: deployment,
@@ -1009,37 +1007,48 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		}
 	}
 
-	// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
-	// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.
-	prov, err := getProvider(s)
-	if err != nil {
-		return resource.StatusOK, nil, err
-	}
-	read, rst, err := prov.Read(s.new.URN, s.new.ID, nil, nil)
-	if err != nil {
-		if initErr, isInitErr := err.(*plugin.InitError); isInitErr {
-			s.new.InitErrors = initErr.Reasons
-		} else {
-			return rst, nil, err
+	// Only need to do anything here for custom resources, components just import as empty
+	inputs := resource.PropertyMap{}
+	outputs := resource.PropertyMap{}
+	var prov plugin.Provider
+	rst := resource.StatusOK
+	if s.new.Custom {
+		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
+		// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.
+		var err error
+		prov, err = getProvider(s)
+		if err != nil {
+			return resource.StatusOK, nil, err
 		}
+		var read plugin.ReadResult
+		read, rst, err = prov.Read(s.new.URN, s.new.ID, nil, nil)
+		if err != nil {
+			if initErr, isInitErr := err.(*plugin.InitError); isInitErr {
+				s.new.InitErrors = initErr.Reasons
+			} else {
+				return rst, nil, err
+			}
+		}
+		if read.Outputs == nil {
+			return rst, nil, fmt.Errorf("resource '%v' does not exist", s.new.ID)
+		}
+		if read.Inputs == nil {
+			return resource.StatusOK, nil,
+				fmt.Errorf("provider does not support importing resources; please try updating the '%v' plugin",
+					s.new.URN.Type().Package())
+		}
+		if read.ID != "" {
+			s.new.ID = read.ID
+		}
+		inputs = read.Inputs
+		outputs = read.Outputs
 	}
-	if read.Outputs == nil {
-		return rst, nil, fmt.Errorf("resource '%v' does not exist", s.new.ID)
-	}
-	if read.Inputs == nil {
-		return resource.StatusOK, nil,
-			fmt.Errorf("provider does not support importing resources; please try updating the '%v' plugin",
-				s.new.URN.Type().Package())
-	}
-	if read.ID != "" {
-		s.new.ID = read.ID
-	}
-	s.new.Outputs = read.Outputs
 
+	s.new.Outputs = outputs
 	// Magic up an old state so the frontend can display a proper diff. This state is the output of the just-executed
 	// `Read` combined with the resource identity and metadata from the desired state. This ensures that the only
 	// differences between the old and new states are between the inputs and outputs.
-	s.old = resource.NewState(s.new.Type, s.new.URN, s.new.Custom, false, s.new.ID, read.Inputs, read.Outputs,
+	s.old = resource.NewState(s.new.Type, s.new.URN, s.new.Custom, false, s.new.ID, inputs, outputs,
 		s.new.Parent, s.new.Protect, false, s.new.Dependencies, s.new.InitErrors, s.new.Provider,
 		s.new.PropertyDependencies, false, nil, nil, &s.new.CustomTimeouts, s.new.ImportID, s.new.RetainOnDelete,
 		s.new.DeletedWith, nil, nil, s.new.SourcePosition)
@@ -1049,6 +1058,11 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	s.new.Modified = &now
 	// Set Created to now as the resource has been created in the state.
 	s.new.Created = &now
+
+	// If this is a component we don't need to do the rest of the input validation
+	if !s.new.Custom {
+		return rst, complete, nil
+	}
 
 	// If this step came from an import deployment, we need to fetch any required inputs from the state.
 	if s.planned {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14444.

This adds two new flags to the import file to signal that a resource is a component, and also if that is a remote (MLC) component. The import system will create empty resources for those import descriptions, but importantly they can then be used as parents for other resources in the import deployment.

We need to know if it's a remote component to know if a provider should be looked up for it. We could probably get away with _just_ knowing if it's a component at import time and not doing any validation that the type token is well formed and the provider exists for MLCs. That makes import a little simpler for users (no need to set if it's remote or not) but pushes error cases downstream to when they actually try to `up` their program. It also means we can't lookup and fill in the default providers for these resources, resulting in a provider diff at `up` time.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
