### PR TITLE
Fix ignoreChanges to handle secrets

### DIFF
--- a/changelog/pending/20231115--engine--fix-ignore-changes-ignoring-secret-values.yaml
+++ b/changelog/pending/20231115--engine--fix-ignore-changes-ignoring-secret-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix ignore changes ignoring secret values.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1322,14 +1322,23 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 		"b": []string{"foo", "baz"},
 	}), []string{"b[*]"}, []display.StepOp{deploy.OpSame})
 
-	// Check that ignoring a secret value works
+	// Check that ignoring a secret value works, first update to make foo, bar secret
+	snap = updateProgramWithProps(snap, resource.PropertyMap{
+		"a": resource.NewNumberProperty(3),
+		"b": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("foo"),
+			resource.NewStringProperty("bar"),
+		})),
+	}, nil, []display.StepOp{deploy.OpUpdate})
+
+	// Now check that changing a value (but not secretness) can be ignored
 	_ = updateProgramWithProps(snap, resource.PropertyMap{
 		"a": resource.NewNumberProperty(3),
 		"b": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 			resource.NewStringProperty("foo"),
 			resource.NewStringProperty("baz"),
 		})),
-	}, []string{"b[*]"}, []display.StepOp{deploy.OpSame})
+	}, []string{"b[1]"}, []display.StepOp{deploy.OpSame})
 }
 
 func TestIgnoreChangesInvalidPaths(t *testing.T) {

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1317,10 +1317,19 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 	}), []string{"b[1]"}, []display.StepOp{deploy.OpSame})
 
 	// Check that ignoring all sub-elements of an array works
-	_ = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
+	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"a": 3,
 		"b": []string{"foo", "baz"},
 	}), []string{"b[*]"}, []display.StepOp{deploy.OpSame})
+
+	// Check that ignoring a secret value works
+	_ = updateProgramWithProps(snap, resource.PropertyMap{
+		"a": resource.NewNumberProperty(3),
+		"b": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("foo"),
+			resource.NewStringProperty("baz"),
+		})),
+	}, []string{"b[*]"}, []display.StepOp{deploy.OpSame})
 }
 
 func TestIgnoreChangesInvalidPaths(t *testing.T) {

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -313,21 +313,26 @@ func (p PropertyPath) Contains(other PropertyPath) bool {
 	return true
 }
 
-func unwrapSecrets(v PropertyValue) PropertyValue {
+// unwrapSecrets recursively unwraps any secrets from the given PropertyValue returning true if any secrets were
+// unwrapped.
+func unwrapSecrets(v PropertyValue) (PropertyValue, bool) {
 	if v.IsSecret() {
-		return unwrapSecrets(v.SecretValue().Element)
+		inner, _ := unwrapSecrets(v.SecretValue().Element)
+		return inner, true
 	}
-	return v
+	return v, false
 }
 
-func (p PropertyPath) reset(old, new PropertyValue) bool {
+func (p PropertyPath) reset(old, new PropertyValue, oldIsSecret, newIsSecret bool) bool {
 	if len(p) == 0 {
 		return false
 	}
 
 	// Unwrap any secrets from old & new, we can just go through them for this traversal.
-	old = unwrapSecrets(old)
-	new = unwrapSecrets(new)
+	old, isSecret := unwrapSecrets(old)
+	oldIsSecret = oldIsSecret || isSecret
+	new, isSecret = unwrapSecrets(new)
+	newIsSecret = newIsSecret || isSecret
 
 	// If this is the last component we want to do the reset, else we want to search for the next component.
 	key := p[0]
@@ -362,6 +367,11 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 			// Otherwise both arrays contain this index and we can reset the value of it in new to what is in
 			// old.
 			v := old.ArrayValue()[key]
+			// If this was a secret value in old, but new isn't currently a secret context then we need to mark this
+			// reset value as secret.
+			if oldIsSecret && !newIsSecret {
+				v = MakeSecret(v)
+			}
 			new.ArrayValue()[key] = v
 			return true
 		}
@@ -379,7 +389,7 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 		}
 		old = old.ArrayValue()[key]
 		new = new.ArrayValue()[key]
-		return p[1:].reset(old, new)
+		return p[1:].reset(old, new, oldIsSecret, newIsSecret)
 
 	case string:
 		if key == "*" {
@@ -388,6 +398,11 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 					if old.IsObject() {
 						for k := range old.ObjectValue() {
 							v := old.ObjectValue()[k]
+							// If this was a secret value in old, but new isn't currently a secret context then we need
+							// to mark this reset value as secret.
+							if oldIsSecret && !newIsSecret {
+								v = MakeSecret(v)
+							}
 							new.ObjectValue()[k] = v
 						}
 						for k := range new.ObjectValue() {
@@ -401,6 +416,11 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 					if old.IsArray() {
 						for i := range old.ArrayValue() {
 							v := old.ArrayValue()[i]
+							// If this was a secret value in old, but new isn't currently a secret context then we need
+							// to mark this reset value as secret.
+							if oldIsSecret && !newIsSecret {
+								v = MakeSecret(v)
+							}
 							new.ArrayValue()[i] = v
 						}
 					}
@@ -422,7 +442,7 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 						return false
 					}
 
-					if !p[1:].reset(oldValue, newValue) {
+					if !p[1:].reset(oldValue, newValue, oldIsSecret, newIsSecret) {
 						return false
 					}
 				}
@@ -432,7 +452,7 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 				newArray := new.ArrayValue()
 
 				for i := range oldArray {
-					if !p[1:].reset(oldArray[i], newArray[i]) {
+					if !p[1:].reset(oldArray[i], newArray[i], oldIsSecret, newIsSecret) {
 						return false
 					}
 				}
@@ -459,7 +479,11 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 					if !new.IsObject() {
 						return false
 					}
-					// Else simply overwrite the value in new with the value from old
+					// Else simply overwrite the value in new with the value from old, if this was a secret value in
+					// old, but new isn't currently a secret context then we need to mark this reset value as secret.
+					if oldIsSecret && !newIsSecret {
+						v = MakeSecret(v)
+					}
 					new.ObjectValue()[pkey] = v
 				} else {
 					// If the path doesn't exist in old then we want to delete it from new, but if new isn't
@@ -492,7 +516,7 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 				return true
 			}
 
-			return p[1:].reset(old, new)
+			return p[1:].reset(old, new, oldIsSecret, newIsSecret)
 		}
 	}
 
@@ -505,7 +529,7 @@ func (p PropertyPath) reset(old, new PropertyValue) bool {
 // intermediate locations, it also won't create or delete array locations (because that would change the size
 // of the array).
 func (p PropertyPath) Reset(old, new PropertyMap) bool {
-	return p.reset(NewObjectProperty(old), NewObjectProperty(new))
+	return p.reset(NewObjectProperty(old), NewObjectProperty(new), false, false)
 }
 
 func requiresQuote(c rune) bool {

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -313,10 +313,21 @@ func (p PropertyPath) Contains(other PropertyPath) bool {
 	return true
 }
 
+func unwrapSecrets(v PropertyValue) PropertyValue {
+	if v.IsSecret() {
+		return unwrapSecrets(v.SecretValue().Element)
+	}
+	return v
+}
+
 func (p PropertyPath) reset(old, new PropertyValue) bool {
 	if len(p) == 0 {
 		return false
 	}
+
+	// Unwrap any secrets from old & new, we can just go through them for this traversal.
+	old = unwrapSecrets(old)
+	new = unwrapSecrets(new)
 
 	// If this is the last component we want to do the reset, else we want to search for the next component.
 	key := p[0]

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -738,7 +738,7 @@ func TestReset(t *testing.T) {
 			PropertyPath{"root", "secret"},
 			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},
 			PropertyMap{"root": NewProperty(PropertyMap{"secret": NewProperty(2.0)})},
-			&PropertyMap{"root": NewProperty(PropertyMap{"secret": NewProperty(1.0)})},
+			&PropertyMap{"root": NewProperty(PropertyMap{"secret": MakeSecret(NewProperty(1.0))})},
 		},
 		{
 			"Nested path, secret new",
@@ -766,7 +766,7 @@ func TestReset(t *testing.T) {
 				NewProperty(4.0),
 			})},
 			&PropertyMap{"root": NewProperty([]PropertyValue{
-				NewProperty(1.0),
+				MakeSecret(NewProperty(1.0)),
 				NewProperty(4.0),
 			})},
 		},

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -733,6 +733,75 @@ func TestReset(t *testing.T) {
 			})},
 			nil,
 		},
