### PR TITLE
[ci] More fixes for the homebrew release job

### DIFF
--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -18,8 +18,7 @@ jobs:
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
-          org: pulumi
-          token: ${{secrets.PULUMI_BOT_TOKEN}}
+          token: ${{secrets.PULUMI_BOT_HOMEBREW_TOKEN}}
           formula: pulumi
           tag: v${{env.VERSION}}
           revision: ${{env.COMMIT_SHA}}

--- a/changelog/pending/20231102--ci--additional-fixes-for-the-homebrew-release-job.yaml
+++ b/changelog/pending/20231102--ci--additional-fixes-for-the-homebrew-release-job.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Additional fixes for the homebrew release job


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fine-grained tokens can't submit PRs against public repos, so we need to continue using classic PATs for this use case.

I'm removing the `org: pulumi` so it will continue to interact with the repo under the `pulumi-bot`. I think this should allow us to still restrict PATs on the pulumi org.

I've already added a `PULUMI_BOT_HOMEBREW_TOKEN` secret to the repo. 

Fixes https://github.com/pulumi/pulumi/issues/14412

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
