### PR TITLE
Add a strict opinionated promise library

### DIFF
--- a/sdk/go/common/promise/promise.go
+++ b/sdk/go/common/promise/promise.go
@@ -1,0 +1,137 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promise
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+const (
+	statusUninitialized int32 = iota
+	statusPending
+	statusFulfilled
+	statusRejected
+)
+
+// Promise is a promise that can be resolved with a value of type T or rejected with an error. It is safe to call Result
+// on it multiple times from multiple goroutines. This is much more permissive than channels.
+type Promise[T any] struct {
+	done   chan struct{}
+	mutex  sync.Mutex
+	status atomic.Int32
+	result T
+	err    error
+}
+
+// Result waits for the promise to be resolved and returns the result.
+func (p *Promise[T]) Result(ctx context.Context) (T, error) {
+	if p.status.Load() == statusUninitialized {
+		panic("Promise must be initialized")
+	}
+
+	// Wait for either the promise or context to be done, if the context is done just exit with it's error
+	select {
+	case <-p.done:
+		break
+	case <-ctx.Done():
+		var t T
+		return t, ctx.Err()
+	}
+
+	contract.Assertf(p.status.Load() != statusPending, "Promise must be resolved")
+	// Only one of result or err will be set, the other will be the zero value so we can just return both.
+	return p.result, p.err
+}
+
+// CompletionSource is a source for a promise that can be resolved or rejected. It is safe to call Resolve or
+// Reject multiple times concurrently, the first will apply and all others will return that they couldn't set the
+// promise.
+type CompletionSource[T any] struct {
+	init    sync.Once
+	promise *Promise[T]
+}
+
+func (ps *CompletionSource[T]) Promise() *Promise[T] {
+	ps.init.Do(func() {
+		p := &Promise[T]{}
+		p.status.Store(statusPending)
+		p.done = make(chan struct{})
+		ps.promise = p
+	})
+	return ps.promise
+}
+
+func (ps *CompletionSource[T]) Fulfill(value T) bool {
+	promise := ps.Promise()
+	promise.mutex.Lock()
+	defer promise.mutex.Unlock()
+
+	contract.Assertf(promise.status.Load() != statusUninitialized, "Promise must be initialized")
+	if promise.status.Load() != statusPending {
+		return false
+	}
+	promise.result = value
+	promise.status.Store(statusFulfilled)
+	close(promise.done)
+	return true
+}
+
+func (ps *CompletionSource[T]) MustFulfill(value T) {
+	if !ps.Fulfill(value) {
+		panic("CompletionSource already resolved")
+	}
+}
+
+func (ps *CompletionSource[T]) Reject(err error) bool {
+	contract.Requiref(err != nil, "err", "err must not be nil")
+
+	promise := ps.Promise()
+	promise.mutex.Lock()
+	defer promise.mutex.Unlock()
+
+	contract.Assertf(promise.status.Load() != statusUninitialized, "Promise must be initialized")
+	if promise.status.Load() != statusPending {
+		return false
+	}
+	promise.err = err
+	promise.status.Store(statusRejected)
+	close(promise.done)
+	return true
+}
+
+func (ps *CompletionSource[T]) MustReject(err error) {
+	if !ps.Reject(err) {
+		panic("CompletionSource already resolved")
+	}
+}
+
+// Run runs the given function in a goroutine and returns a promise that will be resolved with the result of the
+// function.
+func Run[T any](f func() (T, error)) *Promise[T] {
+	ps := &CompletionSource[T]{}
+	go func() {
+		value, err := f()
+		if err != nil {
+			ps.Reject(err)
+		} else {
+			ps.Fulfill(value)
+		}
+	}()
+	return ps.Promise()
+}

