### PR TITLE
[go] Unit test for LanguageResources(...)

### DIFF
--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -158,12 +160,63 @@ func readSchemaFile(file string) *schema.Package {
 	if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
 		panic(err)
 	}
-	pkg, err := schema.ImportSpec(pkgSpec, map[string]schema.Language{"go": Importer})
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	pkg, diags, err := schema.BindSpec(pkgSpec, loader)
 	if err != nil {
 		panic(err)
 	}
 
+	if diags.HasErrors() {
+		panic(diags.Error())
+	}
+
 	return pkg
+}
+
+func readYamlSchemaFile(file string) *schema.Package {
+	// Read in, decode, and import the schema.
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "testing", "test", "testdata", file))
+	if err != nil {
+		panic(err)
+	}
+	var pkgSpec schema.PackageSpec
+	if err = yaml.Unmarshal(schemaBytes, &pkgSpec); err != nil {
+		panic(err)
+	}
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	pkg, diags, err := schema.BindSpec(pkgSpec, loader)
+	if err != nil {
+		panic(err)
+	}
+
+	if diags.HasErrors() {
+		panic(diags.Error())
+	}
+
+	return pkg
+}
+
+func TestLanguageResources(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range test.PulumiPulumiSDKTests {
+		test := test
+		t.Run(test.Directory, func(t *testing.T) {
+			t.Parallel()
+			var pkg *schema.Package
+			if test.Directory == "simple-yaml-schema" || test.Directory == "cyclic-types" {
+				pkg = readYamlSchemaFile(filepath.Join(test.Directory, "schema.yaml"))
+			} else {
+				pkg = readSchemaFile(filepath.Join(test.Directory, "schema.json"))
+			}
+
+			resources, err := LanguageResources("test", pkg)
+			for token, resource := range resources {
+				assert.Equal(t, tokenToName(token), resource.Name)
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 // We test the naming/module structure of generated packages.


### PR DESCRIPTION
One of a bunch of small PRs for go codegen to exercise pieces of code that have no coverage 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
