### PR TITLE
Support converting out yaml templates

### DIFF
--- a/changelog/pending/20231117--cli-new--convert-yaml-templates-to-any-other-language.yaml
+++ b/changelog/pending/20231117--cli-new--convert-yaml-templates-to-any-other-language.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Convert yaml templates to any other language.

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -250,18 +250,18 @@ func promptMock(name string, stackName string) promptForValueFunc {
 
 func loadProject(t *testing.T, dir string) *workspace.Project {
 	path, err := workspace.DetectProjectPathFrom(dir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	proj, err := workspace.LoadProject(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return proj
 }
 
 func currentUser(t *testing.T) string {
 	ctx := context.Background()
 	b, err := currentBackend(ctx, nil, display.Options{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	currentUser, _, _, err := b.CurrentUser()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return currentUser
 }
 
@@ -275,13 +275,13 @@ func removeStack(t *testing.T, dir, name string) {
 	project := loadProject(t, dir)
 	ctx := context.Background()
 	b, err := currentBackend(ctx, project, display.Options{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	stack, err := b.GetStack(context.Background(), ref)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = b.RemoveStack(context.Background(), stack, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func skipIfShortOrNoPulumiAccessToken(t *testing.T) {

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -1052,3 +1052,34 @@ func TestPulumiNewConflictingProject(t *testing.T) {
 		))
 	assert.Truef(t, called, "expected resolution to be called with duplicate name")
 }
+
+//nolint:paralleltest // changes directory for process
+func TestCreatingYamlProjectWithLanguageSpecified(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+	uniqueProjectName := filepath.Base(tempdir) + "test"
+
+	args := newArgs{
+		interactive:       false,
+		yes:               true,
+		name:              uniqueProjectName,
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "aws-yaml",
+		language:          "go",
+	}
+
+	err := runNew(context.Background(), args)
+	require.NoError(t, err)
+
+	removeStack(t, tempdir, stackName)
+
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, "go", proj.Runtime.Name())
+
+	_, err = os.Stat(filepath.Join(tempdir, "main.go"))
+	assert.NoError(t, err)
+}

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -205,6 +205,7 @@ type Template struct {
 	Error       error                                 // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
+	ProjectRuntime     string // The runtime of the project.
 	ProjectDescription string // Optional description of the project.
 }
 
@@ -466,7 +467,8 @@ func LoadTemplate(path string) (Template, error) {
 		Dir:  path,
 		Name: filepath.Base(path),
 
-		ProjectName: proj.Name.String(),
+		ProjectName:    proj.Name.String(),
+		ProjectRuntime: proj.Runtime.Name(),
 	}
 	if proj.Template != nil {
 		template.Description = proj.Template.Description


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14070.

This shows a language selector after picking a YAML template, we then run convert logic to emit the template into the selected language rather than YAML.

If the CLI is currently non-interactive we default to just emiting the YAML version, but this can be set via a command line option (--language) as well.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