--- a/sdk/go/common/promise/promise_test.go
+++ b/sdk/go/common/promise/promise_test.go
@@ -1,0 +1,164 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promise
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroPanic(t *testing.T) {
+	t.Parallel()
+
+	var p Promise[int]
+	assert.PanicsWithValue(t, "Promise must be initialized", func() {
+		p.Result(context.Background()) //nolint:errcheck // Result is expected to panic
+	})
+}
+
+func TestFulfill(t *testing.T) {
+	t.Parallel()
+
+	ps := &CompletionSource[int]{}
+	set := ps.Fulfill(42)
+	assert.True(t, set, "set should be true")
+	promise := ps.Promise()
+	i, err := promise.Result(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 42, i)
+	// Trying to fulfill again should fail
+	set = ps.Fulfill(43)
+	assert.False(t, set, "set should be false")
+	// Asking for the promise again should give the same promise
+	assert.Equal(t, promise, ps.Promise())
+	// Result should still be 42
+	i, err = promise.Result(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 42, i)
+	// Trying to reject should fail
+	set = ps.Reject(errors.New("boom"))
+	assert.False(t, set, "set should be false")
+}
+
+func TestMustFulfill(t *testing.T) {
+	t.Parallel()
+
+	ps := &CompletionSource[int]{}
+	// First call should succeed
+	ps.MustFulfill(42)
+	// And this promise should now resolve to 42
+	i, err := ps.Promise().Result(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 42, i)
+	// Second call should panic
+	assert.PanicsWithValue(t, "CompletionSource already resolved", func() {
+		ps.MustFulfill(43)
+	})
+}
+
+func TestReject(t *testing.T) {
+	t.Parallel()
+
+	ps := &CompletionSource[int]{}
+	boom := errors.New("boom")
+	set := ps.Reject(boom)
+	assert.True(t, set, "set should be true")
+	promise := ps.Promise()
+	_, err := promise.Result(context.Background())
+	require.Equal(t, boom, err)
+	// Trying to reject again should fail
+	set = ps.Reject(errors.New("bigger boom"))
+	assert.False(t, set, "set should be false")
+	// Asking for the promise again should give the same promise
+	assert.Equal(t, promise, ps.Promise())
+	// Result should still be boom
+	promise = ps.Promise()
+	_, err = promise.Result(context.Background())
+	require.Equal(t, boom, err)
+	// Trying to fulfill should fail
+	set = ps.Fulfill(42)
+	assert.False(t, set, "set should be false")
+}
+
+func TestMustReject(t *testing.T) {
+	t.Parallel()
+
+	ps := &CompletionSource[int]{}
+	// First call should succeed
+	boom := errors.New("boom")
+	ps.MustReject(boom)
+	// And this promise should now resolve to boom
+	_, err := ps.Promise().Result(context.Background())
+	require.Equal(t, boom, err)
+	// Second call should panic
+	assert.PanicsWithValue(t, "CompletionSource already resolved", func() {
+		ps.MustReject(errors.New("boom again"))
+	})
+}
+
+func TestManyGets(t *testing.T) {
+	t.Parallel()
+
+	ps := &CompletionSource[int]{}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			got, err := ps.Promise().Result(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, 42, got)
+		}()
+	}
+
+	ps.Fulfill(42)
+	wg.Wait()
+}
+
+func TestAwaitCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ps := &CompletionSource[int]{}
+	p := ps.Promise()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		_, err := p.Result(ctx)
+		assert.ErrorIs(t, err, context.Canceled)
+	}()
+
+	cancel()
+	<-done
+
+	// The await was cancelled, not the promise so we should be able to fulfill and then wait again.
+	set := ps.Fulfill(12)
+	assert.True(t, set, "set should be true")
+
+	i, err := p.Result(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 12, i)
+}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
@@ -35,6 +34,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -70,11 +70,7 @@ type provider struct {
 	disableProviderPreview bool                             // true if previews for Create and Update are disabled.
 	legacyPreview          bool                             // enables legacy behavior for unconfigured provider previews.
 
-	// Await and provide configuration values.
-	// Use of closures here prevents unintentional unguarded access
-	// to the configuration values.
-	awaitConfig   func(context.Context) (pluginConfig, error)
-	provideConfig func(pluginConfig, error)
+	configSource *promise.CompletionSource[pluginConfig] // the source for the provider's configuration.
 }
 
 // pluginConfig holds the configuration of the provider
@@ -86,44 +82,6 @@ type pluginConfig struct {
 	acceptResources bool // true if this plugin accepts strongly-typed resource refs.
 	acceptOutputs   bool // true if this plugin accepts output values.
 	supportsPreview bool // true if this plugin supports previews for Create and Update.
-}
-
-// pluginConfigPromise is an asynchronously filled value for pluginConfig.
-type pluginConfigPromise struct {
-	done chan struct{} // closed on set
-	once sync.Once     // only one set
-	cfg  pluginConfig
-	err  error // non-nil if the operation failed
-}
-
-func newPluginConfigPromise() *pluginConfigPromise {
-	return &pluginConfigPromise{
-		done: make(chan struct{}),
-	}
-}
-
-// Await blocks until the value in the promise has resolved
-// or the given context expires.
-func (p *pluginConfigPromise) Await(ctx context.Context) (pluginConfig, error) {
-	select {
-	case <-ctx.Done():
-		return pluginConfig{}, ctx.Err()
-	case <-p.done:
-		return p.cfg, p.err
-	}
-}
-
-// Fulfill provides values to the promise.
-// A non-nil error indicates failure.
-//
-// Fulfill can be called only once.
-// Any calls after that will be ignored.
-func (p *pluginConfigPromise) Fulfill(cfg pluginConfig, err error) {
-	p.once.Do(func() {
-		defer close(p.done)
-		p.cfg = cfg
-		p.err = err
-	})
 }
 
 // NewProvider attempts to bind to a given package's resource plugin and then creates a gRPC connection to it.  If the
