### PR TITLE
Fix panic in mapper_encode

### DIFF
--- a/changelog/pending/20231103--pkg--fixes-a-panic-in-property-mapping-logic.yaml
+++ b/changelog/pending/20231103--pkg--fixes-a-panic-in-property-mapping-logic.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Fixes a panic in property mapping logic

--- a/sdk/go/common/util/mapper/mapper_encode.go
+++ b/sdk/go/common/util/mapper/mapper_encode.go
@@ -151,6 +151,9 @@ func (md *mapper) encodeValue(vsrc reflect.Value) (interface{}, MappingError) {
 	case reflect.Struct:
 		return md.encode(vsrc)
 	case reflect.Interface:
+		if vsrc.IsNil() {
+			return nil, nil
+		}
 		return md.encodeValue(vsrc.Elem())
 	default:
 		contract.Failf("Unrecognized field type '%v' during encoding", k)

--- a/sdk/go/common/util/mapper/mapper_test.go
+++ b/sdk/go/common/util/mapper/mapper_test.go
@@ -113,10 +113,6 @@ type bagtag struct {
 	MapOpt        map[string]interface{} `pulumi:"mo,optional"`
 }
 
-type AnInterface interface {
-	isAnInterface()
-}
-
 func TestMapperEncode(t *testing.T) {
 	t.Parallel()
 	bag := bagtag{
@@ -131,6 +127,11 @@ func TestMapperEncode(t *testing.T) {
 	md := &mapper{}
 	var err error
 	var m map[string]interface{}
+
+	// Nils
+	m, err = md.Encode(nil)
+	require.NoError(t, err)
+	assert.Len(t, m, 0)
 
 	// Structs
 	m, err = md.encode(reflect.ValueOf(bag))
@@ -148,11 +149,6 @@ func TestMapperEncode(t *testing.T) {
 	assert.Equal(t, "something", m["s"])
 	assert.Equal(t, "ohmv", m["so"])
 	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, m["mo"])
-
-	// Nil
-	m, err = md.Encode((AnInterface)(nil))
-	require.NoError(t, err)
-	assert.Len(t, m, 0)
 }
 
 func TestMapperEncodeValue(t *testing.T) {
@@ -174,7 +170,7 @@ func TestMapperEncodeValue(t *testing.T) {
 	var err error
 	var v any
 
-	// Nil
+	// Nils
 	v, err = md.EncodeValue(nil)
 	require.NoError(t, err)
 	assert.Nil(t, v)
@@ -223,7 +219,7 @@ func TestMapperEncodeValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, v)
 
-	// Struct
+	// Structs
 	v, err = md.encodeValue(reflect.ValueOf(bag))
 	require.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"s": "something", "so": "ohmv"}, v)

--- a/sdk/go/common/util/mapper/mapper_test.go
+++ b/sdk/go/common/util/mapper/mapper_test.go
@@ -106,10 +106,11 @@ func TestFieldMapper(t *testing.T) {
 }
 
 type bagtag struct {
-	String        string `pulumi:"s"`
-	StringSkip    string `pulumi:"sc,skip"`
-	StringOpt     string `pulumi:"so,optional"`
-	StringSkipOpt string `pulumi:"sco,skip,optional"`
+	String        string                 `pulumi:"s"`
+	StringSkip    string                 `pulumi:"sc,skip"`
+	StringOpt     string                 `pulumi:"so,optional"`
+	StringSkipOpt string                 `pulumi:"sco,skip,optional"`
+	MapOpt        map[string]interface{} `pulumi:"mo,optional"`
 }
 
 type AnInterface interface {
@@ -121,19 +122,119 @@ func TestMapperEncode(t *testing.T) {
 	bag := bagtag{
 		String:    "something",
 		StringOpt: "ohmv",
+		MapOpt: map[string]interface{}{
+			"a": "something",
+			"b": nil,
+		},
 	}
 
-	md := New(nil)
-	m, err := md.Encode(bag)
+	md := &mapper{}
+	var err error
+	var m map[string]interface{}
+
+	// Structs
+	m, err = md.encode(reflect.ValueOf(bag))
 	require.NoError(t, err)
 	assert.Equal(t, "something", m["s"])
 	assert.Equal(t, "ohmv", m["so"])
+	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, m["mo"])
 
-	// Encode a nil interface
+	// Pointers
+	m, err = md.encode(reflect.Zero(reflect.TypeOf(&bag)))
+	require.NoError(t, err)
+	assert.Nil(t, m)
+	m, err = md.encode(reflect.ValueOf(&bag))
+	require.NoError(t, err)
+	assert.Equal(t, "something", m["s"])
+	assert.Equal(t, "ohmv", m["so"])
+	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, m["mo"])
 
+	// Nil
 	m, err = md.Encode((AnInterface)(nil))
 	require.NoError(t, err)
 	assert.Len(t, m, 0)
+}
+
+func TestMapperEncodeValue(t *testing.T) {
+	t.Parallel()
+	strdata := "something"
+	bag := bagtag{
+		String:    "something",
+		StringOpt: "ohmv",
+	}
+	slice := []string{"something"}
+	mapdata := map[string]interface{}{
+		"a": "something",
+		"b": nil,
+	}
+	anyType := reflect.TypeOf((*any)(nil)).Elem()
+	assert.Equal(t, reflect.Interface, anyType.Kind())
+
+	md := &mapper{}
+	var err error
+	var v any
+
+	// Nil
+	v, err = md.EncodeValue(nil)
+	require.NoError(t, err)
+	assert.Nil(t, v)
+
+	// Bools
+	v, err = md.encodeValue(reflect.ValueOf(true))
+	require.NoError(t, err)
+	assert.Equal(t, true, v)
+
+	// Ints
+	v, err = md.encodeValue(reflect.ValueOf(int(1)))
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), v)
+
+	// Uints
+	v, err = md.encodeValue(reflect.ValueOf(uint(1)))
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), v)
+
+	// Floats
+	v, err = md.encodeValue(reflect.ValueOf(float32(1.0)))
+	require.NoError(t, err)
+	assert.Equal(t, float64(1.0), v)
+
+	// Pointers
+	v, err = md.encodeValue(reflect.Zero(reflect.TypeOf(&strdata)))
+	require.NoError(t, err)
+	assert.Nil(t, v)
+	v, err = md.encodeValue(reflect.ValueOf(&strdata))
+	require.NoError(t, err)
+	assert.Equal(t, "something", v)
+
+	// Slices
+	v, err = md.encodeValue(reflect.Zero(reflect.TypeOf(slice)))
+	require.NoError(t, err)
+	assert.Nil(t, v)
+	v, err = md.encodeValue(reflect.ValueOf(slice))
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"something"}, v)
+
+	// Maps
+	v, err = md.encodeValue(reflect.Zero(reflect.TypeOf(mapdata)))
+	require.NoError(t, err)
+	assert.Nil(t, v)
+	v, err = md.encodeValue(reflect.ValueOf(mapdata))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, v)
+
+	// Struct
+	v, err = md.encodeValue(reflect.ValueOf(bag))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"s": "something", "so": "ohmv"}, v)
+
+	// Interfaces
+	v, err = md.encodeValue(reflect.Zero(anyType))
+	require.NoError(t, err)
+	assert.Nil(t, v)
+	v, err = md.encodeValue(reflect.ValueOf("something").Convert(anyType))
+	require.NoError(t, err)
+	assert.Equal(t, "something", v)
 }
 
 func TestMapperDecode(t *testing.T) {
@@ -149,12 +250,17 @@ func TestMapperDecode(t *testing.T) {
 		"sc":  "nothing",
 		"so":  "ohmy",
 		"sco": "ohmynada",
+		"mo": map[string]interface{}{
+			"a": "something",
+			"b": nil,
+		},
 	}, &b1)
 	assert.NoError(t, err)
 	assert.Equal(t, "something", b1.String)
 	assert.Equal(t, "", b1.StringSkip)
 	assert.Equal(t, "ohmy", b1.StringOpt)
 	assert.Equal(t, "", b1.StringSkipOpt)
