### PR TITLE
Add deserialisation cache to Python dynamic provider

### DIFF
--- a/changelog/pending/20231103--sdk-python--add-provider-side-caching-for-dynamic-provider-deserialization.yaml
+++ b/changelog/pending/20231103--sdk-python--add-provider-side-caching-for-dynamic-provider-deserialization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add provider side caching for dynamic provider deserialization.

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -15,7 +15,7 @@
 import asyncio
 import base64
 from concurrent import futures
-from threading import Event
+from threading import Event, Lock
 import sys
 import time
 
@@ -34,9 +34,25 @@ _MAX_RPC_MESSAGE_SIZE = 1024 * 1024 * 400
 _GRPC_CHANNEL_OPTIONS = [("grpc.max_receive_message_length", _MAX_RPC_MESSAGE_SIZE)]
 
 
+_PROVIDER_CACHE: dict[str, ResourceProvider] = {}
+_PROVIDER_LOCK = Lock()
+
+
 def get_provider(props) -> ResourceProvider:
-    byts = base64.b64decode(props[PROVIDER_KEY])
-    return dill.loads(byts)
+    providerStr = props[PROVIDER_KEY]
+    provider = _PROVIDER_CACHE.get(providerStr)
+    if provider is None:
+        # This is pesimistic locking, because if two different providers try to fetch at the same time they
+        # serialise. But it means we don't create two instances of the same provider. Also looking at issues
+        # like https://github.com/pulumi/pulumi/issues/14159 there may be resource contention in dill.loads,
+        # that this locking strategy will reduce.
+        with _PROVIDER_LOCK:
+            provider = _PROVIDER_CACHE.get(providerStr)
+            if provider is None:
+                byts = base64.b64decode(providerStr)
+                provider = dill.loads(byts)
+                _PROVIDER_CACHE[providerStr] = provider
+    return provider
 
 
 class DynamicResourceProviderServicer(ResourceProviderServicer):


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Provider side fix for https://github.com/pulumi/pulumi/issues/6675, similar to change made to NodeJS in https://github.com/pulumi/pulumi/pull/6657.

This might also help with https://github.com/pulumi/pulumi/issues/14159, as investigation there looks like the issue might be due to memory pressure.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
