### PR TITLE
Use secret manager from latest deployment snapshot in `preview`s

### DIFF
--- a/changelog/pending/20231113--cli--support-using-secret-manager-from-latest-deployment-snapshot-in-preview-up.yaml
+++ b/changelog/pending/20231113--cli--support-using-secret-manager-from-latest-deployment-snapshot-in-preview-up.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Support using secret manager from latest deployment snapshot in preview/up

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
-	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -190,24 +189,13 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
-			if err != nil {
-				return result.FromError(err)
-			}
-
-			// Use the current snapshot secrets manager, if there is one, as the fallback secrets manager.
-			var defaultSecretsManager secrets.Manager
-			if snap != nil {
-				defaultSecretsManager = snap.SecretsManager
-			}
-
 			getConfig := getStackConfiguration
 			if stackName != "" {
 				// `pulumi destroy --stack <stack>` can be run outside of the project directory.
 				// The config may be missing, fallback on the latest configuration in the backend.
 				getConfig = getStackConfigurationOrLatest
 			}
-			cfg, sm, err := getConfig(ctx, s, proj, defaultSecretsManager)
+			cfg, sm, err := getConfig(ctx, s, proj, nil)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -937,7 +937,7 @@ func promptForConfig(
 		return nil, fmt.Errorf("loading stack config: %w", err)
 	}
 
-	sm, needsSave, err := getStackSecretsManager(stack, ps)
+	sm, needsSave, err := getStackSecretsManager(ctx, stack, ps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -108,7 +108,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 	// Build decrypter based on the existing secrets provider
 	var decrypter config.Decrypter
 	if currentProjectStack.Config.HasSecureValue() {
-		dec, needsSave, decerr := getStackDecrypter(currentStack, currentProjectStack)
+		dec, needsSave, decerr := getStackDecrypter(ctx, currentStack, currentProjectStack)
 		if decerr != nil {
 			return decerr
 		}
@@ -147,7 +147,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(ctx context.Context,
 	}
 
 	// Get the newly created secrets manager for the stack
-	newSecretsManager, needsSave, err := getStackSecretsManager(currentStack, reloadedProjectStack)
+	newSecretsManager, needsSave, err := getStackSecretsManager(ctx, currentStack, reloadedProjectStack)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -60,7 +60,7 @@ This command displays data about previous updates for a stack.`,
 				if err != nil {
 					return fmt.Errorf("getting stack config: %w", err)
 				}
-				crypter, needsSave, err := getStackDecrypter(s, ps)
+				crypter, needsSave, err := getStackDecrypter(ctx, s, ps)
 				if err != nil {
 					return fmt.Errorf("decrypting secrets: %w", err)
 				}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.94.2
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.57.1
+	gopkg.in/yaml.v2 v2.4.0
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600
 )
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -776,7 +776,7 @@ func TestCloudSecretProvider(t *testing.T) {
 	}
 
 	gcpKmsKey := os.Getenv("PULUMI_TEST_GCP_KEY")
-	if azureKeyVault == "" {
+	if gcpKmsKey == "" {
 		t.Skipf("Skipping: PULUMI_TEST_GCP_KEY is not set")
 	}
 


### PR DESCRIPTION
If `preview`/`up` is running on a stack that does not have a `Pulumi.stack-name.yaml` with a configured secret provider, it should use the secret provider available in the last deployment snapshot.

This is useful in cases where `Pulumi.stack-name.yaml` are not committed to source control or when the provider is not specified in them.

Before this commit it will default to the Pulumi Cloud managed secret provider.

`getStackSecretsManager()` was fixed to now return the secret manager from the state if it exists.

In addition:
* Now `pulumi config refresh` will not fail if there are no previous deployments.
* `pulumi stack init --secrets-provider` will now save the secrets provider immediately to the state.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes  https://github.com/pulumi/pulumi/issues/14537

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
