### PR TITLE
Adds nested directory support to pulumi new .zip

### DIFF
--- a/changelog/pending/20231101--cli-new--adds-nested-directory-support-to-pulumi-new-zip.yaml
+++ b/changelog/pending/20231101--cli-new--adds-nested-directory-support-to-pulumi-new-zip.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Adds nested directory support to pulumi new .zip

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -89,19 +89,26 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string) (string, er
 		if err != nil {
 			return "", err
 		}
-		fileReader, err := file.Open()
-		if err != nil {
-			return "", err
-		}
-		defer fileReader.Close()
-		destinationFile, err := os.Create(filePath)
-		if err != nil {
-			return "", err
-		}
-		defer destinationFile.Close()
-		_, err = io.Copy(destinationFile, fileReader) // #nosec G110
-		if err != nil {
-			return "", err
+		if file.FileHeader.FileInfo().IsDir() {
+			err = os.MkdirAll(filePath, 0o777)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			fileReader, err := file.Open()
+			if err != nil {
+				return "", err
+			}
+			defer fileReader.Close()
+			destinationFile, err := os.Create(filePath)
+			if err != nil {
+				return "", err
+			}
+			defer destinationFile.Close()
+			_, err = io.Copy(destinationFile, fileReader) // #nosec G110
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 	return tempDir, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The previous ZIP implementation here only supported a flat .zip file structure - Pulumi Java projects often contain nested directories (and many templates will likely organize code in such a way that involves directories as well). This inspects each file during traversal of the ZIP archive, and creates any necessary directories it encounters along the way.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
