### PR TITLE
Replace PropertyValue type casts with method calls

### DIFF
--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -76,11 +76,11 @@ func TestGetStackResourceOutputs(t *testing.T) {
 	assert.True(t, exists)
 	assert.True(t, resc1Actual.IsObject())
 
-	resc1Type, exists := resc1Actual.V.(resource.PropertyMap)["type"]
+	resc1Type, exists := resc1Actual.ObjectValue()["type"]
 	assert.True(t, exists)
 	assert.Equal(t, typ, resc1Type.V)
 
-	resc1Outs, exists := resc1Actual.V.(resource.PropertyMap)["outputs"]
+	resc1Outs, exists := resc1Actual.ObjectValue()["outputs"]
 	assert.True(t, exists)
 	assert.True(t, resc1Outs.IsObject())
 
@@ -89,11 +89,11 @@ func TestGetStackResourceOutputs(t *testing.T) {
 	assert.True(t, exists)
 	assert.True(t, resc2Actual.IsObject())
 
-	resc2Type, exists := resc2Actual.V.(resource.PropertyMap)["type"]
+	resc2Type, exists := resc2Actual.ObjectValue()["type"]
 	assert.True(t, exists)
 	assert.Equal(t, typ, resc2Type.V) // Same type.
 
-	resc2Outs, exists := resc2Actual.V.(resource.PropertyMap)["outputs"]
+	resc2Outs, exists := resc2Actual.ObjectValue()["outputs"]
 	assert.True(t, exists)
 	assert.True(t, resc2Outs.IsObject())
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
@@ -16,6 +16,7 @@ package codegentest
 
 import (
 	"fmt"
+	"output-funcs-tfbridge20/mypkg"
 	"strings"
 	"testing"
 	"time"
@@ -24,8 +25,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"output-funcs-tfbridge20/mypkg"
 )
 
 type mocks int
@@ -42,12 +41,12 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 		for k, v := range args.Args {
 			switch k {
 			case "accountName":
-				targs.AccountName = v.V.(string)
+				targs.AccountName = v.StringValue()
 			case "expand":
-				expand := v.V.(string)
+				expand := v.StringValue()
 				targs.Expand = &expand
 			case "resourceGroupName":
-				targs.ResourceGroupName = v.V.(string)
+				targs.ResourceGroupName = v.StringValue()
 			}
 		}
 
@@ -82,25 +81,25 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 		for k, v := range args.Args {
 			switch k {
 			case "owners":
-				x := v.V.([]resource.PropertyValue)
+				x := v.ArrayValue()
 				for _, owner := range x {
-					targs.Owners = append(targs.Owners, owner.V.(string))
+					targs.Owners = append(targs.Owners, owner.StringValue())
 				}
 			case "nameRegex":
-				x := v.V.(string)
+				x := v.StringValue()
 				targs.NameRegex = &x
 			case "sortAscending":
-				x := v.V.(bool)
+				x := v.BoolValue()
 				targs.SortAscending = &x
 			case "filters":
-				filters := v.V.([]resource.PropertyValue)
+				filters := v.ArrayValue()
 				for _, filter := range filters {
-					propMap := filter.V.(resource.PropertyMap)
-					name := propMap["name"].V.(string)
-					values := propMap["values"].V.([]resource.PropertyValue)
+					propMap := filter.ObjectValue()
+					name := propMap["name"].StringValue()
+					values := propMap["values"].ArrayValue()
 					var theValues []string
 					for _, v := range values {
-						theValues = append(theValues, v.V.(string))
+						theValues = append(theValues, v.StringValue())
 					}
 					targs.Filters = append(targs.Filters, mypkg.GetAmiIdsFilter{
 						Name:   name,
@@ -173,7 +172,6 @@ func TestListStorageAccountKeysOutput(t *testing.T) {
 }
 
 func TestGetAmiIdsWorks(t *testing.T) {
-
 	makeFilter := func(n int) mypkg.GetAmiIdsFilterInput {
 		return &mypkg.GetAmiIdsFilterArgs{
 			Name: pulumi.String(fmt.Sprintf("filter-%d-name", n)),

--- a/pkg/codegen/testing/test/testdata/output-funcs/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go-extras/tests/codegen_test.go
@@ -16,6 +16,7 @@ package codegentest
 
 import (
 	"fmt"
+	"output-funcs/mypkg"
 	"testing"
 	"time"
 
@@ -23,8 +24,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"output-funcs/mypkg"
 )
 
 type mocks int
@@ -41,12 +40,12 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 		for k, v := range args.Args {
 			switch k {
 			case "accountName":
-				targs.AccountName = v.V.(string)
+				targs.AccountName = v.StringValue()
 			case "expand":
-				expand := v.V.(string)
+				expand := v.StringValue()
 				targs.Expand = &expand
 			case "resourceGroupName":
-				targs.ResourceGroupName = v.V.(string)
+				targs.ResourceGroupName = v.StringValue()
 			}
 		}
 
@@ -90,14 +89,14 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 		for k, v := range args.Args {
 			switch k {
 			case "factoryName":
-				targs.FactoryName = v.V.(string)
+				targs.FactoryName = v.StringValue()
 			case "integrationRuntimeName":
-				targs.IntegrationRuntimeName = v.V.(string)
+				targs.IntegrationRuntimeName = v.StringValue()
 			case "metadataPath":
-				metadataPath := v.V.(string)
+				metadataPath := v.StringValue()
 				targs.MetadataPath = &metadataPath
 			case "resourceGroupName":
-				targs.ResourceGroupName = v.V.(string)
+				targs.ResourceGroupName = v.StringValue()
 			}
 		}
 		nextLink := "my-next-link"

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
@@ -16,6 +16,7 @@ package codegentest
 
 import (
 	"fmt"
+	"plain-object-defaults/example"
 	"testing"
 	"time"
 
@@ -23,8 +24,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"plain-object-defaults/example"
 )
 
 type mocks int
@@ -32,8 +31,8 @@ type mocks int
 // We assert that default values were passed to our constuctor
 func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	checkFloat64 := func(v resource.PropertyValue, k string, expected float64) {
-		m := v.V.(resource.PropertyMap)
-		if m[resource.PropertyKey(k)].V.(float64) != expected {
+		m := v.ObjectValue()
+		if m[resource.PropertyKey(k)].NumberValue() != expected {
 			panic(fmt.Sprintf("Expected %s to have value %.2f", k, expected))
 		}
 	}

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -145,20 +145,20 @@ func renderFunctionCall(t *testing.T, x *model.FunctionCallExpression) resource.
 		if !assert.Len(t, x.Args, 1) {
 			return resource.NewNullProperty()
 		}
-		path, ok := renderExpr(t, x.Args[0]).V.(string)
-		if !assert.True(t, ok) {
+		expr := renderExpr(t, x.Args[0])
+		if !assert.True(t, expr.IsString()) {
 			return resource.NewNullProperty()
 		}
-		return resource.NewStringProperty(path)
+		return resource.NewStringProperty(expr.StringValue())
 	case "fileAsset":
 		if !assert.Len(t, x.Args, 1) {
 			return resource.NewNullProperty()
 		}
-		path, ok := renderExpr(t, x.Args[0]).V.(string)
-		if !assert.True(t, ok) {
+		expr := renderExpr(t, x.Args[0])
+		if !assert.True(t, expr.IsString()) {
 			return resource.NewNullProperty()
 		}
-		return resource.NewStringProperty(path)
+		return resource.NewStringProperty(expr.StringValue())
 	case "secret":
 		if !assert.Len(t, x.Args, 1) {
 			return resource.NewNullProperty()


### PR DESCRIPTION
Prompted by https://github.com/pulumi/pulumi/pull/14534, replace all the cases of `V.(typeCast)` with the accessor methods instead.