### PR TITLE
When calling chooseStack, always set `stackSetCurrent` to true

### DIFF
--- a/changelog/pending/20250305--cli--stack-selections-will-now-always-be-saved-as-if-stack-select-had-been-used.yaml
+++ b/changelog/pending/20250305--cli--stack-selections-will-now-always-be-saved-as-if-stack-select-had-been-used.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Stack selections will now always be saved as if `stack select` had been used

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -181,6 +181,7 @@ func requireCurrentStack(
 func ChooseStack(ctx context.Context, ws pkgWorkspace.Context,
 	b backend.Backend, lopt LoadOption, opts display.Options,
 ) (backend.Stack, error) {
+	lopt ^= SetCurrent
 	// Prepare our error in case we need to issue it.  Bail early if we're not interactive.
 	var chooseStackErr string
 	if lopt.OfferNew() {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This change sets the stackLoadOption in chooseStack to true, whereas 
before it was set to false by default. 
This will cause the chooseStack functionality to set the backend state to remember the stack selected.

Fixes #14490

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
