### PR TITLE
Fix panic in isZIPTemplateURL

### DIFF
--- a/changelog/pending/20231106--cli-new--fix-panic-parsing-template-url.yaml
+++ b/changelog/pending/20231106--cli-new--fix-panic-parsing-template-url.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix panic parsing template URL.

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -37,7 +37,10 @@ func sanitizeArchivePath(d, t string) (v string, err error) {
 }
 
 func isZIPTemplateURL(templateNamePathOrURL string) bool {
-	parsedURL, _ := url.Parse(templateNamePathOrURL)
+	parsedURL, err := url.Parse(templateNamePathOrURL)
+	if err != nil {
+		return false
+	}
 	return parsedURL.Path != "" && strings.HasSuffix(parsedURL.Path, ".zip")
 }
 

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -104,6 +104,11 @@ func TestIsZipArchiveURL(t *testing.T) {
 			templateURL: "https://github.com/pulumi/templates/archive/master",
 			expected:    false,
 		},
+		{
+			testName:    "git_ssh_url",
+			templateURL: "git@gitlab.com:group/project.git",
+			expected:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14505.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
