### PR TITLE
[config] Clean up toDecryptedPropertyValue

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -120,7 +120,7 @@ func (src *evalSource) Iterate(
 	// Keep track of any config keys that have secure values.
 	configSecretKeys := src.runinfo.Target.Config.SecureKeys()
 
-	configMap, err := src.runinfo.Target.Config.AsDecryptedPropertyMap(src.runinfo.Target.Decrypter)
+	configMap, err := src.runinfo.Target.Config.AsDecryptedPropertyMap(ctx, src.runinfo.Target.Decrypter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert config to map: %w", err)
 	}

--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,7 +77,7 @@ func (m Map) HasSecureValue() bool {
 }
 
 // AsDecryptedPropertyMap returns the config as a property map, with secret values decrypted.
-func (m Map) AsDecryptedPropertyMap(decrypter Decrypter) (resource.PropertyMap, error) {
+func (m Map) AsDecryptedPropertyMap(ctx context.Context, decrypter Decrypter) (resource.PropertyMap, error) {
 	pm := resource.PropertyMap{}
 
 	for k, v := range m {
@@ -84,7 +85,11 @@ func (m Map) AsDecryptedPropertyMap(decrypter Decrypter) (resource.PropertyMap, 
 		if err != nil {
 			return resource.PropertyMap{}, err
 		}
-		pm[resource.PropertyKey(k.String())] = newV.toDecryptedPropertyValue(decrypter)
+		plaintext, err := newV.toDecryptedPropertyValue(ctx, decrypter)
+		if err != nil {
+			return resource.PropertyMap{}, err
+		}
+		pm[resource.PropertyKey(k.String())] = plaintext
 	}
 	return pm, nil
 }

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -1491,7 +1492,7 @@ func TestPropertyMap(t *testing.T) {
 			t.Parallel()
 
 			decrypter := nopCrypter{}
-			propMap, err := test.Config.AsDecryptedPropertyMap(decrypter)
+			propMap, err := test.Config.AsDecryptedPropertyMap(context.Background(), decrypter)
 			assert.NoError(t, err)
 
 			assert.Equal(t, test.Expected, propMap)

--- a/sdk/go/common/resource/config/object.go
+++ b/sdk/go/common/resource/config/object.go
@@ -524,36 +524,10 @@ func isSecureValue(v any) (bool, string) {
 	return false, ""
 }
 
-func (c object) toDecryptedPropertyValue(decrypter Decrypter) resource.PropertyValue {
-	var prop resource.PropertyValue
-	switch v := c.value.(type) {
-	case bool, int64, float64, string:
-		if c.secure {
-			plaintext, err := decrypter.DecryptValue(context.Background(), v.(string))
-			contract.AssertNoErrorf(err, "failed to decrypt config")
-			prop = resource.NewPropertyValue(plaintext)
-		} else {
-			prop = resource.NewPropertyValue(v)
-		}
-	case []object:
-		var values []resource.PropertyValue
-		for _, v := range v {
-			values = append(values, v.toDecryptedPropertyValue(decrypter))
-		}
-		prop = resource.NewArrayProperty(values)
-	case map[string]object:
-		values := make(resource.PropertyMap)
-		for k, v := range v {
-			values[resource.PropertyKey(k)] = v.toDecryptedPropertyValue(decrypter)
-		}
-		prop = resource.NewObjectProperty(values)
-	case nil:
-		prop = resource.NewNullProperty()
-	default:
-		contract.Failf("unexpected value type %T", v)
+func (c object) toDecryptedPropertyValue(ctx context.Context, decrypter Decrypter) (resource.PropertyValue, error) {
+	plaintext, err := c.Decrypt(ctx, decrypter)
+	if err != nil {
+		return resource.PropertyValue{}, err
 	}
-	if c.secure {
-		prop = resource.MakeSecret(prop)
-	}
-	return prop
+	return plaintext.PropertyValue(), nil
 }

--- a/sdk/go/common/resource/config/object_test.go
+++ b/sdk/go/common/resource/config/object_test.go
@@ -15,10 +15,12 @@
 package config
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmptyObject(t *testing.T) {
@@ -28,6 +30,7 @@ func TestEmptyObject(t *testing.T) {
 	// without error.
 	o := object{}
 	crypter := nopCrypter{}
-	v := o.toDecryptedPropertyValue(crypter)
+	v, err := o.toDecryptedPropertyValue(context.Background(), crypter)
+	require.NoError(t, err)
 	assert.Equal(t, resource.NewNullProperty(), v)
 }


### PR DESCRIPTION
- Plumb a `context.Context` parameter to pass to the decrypter
- Rephrase conversion over `config.Plaintext` values in order to decouple decryption and conversion