### PR TITLE
Add --import-file to pulumi preview

### DIFF
--- a/changelog/pending/20231116--cli--add-import-file-to-pulumi-preview-to-generate-a-placeholder-import-file-for-every-resource-that-needs-to-create.yaml
+++ b/changelog/pending/20231116--cli--add-import-file-to-pulumi-preview-to-generate-a-placeholder-import-file-for-every-resource-that-needs-to-create.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--import-file` to `pulumi preview` to generate a placeholder import file for every resource that needs to Create.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -179,7 +179,9 @@ type Backend interface {
 	RenameStack(ctx context.Context, stack Stack, newName tokens.QName) (StackReference, error)
 
 	// Preview shows what would be updated given the current workspace's contents.
-	Preview(ctx context.Context, stack Stack, op UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
+	Preview(
+		ctx context.Context, stack Stack, op UpdateOperation, events chan<- engine.Event,
+	) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
 	// Update updates the target stack with the current workspace's contents (config and code).
 	Update(ctx context.Context, stack Stack, op UpdateOperation) (sdkDisplay.ResourceChanges, result.Result)
 	// Import imports resources into a stack.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -883,14 +883,14 @@ func (b *localBackend) PackPolicies(
 }
 
 func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation,
+	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
 	// We can skip PreviewThenPromptThenExecute and just go straight to Execute.
 	opts := backend.ApplierOptions{
 		DryRun:   true,
 		ShowLink: true,
 	}
-	return b.apply(ctx, apitype.PreviewUpdate, stack, op, opts, nil /*events*/)
+	return b.apply(ctx, apitype.PreviewUpdate, stack, op, opts, events)
 }
 
 func (b *localBackend) Update(ctx context.Context, stack backend.Stack,

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -80,9 +81,9 @@ func (s *localStack) Rename(ctx context.Context, newName tokens.QName) (backend.
 
 func (s *localStack) Preview(
 	ctx context.Context,
-	op backend.UpdateOperation,
+	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, display.ResourceChanges, result.Result) {
-	return backend.PreviewStack(ctx, s, op)
+	return backend.PreviewStack(ctx, s, op, events)
 }
 
 func (s *localStack) Update(ctx context.Context, op backend.UpdateOperation) (display.ResourceChanges, result.Result) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1014,7 +1014,7 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stack backend.Stack,
 }
 
 func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation,
+	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
 	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.
 	opts := backend.ApplierOptions{
@@ -1022,7 +1022,7 @@ func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 		ShowLink: true,
 	}
 	return b.apply(
-		ctx, apitype.PreviewUpdate, stack, op, opts, nil /*events*/)
+		ctx, apitype.PreviewUpdate, stack, op, opts, events)
 }
 
 func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -161,8 +162,9 @@ func (s *cloudStack) Rename(ctx context.Context, newName tokens.QName) (backend.
 func (s *cloudStack) Preview(
 	ctx context.Context,
 	op backend.UpdateOperation,
+	events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
-	return backend.PreviewStack(ctx, s, op)
+	return backend.PreviewStack(ctx, s, op, events)
 }
 
 func (s *cloudStack) Update(ctx context.Context, op backend.UpdateOperation) (sdkDisplay.ResourceChanges,

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/esc"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -240,7 +241,7 @@ func (be *MockBackend) GetStackCrypter(stackRef StackReference) (config.Crypter,
 }
 
 func (be *MockBackend) Preview(ctx context.Context, stack Stack,
-	op UpdateOperation,
+	op UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
 	if be.PreviewF != nil {
 		return be.PreviewF(ctx, stack, op)
@@ -507,7 +508,7 @@ func (ms *MockStack) Backend() Backend {
 
 func (ms *MockStack) Preview(
 	ctx context.Context,
-	op UpdateOperation,
+	op UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
 	if ms.PreviewF != nil {
 		return ms.PreviewF(ctx, op)

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -42,7 +43,9 @@ type Stack interface {
 	// the stack's existing tags.
 	Tags() map[apitype.StackTagName]string
 	// Preview changes to this stack.
-	Preview(ctx context.Context, op UpdateOperation) (*deploy.Plan, display.ResourceChanges, result.Result)
+	Preview(
+		ctx context.Context, op UpdateOperation, events chan<- engine.Event,
+	) (*deploy.Plan, display.ResourceChanges, result.Result)
 	// Update this stack.
 	Update(ctx context.Context, op UpdateOperation) (display.ResourceChanges, result.Result)
 	// Import resources into this stack.
@@ -85,8 +88,9 @@ func PreviewStack(
 	ctx context.Context,
 	s Stack,
 	op UpdateOperation,
+	events chan<- engine.Event,
 ) (*deploy.Plan, display.ResourceChanges, result.Result) {
-	return s.Backend().Preview(ctx, s, op)
+	return s.Backend().Preview(ctx, s, op, events)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -25,14 +26,144 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+// buildImportFile takes an event stream from the engine and builds an import file from it for every create.
+func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
+	return promise.Run(func() (importFile, error) {
+		// A mapping of every URN we see to it's name, used to build later resourceSpecs
+		fullNameTable := map[resource.URN]string{}
+		// A set of all URNs we've added to the import list, used to avoid adding parents to NameTable.
+		importSet := map[resource.URN]struct{}{}
+		// All providers that we've seen so far, used to build Version and PluginDownloadURL.
+		providerInputs := map[resource.URN]resource.PropertyMap{}
+
+		imports := importFile{
+			NameTable: map[string]resource.URN{},
+		}
+
+		// This is a pretty trivial mapping of Create operations to import declarations.
+		for e := range events {
+			preEvent, ok := e.Payload().(engine.ResourcePreEventPayload)
+			if !ok {
+				continue
+			}
+
+			urn := preEvent.Metadata.URN
+			fullNameTable[urn] = urn.Name()
+
+			// If this is a provider we need to note we've seen it so we can build the Version and PluginDownloadURL of
+			// any resources that use it.
+			if providers.IsProviderType(urn.Type()) {
+				providerInputs[urn] = preEvent.Metadata.Res.Inputs
+			}
+
+			// Only interested in creates
+			if preEvent.Metadata.Op != deploy.OpCreate {
+				continue
+			}
+			// No need to import the root stack even if it needs creating
+			if preEvent.Metadata.Type == resource.RootStackType {
+				continue
+			}
+
+			// We're importing this URN so track that we've seen it.
+			importSet[urn] = struct{}{}
+
+			// We can't actually import providers yet, just skip them. We'll only error if anything
+			// actually tries to use it.
+			if providers.IsProviderType(urn.Type()) {
+				continue
+			}
+
+			new := preEvent.Metadata.New
+			contract.Assertf(new != nil, "%s: expected new resource for a create to be non-nil", urn)
+
+			var parent string
+			if new.Parent != "" {
+				// If the parent is just the root stack then skip it as we don't need to import that.
+				if new.Parent.Type() != resource.RootStackType {
+					var has bool
+					parent, has = fullNameTable[new.Parent]
+					contract.Assertf(has, "expected parent %q to be in full name table", new.Parent)
+					// Don't add to the import NameTable if we're importing this in the same deployment.
+					if _, has := importSet[new.Parent]; !has {
+						imports.NameTable[parent] = new.Parent
+					}
+				}
+			}
+
+			var provider, version, pluginDownloadURL string
+			if new.Provider != "" {
+				ref, err := providers.ParseReference(new.Provider)
+				if err != nil {
+					return importFile{}, fmt.Errorf("could not parse provider reference: %v", err)
+				}
+
+				// If we're trying to create this provider in the same deployment and it's not a default provider then
+				// we need to error, the import system can't yet "import" providers.
+				if !providers.IsDefaultProvider(ref.URN()) {
+					if _, has := importSet[ref.URN()]; has {
+						return importFile{}, fmt.Errorf("cannot import resource %q with a new explicit provider %q", new.URN, ref.URN())
+					}
+
+					var has bool
+					provider, has = fullNameTable[ref.URN()]
+					contract.Assertf(has, "expected provider %q to be in full name table", new.Provider)
+
+					imports.NameTable[provider] = ref.URN()
+				}
+
+				inputs, has := providerInputs[ref.URN()]
+				contract.Assertf(has, "expected provider %q to be in provider inputs table", ref)
+
+				v, err := providers.GetProviderVersion(inputs)
+				if err != nil {
+					return importFile{}, fmt.Errorf("could not get provider version for %s: %v", ref, err)
+				}
+				if v != nil {
+					version = v.String()
+				}
+
+				pluginDownloadURL, err = providers.GetProviderDownloadURL(inputs)
+				if err != nil {
+					return importFile{}, fmt.Errorf("could not get provider download url for %s: %v", ref, err)
+				}
+			}
+
+			var id resource.ID
+			// id only needs filling in for custom resources, set it to a placeholder so the user can easily
+			// search for that.
+			if new.Custom {
+				id = "<PLACEHOLDER>"
+			}
+
+			imports.Resources = append(imports.Resources, importSpec{
+				Type:              new.Type,
+				Name:              urn.Name(),
+				ID:                id,
+				Parent:            parent,
+				Provider:          provider,
+				Component:         !new.Custom,
+				Remote:            !new.Custom && new.Provider != "",
+				Version:           version,
+				PluginDownloadURL: pluginDownloadURL,
+			})
+		}
+
+		return imports, nil
+	})
+}
 
 func newPreviewCmd() *cobra.Command {
 	var debug bool
@@ -45,6 +176,7 @@ func newPreviewCmd() *cobra.Command {
 	var configPath bool
 	var client string
 	var planFilePath string
+	var importFilePath string
 	var showSecrets bool
 
 	// Flags for remote operations.
@@ -236,6 +368,15 @@ func newPreviewCmd() *cobra.Command {
 				Display: displayOpts,
 			}
 
+			// If we're building an import file we want to hook the event stream from the engine to transform
+			// create operations into import specs.
+			var importFilePromise *promise.Promise[importFile]
+			var events chan engine.Event
+			if importFilePath != "" {
+				events = make(chan engine.Event)
+				importFilePromise = buildImportFile(events)
+			}
+
 			plan, changes, res := s.Preview(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
@@ -245,7 +386,13 @@ func newPreviewCmd() *cobra.Command {
 				SecretsManager:     sm,
 				SecretsProvider:    stack.DefaultSecretsProvider,
 				Scopes:             backend.CancellationScopes,
-			})
+			}, events)
+			// If we made an events channel then we need to close it to trigger the exit of the import goroutine above.
+			// The engine doesn't close the channel for us, but once its returned here we know it won't append any more
+			// events.
+			if events != nil {
+				close(events)
+			}
 
 			switch {
 			case res != nil:
@@ -271,6 +418,22 @@ func newPreviewCmd() *cobra.Command {
 							"\nRun `pulumi up --plan='%s'` to constrain the update to the operations planned by this preview",
 							planFilePath)
 						cmdutil.Diag().Infof(diag.RawMessage("" /*urn*/, buf.String()))
+					}
+				}
+				if importFilePromise != nil {
+					importFile, err := importFilePromise.Result(ctx)
+					if err != nil {
+						return result.FromError(err)
+					}
+
+					f, err := os.Create(importFilePath)
+					if err != nil {
+						return result.FromError(err)
+					}
+					err = writeImportFile(importFile, f)
+					err = errors.Join(err, f.Close())
+					if err != nil {
+						return result.FromError(err)
 					}
 				}
 				return nil
@@ -302,6 +465,10 @@ func newPreviewCmd() *cobra.Command {
 	if !hasExperimentalCommands() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"), `Could not mark "save-plan" as hidden`)
 	}
+	cmd.PersistentFlags().StringVar(
+		&importFilePath, "import-file", "",
+		"Save any creates seen during the preview into an import file to use with `pulumi import`")
+
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false, "Emit secrets in plaintext in the plan file. Defaults to `false`")
 

--- a/pkg/cmd/pulumi/preview_test.go
+++ b/pkg/cmd/pulumi/preview_test.go
@@ -1,0 +1,390 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRootStackMetadata(op display.StepOp) engine.StepEventMetadata {
+	return engine.StepEventMetadata{
+		Op:   op,
+		URN:  resource.DefaultRootStackURN("stack", "project"),
+		Type: resource.RootStackType,
+		New: &engine.StepEventStateMetadata{
+			URN:  resource.DefaultRootStackURN("stack", "project"),
+			Type: resource.RootStackType,
+		},
+	}
+}
+
+type stateOptions struct {
+	Parent   resource.URN
+	Provider *providers.Reference
+	Inputs   resource.PropertyMap
+}
+
+func makeStateMetadata(
+	t *testing.T, name string, typ tokens.Type, custom bool, opts stateOptions,
+) engine.StepEventStateMetadata {
+	var provider string
+	if opts.Provider != nil {
+		provider = opts.Provider.String()
+	}
+
+	parent := opts.Parent
+	if parent == "" {
+		// Default to the root stack
+		parent = resource.DefaultRootStackURN("stack", "project")
+	}
+
+	urn := resource.CreateURN(name, string(typ), "", "project", "stack")
+
+	return engine.StepEventStateMetadata{
+		URN:      urn,
+		Type:     typ,
+		Custom:   custom,
+		Provider: provider,
+		Parent:   parent,
+		Inputs:   opts.Inputs,
+	}
+}
+
+func makeMetadata(op display.StepOp, state engine.StepEventStateMetadata) engine.StepEventMetadata {
+	return engine.StepEventMetadata{
+		Op:       op,
+		URN:      state.URN,
+		Type:     state.Type,
+		Provider: state.Provider,
+		New:      &state,
+		Res:      &state,
+	}
+}
+
+// Adds a default provider for the given type if appropriate (i.e. the type token is pkg:mod:typ).
+func addDefaultProvider(t *testing.T, typ tokens.Type, events chan<- engine.Event) string {
+	pkg := typ.Package()
+	if pkg != "" {
+		state := makeStateMetadata(t, "default_1_2_3", providers.MakeProviderType(pkg), true, stateOptions{
+			Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"version": "1.2.3",
+			}),
+		})
+		state.ID = providers.UnknownID
+		events <- engine.NewEvent(engine.ResourcePreEventPayload{
+			Metadata: makeMetadata(deploy.OpCreate, state),
+		})
+
+		ref, err := providers.NewReference(state.URN, state.ID)
+		require.NoError(t, err)
+		return ref.String()
+	}
+	return ""
+}
+
+// TestBuildImportFile_SingleResource tests that for each case below creating a single resource it generates
+// the expected import file.
+func TestBuildImportFile_SingleResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    engine.StepEventStateMetadata
+		expected importSpec
+	}{
+		{
+			"custom",
+			makeStateMetadata(t, "res", "pkg:mod:typ", true, stateOptions{}),
+			importSpec{
+				ID:      "<PLACEHOLDER>",
+				Type:    "pkg:mod:typ",
+				Name:    "res",
+				Version: "1.2.3",
+			},
+		},
+		{
+			"component",
+			makeStateMetadata(t, "comp", "my/component", false, stateOptions{}),
+			importSpec{
+				Type:      "my/component",
+				Name:      "comp",
+				Component: true,
+			},
+		},
+		{
+			"remote component",
+			makeStateMetadata(t, "rem", "mlc:index:typ", false, stateOptions{}),
+			importSpec{
+				Type:      "mlc:index:typ",
+				Name:      "rem",
+				Component: true,
+				Remote:    true,
+				Version:   "1.2.3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := make(chan engine.Event)
+			importFilePromise := buildImportFile(events)
+
+			// Always create a root stack (which shouldn't show in the import file)
+			events <- engine.NewEvent(engine.ResourcePreEventPayload{
+				Metadata: makeRootStackMetadata(deploy.OpCreate),
+			})
+
+			// Set the default provider (if any)
+			tt.input.Provider = addDefaultProvider(t, tt.input.Type, events)
+
+			// And then create the one resource we're testing
+			events <- engine.NewEvent(engine.ResourcePreEventPayload{
+				Metadata: makeMetadata(deploy.OpCreate, tt.input),
+			})
+
+			// Finally, close the events channel to signal that we're done
+			close(events)
+			importFile, err := importFilePromise.Result(context.Background())
+			require.NoError(t, err)
+			// There shouldn't be any thing in the name table
+			assert.Len(t, importFile.NameTable, 0)
+			// And there should be the one expected resource in the resources table
+			require.Len(t, importFile.Resources, 1)
+			assert.Equal(t, tt.expected, importFile.Resources[0])
+		})
+	}
+}
+
+// TestBuildImportFile_ExistingParent test that if we try to import a resource that has a parent that already
+// exists we correctly reference that parent in the importSpec and name table.
+func TestBuildImportFile_ExistingParent(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(events)
+
+	// Pretend the root stack already exists
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	provider := addDefaultProvider(t, "pkg:mod:parent", events)
+
+	// And then same a parent resource
+	parentState := makeStateMetadata(t, "parent", "pkg:mod:parent", true, stateOptions{})
+	parentState.Provider = provider
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, parentState),
+	})
+
+	// And then create a resource that has that parent
+	state := makeStateMetadata(t, "child", "pkg:mod:child", true, stateOptions{
+		Parent: parentState.URN,
+	})
+	state.Provider = provider
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, state),
+	})
+
+	// Finally, close the events channel to signal that we're done
+	close(events)
+	importFile, err := importFilePromise.Result(context.Background())
+	require.NoError(t, err)
+
+	// There should be one thing in the name table
+	require.Len(t, importFile.NameTable, 1)
+	assert.Equal(t, parentState.URN, importFile.NameTable["parent"])
+
+	// And there should be the one expected resource in the resources table
+	require.Len(t, importFile.Resources, 1)
+	expected := importSpec{
+		ID:      "<PLACEHOLDER>",
+		Type:    "pkg:mod:child",
+		Name:    "child",
+		Parent:  "parent",
+		Version: "1.2.3",
+	}
+	assert.Equal(t, expected, importFile.Resources[0])
+}
+
+// TestBuildImportFile_NewParent test that if we try to import a resource that has a parent that we're
+// importing with the child that we correctly reference that parent in the importSpec and don't add it to
+// the name table (because the import system should auto-build the URN).
+func TestBuildImportFile_NewParent(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(events)
+
+	// Pretend the root stack already exists
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	provider := addDefaultProvider(t, "pkg:mod:parent", events)
+
+	// And then create a parent resource
+	parentState := makeStateMetadata(t, "parent", "pkg:mod:parent", true, stateOptions{})
+	parentState.Provider = provider
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, parentState),
+	})
+
+	// And then create a resource that has that parent
+	state := makeStateMetadata(t, "child", "pkg:mod:child", true, stateOptions{
+		Parent: parentState.URN,
+	})
+	state.Provider = provider
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, state),
+	})
+
+	// Finally, close the events channel to signal that we're done
+	close(events)
+	importFile, err := importFilePromise.Result(context.Background())
+	require.NoError(t, err)
+
+	// There shouldn't be anything in the name table
+	assert.Len(t, importFile.NameTable, 0)
+
+	// And there should be the two expected resources in the resources table
+	require.Len(t, importFile.Resources, 2)
+	expected := importSpec{
+		ID:      "<PLACEHOLDER>",
+		Type:    "pkg:mod:parent",
+		Name:    "parent",
+		Version: "1.2.3",
+	}
+	assert.Equal(t, expected, importFile.Resources[0])
+	expected = importSpec{
+		ID:      "<PLACEHOLDER>",
+		Type:    "pkg:mod:child",
+		Name:    "child",
+		Parent:  "parent",
+		Version: "1.2.3",
+	}
+	assert.Equal(t, expected, importFile.Resources[1])
+}
+
+// TestBuildImportFile_ExistingProvider test that if we try to import a resource that has an explicit provider
+// that we reference that correctly in the name table and importSpec.
+func TestBuildImportFile_ExistingProvider(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(events)
+
+	// Pretend the root stack already exists
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	// And then same a provider resource
+	providerState := makeStateMetadata(t, "prov", "pulumi:providers:pkg", true, stateOptions{
+		Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+			"version": "3.2.1",
+		}),
+	})
+	uuid, err := uuid.NewV4()
+	require.NoError(t, err)
+	providerState.ID = resource.ID(uuid.String())
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, providerState),
+	})
+
+	// And then create a resource that has that provider
+	providerRef, err := providers.NewReference(providerState.URN, providerState.ID)
+	require.NoError(t, err)
+	state := makeStateMetadata(t, "res", "pkg:mod:typ", true, stateOptions{
+		Provider: &providerRef,
+	})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, state),
+	})
+
+	// Finally, close the events channel to signal that we're done
+	close(events)
+	importFile, err := importFilePromise.Result(context.Background())
+	require.NoError(t, err)
+
+	// There should be one thing in the name table
+	require.Len(t, importFile.NameTable, 1)
+	assert.Equal(t, providerState.URN, importFile.NameTable["prov"])
+
+	// And there should be the one expected resource in the resources table
+	require.Len(t, importFile.Resources, 1)
+	expected := importSpec{
+		ID:       "<PLACEHOLDER>",
+		Type:     "pkg:mod:typ",
+		Name:     "res",
+		Provider: "prov",
+		Version:  "3.2.1",
+	}
+	assert.Equal(t, expected, importFile.Resources[0])
+}
+
+// TestBuildImportFile_NewProvider test that if we try to import a resource that has an explicit provider
+// that we haven't created yet that we error. We can't handle this case yet in the import system.
+func TestBuildImportFile_NewProvider(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(events)
+
+	// Pretend the root stack already exists
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	// And then create a provider resource
+	providerState := makeStateMetadata(t, "prov", "pulumi:providers:pkg", true, stateOptions{})
+	providerState.ID = providers.UnknownID
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, providerState),
+	})
+
+	// And then create a resource that has that provider
+	providerRef, err := providers.NewReference(providerState.URN, providerState.ID)
+	require.NoError(t, err)
+	state := makeStateMetadata(t, "res", "pkg:mod:typ", true, stateOptions{
+		Provider: &providerRef,
+	})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, state),
+	})
+
+	// Finally, close the events channel to signal that we're done
+	close(events)
+
+	// This should error because we can't yet handle importing an explicit provider
+	_, err = importFilePromise.Result(context.Background())
+	assert.ErrorContains(
+		t, err,
+		"cannot import resource \"urn:pulumi:stack::project::pkg:mod:typ::res\" "+
+			"with a new explicit provider \"urn:pulumi:stack::project::pulumi:providers:pkg::prov\"")
+}

--- a/tests/testdata/import_node/.gitignore
+++ b/tests/testdata/import_node/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/tests/testdata/import_node/Pulumi.yaml
+++ b/tests/testdata/import_node/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: import_node
+runtime: nodejs
+description: A minimal NodeJS program to test import generation.

--- a/tests/testdata/import_node/index.ts
+++ b/tests/testdata/import_node/index.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, opts: pulumi.ComponentResourceOptions) {
+        super("pkg:index:MyComponent", name, {}, opts);
+
+        new random.RandomPet("username", {}, { parent: this });
+    }
+}
+
+const username = new random.RandomPet("username", {});
+
+const component = new MyComponent("component", {});

--- a/tests/testdata/import_node/package.json
+++ b/tests/testdata/import_node/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "import_node",
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^16"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.19.0",
+    "@pulumi/random": "4.12.0"
+  }
+}

--- a/tests/testdata/import_node/tsconfig.json
+++ b/tests/testdata/import_node/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12768.

This will generate an import file for every resource the preview wants to Create.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
