### PR TITLE
[sdk/python] Maintain old behavior for empty k8s invoke results

### DIFF
--- a/changelog/pending/20231111--sdk-python--maintain-old-behavior-for-empty-kubernetes-invoke-results.yaml
+++ b/changelog/pending/20231111--sdk-python--maintain-old-behavior-for-empty-kubernetes-invoke-results.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Maintain old behavior for empty Kubernetes invoke results

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -120,6 +120,18 @@ def invoke(
 
         # Otherwise, return the output properties.
         ret_obj = getattr(resp, "return")
+
+        # To avoid breaking older versions of the Kubernetes Python SDK, if the result of
+        # the invoke is not truthy (e.g. it's an empty struct), and the token is one of the
+        # known kubernetes invoke tokens, return None instead of an empty dict.
+        # See https://github.com/pulumi/pulumi/issues/14508.
+        if not ret_obj and tok in {
+            "kubernetes:yaml:decode",
+            "kubernetes:helm:template",
+            "kubernetes:kustomize:directory",
+        }:
+            return None, None
+
         deserialized = rpc.deserialize_properties(ret_obj)
         # If typ is not None, call translate_output_properties to instantiate any output types.
         return (

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -17,6 +17,9 @@ import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import grpc
+from google.protobuf import struct_pb2
+
+from semver import VersionInfo
 
 from .. import _types, log
 from ..invoke import InvokeOptions
@@ -32,6 +35,40 @@ from .sync_await import _sync_await
 
 if TYPE_CHECKING:
     from .. import Inputs, Output, Resource
+
+
+def _requires_legacy_none_return_for_empty_struct(
+    ret_obj: struct_pb2.Struct, tok: str, version: str
+) -> bool:
+    """
+    To avoid breaking older versions of the Kubernetes Python SDK, we maintain the legacy behavior of
+    returning None instead of an empty dict for empty results if the invoke is for a version of the
+    Pulumi Kubernetes SDK that can't handle empty dicts.
+    See https://github.com/pulumi/pulumi/issues/14508.
+    """
+
+    # If re_obj is truthy or the token is not one of the known Kubernetes tokens, we don't need the legacy
+    # behavior.
+    if ret_obj or tok not in {
+        "kubernetes:yaml:decode",
+        "kubernetes:helm:template",
+        "kubernetes:kustomize:directory",
+    }:
+        return False
+
+    # If we have a version and it's less than or equal to pulumi-kubernetes 4.5.4, we need the legacy behavior;
+    # otherwise, we don't because later versions can handle the new behavior correctly.
+    if version:
+        k8s_ver = VersionInfo(4, 5, 4)
+        try:
+            ver = VersionInfo.parse(version)
+        except Exception as ex:
+            log.debug(f"Failed to parse version {version} as semver: {ex}")
+            ver = k8s_ver
+        return ver <= k8s_ver
+
+    # We don't have a version, default to the legacy behavior.
+    return True
 
 
 class InvokeResult:
@@ -121,15 +158,11 @@ def invoke(
         # Otherwise, return the output properties.
         ret_obj = getattr(resp, "return")
 
-        # To avoid breaking older versions of the Kubernetes Python SDK, if the result of
-        # the invoke is not truthy (e.g. it's an empty struct), and the token is one of the
-        # known kubernetes invoke tokens, return None instead of an empty dict.
-        # See https://github.com/pulumi/pulumi/issues/14508.
-        if not ret_obj and tok in {
-            "kubernetes:yaml:decode",
-            "kubernetes:helm:template",
-            "kubernetes:kustomize:directory",
-        }:
+        # To avoid breaking older versions of the Kubernetes Python SDK, return None instead
+        # of an empty dict for empty results if this invoke is for a version of the Pulumi
+        # Kubernetes SDK that can't handle empty dicts.
+        if _requires_legacy_none_return_for_empty_struct(ret_obj, tok, version):
+            log.debug(f"Returning None for empty result for invoke of {tok}")
             return None, None
 
         deserialized = rpc.deserialize_properties(ret_obj)

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import pulumi
 
 
@@ -20,42 +22,72 @@ class MyMocks(pulumi.runtime.Mocks):
         return [args.name + '_id', args.inputs]
 
     def call(self, args: pulumi.runtime.MockCallArgs):
-        assert args.token == "test:index:MyFunction"
-        return {}
+        return {} if args.args.get("empty") else {"result": "mock"}
 
 
+@pytest.mark.parametrize("tok,version,empty,expected", [
+    ("test:index:MyFunction", "", True, {}),
+    ("test:index:MyFunction", "invalid", True, {}),
+    ("test:index:MyFunction", "1.0.0", True, {}),
+    ("test:index:MyFunction", "", False, {"result": "mock"}),
+    ("test:index:MyFunction", "invalid", False, {"result": "mock"}),
+    ("test:index:MyFunction", "1.0.0", False, {"result": "mock"}),
+
+    ("kubernetes:something:new", "", True, {}),
+    ("kubernetes:something:new", "invalid", True, {}),
+    ("kubernetes:something:new", "1.0.0", True, {}),
+    ("kubernetes:something:new", "4.5.3", True, {}),
+    ("kubernetes:something:new", "4.5.4", True, {}),
+    ("kubernetes:something:new", "4.5.5", True, {}),
+    ("kubernetes:something:new", "4.6.0", True, {}),
+    ("kubernetes:something:new", "5.0.0", True, {}),
+    ("kubernetes:something:new", "", False, {"result": "mock"}),
+    ("kubernetes:something:new", "invalid", False, {"result": "mock"}),
+    ("kubernetes:something:new", "1.0.0", False, {"result": "mock"}),
+
+    # Expect the legacy behavior of getting None for empty results for these Kubernetes
+    # function tokens when the version is unspecified, invalid, or <= 4.5.4.
+
+    ("kubernetes:yaml:decode", "", True, None),
+    ("kubernetes:yaml:decode", "invalid", True, None),
+    ("kubernetes:yaml:decode", "1.0.0", True, None),
+    ("kubernetes:yaml:decode", "4.5.3", True, None),
+    ("kubernetes:yaml:decode", "4.5.4", True, None),
+    ("kubernetes:yaml:decode", "4.5.5", True, {}),
+    ("kubernetes:yaml:decode", "4.6.0", True, {}),
+    ("kubernetes:yaml:decode", "5.0.0", True, {}),
+    ("kubernetes:yaml:decode", "", False, {"result": "mock"}),
+    ("kubernetes:yaml:decode", "invalid", False, {"result": "mock"}),
+    ("kubernetes:yaml:decode", "1.0.0", False, {"result": "mock"}),
+
+    ("kubernetes:helm:template", "", True, None),
+    ("kubernetes:helm:template", "invalid", True, None),
+    ("kubernetes:helm:template", "1.0.0", True, None),
+    ("kubernetes:helm:template", "4.5.3", True, None),
+    ("kubernetes:helm:template", "4.5.4", True, None),
+    ("kubernetes:helm:template", "4.5.5", True, {}),
+    ("kubernetes:helm:template", "4.6.0", True, {}),
+    ("kubernetes:helm:template", "5.0.0", True, {}),
+    ("kubernetes:helm:template", "", False, {"result": "mock"}),
+    ("kubernetes:helm:template", "invalid", False, {"result": "mock"}),
+    ("kubernetes:helm:template", "1.0.0", False, {"result": "mock"}),
+
+    ("kubernetes:kustomize:directory", "", True, None),
+    ("kubernetes:kustomize:directory", "invalid", True, None),
+    ("kubernetes:kustomize:directory", "1.0.0", True, None),
+    ("kubernetes:kustomize:directory", "4.5.3", True, None),
+    ("kubernetes:kustomize:directory", "4.5.4", True, None),
+    ("kubernetes:kustomize:directory", "4.5.5", True, {}),
+    ("kubernetes:kustomize:directory", "4.6.0", True, {}),
+    ("kubernetes:kustomize:directory", "5.0.0", True, {}),
+    ("kubernetes:kustomize:directory", "", False, {"result": "mock"}),
+    ("kubernetes:kustomize:directory", "invalid", False, {"result": "mock"}),
+    ("kubernetes:kustomize:directory", "1.0.0", False, {"result": "mock"}),
+])
 @pulumi.runtime.test
-def test_invoke_empty_return() -> None:
+def test_invoke_empty_return(tok: str, version: str, empty: bool, expected) -> None:
     pulumi.runtime.mocks.set_mocks(MyMocks())
 
-    ret = pulumi.runtime.invoke("test:index:MyFunction", {})
-    assert ret.value == {}, "Expected the return value of the invoke to be an empty dict"
-
-
-class MyKubernetesMocks(pulumi.runtime.Mocks):
-    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
-        return [args.name + '_id', args.inputs]
-
-    def call(self, args: pulumi.runtime.MockCallArgs):
-        assert args.token in {
-            "kubernetes:yaml:decode",
-            "kubernetes:helm:template",
-            "kubernetes:kustomize:directory",
-        }
-        return {"result": "mock"} if args.args.get("nonempty") else {}
-
-
-# Regression test for https://github.com/pulumi/pulumi/issues/14508.
-@pulumi.runtime.test
-def test_invoke_kubernetes() -> None:
-    pulumi.runtime.mocks.set_mocks(MyKubernetesMocks())
-
-    # Invokes to these specific Kubernetes functions return None rather than an empty dict for empty results.
-    assert pulumi.runtime.invoke("kubernetes:yaml:decode", {}).value is None
-    assert pulumi.runtime.invoke("kubernetes:helm:template", {}).value is None
-    assert pulumi.runtime.invoke("kubernetes:kustomize:directory", {}).value is None
-
-    # Non-empty results are returned as-is.
-    assert pulumi.runtime.invoke("kubernetes:yaml:decode", {"nonempty": True}).value == {"result": "mock"}
-    assert pulumi.runtime.invoke("kubernetes:helm:template", {"nonempty": True}).value == {"result": "mock"}
-    assert pulumi.runtime.invoke("kubernetes:kustomize:directory", {"nonempty": True}).value == {"result": "mock"}
+    props = {"empty": True} if empty else {}
+    opts = pulumi.InvokeOptions(version=version) if version else None
+    assert pulumi.runtime.invoke(tok, props, opts).value == expected


### PR DESCRIPTION
The hand-rolled invoke code in the Kubernetes Python SDK is not expecting empty dicts for empty results. Instead, it has code that checks for `None`.

In general, we want to keep the behavior of returning empty dicts rather than `None` for empty results, as this aligns with the behavior of other SDKs (Node.js and Go) and is actually the original behavior of the Python SDK (it regressed unintentionally in the v2 timeframe).

We're updating the Kubernetes Python SDK to be resilient to either getting an empty dict or `None` for invokes with empty results.

Additionally, to maintain compat with older versions of the Kubernetes Python SDK, we'll special case those invoke tokens. When an invoke's result is empty and the token is one of the Kubernete's function tokens, we'll return `None` rather than the empty dict.

Fixes #14508