### PR TITLE
Don't use callerCtx for cancellation in runWithContext

### DIFF
--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -775,7 +775,7 @@ func TestCanceledRefresh(t *testing.T) {
 	}
 
 	snap, err := op.RunWithContext(ctx, project, target, options, false, nil, validate)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "BAIL: canceled")
 	assert.Equal(t, 1, len(refreshed))
 
 	provURN := p.NewProviderURN("pkgA", "default", "")

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -127,7 +127,10 @@ func (op TestOp) runWithContext(
 	close(events)
 	contract.IgnoreClose(journal)
 
-	firedEvents, err := firedEventsPromise.Result(callerCtx)
+	// Wait for the events to finish. You'd think this would cancel with the callerCtx but tests explicitly use that for
+	// the deployment context, not expecting it to have any effect on the test code here. See
+	// https://github.com/pulumi/pulumi/issues/14588 for what happens if you try to use callerCtx here.
+	firedEvents, err := firedEventsPromise.Result(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/14588.