+	assert.Equal(t, map[string]interface{}{"a": "something", "b": nil}, b1.MapOpt)
 
 	// Now let optional fields go missing.
 	var b2 bagtag

--- a/sdk/go/common/util/mapper/mapper_test.go
+++ b/sdk/go/common/util/mapper/mapper_test.go
@@ -113,6 +113,10 @@ type bagtag struct {
 	MapOpt        map[string]interface{} `pulumi:"mo,optional"`
 }
 
+type AnInterface interface {
+	isAnInterface()
+}
+
 func TestMapperEncode(t *testing.T) {
 	t.Parallel()
 	bag := bagtag{
@@ -130,6 +134,11 @@ func TestMapperEncode(t *testing.T) {
 
 	// Nils
 	m, err = md.Encode(nil)
+	require.NoError(t, err)
+	assert.Len(t, m, 0)
+
+	// Nil (interface)
+	m, err = md.Encode((AnInterface)(nil))
 	require.NoError(t, err)
 	assert.Len(t, m, 0)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Fixes a panic that occurs when attempting to encode certain values, for example a map that contains a nil value:
```go
	bag := bagtag{
		String:    "something",
		StringOpt: "ohmv",
		MapOpt: map[string]interface{}{
			"a": "something",
			"b": nil,   // this reflect.Value is of type Interface and IsNil is true.
		},
	}
        _ = resource.NewPropertyMap(bag) // panic here
```

New tests are provided to cover the above scenario and to cover each type of value, including nil cases where appropriate.

Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/2622
Follow-up to: https://github.com/pulumi/pulumi/pull/9810

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
