### PR TITLE
[sdk/python] Adds a default exception when dependency cycles are created

### DIFF
--- a/changelog/pending/20231116--sdk-python--introduces-runtimeerror-when-we-detect-a-cycle-upon-adding-dependencies-to-the-graph.yaml
+++ b/changelog/pending/20231116--sdk-python--introduces-runtimeerror-when-we-detect-a-cycle-upon-adding-dependencies-to-the-graph.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Introduces RuntimeError when we detect a cycle upon adding dependencies to the graph. Additionally adds "PULUMI_ERROR_ON_DEPENDENCY_CYCLES" as a new environment variable to control this behavior. Set to `False` to return to the previous behavior, which could potentially re-introduce infinite hangs for some programs.

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -75,6 +75,9 @@ The variable should be set to the log file to which gRPC debug traces will be se
 var GitSSHPassphrase = env.String("GITSSH_PASSPHRASE",
 	"The passphrase to use with Git operations that use SSH.", env.Secret)
 
+var ErrorOnDependencyCycles = env.Bool("ERROR_ON_DEPENDENCY_CYCLES",
+	"Whether or not to error when dependency cycles are detected.")
+
 // Environment variables that affect the self-managed backend.
 var (
 	SelfManagedStateNoLegacyWarning = env.Bool("SELF_MANAGED_STATE_NO_LEGACY_WARNING",

--- a/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
@@ -11,16 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from os import path
+from os import path, environ
 import unittest
 from ..util import LanghostTest
 
 
 class ComponentDependenciesTest(LanghostTest):
     def test_component_dependencies(self):
+        environ["PULUMI_ERROR_ON_DEPENDENCY_CYCLES"] = "false"
         self.run_test(
             program=path.join(self.base_path(), "component_dependencies"),
             expected_resource_count=16)
+        del environ["PULUMI_ERROR_ON_DEPENDENCY_CYCLES"]
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
                           _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,

--- a/tests/integration/python/implicit-dependency-cycles/.gitignore
+++ b/tests/integration/python/implicit-dependency-cycles/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info

--- a/tests/integration/python/implicit-dependency-cycles/Pulumi.yaml
+++ b/tests/integration/python/implicit-dependency-cycles/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: complex_implicit_parent_child_dependencies
+description: A Python program that errors out due to implicitly created dependency cycles
+runtime: python

--- a/tests/integration/python/implicit-dependency-cycles/__main__.py
+++ b/tests/integration/python/implicit-dependency-cycles/__main__.py
@@ -1,0 +1,12 @@
+# Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+# Regression test for https://github.com/pulumi/pulumi/issues/13551
+import pulumi
+
+class A(pulumi.ComponentResource):
+    def __init__(self, name: str, opts=None):
+        super().__init__("my:modules:A", name, {}, opts)
+        a_1 = pulumi.CustomResource("my:module:Child-1", "a-child-1", opts=pulumi.ResourceOptions(parent=self, depends_on=[self]))
+        pulumi.CustomResource("my:module:Child-2", "a-child-2", props={"transitive_urn": a_1.urn} ,opts=pulumi.ResourceOptions(parent=self))
+
+A("a")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently, when we detect that we've created a cycle in the dependency graph, we early-exit. This works well enough for simple cycles, but when early exiting is not sufficient (as when providing a resource output as an argument to another resource's inputs), we will still fail to resolve the full dependency graph. This PR introduces an exception-by-default, as any cycles represent an unsafe/invalid dependency graph and should be resolved manually. We also provide an escape hatch to fall back to current behavior, in case users would prefer to retain the ability to create unsafe dependency graphs (potentially introducing infinite hangs when resolving those graphs).

Fixes https://github.com/pulumi/pulumi/issues/13551

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
