### PR TITLE
Auto fill in URNs for parents in import files

### DIFF
--- a/changelog/pending/20231113--engine--import-files-no-longer-need-parent-urns-in-the-name-table-for-resource-being-imported-in-the-same-file.yaml
+++ b/changelog/pending/20231113--engine--import-files-no-longer-need-parent-urns-in-the-name-table-for-resource-being-imported-in-the-same-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Import files no longer need parent URNs in the name table for resource being imported in the same file.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -196,11 +196,49 @@ func writeImportFile(v importFile) (string, error) {
 	return path, f.Close()
 }
 
-func parseImportFile(f importFile, protectResources bool) ([]deploy.Import, importer.NameTable, error) {
-	// Build the name table.
-	names := importer.NameTable{}
-	for name, urn := range f.NameTable {
-		names[urn] = name
+func parseImportFile(
+	f importFile, stack tokens.Name, proj tokens.PackageName, protectResources bool,
+) ([]deploy.Import, importer.NameTable, error) {
+	// First check for uniqueness and ambiguity, takenNames tracks both that a name is used (it's in the map) and if
+	// it's ambiguous (it's true).
+	takenNames := map[tokens.QName]bool{}
+	// Prefill takenNames with all the resource names so we can do quick uniqness checks below
+	for _, spec := range f.Resources {
+		takenNames[spec.Name] = false
+	}
+	// A remapping by index from the resource list to it's final unique name.
+	nameMapping := make([]tokens.QName, 0, len(f.Resources))
+	for i, spec := range f.Resources {
+		// Check if any earlier resource has this name, if so mark it as ambiguous
+		for j, other := range f.Resources {
+			if i > j && spec.Name == other.Name {
+				takenNames[spec.Name] = true
+			}
+		}
+
+		if !takenNames[spec.Name] {
+			// This name isn't ambiguous so we can use it as is
+			nameMapping = append(nameMapping, spec.Name)
+		} else {
+			// This names already used so we need to make it unique
+			newName := spec.Name
+			for suffix := 1; ; suffix++ {
+				if _, exists := takenNames[newName]; !exists {
+					break
+				}
+				newName = tokens.QName(fmt.Sprintf("%s_%d", spec.Name, suffix))
+			}
+			// At this point newName is unique and can't clash with other names, but need to ensure nothing
+			// else tries to now use it.
+			takenNames[newName] = false
+			nameMapping = append(nameMapping, newName)
+		}
+	}
+
+	// TODO: When Go 1.21 is released, switch to errors.Join.
+	var errs error
+	pusherrf := func(format string, args ...interface{}) {
+		errs = multierror.Append(errs, fmt.Errorf(format, args...))
 	}
 
 	// Attempts to generate a human-readable description of the given import spec
@@ -231,47 +269,79 @@ func parseImportFile(f importFile, protectResources bool) ([]deploy.Import, impo
 		return sb.String()
 	}
 
-	// TODO: When Go 1.21 is released, switch to errors.Join.
-	var errs error
-	pusherrf := func(format string, args ...interface{}) {
-		errs = multierror.Append(errs, fmt.Errorf(format, args...))
+	// A mapping from name to URN, prefilled with emptys and what was in the name table so we can do existence checks
+	// for expected names.
+	urnMapping := make(map[string]resource.URN)
+	for name, urn := range f.NameTable {
+		urnMapping[name] = urn
+	}
+	for _, spec := range f.Resources {
+		urnMapping[string(spec.Name)] = ""
 	}
 
-	makeUnique, checkAmbiguous := func() (func(int, tokens.QName) tokens.QName, func(tokens.QName) bool) {
-		// Track used resource names.
-		takenNames := map[tokens.QName]struct{}{}
-		// Track indexes that are not unique and need to be made unique.
-		duplicateIndexes := map[int]struct{}{}
-		// Track parent/provider/etc references that are ambiguous when referenced.
-		ambiguousNames := map[tokens.QName]struct{}{}
+	// We need to keep going till all the URNs are filled in or we have an error.
+	done := func() bool {
+		if errs != nil {
+			return true
+		}
+		for _, urn := range urnMapping {
+			if urn == "" {
+				return false
+			}
+		}
+		return true
+	}
+
+	for !done() {
 		for i, spec := range f.Resources {
-			if _, exists := takenNames[spec.Name]; exists {
-				duplicateIndexes[i] = struct{}{}
-				ambiguousNames[spec.Name] = struct{}{}
+			// If we've already done this URN no need to do it again
+			if urnMapping[string(spec.Name)] != "" {
+				continue
 			}
-			// Prepopulate already taken names first to avoid using them in makeUnique.
-			takenNames[spec.Name] = struct{}{}
-		}
-		checkAmbiguous := func(name tokens.QName) bool {
-			_, isAmbiguous := ambiguousNames[name]
-			return isAmbiguous
-		}
-		makeUnique := func(i int, name tokens.QName) tokens.QName {
-			if _, isDuplicate := duplicateIndexes[i]; !isDuplicate {
-				return name
-			}
-			newName := name
-			for suffix := 1; ; suffix++ {
-				if _, exists := takenNames[newName]; !exists {
-					// No conflict.
-					takenNames[newName] = struct{}{}
-					return newName
+
+			var parentType tokens.Type
+			if spec.Parent != "" {
+				// We can find the parent type by looking up the parent by name then finding it's type
+
+				// takenNames will be true if this name is ambiguous, in which case we can't use it as a
+				// parent but we just let the rest of the code below run so we can collect further errors.
+				if takenNames[tokens.QName(spec.Parent)] {
+					pusherrf("%v has an ambiguous parent",
+						describeResource(i, spec))
 				}
-				newName = tokens.QName(fmt.Sprintf("%s_%d", name, suffix))
+
+				// Is this name already in the name table?
+				if urn, ok := f.NameTable[spec.Parent]; ok {
+					parentType = urn.QualifiedType()
+				} else {
+					// Not in the name table, is it in the urn mapping yet?
+					urn, ok := urnMapping[spec.Parent]
+
+					// There's three cases to cover here:
+					// 1. We didn't find the parent, in which case just push an error
+					// 2. We found the parent but it's urn is currently blank, in which case we'll loop around
+					// 3. We found the parent and got it's URN
+					if !ok {
+						pusherrf("the parent '%v' for %v has no entry in 'nameTable'",
+							spec.Parent, describeResource(i, spec))
+					} else if urn == "" {
+						// Skip this resource for now, we'll have to loop again to get it once it's parent URN is worked out
+						continue
+					} else {
+						parentType = urn.QualifiedType()
+					}
+				}
 			}
+
+			actualName := nameMapping[i]
+			urnMapping[string(spec.Name)] = resource.NewURN(stack.Q(), proj, parentType, spec.Type, actualName)
 		}
-		return makeUnique, checkAmbiguous
-	}()
+	}
+
+	// If we've got errors already just exit
+	if errs != nil {
+		return nil, nil, errs
+	}
 
 	imports := make([]deploy.Import, len(f.Resources))
 	for i, spec := range f.Resources {
@@ -292,7 +362,7 @@ func parseImportFile(f importFile, protectResources bool) ([]deploy.Import, impo
 
 		imp := deploy.Import{
 			Type:              spec.Type,
-			Name:              makeUnique(i, spec.Name),
+			Name:              nameMapping[i],
 			ID:                spec.ID,
 			Protect:           protectResources,
 			Properties:        spec.Properties,
@@ -302,21 +372,15 @@ func parseImportFile(f importFile, protectResources bool) ([]deploy.Import, impo
 		}
 
 		if spec.Parent != "" {
-			if checkAmbiguous(tokens.QName(spec.Parent)) {
-				pusherrf("%v has an ambiguous parent",
-					describeResource(i, spec))
-			}
-			urn, ok := f.NameTable[spec.Parent]
-			if !ok {
-				pusherrf("the parent '%v' for %v has no entry in 'nameTable'",
-					spec.Parent, describeResource(i, spec))
-			} else {
+			urn, ok := urnMapping[spec.Parent]
+			if ok {
+				// No need to add errors here, we'll have done that above when building URNs
 				imp.Parent = urn
 			}
 		}
 
 		if spec.Provider != "" {
-			if checkAmbiguous(tokens.QName(spec.Provider)) {
+			if takenNames[tokens.QName(spec.Provider)] {
 				pusherrf("%v has an ambiguous provider",
 					describeResource(i, spec))
 			}
@@ -340,6 +404,12 @@ func parseImportFile(f importFile, protectResources bool) ([]deploy.Import, impo
 		}
 
 		imports[i] = imp
+	}
+
+	// Build the name table.
+	names := importer.NameTable{}
+	for name, urn := range urnMapping {
+		names[urn] = name
 	}
 
 	return imports, names, errs
@@ -669,7 +739,8 @@ func newImportCmd() *cobra.Command {
 				output = f
 			}
 
-			imports, nameTable, err := parseImportFile(importFile, protectResources)
+			// Fetch the project.
+			proj, root, err := readProject()
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -720,8 +791,13 @@ func newImportCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			// Fetch the project.
-			proj, root, err := readProject()
+			// Fetch the current stack.
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts.Display)
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			imports, nameTable, err := parseImportFile(importFile, s.Ref().Name(), proj.Name, protectResources)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -777,12 +853,6 @@ func newImportCmd() *cobra.Command {
 
 					return files, diagnostics, nil
 				}
-			}
-
-			// Fetch the current stack.
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts.Display)
-			if err != nil {
-				return result.FromError(err)
 			}
 
 			m, err := getUpdateMetadata(message, root, execKind, execAgent, false, cmd.Flags())


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This allows you to use the parent feature in an import file for another resource in the same deployment without having to fill in what the URN for that parent resource is in the name table.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
