### PR TITLE
Update test matrix to run on Python 3.8.x

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -117,7 +117,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
     "dotnet": "6",
     "go": "1.20.x",
     "nodejs": "16.x",
-    "python": "3.9.x",
+    "python": "3.8.x",
 }
 
 CURRENT_VERSION_SET = {


### PR DESCRIPTION
In general, our test matrix runs on the minimum supported version and latest version of each language runtime. Python 3.8.x is still a supported version so try running the tests on 3.8.x.
