### PR TITLE
Make `engine.NewEvent` type safe

### DIFF
--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -44,7 +44,7 @@ func TestComputeUpdateStats(t *testing.T) {
 }
 
 func makeResourcePreEvent(urn, resType string, op display.StepOp, retainOnDelete bool) engine.Event {
-	event := engine.NewEvent(engine.ResourcePreEvent, engine.ResourcePreEventPayload{
+	event := engine.NewEvent(engine.ResourcePreEventPayload{
 		Metadata: engine.StepEventMetadata{
 			Op:   op,
 			URN:  resource.URN(urn),

--- a/pkg/backend/cancellation_scope.go
+++ b/pkg/backend/cancellation_scope.go
@@ -63,7 +63,7 @@ func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bo
 					message += colors.BrightRed + "Note that terminating immediately may lead to orphaned resources " +
 						"and other inconsistencies.\n" + colors.Reset
 				}
-				engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+				engine.NewEvent(engine.StdoutEventPayload{
 					Message: message,
 					Color:   colors.Always,
 				})
@@ -71,7 +71,7 @@ func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bo
 				cancelSource.Cancel()
 			} else {
 				message := colors.BrightRed + "^C received; terminating" + colors.Reset
-				engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+				engine.NewEvent(engine.StdoutEventPayload{
 					Message: message,
 					Color:   colors.Always,
 				})

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -63,7 +63,7 @@ func loadEvents(path string) (events []engine.Event, err error) {
 	// If there are no events or if the event stream does not terminate with a cancel event,
 	// synthesize one here.
 	if len(events) == 0 || events[len(events)-1].Type != engine.CancelEvent {
-		events = append(events, engine.NewEvent(engine.CancelEvent, nil))
+		events = append(events, engine.NewCancelEvent())
 	}
 
 	return events, nil

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -276,18 +276,18 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 
 	switch {
 	case apiEvent.CancelEvent != nil:
-		event = engine.NewEvent(engine.CancelEvent, nil)
+		event = engine.NewCancelEvent()
 
 	case apiEvent.StdoutEvent != nil:
 		p := apiEvent.StdoutEvent
-		event = engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+		event = engine.NewEvent(engine.StdoutEventPayload{
 			Message: p.Message,
 			Color:   colors.Colorization(p.Color),
 		})
 
 	case apiEvent.DiagnosticEvent != nil:
 		p := apiEvent.DiagnosticEvent
-		event = engine.NewEvent(engine.DiagEvent, engine.DiagEventPayload{
+		event = engine.NewEvent(engine.DiagEventPayload{
 			URN:       resource.URN(p.URN),
 			Prefix:    p.Prefix,
 			Message:   p.Message,
@@ -299,7 +299,7 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 
 	case apiEvent.PolicyEvent != nil:
 		p := apiEvent.PolicyEvent
-		event = engine.NewEvent(engine.PolicyViolationEvent, engine.PolicyViolationEventPayload{
+		event = engine.NewEvent(engine.PolicyViolationEventPayload{
 			ResourceURN:       resource.URN(p.ResourceURN),
 			Message:           p.Message,
 			Color:             colors.Colorization(p.Color),
@@ -320,7 +320,7 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 		after, err := stack.DeserializeProperties(p.After, crypter, crypter)
 		contract.IgnoreError(err)
 
-		event = engine.NewEvent(engine.PolicyRemediationEvent, engine.PolicyRemediationEventPayload{
+		event = engine.NewEvent(engine.PolicyRemediationEventPayload{
 			ResourceURN:       resource.URN(p.ResourceURN),
 			Color:             colors.Colorization(p.Color),
 			PolicyName:        p.PolicyName,
@@ -334,7 +334,7 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 		p := apiEvent.PreludeEvent
 
 		// Convert the config bag.
-		event = engine.NewEvent(engine.PreludeEvent, engine.PreludeEventPayload{
+		event = engine.NewEvent(engine.PreludeEventPayload{
 			Config: p.Config,
 		})
 
@@ -345,7 +345,7 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 		for op, count := range p.ResourceChanges {
 			changes[display.StepOp(op)] = count
 		}
-		event = engine.NewEvent(engine.SummaryEvent, engine.SummaryEventPayload{
+		event = engine.NewEvent(engine.SummaryEventPayload{
 			MaybeCorrupt:    p.MaybeCorrupt,
 			Duration:        time.Duration(p.DurationSeconds) * time.Second,
 			ResourceChanges: changes,
@@ -354,21 +354,21 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 
 	case apiEvent.ResourcePreEvent != nil:
 		p := apiEvent.ResourcePreEvent
-		event = engine.NewEvent(engine.ResourcePreEvent, engine.ResourcePreEventPayload{
+		event = engine.NewEvent(engine.ResourcePreEventPayload{
 			Metadata: convertJSONStepEventMetadata(p.Metadata),
 			Planning: p.Planning,
 		})
 
 	case apiEvent.ResOutputsEvent != nil:
 		p := apiEvent.ResOutputsEvent
-		event = engine.NewEvent(engine.ResourceOutputsEvent, engine.ResourceOutputsEventPayload{
+		event = engine.NewEvent(engine.ResourceOutputsEventPayload{
 			Metadata: convertJSONStepEventMetadata(p.Metadata),
 			Planning: p.Planning,
 		})
 
 	case apiEvent.ResOpFailedEvent != nil:
 		p := apiEvent.ResOpFailedEvent
-		event = engine.NewEvent(engine.ResourceOperationFailed, engine.ResourceOperationFailedPayload{
+		event = engine.NewEvent(engine.ResourceOperationFailedPayload{
 			Metadata: convertJSONStepEventMetadata(p.Metadata),
 			Status:   resource.Status(p.Status),
 			Steps:    p.Steps,

--- a/pkg/backend/display/events_test.go
+++ b/pkg/backend/display/events_test.go
@@ -30,7 +30,6 @@ func TestRemoveANSI(t *testing.T) {
 	input := "\033[31mHello, World!\033[0m"
 	expected := "Hello, World!"
 	e := engine.NewEvent(
-		engine.DiagEvent,
 		engine.DiagEventPayload{
 			Message: input,
 		},

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -837,7 +837,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		payload := event.Payload().(engine.PreludeEventPayload)
 		preludeEventString := renderPreludeEvent(payload, display.opts)
 		if display.isTerminal {
-			display.processNormalEvent(engine.NewEvent(engine.DiagEvent, engine.DiagEventPayload{
+			display.processNormalEvent(engine.NewEvent(engine.DiagEventPayload{
 				Ephemeral: false,
 				Severity:  diag.Info,
 				Color:     cmdutil.GetGlobalColorization(),
@@ -888,7 +888,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 			// what's going on, we can show them as ephemeral diagnostic messages that are
 			// associated at the top level with the stack.  That way if things are taking a while,
 			// there's insight in the display as to what's going on.
-			display.processNormalEvent(engine.NewEvent(engine.DiagEvent, engine.DiagEventPayload{
+			display.processNormalEvent(engine.NewEvent(engine.DiagEventPayload{
 				Ephemeral: true,
 				Severity:  diag.Info,
 				Color:     cmdutil.GetGlobalColorization(),

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -275,7 +275,7 @@ func TestProgressPolicyPacks(t *testing.T) {
 		}, false)
 
 	// Send policy pack event to the channel
-	eventChannel <- engine.NewEvent(engine.PolicyLoadEvent, engine.PolicyLoadEventPayload{})
+	eventChannel <- engine.NewEvent(engine.PolicyLoadEventPayload{})
 	close(eventChannel)
 	<-doneChannel
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1844,7 +1844,7 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 		if continuationToken == nil {
 			// If the event stream does not terminate with a cancel event, synthesize one here.
 			if lastEvent.Type != engine.CancelEvent {
-				events <- engine.NewEvent(engine.CancelEvent, nil)
+				events <- engine.NewCancelEvent()
 			}
 
 			close(events)

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -187,7 +187,7 @@ func loadEvents(path string) ([]engine.Event, error) {
 	// If there are no events or if the event stream does not terminate with a cancel event,
 	// synthesize one here.
 	if len(events) == 0 || events[len(events)-1].Type != engine.CancelEvent {
-		events = append(events, engine.NewEvent(engine.CancelEvent, nil))
+		events = append(events, engine.NewCancelEvent())
 	}
 
 	return events, nil

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -34,7 +34,7 @@ func Destroy(
 	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
-	defer func() { ctx.Events <- cancelEvent() }()
+	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	info, err := newDeploymentContext(u, "destroy", ctx.ParentSpan)
 	if err != nil {

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -26,7 +26,7 @@ func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Imp
 	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
-	defer func() { ctx.Events <- cancelEvent() }()
+	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	info, err := newDeploymentContext(u, "import", ctx.ParentSpan)
 	if err != nil {

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -42,7 +42,7 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) error {
 	contract.Requiref(q != nil, "update", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
-	defer func() { ctx.Events <- cancelEvent() }()
+	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	tracingSpan := func(opName string, parentSpan opentracing.SpanContext) opentracing.Span {
 		// Create a root span for the operation

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -34,7 +34,7 @@ func Refresh(
 	contract.Requiref(u != nil, "u", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
-	defer func() { ctx.Events <- cancelEvent() }()
+	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	info, err := newDeploymentContext(u, "refresh", ctx.ParentSpan)
 	if err != nil {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -189,7 +189,7 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	contract.Requiref(u != nil, "update", "cannot be nil")
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
-	defer func() { ctx.Events <- cancelEvent() }()
+	defer func() { ctx.Events <- NewCancelEvent() }()
 
 	info, err := newDeploymentContext(u, "update", ctx.ParentSpan)
 	if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Small refactor I noticed while writing a test with engine events. We always had to call `NewEvent` with the tag and payload value for an event and these _had_ to match up else the engine panics. But we can just pass the payload and type switch to work out the tag. Means one less parameter to pass to `NewEvent` and pretty much no chance of it going wrong. To ensure there's really no chance I've added a generic union type so you can only pass payload types to this method now. 

Cancel had to be handled separately because it doesn't have a payload type, it's just nil.