### PR TITLE
[cli] Colorize table headers

### DIFF
--- a/pkg/cmd/pulumi/about_env.go
+++ b/pkg/cmd/pulumi/about_env.go
@@ -50,7 +50,7 @@ func newAboutEnvCmd() *cobra.Command {
 					Columns: []string{v.Name(), v.Description, v.Value.String()},
 				})
 			}
-			cmdutil.PrintTable(table)
+			printTable(table, nil)
 			if foundError {
 				return errors.New("invalid environmental variables found")
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -881,10 +881,10 @@ func listConfig(ctx context.Context,
 			rows = append(rows, cmdutil.TableRow{Columns: []string{prettyKey(key), decrypted}})
 		}
 
-		cmdutil.PrintTable(cmdutil.Table{
+		printTable(cmdutil.Table{
 			Headers: []string{"KEY", "VALUE"},
 			Rows:    rows,
-		})
+		}, nil)
 	}
 
 	if showSecrets {

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -159,10 +159,10 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 		totalSize += uint64(plugin.Size)
 	}
 
-	cmdutil.PrintTable(cmdutil.Table{
+	printTable(cmdutil.Table{
 		Headers: []string{"NAME", "KIND", "VERSION", "SIZE", "INSTALLED", "LAST USED"},
 		Rows:    rows,
-	})
+	}, nil)
 
 	fmt.Printf("\n")
 	fmt.Printf("TOTAL plugin cache size: %s\n", humanize.Bytes(totalSize))

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -130,10 +130,10 @@ func formatPolicyGroupsConsole(policyGroups []apitype.PolicyGroupSummary) error 
 		columns := []string{name, defaultGroup, numPolicyPacks, numStacks}
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
-	cmdutil.PrintTable(cmdutil.Table{
+	printTable(cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
-	})
+	}, nil)
 	return nil
 }
 

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -109,10 +109,10 @@ func formatPolicyPacksConsole(policyPacks []apitype.PolicyPackWithVersions) erro
 		columns := []string{name, versionTags}
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
-	cmdutil.PrintTable(cmdutil.Table{
+	printTable(cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
-	})
+	}, nil)
 	return nil
 }
 

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -134,11 +134,11 @@ func newStackCmd() *cobra.Command {
 					}
 				}
 
-				cmdutil.PrintTable(cmdutil.Table{
+				printTable(cmdutil.Table{
 					Headers: []string{"TYPE", "NAME"},
 					Rows:    rows,
 					Prefix:  "    ",
-				})
+				}, nil)
 
 				outputs, err := getStackOutputs(snap, showSecrets)
 				if err == nil {

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -300,10 +300,10 @@ func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSu
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
 
-	cmdutil.PrintTable(cmdutil.Table{
+	printTable(cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
-	})
+	}, nil)
 
 	return nil
 }

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -137,10 +137,10 @@ func printStackTags(tags map[apitype.StackTagName]string) {
 		rows = append(rows, cmdutil.TableRow{Columns: []string{name, tags[name]}})
 	}
 
-	cmdutil.PrintTable(cmdutil.Table{
+	printTable(cmdutil.Table{
 		Headers: []string{"NAME", "VALUE"},
 		Rows:    rows,
-	})
+	}, nil)
 }
 
 func newStackTagRmCmd(stack *string) *cobra.Command {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1134,3 +1134,24 @@ func promptUser(msg string, options []string, defaultOption string, colorization
 	}
 	return response
 }
+
+func printTable(table cmdutil.Table, opts *cmdutil.TableRenderOptions) {
+	fmt.Print(renderTable(table, opts))
+}
+
+func renderTable(table cmdutil.Table, opts *cmdutil.TableRenderOptions) string {
+	if opts == nil {
+		opts = &cmdutil.TableRenderOptions{}
+	}
+	if len(opts.HeaderStyle) == 0 {
+		style := make([]colors.Color, len(table.Headers))
+		for i := range style {
+			style[i] = colors.SpecHeadline
+		}
+		opts.HeaderStyle = style
+	}
+	if opts.Color == "" {
+		opts.Color = cmdutil.GetGlobalColorization()
+	}
+	return table.Render(opts)
+}

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rivo/uniseg"
 	"golang.org/x/term"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -201,7 +202,7 @@ func MeasureText(text string) int {
 // normalizedRows returns the rows of a table in normalized form.
 //
 // A row is considered normalized if and only if it has no new lines in any of its fields.
-func (table *Table) normalizedRows() []TableRow {
+func (table Table) normalizedRows() []TableRow {
 	rows := slice.Prealloc[TableRow](len(table.Rows))
 	for _, row := range table.Rows {
 		info := row.AdditionalInfo
@@ -229,7 +230,28 @@ func (table *Table) normalizedRows() []TableRow {
 	return rows
 }
 
-func (table *Table) ToStringWithGap(columnGap string) string {
+func (table Table) ToStringWithGap(columnGap string) string {
+	return table.Render(&TableRenderOptions{ColumnGap: columnGap})
+}
+
+type TableRenderOptions struct {
+	ColumnGap   string
+	HeaderStyle []colors.Color
+	ColumnStyle []colors.Color
+	Color       colors.Colorization
+}
+
+func (table Table) Render(opts *TableRenderOptions) string {
+	if opts == nil {
+		opts = &TableRenderOptions{}
+	}
+	if opts.ColumnGap == "" {
+		opts.ColumnGap = "  "
+	}
+	if opts.Color == "" {
+		opts.Color = colors.Never
+	}
+
 	columnCount := len(table.Headers)
 
 	// Figure out the preferred column width for each column.  It will be set to the max length of
@@ -255,12 +277,25 @@ func (table *Table) ToStringWithGap(columnGap string) string {
 		}
 	}
 
-	result := ""
-	for _, row := range allRows {
-		result += table.Prefix
+	var result strings.Builder
+	for rowIndex, row := range allRows {
+		result.WriteString(table.Prefix)
 
 		for columnIndex, val := range row.Columns {
-			result += val
+			style := opts.HeaderStyle
+			if rowIndex != 0 {
+				style = opts.ColumnStyle
+			}
+
+			if len(style) != 0 {
+				result.WriteString(opts.Color.Colorize(style[columnIndex]))
+			}
+
+			result.WriteString(val)
+
+			if len(style) != 0 {
+				result.WriteString(opts.Color.Colorize(colors.Reset))
+			}
 
 			if columnIndex < columnCount-1 {
 				// Work out how much whitespace we need to add to this string to bring it up to the
@@ -268,22 +303,22 @@ func (table *Table) ToStringWithGap(columnGap string) string {
 
 				maxWidth := preferredColumnWidths[columnIndex]
 				padding := maxWidth - MeasureText(val)
-				result += strings.Repeat(" ", padding)
+				result.WriteString(strings.Repeat(" ", padding))
 
 				// Now, ensure we have the requested gap between columns as well.
-				result += columnGap
+				result.WriteString(opts.ColumnGap)
 			}
 			// do not want whitespace appended to the last column.  It would cause wrapping on lines
 			// that were not actually long if some other line was very long.
 		}
 
-		result += "\n"
+		result.WriteByte('\n')
 
 		if row.AdditionalInfo != "" {
-			result += row.AdditionalInfo
+			result.WriteString(row.AdditionalInfo)
 		}
 	}
-	return result
+	return result.String()
 }
 
 func max(a, b int) int {


### PR DESCRIPTION
These changes colorize the header row of each table printed by the CLI using the `SpecHeadline` style (bold + pinkish). This improves the readability of the tables on rich terminals.