### PR TITLE
Simplifies URL parsing for pulumi new <zip>

### DIFF
--- a/changelog/pending/20231113--cli-new--simplifies-url-parsing-for-pulumi-new-zip.yaml
+++ b/changelog/pending/20231113--cli-new--simplifies-url-parsing-for-pulumi-new-zip.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Simplifies URL parsing for pulumi new zip

--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -52,7 +52,7 @@ func retrieveZIPTemplates(templateURL string) (TemplateRepository, error) {
 		return TemplateRepository{}, err
 	}
 
-	parsedURL, err := url.Parse(strings.ReplaceAll(templateURL, ".zip", ""))
+	parsedURL, err := url.Parse(templateURL)
 	if err != nil {
 		return TemplateRepository{}, err
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently, we add a bit of "cleverness" to our URL parsing, by removing `.zip` suffixes when we've determined one exists (and started down the path of pulumi new-ing a zip ref). That requires upstream API providers to host their zipfiles at a location _without_ that suffix, which precludes any existing .zip files hosted at places like github etc which may have that extension. 

This PR removes that logic so we serve as a simple passthrough for whichever URL we're passed (extending the existing contract).  It also depends on https://github.com/pulumi/pulumi.ai/pull/414 being merged and deployed.

Fixes https://github.com/pulumi/pulumi.ai/issues/415

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