@@ -196,7 +154,6 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 
 	legacyPreview := cmdutil.IsTruthy(os.Getenv("PULUMI_LEGACY_PROVIDER_PREVIEW"))
 
-	cfgPromise := newPluginConfigPromise()
 	p := &provider{
 		ctx:                    ctx,
 		pkg:                    pkg,
@@ -204,8 +161,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		clientRaw:              pulumirpc.NewResourceProviderClient(plug.Conn),
 		disableProviderPreview: disableProviderPreview,
 		legacyPreview:          legacyPreview,
-		awaitConfig:            cfgPromise.Await,
-		provideConfig:          cfgPromise.Fulfill,
+		configSource:           &promise.CompletionSource[pluginConfig]{},
 	}
 
 	// If we just attached (i.e. plugin bin is nil) we need to call attach
@@ -256,14 +212,12 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 
 	legacyPreview := cmdutil.IsTruthy(os.Getenv("PULUMI_LEGACY_PROVIDER_PREVIEW"))
 
-	cfgPromise := newPluginConfigPromise()
 	p := &provider{
 		ctx:           ctx,
 		plug:          plug,
 		clientRaw:     pulumirpc.NewResourceProviderClient(plug.Conn),
 		legacyPreview: legacyPreview,
-		awaitConfig:   cfgPromise.Await,
-		provideConfig: cfgPromise.Fulfill,
+		configSource:  &promise.CompletionSource[pluginConfig]{},
 	}
 
 	// If we just attached (i.e. plugin bin is nil) we need to call attach
@@ -279,14 +233,12 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 func NewProviderWithClient(ctx *Context, pkg tokens.Package, client pulumirpc.ResourceProviderClient,
 	disableProviderPreview bool,
 ) Provider {
-	cfgPromise := newPluginConfigPromise()
 	return &provider{
 		ctx:                    ctx,
 		pkg:                    pkg,
 		clientRaw:              client,
 		disableProviderPreview: disableProviderPreview,
-		awaitConfig:            cfgPromise.Await,
-		provideConfig:          cfgPromise.Fulfill,
+		configSource:           &promise.CompletionSource[pluginConfig]{},
 	}
 }
 
@@ -709,11 +661,11 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 		}
 
 		if v.ContainsUnknowns() {
-			p.provideConfig(pluginConfig{
+			p.configSource.MustFulfill(pluginConfig{
 				known:           false,
 				acceptSecrets:   false,
 				acceptResources: false,
-			}, nil)
+			})
 			return nil
 		}
 
@@ -722,7 +674,7 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 			marshalled, err := json.Marshal(mapped)
 			if err != nil {
 				err := errors.Wrapf(err, "marshaling configuration property '%v'", k)
-				p.provideConfig(pluginConfig{}, err)
+				p.configSource.MustReject(err)
 				return err
 			}
 			mapped = string(marshalled)
@@ -741,7 +693,7 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 	})
 	if err != nil {
 		err := errors.Wrapf(err, "marshaling provider inputs")
-		p.provideConfig(pluginConfig{}, err)
+		p.configSource.MustReject(err)
 		return err
 	}
 
@@ -760,15 +712,17 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 			rpcError := rpcerror.Convert(err)
 			logging.V(7).Infof("%s failed: err=%v", label, rpcError.Message())
 			err = createConfigureError(rpcError)
+			p.configSource.MustReject(err)
+			return
 		}
 
-		p.provideConfig(pluginConfig{
+		p.configSource.MustFulfill(pluginConfig{
 			known:           true,
 			acceptSecrets:   resp.GetAcceptSecrets(),
 			acceptResources: resp.GetAcceptResources(),
 			supportsPreview: resp.GetSupportsPreview(),
 			acceptOutputs:   resp.GetAcceptOutputs(),
-		}, err)
+		})
 	}()
 
 	return nil
