### PR TITLE
[sdk/python] Fix error on empty invoke returns

### DIFF
--- a/changelog/pending/20231101--sdk-python--fix-error-on-empty-invoke-returns.yaml
+++ b/changelog/pending/20231101--sdk-python--fix-error-on-empty-invoke-returns.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix error on empty invoke returns

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -120,16 +120,14 @@ def invoke(
 
         # Otherwise, return the output properties.
         ret_obj = getattr(resp, "return")
-        if ret_obj:
-            deserialized = rpc.deserialize_properties(ret_obj)
-            # If typ is not None, call translate_output_properties to instantiate any output types.
-            return (
-                rpc.translate_output_properties(deserialized, lambda prop: prop, typ)
-                if typ
-                else deserialized,
-                None,
-            )
-        return None, None
+        deserialized = rpc.deserialize_properties(ret_obj)
+        # If typ is not None, call translate_output_properties to instantiate any output types.
+        return (
+            rpc.translate_output_properties(deserialized, lambda prop: prop, typ)
+            if typ
+            else deserialized,
+            None,
+        )
 
     async def do_rpc():
         resp, exn = await _get_rpc_manager().do_rpc("invoke", do_invoke)()

--- a/sdk/python/lib/test/langhost/invoke_empty_return/__init__.py
+++ b/sdk/python/lib/test/langhost/invoke_empty_return/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/invoke_empty_return/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke_empty_return/__main__.py
@@ -1,0 +1,19 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pulumi.runtime import invoke
+
+
+ret = invoke("test:index:MyFunction", {})
+assert ret.value == {}, "Expected the return value of the invoke to be an empty dict"

--- a/sdk/python/lib/test/langhost/invoke_empty_return/test_invoke_empty_return.py
+++ b/sdk/python/lib/test/langhost/invoke_empty_return/test_invoke_empty_return.py
@@ -1,0 +1,28 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import path
+from ..util import LanghostTest
+
+
+class TestInvokeEmptyReturn(LanghostTest):
+    def test_invoke_emptyReturn(self):
+        self.run_test(
+            program=path.join(self.base_path(), "invoke_empty_return"),
+            expected_resource_count=0)
+
+    def invoke(self, _ctx, token, _args, provider, _version):
+        self.assertEqual("test:index:MyFunction", token)
+        self.assertEqual("", provider)
+        return [], {}

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -1,0 +1,32 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+
+class MyMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + '_id', args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        assert args.token == "test:index:MyFunction"
+        return {}
+
+
+@pulumi.runtime.test
+def test_invoke_empty_return() -> None:
+    pulumi.runtime.mocks.set_mocks(MyMocks())
+
+    ret = pulumi.runtime.invoke("test:index:MyFunction", {})
+    assert ret.value == {}, "Expected the return value of the invoke to be an empty dict"


### PR DESCRIPTION
When an empty struct is returned from an invoke, the Python SDK was returning None, which causes the following error to be raised from generated provider Python SDKs when calling the invoke:

```
AssertionError: get can only be used with classes decorated with @input_type or @output_type
```

This is because the Python SDK is returning None if the return value isn't truthy, roughly:

```
ret_obj = getattr(resp, "return")
if ret_obj:
    return ret_obj
return None
```

However, an empty struct isn't truthy, so we're returning None in that case, and generated provider Python SDKs can't handle that.

Other SDKs like the Node.js and Go SDKs don't have this problem.

This commit fixes the issue by removing the `if ret_obj` check, as it's not necessary. In practice, `ret_obj` is always going to be an instance of `struct_pb2.Struct` because all monitors (CLI and mock) return an instance, though the instance may be empty, which is ok.

Fixes #13985