### PR TITLE
Add support for S3 server side encryption headers when using S3 backend

### DIFF
--- a/changelog/pending/20231024--backend-filestate--adds-support-for-specifying-bucket-encryption-headers-when-using-the-s3-backend.yaml
+++ b/changelog/pending/20231024--backend-filestate--adds-support-for-specifying-bucket-encryption-headers-when-using-the-s3-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/filestate
+  description: Adds support for specifying bucket encryption headers when using the S3 backend

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+var cache map[string]string
+
+// GetEnvironmentVariables returns the environment variables for the system
+// represented as a map of key value pairs to the environment variable and value
+func GetEnvironmentVariables() map[string]string {
+	if cache == nil {
+		cache = make(map[string]string)
+		for _, e := range os.Environ() {
+			if i := strings.Index(e, "="); i >= 0 {
+				cache[e[:i]] = e[i+1:]
+			}
+		}
+	}
+
+	return cache
+}


### PR DESCRIPTION
# Description
Adds support for specifying S3 Server Side Encryption Headers when using an S3 backend. Users might be required to specify these headers when the bucket policy on the bucket disallows unencrypted uploads, or when only a certain type of server side encryption is in use. 

These changes added support for new `PULUMI_S3_BUCKET_ENCRYPTION_TYPE` and `PULUMI_S3_BUCKET_ENCRYPTION_KMS_KEY_ID` environment variables which, if present, will be set in the `Copy` and `Write` requests for the bucket.

Fixes #9341

## Integration Testing
### No headers, with a bucket that does not enforce KMS
```
➜  quickstart pulumi stack init no-encryption -v=7 --logtostderr
I1102 15:17:30.841548   95403 log.go:81] Attempting to add backend specific headers for WRITE
I1102 15:17:30.841678   95403 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
I1102 15:17:32.035570   95403 log.go:81] Attempting to add backend specific headers for COPY
I1102 15:17:32.035707   95403 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
I1102 15:17:32.256628   95403 log.go:81] error copying .pulumi/stacks/test-s3-updates/no-encryption.json.gz to .pulumi/stacks/test-s3-updates/no-encryption.json.gz.bak: blob (key ".pulumi/stacks/test-s3-updates/no-encryption.json.gz -> .pulumi/stacks/test-s3-updates/no-encryption.json.gz.bak") (code=NotFound): NoSuchKey: The specified key does not exist.
	status code: 404, request id: TGRHEE134DJKKVA6, host id: wCFl9JbPePrMWicKc7Jh+IGaKlspJaAwjYOQVh9pouWQunan2artQLiBsHBl+Vt6k69dzRr9kwo=
I1102 15:17:32.481735   95403 log.go:81] error deleting source object after rename: .pulumi/stacks/test-s3-updates/no-encryption.json.gz (blob (key ".pulumi/stacks/test-s3-updates/no-encryption.json.gz") (code=NotFound): NotFound: Not Found
	status code: 404, request id: TGRS3HMWQ1YTGAKD, host id: FWlmLkkT1P/GiTdSlq28o9zR0Gj7B98b3NrhvMlM2zlhBztrdxm/uIVq5V3hmnL9ccxoM5micHc=) skipping
I1102 15:17:32.481901   95403 log.go:81] Attempting to add backend specific headers for COPY
I1102 15:17:32.481914   95403 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
I1102 15:17:32.707097   95403 log.go:81] error copying .pulumi/stacks/test-s3-updates/no-encryption.json to .pulumi/stacks/test-s3-updates/no-encryption.json.bak: blob (key ".pulumi/stacks/test-s3-updates/no-encryption.json -> .pulumi/stacks/test-s3-updates/no-encryption.json.bak") (code=NotFound): NoSuchKey: The specified key does not exist.
	status code: 404, request id: TGRW74EV0PER959X, host id: QQ8oiWIntUhpCGPnYc7QnKPcoO96X4wMaKuOWsAwwBuy9Owex1UE70oKcLvDa0/of3DWJ9gUts4=
I1102 15:17:32.707319   95403 log.go:81] Attempting to add backend specific headers for WRITE
I1102 15:17:32.707333   95403 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
I1102 15:17:33.015672   95403 log.go:81] Saved stack organization/test-s3-updates/no-encryption checkpoint to: .pulumi/stacks/test-s3-updates/no-encryption.json (backup=.pulumi/stacks/test-s3-updates/no-encryption.json.bak)
I1102 15:17:33.015887   95403 log.go:81] defaultSink::Info(Created stack 'no-encryption')
Created stack 'no-encryption'
Enter your passphrase to protect config/secrets:  
Re-enter your passphrase to confirm:  
➜  quickstart pulumi stack ls -v=7 --logtostderr
NAME            LAST UPDATE  RESOURCE COUNT
no-encryption*  n/a          n/a
➜  quickstart pulumi stack rm no-encryption -v=7 --logtostderr
This will permanently remove the 'no-encryption' stack!
Please confirm that this is what you'd like to do by typing `no-encryption`: no-encryption
I1102 15:18:33.992485   95418 log.go:81] Attempting to add backend specific headers for WRITE
I1102 15:18:33.992609   95418 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
I1102 15:18:35.132545   95418 log.go:81] Attempting to add backend specific headers for COPY
I1102 15:18:35.132680   95418 log.go:65] No 'PULUMI_S3_BUCKET' environment variables are set
Stack 'no-encryption' has been removed!
```

