### PR TITLE
Cleanup generated import files

### DIFF
--- a/changelog/pending/20231115--cli-import--generated-import-files-from-converter-plugins-omit-empty-optional-fields.yaml
+++ b/changelog/pending/20231115--cli-import--generated-import-files-from-converter-plugins-omit-empty-optional-fields.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Generated import files from converter plugins omit empty optional fields.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -146,12 +146,12 @@ func makeImportFile(
 type importSpec struct {
 	Type              tokens.Type  `json:"type"`
 	Name              tokens.QName `json:"name"`
-	ID                resource.ID  `json:"id"`
-	Parent            string       `json:"parent"`
-	Provider          string       `json:"provider"`
-	Version           string       `json:"version"`
-	PluginDownloadURL string       `json:"pluginDownloadUrl"`
-	Properties        []string     `json:"properties"`
+	ID                resource.ID  `json:"id,omitempty"`
+	Parent            string       `json:"parent,omitempty"`
+	Provider          string       `json:"provider,omitempty"`
+	Version           string       `json:"version,omitempty"`
+	PluginDownloadURL string       `json:"pluginDownloadUrl,omitempty"`
+	Properties        []string     `json:"properties,omitempty"`
 	Component         bool         `json:"component,omitempty"`
 	Remote            bool         `json:"remote,omitempty"`
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Small fixup to the JSON annotations for `importFile` and a little test to verify that. Just want to ensure we don't write out generated import files with all the optional fields written out with empty values, they should just be omited.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
