### PR TITLE
Send all events to the engine event stream

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -95,6 +95,10 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	go func() {
 		// Pull out relevant events we will want to display in the confirmation below.
 		for e := range eventsChannel {
+			// Don't include internal events in the confirmation stats.
+			if e.Internal() {
+				continue
+			}
 			if e.Type == engine.ResourcePreEvent ||
 				e.Type == engine.ResourceOutputsEvent ||
 				e.Type == engine.PolicyRemediationEvent ||

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/channel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -63,6 +64,11 @@ func ShowEvents(
 	op string, action apitype.UpdateKind, stack tokens.StackName, proj tokens.PackageName,
 	permalink string, events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool,
 ) {
+	// Need to filter the engine events here to exclude any internal events.
+	events = channel.FilterRead(events, func(e engine.Event) bool {
+		return !e.Internal()
+	})
+
 	if opts.EventLogPath != "" {
 		events, done = startEventLogger(events, done, opts)
 	}

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -100,6 +100,9 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 						for _, event := range events {
 							if event.Type == ResourcePreEvent {
 								payload := event.Payload().(ResourcePreEventPayload)
+								if payload.Metadata.Type == "pulumi:providers:pkgA" {
+									continue
+								}
 								assert.Subset(t, allowedOps, []display.StepOp{payload.Metadata.Op})
 							}
 						}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1238,7 +1238,11 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 						for _, event := range events {
 							if event.Type == ResourcePreEvent {
 								payload := event.Payload().(ResourcePreEventPayload)
-								assert.Subset(t, allowedOps, []display.StepOp{payload.Metadata.Op})
+								if payload.Metadata.URN == "urn:pulumi:test::test::pkgA:m:typA::resA" {
+									assert.Subset(t,
+										allowedOps, []display.StepOp{payload.Metadata.Op},
+										"event operation unexpected: %v", payload)
+								}
 							}
 						}
 						return err
@@ -1477,7 +1481,10 @@ func replaceOnChangesTest(t *testing.T, name string, diffFunc DiffFunc) {
 							for _, event := range events {
 								if event.Type == ResourcePreEvent {
 									payload := event.Payload().(ResourcePreEventPayload)
-									assert.Subset(t, allowedOps, []display.StepOp{payload.Metadata.Op})
+									// Ignore any events for default providers
+									if !payload.Internal {
+										assert.Subset(t, allowedOps, []display.StepOp{payload.Metadata.Op})
+									}
 								}
 							}
 							return err

--- a/sdk/go/common/channel/channel.go
+++ b/sdk/go/common/channel/channel.go
@@ -1,0 +1,30 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+// FilterRead reads every item from the input channel and writes it to the output channel if the given filter function
+// returns true for it.
+func FilterRead[T any](ch <-chan T, f func(T) bool) <-chan T {
+	out := make(chan T)
+	go func() {
+		for v := range ch {
+			if f(v) {
+				out <- v
+			}
+		}
+		close(out)
+	}()
+	return out
+}

--- a/sdk/go/common/channel/channel_test.go
+++ b/sdk/go/common/channel/channel_test.go
@@ -1,0 +1,48 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterRead(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan int)
+	filter := func(i int) bool { return i < 10 }
+	filtered := FilterRead(ch, filter)
+	seenP := promise.Run(func() ([]int, error) {
+		var out []int
+		for i := range filtered {
+			out = append(out, i)
+		}
+		return out, nil
+	})
+
+	for i := 0; i < 20; i++ {
+		ch <- i
+	}
+	close(ch)
+
+	seen, err := seenP.Result(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, seen)
+}


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently the engine skips sending some resource events to the event stream. Currently that's any "RemovePendingDelete" steps and anything to do with default providers.

This was added so that we wouldn't display "internal implemntation details" like default providers to the user in the tree or diff views.

However we wanted to use the engine event stream to support generating an import file from preview deployments (make an import for every resource that needs to be created). This mostly works except for the imports we also need to know some of the provider details, and while the event stream will tell us about explicit providers the skipping of default providers means we can't get their information in the import generater code.

So this moves this filtering out of the engine and to the display logic instead. We still leave it up to the engine to mark what events it considers "internal" but they're always sent to the event stream.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - This shouldn't change anything user visible so should be covered by existing tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - No user visible change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
