### PR TITLE
[go/program-gen] Fix using inline invoke expressions inside resources, objects and arrays

### DIFF
--- a/changelog/pending/20231102--programgen-go--fix-using-inline-invoke-expressions-inside-resources-objects-and-arrays.yaml
+++ b/changelog/pending/20231102--programgen-go--fix-using-inline-invoke-expressions-inside-resources-objects-and-arrays.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix using inline invoke expressions inside resources, objects and arrays

--- a/pkg/codegen/go/gen_program_inline_invoke.go
+++ b/pkg/codegen/go/gen_program_inline_invoke.go
@@ -1,0 +1,78 @@
+package gen
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+)
+
+type inlineInvokeTemp struct {
+	Name  string
+	Value *model.FunctionCallExpression
+}
+
+func (temp *inlineInvokeTemp) Type() model.Type {
+	return temp.Value.Type()
+}
+
+func (temp *inlineInvokeTemp) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return temp.Type().Traverse(traverser)
+}
+
+func (temp *inlineInvokeTemp) SyntaxNode() hclsyntax.Node {
+	return syntax.None
+}
+
+type inlineInvokeSpiller struct {
+	temps []*inlineInvokeTemp
+	count int
+}
+
+func (spiller *inlineInvokeSpiller) spillExpression(
+	expr model.Expression,
+	g *generator,
+) (model.Expression, hcl.Diagnostics) {
+	switch expr := expr.(type) {
+	case *model.FunctionCallExpression:
+		isOutputInvoke, _, _ := pcl.RecognizeOutputVersionedInvoke(expr)
+		if expr.Name == "invoke" && !isOutputInvoke {
+			// non-output-versioned invokes are the only ones that need to be converted
+			// because their return type Tuple(InvokeResult, error)
+			_, _, fn, _ := g.functionName(expr.Args[0])
+			tempName := fmt.Sprintf("invoke%s%d", fn, spiller.count)
+			if spiller.count == 0 {
+				tempName = fmt.Sprintf("invoke%s", fn)
+			}
+			temp := &inlineInvokeTemp{
+				Name:  tempName,
+				Value: expr,
+			}
+			spiller.temps = append(spiller.temps, temp)
+
+			spiller.count++
+			reference := model.VariableReference(&model.Variable{
+				Name: temp.Name,
+			})
+
+			return reference, nil
+		}
+
+		return expr, nil
+	default:
+		return expr, nil
+	}
+}
+
+func (g *generator) rewriteInlineInvokes(x model.Expression) (model.Expression, []*inlineInvokeTemp) {
+	spiller := g.inlineInvokeSpiller
+	spiller.temps = nil
+	spill := func(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+		return spiller.spillExpression(expr, g)
+	}
+	expr, _ := model.VisitExpression(x, spill, spill)
+	return expr, spiller.temps
+}

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -488,6 +488,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 		readDirTempSpiller:  &readDirSpiller{},
 		splatSpiller:        &splatSpiller{},
 		optionalSpiller:     &optionalSpiller{},
+		inlineInvokeSpiller: &inlineInvokeSpiller{},
 		scopeTraversalRoots: codegen.NewStringSet(),
 		arrayHelpers:        make(map[string]*promptToInputArrayHelper),
 		importer:            newFileImporter(),

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -383,6 +383,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Regression test for rewriting qoutes in python",
 		Skip:        allProgLanguages.Except("python"),
 	},
+	{
+		Directory:   "inline-invokes",
+		Description: "Tests whether using inline invoke expressions works",
+		SkipCompile: codegen.NewStringSet("go"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/inline-invokes-pp/dotnet/inline-invokes.cs
+++ b/pkg/codegen/testing/test/testdata/inline-invokes-pp/dotnet/inline-invokes.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var webSecurityGroup = new Aws.Ec2.SecurityGroup("webSecurityGroup", new()
+    {
+        VpcId = Aws.Ec2.GetVpc.Invoke(new()
+        {
+            Default = true,
+        }).Apply(invoke => invoke.Id),
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/inline-invokes-pp/go/inline-invokes.go
+++ b/pkg/codegen/testing/test/testdata/inline-invokes-pp/go/inline-invokes.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		invokeLookupVpc, err := ec2.LookupVpc(ctx, &ec2.LookupVpcArgs{
+			Default: pulumi.BoolRef(true),
+		}, nil)
+		if err != nil {
+			return err
+		}
+		_, err = ec2.NewSecurityGroup(ctx, "webSecurityGroup", &ec2.SecurityGroupArgs{
+			VpcId: invokeLookupVpc.Id,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/inline-invokes-pp/inline-invokes.pp
+++ b/pkg/codegen/testing/test/testdata/inline-invokes-pp/inline-invokes.pp
@@ -1,0 +1,3 @@
+resource webSecurityGroup "aws:ec2:SecurityGroup" {
+  vpcId = invoke("aws:ec2:getVpc", { default = true }).id
+}

--- a/pkg/codegen/testing/test/testdata/inline-invokes-pp/nodejs/inline-invokes.ts
+++ b/pkg/codegen/testing/test/testdata/inline-invokes-pp/nodejs/inline-invokes.ts
@@ -1,0 +1,6 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {vpcId: aws.ec2.getVpc({
+    "default": true,
+}).then(invoke => invoke.id)});

--- a/pkg/codegen/testing/test/testdata/inline-invokes-pp/python/inline-invokes.py
+++ b/pkg/codegen/testing/test/testdata/inline-invokes-pp/python/inline-invokes.py
@@ -1,0 +1,4 @@
+import pulumi
+import pulumi_aws as aws
+
+web_security_group = aws.ec2.SecurityGroup("webSecurityGroup", vpc_id=aws.ec2.get_vpc(default=True).id)


### PR DESCRIPTION
# Description

This PR fixes an issue in Go program where if users are writing invoke expressions inline inside other expressions, then that invoke is extracted into a temporary variable and then later referenced the same way it was used. This is because non-output-versioned invokes cannot be used directly since they return a tuple (InvokeResult, err) so we need to check for the error before proceeding. 

Fixes #14064

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