+		{
+			"Nested path, secret old",
+			PropertyPath{"root", "secret"},
+			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},
+			PropertyMap{"root": NewProperty(PropertyMap{"secret": NewProperty(2.0)})},
+			&PropertyMap{"root": NewProperty(PropertyMap{"secret": NewProperty(1.0)})},
+		},
+		{
+			"Nested path, secret new",
+			PropertyPath{"root", "secret"},
+			PropertyMap{"root": NewProperty(PropertyMap{"secret": NewProperty(1.0)})},
+			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(2.0)}))},
+			&PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},
+		},
+		{
+			"Nested path, secret both",
+			PropertyPath{"root", "secret"},
+			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},
+			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(2.0)}))},
+			&PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},
+		},
+		{
+			"Nested array, secret old",
+			PropertyPath{"root", 0},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(2.0),
+			}))},
+			PropertyMap{"root": NewProperty([]PropertyValue{
+				NewProperty(3.0),
+				NewProperty(4.0),
+			})},
+			&PropertyMap{"root": NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(4.0),
+			})},
+		},
+		{
+			"Nested array, secret new",
+			PropertyPath{"root", 0},
+			PropertyMap{"root": NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(2.0),
+			})},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(3.0),
+				NewProperty(4.0),
+			}))},
+			&PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(4.0),
+			}))},
+		},
+		{
+			"Nested array, secret both",
+			PropertyPath{"root", 0},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(2.0),
+			}))},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(3.0),
+				NewProperty(4.0),
+			}))},
+			&PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(4.0),
+			}))},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/6272.

#6272 was failing because the type checks in `PropertyPath.Reset` were too strict. We'd check if a value was an object or array to correctly traverse it, but didn't handle that it might be a "secret object" or "secret array". 

Pretty simple fix, we can just unwrap any outer layers of secretness at each layer as we traverse.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