### Without the headers, with a bucket enforcing KMS (current state, as noted in linked issue)
Bucket policy enforcing KMS, that will store pulumi state
```json
{
            "Sid": "DenyUnEncryptedObjectUploads",
            "Effect": "Deny",
            "Principal": "*",
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::bucket/*",
            "Condition": {
                "StringNotEquals": {
                    "s3:x-amz-server-side-encryption": "aws:kms"
                }
            }
        },
        {
            "Sid": "DenyEncryptedObjectUploadsWrongKey",
            "Effect": "Deny",
            "Principal": "*",
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::bucket/*",
            "Condition": {
                "StringNotEquals": {
                    "s3:x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:us-east-1:etc"
                }
            }
        }
```

```
➜  quickstart pulumi login 's3://bucket?region=us-east-1' 
Logged in to GDJ249NG41 as tristan.newman (s3://bucket?region=us-east-1)
➜  quickstart echo Before setting environment variables
Before setting environment variables
➜  quickstart pulumi stack init fails
error: could not create stack: blob (key ".pulumi/locks/organization/test-s3-updates/fails/026f1a60-29b0-4d49-9a27-a0aaffa4513f.json") (code=Unknown): AccessDenied: Access Denied
	status code: 403, request id: RRP5CMJMXJ03ASTW, host id: mb1eeoD2H4NwPE4Hs2N06D5tSWNsvc/9+B6SOMWq9rgn07cx9F0cDixNFdRWCOx1nPcgrliGoEUGkehFqwfxlpClETEaHipb
```
### With the headers, with a bucket enforcing KMS
Setting the environment variables (full key ID omitted)
![image](https://github.com/pulumi/pulumi/assets/28725980/6c7ba711-32e1-4bed-9f3e-9db7b88ddc27)

Create the stack
```
➜  quickstart pulumi stack init succeeds -v=7 --logtostderr                                                 
I1102 15:23:48.095114   96737 log.go:81] Attempting to add backend specific headers for WRITE
I1102 15:23:48.095256   96737 log.go:81] Setting bucket encryption type to aws:kms
I1102 15:23:48.095263   96737 log.go:81] Setting bucket encryption id to arn:aws:kms:us-east-1:etc
I1102 15:23:48.095275   96737 log.go:81] Request was s3manager.UploadInput
I1102 15:23:49.367885   96737 log.go:81] Attempting to add backend specific headers for COPY
I1102 15:23:49.368022   96737 log.go:81] Setting bucket encryption type to aws:kms
I1102 15:23:49.368037   96737 log.go:81] Setting bucket encryption id to arn:aws:kms:us-east-1:etc
I1102 15:23:49.368050   96737 log.go:81] Request was s3manager.UploadInput
I1102 15:23:49.592921   96737 log.go:81] error copying .pulumi/stacks/test-s3-updates/succeeds.json.gz to .pulumi/stacks/test-s3-updates/succeeds.json.gz.bak: blob (key ".pulumi/stacks/test-s3-updates/succeeds.json.gz -> .pulumi/stacks/test-s3-updates/succeeds.json.gz.bak") (code=NotFound): NoSuchKey: The specified key does not exist.
	status code: 404, request id: VETRJ3QD0VC2AJJC, host id: xYxZeJoWpCtBb9+0WAjPdDTkkYh4KDNrlsBuiB0eamderxpVo9KtQ4ePtUvd8YhnKrvroShH/Ag=
I1102 15:23:49.815459   96737 log.go:81] error deleting source object after rename: .pulumi/stacks/test-s3-updates/succeeds.json.gz (blob (key ".pulumi/stacks/test-s3-updates/succeeds.json.gz") (code=NotFound): NotFound: Not Found
	status code: 404, request id: VETGD87RS8S0QPQB, host id: RU6jx2aSHX7YRbmCLm6mpv4UVWzFTWWxzWnpNyW1M7db2MomC2th601GKvAJtNNOz9r8jplHml4=) skipping
I1102 15:23:49.815613   96737 log.go:81] Attempting to add backend specific headers for COPY
I1102 15:23:49.815628   96737 log.go:81] Setting bucket encryption type to aws:kms
I1102 15:23:49.815638   96737 log.go:81] Setting bucket encryption id to arn:aws:kms:us-east-1:etc
I1102 15:23:49.815647   96737 log.go:81] Request was s3manager.UploadInput
I1102 15:23:50.037741   96737 log.go:81] error copying .pulumi/stacks/test-s3-updates/succeeds.json to .pulumi/stacks/test-s3-updates/succeeds.json.bak: blob (key ".pulumi/stacks/test-s3-updates/succeeds.json -> .pulumi/stacks/test-s3-updates/succeeds.json.bak") (code=NotFound): NoSuchKey: The specified key does not exist.
	status code: 404, request id: DRHCCE53QM5HG3SA, host id: Fd+MHGUo4KD2fievW9I+kD/P+dd4RufLQPe2xehtF9kzpRV/3JYWibdRI0Zw2VeUJRM0rnCb00M=
I1102 15:23:50.037943   96737 log.go:81] Attempting to add backend specific headers for WRITE
I1102 15:23:50.037957   96737 log.go:81] Setting bucket encryption type to aws:kms
I1102 15:23:50.037963   96737 log.go:81] Setting bucket encryption id to arn:aws:kms:us-east-1:etc
I1102 15:23:50.037969   96737 log.go:81] Request was s3manager.UploadInput
I1102 15:23:50.298456   96737 log.go:81] Saved stack organization/test-s3-updates/succeeds checkpoint to: .pulumi/stacks/test-s3-updates/succeeds.json (backup=.pulumi/stacks/test-s3-updates/succeeds.json.bak)
I1102 15:23:50.298672   96737 log.go:81] defaultSink::Info(Created stack 'succeeds')
Created stack 'succeeds'
Enter your passphrase to protect config/secrets:  
Re-enter your passphrase to confirm:  
➜  quickstart 
➜  quickstart pulumi stack rm succeeds
This will permanently remove the 'succeeds' stack!
Please confirm that this is what you'd like to do by typing `succeeds`: succeeds
Stack 'succeeds' has been removed!

```



## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
Tests omitted since the changes are backend specific and this area of the code does not appear to be extensively tested already. See integration testing evidence above

- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