@@ -784,7 +738,7 @@ func (p *provider) Check(urn resource.URN,
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -875,7 +829,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -978,7 +932,7 @@ func (p *provider) Create(urn resource.URN, props resource.PropertyMap, timeout 
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return "", nil, resource.StatusOK, err
 	}
@@ -1085,7 +1039,7 @@ func (p *provider) Read(urn resource.URN, id resource.ID,
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return ReadResult{}, resource.StatusUnknown, err
 	}
@@ -1214,7 +1168,7 @@ func (p *provider) Update(urn resource.URN, id resource.ID,
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return newInputs, resource.StatusOK, err
 	}
@@ -1334,7 +1288,7 @@ func (p *provider) Delete(urn resource.URN, id resource.ID, oldInputs, oldOutput
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return resource.StatusOK, err
 	}
@@ -1395,7 +1349,7 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QN
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return ConstructResult{}, err
 	}
@@ -1532,7 +1486,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1596,7 +1550,7 @@ func (p *provider) StreamInvoke(
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -1674,7 +1628,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
-	pcfg, err := p.awaitConfig(context.Background())
+	pcfg, err := p.configSource.Promise().Result(context.Background())
 	if err != nil {
 		return CallResult{}, err
 	}

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -2,11 +2,9 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
-	"sync"
 	"testing"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -293,97 +291,6 @@ func TestRestoreElidedAssetContents(t *testing.T) {
 	restoreElidedAssetContents(original, deserialized)
 	deserializedRaw = deserialized.Mappable()
 	assert.Equal(t, originalRaw, deserializedRaw)
-}
-
-func TestPluginConfigPromise(t *testing.T) {
-	t.Parallel()
-
-	t.Run("many gets", func(t *testing.T) {
-		t.Parallel()
-
-		prom := newPluginConfigPromise()
-		ctx := context.Background()
-
-		cfg := pluginConfig{
-			known:           true,
-			acceptSecrets:   true,
-			acceptResources: true,
-			acceptOutputs:   true,
-			supportsPreview: true,
-		}
-
-		var wg sync.WaitGroup
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				got, err := prom.Await(ctx)
-				assert.NoError(t, err)
-				assert.Equal(t, cfg, got)
-			}()
-		}
-
-		prom.Fulfill(cfg, nil)
-		wg.Wait()
-	})
-
-	t.Run("error", func(t *testing.T) {
-		t.Parallel()
-
-		giveErr := errors.New("great sadness")
-		prom := newPluginConfigPromise()
-		ctx := context.Background()
-
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-
-			_, err := prom.Await(ctx)
-			assert.ErrorIs(t, err, giveErr)
-		}()
-
-		prom.Fulfill(pluginConfig{}, giveErr)
-		<-done
-	})
-
-	t.Run("set twice", func(t *testing.T) {
-		t.Parallel()
-
-		prom := newPluginConfigPromise()
-		ctx := context.Background()
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			got, err := prom.Await(ctx)
-			assert.NoError(t, err)
-			assert.Equal(t, pluginConfig{acceptSecrets: true}, got)
-		}()
-
-		prom.Fulfill(pluginConfig{acceptSecrets: true}, nil)
-		prom.Fulfill(pluginConfig{acceptOutputs: true}, errors.New("ignored"))
-
-		// Should still see the first configuration.
-		got, err := prom.Await(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, pluginConfig{acceptSecrets: true}, got)
-
-		wg.Wait()
-	})
-
-	t.Run("await cancelled", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		prom := newPluginConfigPromise()
-		_, err := prom.Await(ctx)
-		assert.ErrorIs(t, err, context.Canceled)
-	})
 }
 
 func TestProvider_ConstructOptions(t *testing.T) {


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Prompted by having another case in https://github.com/pulumi/pulumi/pull/14548 that looked like "this is just a promise".

We already had a mini-promise library for provider config in sdk/go/common/resource/plugin/provider_plugin.go. Plus a couple of places where we did a poor mans Go promise by having a WaitGroup plus a variable to set (see the two changes in /pkg).

This adds a little promise library to safely cover all three of these cases plus the case I'll be adding in #14548. It is _minimal_ adding just the features of promises needed for these initial cases. We can add to it as needed.

I suspect we've got a number of places in test code that could probably use this as well, but I haven't gone through that. I also suspect that having this type available will result in more places in the future being simpler because "its just a promise" is a fairly common scenario in async systems. In fact Output's internally _are just a promise_ so we could probably rewrite their internals using this, add a `Then()` like method for apply and all the async complexity gets handled in the promise layer while the output layer just cares about unknowns/secrets/etc.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - This is in sdk/go/common and I'm considering it an non-public api for now.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
