### PR TITLE
Add tokens.StackName

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ type StackReference interface {
 	// Name is the name that will be passed to the Pulumi engine when preforming operations on this stack. This
 	// name may not uniquely identify the stack (e.g. the cloud backend embeds owner information in the StackReference
 	// but that information is not part of the StackName() we pass to the engine.
-	Name() tokens.Name
+	Name() tokens.StackName
 
 	// Project is the project name that this stack belongs to.
 	// For old filestate backends this will return false.

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ func printPermalink(out io.Writer, opts Options, message, permalink string) {
 // it comes in. Once all events have been read from the channel and displayed, it closes the `done`
 // channel so the caller can await all the events being written.
 func ShowEvents(
-	op string, action apitype.UpdateKind, stack tokens.Name, proj tokens.PackageName,
+	op string, action apitype.UpdateKind, stack tokens.StackName, proj tokens.PackageName,
 	permalink string, events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool,
 ) {
 	if opts.EventLogPath != "" {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ type ProgressDisplay struct {
 	// action is the kind of action (preview, update, refresh, etc) being performed.
 	action apitype.UpdateKind
 	// stack is the stack this progress pertains to.
-	stack tokens.Name
+	stack tokens.StackName
 	// proj is the project this progress pertains to.
 	proj tokens.PackageName
 
@@ -182,7 +182,7 @@ func getEventUrnAndMetadata(event engine.Event) (resource.URN, *engine.StepEvent
 }
 
 // ShowProgressEvents displays the engine events with docker's progress view.
-func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Name, proj tokens.PackageName,
+func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.StackName, proj tokens.PackageName,
 	permalink string, events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool,
 ) {
 	stdin := opts.Stdin

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,18 +63,20 @@ func testProgressEvents(t *testing.T, path string, accept, interactive bool, wid
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	go ShowProgressEvents("test", "update", "stack", "project", "link", eventChannel, doneChannel, Options{
-		IsInteractive:        interactive,
-		Color:                colors.Raw,
-		ShowConfig:           true,
-		ShowReplacementSteps: true,
-		ShowSameResources:    true,
-		ShowReads:            true,
-		Stdout:               &stdout,
-		Stderr:               &stderr,
-		term:                 terminal.NewMockTerminal(&stdout, width, height, true),
-		deterministicOutput:  true,
-	}, false)
+	go ShowProgressEvents(
+		"test", "update", tokens.MustParseStackName("stack"), "project", "link", eventChannel, doneChannel,
+		Options{
+			IsInteractive:        interactive,
+			Color:                colors.Raw,
+			ShowConfig:           true,
+			ShowReplacementSteps: true,
+			ShowSameResources:    true,
+			ShowReads:            true,
+			Stdout:               &stdout,
+			Stderr:               &stderr,
+			term:                 terminal.NewMockTerminal(&stdout, width, height, true),
+			deterministicOutput:  true,
+		}, false)
 
 	for _, e := range events {
 		eventChannel <- e

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -109,7 +109,7 @@ func TestGetLogsForTargetWithNoSnapshot(t *testing.T) {
 	t.Parallel()
 
 	target := &deploy.Target{
-		Name:      "test",
+		Name:      tokens.MustParseStackName("test"),
 		Config:    config.Map{},
 		Decrypter: config.NopDecrypter,
 		Snapshot:  nil,
@@ -1070,12 +1070,16 @@ func TestLegacyUpgrade_ProjectsForDetachedStacks(t *testing.T) {
 	// For the first two stacks, we'll return project names to upgrade them.
 	// For the third stack, we will not set a project name, and it should be skipped.
 	err = b.Upgrade(ctx, &UpgradeOptions{
-		ProjectsForDetachedStacks: func(stacks []tokens.Name) (projects []tokens.Name, err error) {
-			assert.ElementsMatch(t, []tokens.Name{"foo", "bar", "baz"}, stacks)
+		ProjectsForDetachedStacks: func(stacks []tokens.StackName) (projects []tokens.Name, err error) {
+			assert.ElementsMatch(t, []tokens.StackName{
+				tokens.MustParseStackName("foo"),
+				tokens.MustParseStackName("bar"),
+				tokens.MustParseStackName("baz"),
+			}, stacks)
 
 			projects = make([]tokens.Name, len(stacks))
 			for idx, stack := range stacks {
-				switch stack {
+				switch stack.String() {
 				case "foo":
 					projects[idx] = "proj1"
 				case "bar":
@@ -1142,8 +1146,10 @@ func TestLegacyUpgrade_ProjectsForDetachedStacks_error(t *testing.T) {
 
 	giveErr := errors.New("canceled operation")
 	err = b.Upgrade(ctx, &UpgradeOptions{
-		ProjectsForDetachedStacks: func(stacks []tokens.Name) (projects []tokens.Name, err error) {
-			assert.Equal(t, []tokens.Name{"bar"}, stacks)
+		ProjectsForDetachedStacks: func(stacks []tokens.StackName) (projects []tokens.Name, err error) {
+			assert.Equal(t, []tokens.StackName{
+				tokens.MustParseStackName("bar"),
+			}, stacks)
 			return nil, giveErr
 		},
 	})

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -108,7 +108,7 @@ func newProjectReferenceStore(bucket Bucket, currentProject func() *workspace.Pr
 
 // newReference builds a new localBackendReference with the provided arguments.
 // This DOES NOT modify the underlying storage.
-func (p *projectReferenceStore) newReference(project, name tokens.Name) *localBackendReference {
+func (p *projectReferenceStore) newReference(project tokens.Name, name tokens.StackName) *localBackendReference {
 	return &localBackendReference{
 		name:           name,
 		project:        project,
@@ -119,17 +119,18 @@ func (p *projectReferenceStore) newReference(project, name tokens.Name) *localBa
 
 func (p *projectReferenceStore) StackBasePath(ref *localBackendReference) string {
 	contract.Requiref(ref.project != "", "ref.project", "must not be empty")
-	return filepath.Join(StacksDir, fsutil.NamePath(ref.project), fsutil.NamePath(ref.name))
+	// No need for NamePath for the StackName because it's already constrained to characters that are valid for filenames.
+	return filepath.Join(StacksDir, fsutil.NamePath(ref.project), ref.name.String())
 }
 
 func (p *projectReferenceStore) HistoryDir(stack *localBackendReference) string {
 	contract.Requiref(stack.project != "", "ref.project", "must not be empty")
-	return filepath.Join(HistoriesDir, fsutil.NamePath(stack.project), fsutil.NamePath(stack.name))
+	return filepath.Join(HistoriesDir, fsutil.NamePath(stack.project), stack.name.String())
 }
 
 func (p *projectReferenceStore) BackupDir(stack *localBackendReference) string {
 	contract.Requiref(stack.project != "", "ref.project", "must not be empty")
-	return filepath.Join(BackupsDir, fsutil.NamePath(stack.project), fsutil.NamePath(stack.name))
+	return filepath.Join(BackupsDir, fsutil.NamePath(stack.project), stack.name.String())
 }
 
 func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendReference, error) {
@@ -186,13 +187,12 @@ func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendRe
 		}
 	}
 
-	if !tokens.IsName(name) || len(name) > 100 {
-		return nil, fmt.Errorf(
-			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %s",
-			name)
+	parsedName, err := tokens.ParseStackName(name)
+	if err != nil {
+		return nil, err
 	}
 
-	return p.newReference(tokens.Name(project), tokens.Name(name)), nil
+	return p.newReference(tokens.Name(project), parsedName), nil
 }
 
 func (p *projectReferenceStore) ValidateReference(ref *localBackendReference) error {
@@ -301,7 +301,13 @@ func (p *projectReferenceStore) ListReferences(ctx context.Context) ([]*localBac
 
 		// Read in this stack's information.
 		name := objName[:len(objName)-len(ext)]
-		stacks = append(stacks, p.newReference(tokens.Name(projName), tokens.Name(name)))
+		parsedName, err := tokens.ParseStackName(name)
+		if err != nil {
+			// This looked like a stack file, but it wasn't a valid stack name so skip it.
+			continue
+		}
+
+		stacks = append(stacks, p.newReference(tokens.Name(projName), parsedName))
 	}
 	return stacks, nil
 }
@@ -326,7 +332,7 @@ func newLegacyReferenceStore(b Bucket) *legacyReferenceStore {
 
 // newReference builds a new localBackendReference with the provided arguments.
 // This DOES NOT modify the underlying storage.
-func (p *legacyReferenceStore) newReference(name tokens.Name) *localBackendReference {
+func (p *legacyReferenceStore) newReference(name tokens.StackName) *localBackendReference {
 	return &localBackendReference{
 		name:  name,
 		store: p,
@@ -335,26 +341,25 @@ func (p *legacyReferenceStore) newReference(name tokens.Name) *localBackendRefer
 
 func (p *legacyReferenceStore) StackBasePath(ref *localBackendReference) string {
 	contract.Requiref(ref.project == "", "ref.project", "must be empty")
-	return filepath.Join(StacksDir, fsutil.NamePath(ref.name))
+	return filepath.Join(StacksDir, ref.name.String())
 }
 
 func (p *legacyReferenceStore) HistoryDir(stack *localBackendReference) string {
 	contract.Requiref(stack.project == "", "ref.project", "must be empty")
-	return filepath.Join(HistoriesDir, fsutil.NamePath(stack.name))
+	return filepath.Join(HistoriesDir, stack.name.String())
 }
 
 func (p *legacyReferenceStore) BackupDir(stack *localBackendReference) string {
 	contract.Requiref(stack.project == "", "ref.project", "must be empty")
-	return filepath.Join(BackupsDir, fsutil.NamePath(stack.name))
+	return filepath.Join(BackupsDir, stack.name.String())
 }
 
 func (p *legacyReferenceStore) ParseReference(stackRef string) (*localBackendReference, error) {
-	if !tokens.IsName(stackRef) || len(stackRef) > 100 {
-		return nil, fmt.Errorf(
-			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %q",
-			stackRef)
+	parsedName, err := tokens.ParseStackName(stackRef)
+	if err != nil {
+		return nil, err
 	}
-	return p.newReference(tokens.Name(stackRef)), nil
+	return p.newReference(parsedName), nil
 }
 
 func (p *legacyReferenceStore) ValidateReference(ref *localBackendReference) error {
@@ -391,7 +396,13 @@ func (p *legacyReferenceStore) ListReferences(ctx context.Context) ([]*localBack
 
 		// Read in this stack's information.
 		name := objName[:len(objName)-len(ext)]
-		stacks = append(stacks, p.newReference(tokens.Name(name)))
+		parsedName, err := tokens.ParseStackName(name)
+		if err != nil {
+			// This looked like a stack file, but it wasn't a valid stack name so skip it.
+			continue
+		}
+
+		stacks = append(stacks, p.newReference(parsedName))
 	}
 
 	return stacks, nil

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -35,7 +35,7 @@ func TestLegacyReferenceStore_referencePaths(t *testing.T) {
 	ref, err := store.ParseReference("foo")
 	require.NoError(t, err)
 
-	assert.Equal(t, tokens.Name("foo"), ref.Name())
+	assert.Equal(t, tokens.MustParseStackName("foo"), ref.Name())
 	assert.Equal(t, tokens.QName("foo"), ref.FullyQualifiedName())
 	assert.Equal(t, ".pulumi/stacks/foo", ref.StackBasePath())
 	assert.Equal(t, ".pulumi/history/foo", ref.HistoryDir())
@@ -71,7 +71,7 @@ func TestProjectReferenceStore_ParseReference(t *testing.T) {
 		give string
 
 		fqname  tokens.QName
-		name    tokens.Name
+		name    string
 		project tokens.Name
 		str     string
 	}{
@@ -111,7 +111,7 @@ func TestProjectReferenceStore_ParseReference(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.fqname, ref.FullyQualifiedName())
-			assert.Equal(t, tt.name, ref.Name())
+			assert.Equal(t, tokens.MustParseStackName(tt.name), ref.Name())
 			proj, has := ref.Project()
 			assert.True(t, has)
 			assert.Equal(t, tt.project, proj)
@@ -182,7 +182,7 @@ func TestProjectReferenceStore_ParseReference_errors(t *testing.T) {
 		{
 			desc:    "long project stack name",
 			give:    "organization/foo/" + strings.Repeat("a", 101),
-			wantErr: "stack names are limited to 100 characters",
+			wantErr: "a stack name cannot exceed 100 characters",
 		},
 		{
 			desc:    "no current project",

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/pkg/v3/util/validation"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -694,16 +693,15 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 		qualifiedName.Project = b.currentProject.Name.String()
 	}
 
-	if err := validation.ValidateStackName(qualifiedName.Name); err != nil {
+	parsedName, err := tokens.ParseStackName(qualifiedName.Name)
+	if err != nil {
 		return nil, err
 	}
-	contract.Assertf(tokens.IsName(qualifiedName.Name),
-		"qualifiedName.Name must be a valid name because it is a valid stack name")
 
 	return cloudBackendReference{
 		owner:   qualifiedName.Owner,
 		project: tokens.Name(qualifiedName.Project),
-		name:    tokens.Name(qualifiedName.Name),
+		name:    parsedName,
 		b:       b,
 	}, nil
 }
@@ -728,7 +726,8 @@ func (b *cloudBackend) ValidateStackName(s string) error {
 		}
 	}
 
-	return validation.ValidateStackName(qualifiedName.Name)
+	_, err = tokens.ParseStackName(qualifiedName.Name)
+	return err
 }
 
 // validateOwnerName checks if a stack owner name is valid. An "owner" is simply the namespace
@@ -785,7 +784,7 @@ func serveBrowserLoginServer(l net.Listener, expectedNonce string, destinationUR
 // CloudConsoleStackPath returns the stack path components for getting to a stack in the cloud console.  This path
 // must, of course, be combined with the actual console base URL by way of the CloudConsoleURL function above.
 func (b *cloudBackend) cloudConsoleStackPath(stackID client.StackIdentifier) string {
-	return path.Join(stackID.Owner, stackID.Project, stackID.Stack)
+	return path.Join(stackID.Owner, stackID.Project, stackID.Stack.String())
 }
 
 func inferOrg(ctx context.Context,
@@ -1535,7 +1534,7 @@ func (b *cloudBackend) getCloudStackIdentifier(stackRef backend.StackReference) 
 	return client.StackIdentifier{
 		Owner:   cloudBackendStackRef.owner,
 		Project: cleanProjectName(string(cloudBackendStackRef.project)),
-		Stack:   string(cloudBackendStackRef.name),
+		Stack:   cloudBackendStackRef.name,
 	}, nil
 }
 
@@ -1820,7 +1819,7 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 
 	permalink := b.getPermalink(update, version, dryRun)
 	go display.ShowEvents(
-		backend.ActionLabel(kind, dryRun), kind, tokens.Name(stackID.Stack), tokens.PackageName(stackID.Project),
+		backend.ActionLabel(kind, dryRun), kind, stackID.Stack, tokens.PackageName(stackID.Project),
 		permalink, events, done, opts, dryRun)
 
 	// The UpdateEvents API returns a continuation token to only get events after the previous call.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -52,7 +53,7 @@ func UserAgent() string {
 type StackIdentifier struct {
 	Owner   string
 	Project string
-	Stack   string
+	Stack   tokens.StackName
 }
 
 func (s StackIdentifier) String() string {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -396,18 +395,18 @@ func (pc *Client) CreateStack(
 	ctx context.Context, stackID StackIdentifier, tags map[apitype.StackTagName]string, teams []string,
 ) (apitype.Stack, error) {
 	// Validate names and tags.
-	if err := validation.ValidateStackProperties(stackID.Stack, tags); err != nil {
+	if err := validation.ValidateStackTags(tags); err != nil {
 		return apitype.Stack{}, fmt.Errorf("validating stack properties: %w", err)
 	}
 
 	stack := apitype.Stack{
-		StackName:   tokens.QName(stackID.Stack),
+		StackName:   stackID.Stack.Q(),
 		ProjectName: stackID.Project,
 		OrgName:     stackID.Owner,
 		Tags:        tags,
 	}
 	createStackReq := apitype.CreateStackRequest{
-		StackName: stackID.Stack,
+		StackName: stackID.Stack.String(),
 		Tags:      tags,
 		Teams:     teams,
 	}
@@ -644,7 +643,7 @@ func (pc *Client) CreateUpdate(
 // RenameStack renames the provided stack to have the new identifier.
 func (pc *Client) RenameStack(ctx context.Context, currentID, newID StackIdentifier) error {
 	req := apitype.StackRenameRequest{
-		NewName:    newID.Stack,
+		NewName:    newID.Stack.String(),
 		NewProject: newID.Project,
 	}
 	return pc.restCall(ctx, "POST", getStackPath(currentID, "rename"), nil, &req, nil)
@@ -656,7 +655,7 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 	tags map[apitype.StackTagName]string,
 ) (int, string, error) {
 	// Validate names and tags.
-	if err := validation.ValidateStackProperties(update.StackIdentifier.Stack, tags); err != nil {
+	if err := validation.ValidateStackTags(tags); err != nil {
 		return 0, "", fmt.Errorf("validating stack properties: %w", err)
 	}
 

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -100,7 +101,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 	stackID := client.StackIdentifier{
 		Owner:   "owner",
 		Project: "project",
-		Stack:   "stack",
+		Stack:   tokens.MustParseStackName("stack"),
 	}
 	updateID := "update-id"
 

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -249,7 +249,7 @@ func (b *cloudBackend) getTarget(ctx context.Context, secretsProvider secrets.Pr
 	}
 
 	return &deploy.Target{
-		Name:         tokens.Name(stackID.Stack),
+		Name:         stackID.Stack,
 		Organization: tokens.Name(stackID.Owner),
 		Config:       cfg,
 		Decrypter:    dec,

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ func newCancelCmd() *cobra.Command {
 			}
 
 			// Ensure the user really wants to do this.
-			stackName := string(s.Ref().Name())
+			stackName := s.Ref().Name().String()
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
 			if cmdutil.Interactive() && (!yes && !confirmPrompt(prompt, stackName, opts)) {
 				return result.FprintBailf(os.Stdout, "confirmation declined")

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 			RefF: func() backend.StackReference {
 				return &backend.MockStackReference{
 					StringV:             "org/project/name",
-					NameV:               "name",
+					NameV:               tokens.MustParseStackName("name"),
 					ProjectV:            "project",
 					FullyQualifiedNameV: tokens.QName("org/project/name"),
 				}
@@ -94,7 +94,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 			RefF: func() backend.StackReference {
 				return &backend.MockStackReference{
 					StringV:             "org/project/name",
-					NameV:               "name",
+					NameV:               tokens.MustParseStackName("name"),
 					ProjectV:            "project",
 					FullyQualifiedNameV: tokens.QName("org/project/name"),
 				}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -197,7 +197,7 @@ func writeImportFile(v importFile) (string, error) {
 }
 
 func parseImportFile(
-	f importFile, stack tokens.Name, proj tokens.PackageName, protectResources bool,
+	f importFile, stack tokens.StackName, proj tokens.PackageName, protectResources bool,
 ) ([]deploy.Import, importer.NameTable, error) {
 	// First check for uniqueness and ambiguity, takenNames tracks both that a name is used (it's in the map) and if
 	// it's ambiguous (it's true).
@@ -444,7 +444,7 @@ type programGeneratorFunc func(
 ) (map[string][]byte, hcl.Diagnostics, error)
 
 func generateImportedDefinitions(ctx *plugin.Context,
-	out io.Writer, stackName tokens.Name, projectName tokens.PackageName,
+	out io.Writer, stackName tokens.StackName, projectName tokens.PackageName,
 	snap *deploy.Snapshot, programGenerator programGeneratorFunc, names importer.NameTable,
 	imports []deploy.Import, protectResources bool,
 ) (bool, error) {

--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -219,7 +219,7 @@ func TestParseImportFile_errors(t *testing.T) {
 
 			require.NotEmpty(t, tt.wantErrs, "invalid test: wantErrs must not be empty")
 
-			_, _, err := parseImportFile(tt.give, "stack", "proj", false)
+			_, _, err := parseImportFile(tt.give, tokens.MustParseStackName("stack"), "proj", false)
 			require.Error(t, err)
 			for _, wantErr := range tt.wantErrs {
 				assert.ErrorContains(t, err, wantErr)
@@ -246,7 +246,7 @@ func TestParseImportFileSameName(t *testing.T) {
 			},
 		},
 	}
-	imports, _, err := parseImportFile(f, "stack", "proj", false)
+	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
 	resourceNames := map[tokens.QName]struct{}{}
 	for _, imp := range imports {
@@ -286,7 +286,7 @@ func TestParseImportFileRenameNoClash(t *testing.T) {
 			},
 		},
 	}
-	imports, _, err := parseImportFile(f, "stack", "proj", false)
+	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
 	resourceNames := map[tokens.QName]struct{}{}
 	// Check resource names are unique.
@@ -329,7 +329,7 @@ func TestParseImportFileAutoURN(t *testing.T) {
 			},
 		},
 	}
-	imports, nt, err := parseImportFile(f, "stack", "proj", false)
+	imports, nt, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
 
 	// Check the parent URN was auto filled in.

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -854,17 +854,17 @@ func TestValidateStackRefAndProjectName(t *testing.T) {
 			switch len(parts) {
 			case 1:
 				return &backend.MockStackReference{
-					NameV: tokens.Name(parts[0]),
+					NameV: tokens.MustParseStackName(parts[0]),
 				}, nil
 			case 2:
 				return &backend.MockStackReference{
 					ProjectV: tokens.Name(parts[0]),
-					NameV:    tokens.Name(parts[1]),
+					NameV:    tokens.MustParseStackName(parts[1]),
 				}, nil
 			case 3:
 				return &backend.MockStackReference{
 					ProjectV: tokens.Name(parts[1]),
-					NameV:    tokens.Name(parts[2]),
+					NameV:    tokens.MustParseStackName(parts[2]),
 				}, nil
 
 			default:

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -106,7 +107,7 @@ func newReplayEventsCmd() *cobra.Command {
 			}
 
 			go display.ShowEvents(
-				"replay", action, "replay", "replay", "",
+				"replay", action, tokens.MustParseStackName("replay"), "replay", "",
 				eventChannel, doneChannel, displayOpts, preview)
 
 			for _, e := range events {

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{
 				StringV: "testStack",
-				NameV:   "testStack",
+				NameV:   tokens.MustParseStackName("testStack"),
 			}
 		},
 		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -189,7 +190,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{
 				StringV: "testStack",
-				NameV:   "testStack",
+				NameV:   tokens.MustParseStackName("testStack"),
 			}
 		},
 		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ type mockStackSummary struct {
 }
 
 func (mss *mockStackSummary) Name() backend.StackReference {
-	name := tokens.Name(mss.name)
+	name := tokens.MustParseStackName(mss.name)
 	return &backend.MockStackReference{
 		NameV:               name,
 		FullyQualifiedNameV: name.Q(),

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -118,7 +118,7 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 	return lb.Upgrade(ctx, &opts)
 }
 
-func (cmd *stateUpgradeCmd) projectsForDetachedStacks(stacks []tokens.Name) ([]tokens.Name, error) {
+func (cmd *stateUpgradeCmd) projectsForDetachedStacks(stacks []tokens.StackName) ([]tokens.Name, error) {
 	projects := make([]tokens.Name, len(stacks))
 	err := (&stateUpgradeProjectNameWidget{
 		Stdin:  cmd.Stdin,
@@ -143,7 +143,7 @@ type stateUpgradeProjectNameWidget struct {
 // and stores the result in the corresponding index of projects.
 //
 // The length of projects must be equal to the length of stacks.
-func (w *stateUpgradeProjectNameWidget) Prompt(stacks, projects []tokens.Name) error {
+func (w *stateUpgradeProjectNameWidget) Prompt(stacks []tokens.StackName, projects []tokens.Name) error {
 	contract.Assertf(len(stacks) == len(projects),
 		"length of stacks (%d) must equal length of projects (%d)", len(stacks), len(projects))
 

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -226,7 +226,11 @@ func TestStateUpgradeProjectNameWidget(t *testing.T) {
 	go func() {
 		defer close(donec)
 
-		stacks := []tokens.Name{"foo", "bar", "baz"}
+		stacks := []tokens.StackName{
+			tokens.MustParseStackName("foo"),
+			tokens.MustParseStackName("bar"),
+			tokens.MustParseStackName("baz"),
+		}
 		projects := make([]tokens.Name, len(stacks))
 
 		err := (&stateUpgradeProjectNameWidget{
@@ -307,14 +311,18 @@ func TestStateUpgradeProjectNameWidget_noStacks(t *testing.T) {
 		Stdin:  tty,
 		Stdout: tty,
 		Stderr: iotest.LogWriterPrefixed(t, "[stderr] "),
-	}).Prompt([]tokens.Name{}, []tokens.Name{})
+	}).Prompt([]tokens.StackName{}, []tokens.Name{})
 	require.NoError(t, err)
 }
 
 func TestStateUpgradeProjectNameWidget_notATerminal(t *testing.T) {
 	t.Parallel()
 
-	stacks := []tokens.Name{"foo", "bar", "baz"}
+	stacks := []tokens.StackName{
+		tokens.MustParseStackName("foo"),
+		tokens.MustParseStackName("bar"),
+		tokens.MustParseStackName("baz"),
+	}
 	projects := make([]tokens.Name, len(stacks))
 
 	err := (&stateUpgradeProjectNameWidget{

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -53,7 +54,7 @@ func makeUpdateInfo() *updateInfo {
 			Name:    "test",
 			Runtime: workspace.NewProjectRuntimeInfo("test", nil),
 		},
-		target: deploy.Target{Name: "test"},
+		target: deploy.Target{Name: tokens.MustParseStackName("test")},
 	}
 }
 

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -194,7 +194,7 @@ type TestPlan struct {
 	Steps          []TestStep
 }
 
-func (p *TestPlan) getNames() (stack tokens.Name, project tokens.PackageName, runtime string) {
+func (p *TestPlan) getNames() (stack tokens.StackName, project tokens.PackageName, runtime string) {
 	project = tokens.PackageName(p.Project)
 	if project == "" {
 		project = "test"
@@ -203,9 +203,9 @@ func (p *TestPlan) getNames() (stack tokens.Name, project tokens.PackageName, ru
 	if runtime == "" {
 		runtime = "test"
 	}
-	stack = tokens.Name(p.Stack)
-	if stack == "" {
-		stack = "test"
+	stack = tokens.MustParseStackName("test")
+	if p.Stack != "" {
+		stack = tokens.MustParseStackName(p.Stack)
 	}
 	return stack, project, runtime
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ func (src *evalSource) Project() tokens.PackageName {
 }
 
 // Stack is the name of the stack being targeted by this evaluation source.
-func (src *evalSource) Stack() tokens.Name {
+func (src *evalSource) Stack() tokens.StackName {
 	return src.runinfo.Target.Name
 }
 
@@ -230,7 +230,7 @@ func (iter *evalSourceIterator) forkRun(
 			// Now run the actual program.
 			progerr, bail, err := langhost.Run(plugin.RunInfo{
 				MonitorAddress:    iter.mon.Address(),
-				Stack:             string(iter.src.runinfo.Target.Name),
+				Stack:             iter.src.runinfo.Target.Name.String(),
 				Project:           string(iter.src.runinfo.Proj.Name),
 				Pwd:               iter.src.runinfo.Pwd,
 				Program:           iter.src.runinfo.Program,
@@ -584,7 +584,7 @@ func newResourceMonitor(src *evalSource, provs ProviderSource, regChan chan *reg
 
 	resmon.constructInfo = plugin.ConstructInfo{
 		Project:          string(src.runinfo.Proj.Name),
-		Stack:            string(src.runinfo.Target.Name),
+		Stack:            src.runinfo.Target.Name.String(),
 		Config:           config,
 		ConfigSecretKeys: configSecretKeys,
 		DryRun:           src.dryRun,

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 
 	runInfo := &EvalRunInfo{
 		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: "test"},
+		Target: &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -254,7 +254,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 
 	runInfo := &EvalRunInfo{
 		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: "test"},
+		Target: &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -348,7 +348,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 
 	runInfo := &EvalRunInfo{
 		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: "test"},
+		Target: &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -440,7 +440,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 
 	runInfo := &EvalRunInfo{
 		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: "test"},
+		Target: &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -581,7 +581,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 
 			runInfo := &EvalRunInfo{
 				Proj:   &workspace.Project{Name: "test"},
-				Target: &Target{Name: "test"},
+				Target: &Target{Name: tokens.MustParseStackName("test")},
 			}
 			if tt.disableDefault {
 				disableDefaultProviders(runInfo, "pkgA")
@@ -724,7 +724,7 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 
 	runInfo := &EvalRunInfo{
 		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: "test"},
+		Target: &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ func runLangPlugin(src *querySource) error {
 
 	var name, organization string
 	if src.runinfo.Target != nil {
-		name = string(src.runinfo.Target.Name)
+		name = src.runinfo.Target.Name.String()
 		organization = string(src.runinfo.Target.Organization)
 	}
 
@@ -273,7 +273,7 @@ func newQueryResourceMonitor(
 
 	var name string
 	if runinfo.Target != nil {
-		name = string(runinfo.Target.Name)
+		name = runinfo.Target.Name.String()
 	}
 
 	queryResmon.callInfo = plugin.CallInfo{

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -338,11 +339,11 @@ func TestGenerateAliases(t *testing.T) {
 
 	const (
 		project = "project"
-		stack   = "stack"
 	)
+	stack := tokens.MustParseStackName("stack")
 
-	parentTypeAlias := resource.CreateURN("myres", "test:resource:type2", "", project, stack)
-	parentNameAlias := resource.CreateURN("myres2", "test:resource:type", "", project, stack)
+	parentTypeAlias := resource.CreateURN("myres", "test:resource:type2", "", project, stack.String())
+	parentNameAlias := resource.CreateURN("myres2", "test:resource:type", "", project, stack.String())
 
 	cases := []struct {
 		name         string
@@ -389,7 +390,7 @@ func TestGenerateAliases(t *testing.T) {
 			childAliases: []resource.Alias{
 				{
 					Type:   "test:resource:child2",
-					Parent: resource.CreateURN("originalparent", "test:resource:original", "", project, stack),
+					Parent: resource.CreateURN("originalparent", "test:resource:original", "", project, stack.String()),
 				},
 			},
 			expected: []resource.URN{
@@ -427,7 +428,7 @@ func TestGenerateAliases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			parentURN := resource.CreateURN("myres", "test:resource:type", "", project, stack)
+			parentURN := resource.CreateURN("myres", "test:resource:type", "", project, stack.String())
 			goal := &resource.Goal{
 				Parent:  parentURN,
 				Name:    "myres-child",

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import (
 
 // Target represents information about a deployment target.
 type Target struct {
-	Name         tokens.Name      // the target stack name.
+	Name         tokens.StackName // the target stack name.
 	Organization tokens.Name      // the target organization name (if any).
 	Config       config.Map       // optional configuration key/value pairs.
 	Decrypter    config.Decrypter // decrypter for secret configuration values.

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
 // the root Stack resource itself. May optionally change the project/package name as well.
-func RenameStack(snap *deploy.Snapshot, newName tokens.Name, newProject tokens.PackageName) error {
+func RenameStack(snap *deploy.Snapshot, newName tokens.StackName, newProject tokens.PackageName) error {
 	contract.Requiref(snap != nil, "snap", "must not be nil")
 
 	rewriteUrn := func(u resource.URN) resource.URN {
@@ -170,7 +170,7 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.Name, newProject tokens.P
 			return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), tokens.QName(project)+"-"+newName.Q())
 		}
 
-		return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), u.Name())
+		return resource.NewURN(tokens.QName(newName.String()), project, "", u.QualifiedType(), u.Name())
 	}
 
 	rewriteState := func(res *resource.State) {

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -492,7 +492,7 @@ func TestRenameStack(t *testing.T) {
 	// Rename just the stack.
 	//nolint:paralleltest // uses shared stack
 	t.Run("JustTheStack", func(t *testing.T) {
-		err := RenameStack(snap, tokens.Name("new-stack"), tokens.PackageName(""))
+		err := RenameStack(snap, tokens.MustParseStackName("new-stack"), tokens.PackageName(""))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}
@@ -512,7 +512,7 @@ func TestRenameStack(t *testing.T) {
 	// Rename the stack and project.
 	//nolint:paralleltest // uses shared stack
 	t.Run("StackAndProject", func(t *testing.T) {
-		err := RenameStack(snap, tokens.Name("new-stack2"), tokens.PackageName("new-project"))
+		err := RenameStack(snap, tokens.MustParseStackName("new-stack2"), tokens.PackageName("new-project"))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -144,7 +145,7 @@ func NewServiceSecretsManager(
 		URL:      client.URL(),
 		Owner:    id.Owner,
 		Project:  id.Project,
-		Stack:    id.Stack,
+		Stack:    id.Stack.String(),
 		Insecure: client.Insecure(),
 	})
 	if err != nil {
@@ -175,10 +176,15 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		return nil, fmt.Errorf("could not find access token for %s, have you logged in?", s.URL)
 	}
 
+	stack, err := tokens.ParseStackName(s.Stack)
+	if err != nil {
+		return nil, fmt.Errorf("parsing stack name: %w", err)
+	}
+
 	id := client.StackIdentifier{
 		Owner:   s.Owner,
 		Project: s.Project,
-		Stack:   s.Stack,
+		Stack:   stack,
 	}
 	c := client.NewClient(s.URL, token, s.Insecure, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never,

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,39 +20,7 @@ import (
 	"regexp"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
-
-var stackNameRE = regexp.MustCompile("^" + tokens.NameRegexpPattern)
-
-// ValidateStackName checks if s is a valid stack name, otherwise returns a descriptive error.
-// This should match the stack naming rules enforced by the Pulumi Service.
-func ValidateStackName(s string) error {
-	if s == "" {
-		return errors.New("a stack name may not be empty")
-	}
-	if len(s) > 100 {
-		return errors.New("a stack name cannot exceed 100 characters")
-	}
-
-	failure := -1
-	if match := stackNameRE.FindStringIndex(s); match == nil {
-		// We have failed to find any match, so the first token must be invalid.
-		failure = 0
-	} else if match[1] != len(s) {
-		// Our match did not extend to the end, so the invalid token must be the
-		// first token not matched.
-		failure = match[1]
-	}
-
-	if failure == -1 {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"a stack name may only contain alphanumeric, hyphens, underscores, or periods: "+
-			"invalid character %q at position %d", s[failure], failure)
-}
 
 // validateStackTagName checks if s is a valid stack tag name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
@@ -87,16 +55,4 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 	}
 
 	return nil
-}
-
-// ValidateStackProperties validates the stack name and its tags to confirm they adhear to various
-// naming and length restrictions.
-func ValidateStackProperties(stack string, tags map[apitype.StackTagName]string) error {
-	if err := ValidateStackName(stack); err != nil {
-		return err
-	}
-
-	// Ensure tag values won't be rejected by the Pulumi Service. We do not validate that their
-	// values make sense, e.g. ProjectRuntimeTag is a supported runtime.
-	return ValidateStackTags(tags)
 }

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -9,52 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateStackName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		title     string
-		stackName string
-		error     string
-	}{
-		{"empty", "", "a stack name may not be empty"},
-		{"valid", "foo", ""},
-		{
-			title:     "slash",
-			stackName: "foo/bar",
-			error: "a stack name may only contain alphanumeric, hyphens, " +
-				"underscores, or periods: invalid character '/'" +
-				" at position 3",
-		},
-		{"long", strings.Repeat("a", 100), ""},
-		{
-			title:     "too-long",
-			stackName: strings.Repeat("a", 101),
-			error:     "a stack name cannot exceed 100 characters",
-		},
-		{
-			title:     "first-char-invalid",
-			stackName: "@stack-name",
-			error: "a stack name may only contain alphanumeric, hyphens, " +
-				"underscores, or periods: invalid character '@' " +
-				"at position 0",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.title, func(t *testing.T) {
-			t.Parallel()
-			err := ValidateStackName(tt.stackName)
-			if tt.error == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.ErrorContains(t, err, tt.error)
-			}
-		})
-	}
-}
-
 func TestValidateStackTag(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,3 +97,14 @@ var (
 var (
 	AIServiceEndpoint = env.String("AI_SERVICE_ENDPOINT", "Endpoint for Pulumi AI service")
 )
+
+var DisableValidation = env.Bool(
+	"DISABLE_VALIDATION",
+	`Disables format validation of system inputs.
+
+Currently this disables validation of the following formats:
+	- Stack names
+
+This should only be used in cases where current data does not conform to the format and either cannot be migrated
+without using the system itself, or show that the validation is too strict. Over time entries in the list above will be
+removed and enforced to be validated.`)

--- a/sdk/go/common/tokens/stack_name.go
+++ b/sdk/go/common/tokens/stack_name.go
@@ -1,0 +1,91 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// StackName is a valid stack name. It should always be initialised via ParseStackName, the use of it's zero
+// value will panic.
+type StackName struct {
+	str string
+}
+
+// IsEmpty returns true if the stack name is empty.
+func (sn StackName) IsEmpty() bool {
+	return sn.str == ""
+}
+
+// String implements fmt.Stringer. This method panics if StackName was zero initialized.
+func (sn StackName) String() string {
+	if env.DisableValidation.Value() {
+		contract.Assertf(sn.str != "", "stack name must not be empty")
+	}
+	return sn.str
+}
+
+// Q is a convenience method that returns the stack name as a QName. This method panics if StackName was zero
+// initialized.
+func (sn StackName) Q() QName {
+	return QName(sn.String())
+}
+
+var stackNameRegex = regexp.MustCompile("^[A-Za-z0-9_.-]*")
+
+// ParseStackName parses a stack name from a string.
+func ParseStackName(s string) (StackName, error) {
+	// Temporary flag to allow stack names validation to be disabled for the time being. Be sure to update the
+	// DisableValidation help text when this is removed.
+	if env.DisableValidation.Value() {
+		return StackName{s}, nil
+	}
+
+	if s == "" {
+		return StackName{}, fmt.Errorf("a stack name may not be empty")
+	}
+	if len(s) > 100 {
+		return StackName{}, fmt.Errorf("a stack name cannot exceed 100 characters")
+	}
+
+	failure := -1
+	if match := stackNameRegex.FindStringIndex(s); match == nil {
+		// We have failed to find any match, so the first char must be invalid.
+		failure = 0
+	} else if match[1] != len(s) {
+		// Our match did not extend to the end, so the invalid char must be the
+		// first char not matched.
+		failure = match[1]
+	}
+
+	if failure != -1 {
+		return StackName{}, fmt.Errorf(
+			"a stack name may only contain alphanumeric, hyphens, underscores, or periods: "+
+				"invalid character %q at position %d", s[failure], failure)
+	}
+
+	return StackName{s}, nil
+}
+
+// MustParseStackName parses a stack name from a string.
+func MustParseStackName(s string) StackName {
+	n, err := ParseStackName(s)
+	contract.AssertNoErrorf(err, "failed to parse stack name %q", s)
+	return n
+}

--- a/sdk/go/common/tokens/stack_name_test.go
+++ b/sdk/go/common/tokens/stack_name_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseStackName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc  string
+		input string
+		err   string
+	}{
+		{
+			desc:  "simple valid stack name",
+			input: "my-stack",
+		},
+		{
+			desc:  "stack name empty",
+			input: "",
+			err:   "a stack name may not be empty",
+		},
+		{
+			desc: "stack name too long",
+			input: "this-stack-name-is-just-too-long-for-the-service-to-handle-and-should-be-rejected-by-the-service-" +
+				"because-it-is-just-too-long-for-the-service-to-handle-and-should-be-rejected-by-the-service",
+			err: "a stack name cannot exceed 100 characters",
+		},
+		{
+			desc:  "invalid start to stack name",
+			input: "!my stack!",
+			err: "a stack name may only contain alphanumeric, hyphens, underscores, " +
+				"or periods: invalid character '!' at position 0",
+		},
+		{
+			desc:  "invalid rest of stack name",
+			input: "my bad",
+			err: "a stack name may only contain alphanumeric, hyphens, underscores, " +
+				"or periods: invalid character ' ' at position 2",
+		},
+		{
+			desc:  "invalid end of stack name",
+			input: "mybad%",
+			err: "a stack name may only contain alphanumeric, hyphens, underscores, " +
+				"or periods: invalid character '%' at position 5",
+		},
+		{
+			desc:  "invalid slash in stack name",
+			input: "foo/bar",
+			err: "a stack name may only contain alphanumeric, hyphens, underscores, " +
+				"or periods: invalid character '/' at position 3",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			sn, err := ParseStackName(tt.input)
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.input, sn.String())
+				assert.Equal(t, QName(tt.input), sn.Q())
+			}
+		})
+	}
+}

--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 // Store holds a collection of key, value? pairs.
@@ -287,7 +285,7 @@ func (b BoolValue) Value() bool {
 	if !ok {
 		return false
 	}
-	return cmdutil.IsTruthy(v)
+	return v == "1" || strings.EqualFold(v, "true")
 }
 
 // An integer retrieved from the environment.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ func TestStackTagValidation(t *testing.T) {
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "invalid name (spaces, parens, etc.)")
 		assert.Equal(t, "", stdout)
 		assert.Contains(t, stderr,
-			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
+			"a stack name may only contain alphanumeric, hyphens, underscores, or periods")
 	})
 
 	t.Run("Error_DescriptionLength", func(t *testing.T) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This adds a new type `tokens.StackName` which is a relatively strongly typed container for a stack name. The only weakly typed aspect of it is Go will always allow the "zero" value to be created for a struct, which for a stack name is the empty string which is invalid. To prevent introducing unexpected empty strings when working with stack names the `String()` method will panic for zero initialized stack names.
 
Apart from the zero value, all other instances of `StackName` are via `ParseStackName` which returns a descriptive error if the string is not valid.

This PR only updates "pkg/" to use this type. There are a number of places in "sdk/" which could do with this type as well, but there's no harm in doing a staggered roll out, and some parts of "sdk/" are user facing and will probably have to stay on the current `tokens.Name` and `tokens.QName` types.

There are two places in the system where we panic on invalid stack names, both in the http backend. This _should_ be fine as we've had long standing validation that stacks created in the service are valid stack names.

Just in case people have managed to introduce invalid stack names, there is the `PULUMI_DISABLE_VALIDATION` environment variable which will turn off the validation _and_ panicing for stack names. Users can use that to temporarily disable the validation and continue working, but it should only be seen as a temporary measure. If they have invalid names they should rename them, or if they think they should be valid raise an issue with us to change the validation code.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
