### PR TITLE
[sdk] add optional display name and tag fields to project templates

### DIFF
--- a/changelog/pending/20231115--sdk-go--add-project-template-fields.yaml
+++ b/changelog/pending/20231115--sdk-go--add-project-template-fields.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: add optional display name and tag fields to project templates

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -63,14 +63,18 @@ type Analyzers []tokens.QName
 
 // ProjectTemplate is a Pulumi project template manifest.
 type ProjectTemplate struct {
+	// DisplayName is an optional user friendly name of the template.
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	// Description is an optional description of the template.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Quickstart contains optional text to be displayed after template creation.
 	Quickstart string `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`
 	// Config is an optional template config.
 	Config map[string]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`
-	// Important indicates the template is important and should be listed by default.
+	// Important indicates the template is important.
 	Important bool `json:"important,omitempty" yaml:"important,omitempty"`
+	// Tags are key/value pairs used to attach additional metadata to a template.
+	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // ProjectTemplateConfigValue is a config value included in the project template manifest.

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -73,8 +73,8 @@ type ProjectTemplate struct {
 	Config map[string]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`
 	// Important indicates the template is important.
 	Important bool `json:"important,omitempty" yaml:"important,omitempty"`
-	// Tags are key/value pairs used to attach additional metadata to a template.
-	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	// Metadata are key/value pairs used to attach additional metadata to a template.
+	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // ProjectTemplateConfigValue is a config value included in the project template manifest.

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -149,6 +149,13 @@
                 "null"
             ],
             "properties":{
+                "displayName":{
+                    "description":"Optional user-friendly name of the template.",
+                    "type":[
+                        "string",
+                        "null"
+                    ]
+                },
                 "description":{
                     "description":"Description of the template.",
                     "type":[
@@ -169,6 +176,16 @@
                         "boolean",
                         "null"
                     ]
+                },
+                "metadata":{
+                    "description":"Metadata is a map of key/value pairs to associate with the template",
+                    "type":[
+                        "object",
+                        "null"
+                    ],
+                    "additionalProperties":{
+                        "type": "string"
+                    }
                 },
                 "config":{
                     "description":"Config to apply to each stack in the project.",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Add support for two new fields to a project template block:
* `DisplayName` which is used to store a user friendly template name
* `Tags` which is used to store additional template metadata that is author-defined (e.g. team, environment, etc.)

This information will be used in the near-term within the console but longer term could also be used within the CLI.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works

Since this change only adds optional fields I didn't think tests would be worthwhile. I can add tests if it's thought they would be valuable.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
