### PR TITLE
handle PolicyLoadEvent in more cases

### DIFF
--- a/changelog/pending/20231117--cli-engine--fix-an-issue-where-the-cli-could-panic-because-of-a-newly-introduced-event.yaml
+++ b/changelog/pending/20231117--cli-engine--fix-an-issue-where-the-cli-could-panic-because-of-a-newly-introduced-event.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/engine
+  description: Fix an issue where the CLI could panic because of a newly introduced event

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -98,6 +98,8 @@ func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventM
 	switch event.Type {
 	case engine.CancelEvent:
 		return ""
+	case engine.PolicyLoadEvent:
+		return ""
 
 		// Currently, prelude, summary, and stdout events are printed the same for both the diff and
 		// progress displays.

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -168,6 +168,9 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 			Steps:    p.Steps,
 		}
 
+	case engine.PolicyLoadEvent:
+		apiEvent.PolicyLoadEvent = &apitype.PolicyLoadEvent{}
+
 	default:
 		return apiEvent, fmt.Errorf("unknown event type %q", e.Type)
 	}
@@ -373,6 +376,9 @@ func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
 			Status:   resource.Status(p.Status),
 			Steps:    p.Steps,
 		})
+
+	case apiEvent.PolicyLoadEvent != nil:
+		event = engine.NewEvent(engine.PolicyLoadEventPayload{})
 
 	default:
 		return event, errors.New("unknown event type")

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -203,6 +203,9 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 		case engine.PolicyViolationEvent:
 			// At this point in time, we don't handle policy events in JSON serialization
 			continue
+		case engine.PolicyLoadEvent:
+			// At this point in time, we don't handle policy events in JSON serialization
+			continue
 		case engine.SummaryEvent:
 			// At the end of the preview, a summary event indicates the final conclusions.
 			p := e.Payload().(engine.SummaryEventPayload)

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -93,6 +93,9 @@ func renderQueryEvent(event engine.Event, opts Options) string {
 		contract.Failf("query mode does not support resource operations")
 		return ""
 
+	case engine.PolicyLoadEvent:
+		return ""
+
 	default:
 		contract.Failf("unknown event type '%s'", event.Type)
 		return ""

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -46,7 +46,7 @@ func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, op
 		// For all other events, use the payload to build up the JSON digest we'll emit later.
 		switch e.Type {
 		// Events occurring early:
-		case engine.PreludeEvent, engine.SummaryEvent, engine.StdoutColorEvent:
+		case engine.PreludeEvent, engine.SummaryEvent, engine.StdoutColorEvent, engine.PolicyLoadEvent:
 			// Ignore it
 			continue
 		case engine.PolicyViolationEvent:

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -195,6 +195,9 @@ type ResOpFailedEvent struct {
 	Steps    int               `json:"steps"`
 }
 
+// PolicyLoadEvent is emitted when a policy starts loading
+type PolicyLoadEvent struct{}
+
 // EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
 // message. EngineEvent is a discriminated union of all possible event types, and exactly one
 // field will be non-nil.
@@ -221,6 +224,7 @@ type EngineEvent struct {
 	ResOpFailedEvent       *ResOpFailedEvent       `json:"resOpFailedEvent,omitempty"`
 	PolicyEvent            *PolicyEvent            `json:"policyEvent,omitempty"`
 	PolicyRemediationEvent *PolicyRemediationEvent `json:"policyRemediationEvent,omitempty"`
+	PolicyLoadEvent        *PolicyLoadEvent        `json:"policyLoadEvent,omitempty"`
 }
 
 // EngineEventBatch is a group of engine events.


### PR DESCRIPTION
When introducing the PolicyLoadEvent I missed handling it in some cases.  Do so now to avoid panics because it's not handled properly.

Fixes #14598

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
