### PR TITLE
Run dotnet tests on 8

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -122,7 +122,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 
 CURRENT_VERSION_SET = {
     "name": "current",
-    "dotnet": "7",
+    "dotnet": "8",
     "go": "1.21.x",
     "nodejs": "20.x",
     "python": "3.11.x",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

.NET 8 is released, we should ensure tests run against that now.