### PR TITLE
Use promise rather than `atomic.Value` to record step errors.

### DIFF
--- a/changelog/pending/20231117--engine--fix-a-panic-in-cancellation.yaml
+++ b/changelog/pending/20231117--engine--fix-a-panic-in-cancellation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic in cancellation.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14611.

`atomic.Value` panics if a second value is written to it which isn't _exactly_ the same type. We were using this to atomically record any errors that happened, although where only interested in saving the first error.

This was fine if no or one error happened, or if multiple errors happened that all were the same error type. But if two errors if different error types happened `sync.Value` would panic.

Switched to use a promise completion source instead. If any error happens we use it to reject the completion source, we also log if this isn't the first error we've seen (a capabilitiy that `sync.Value` didn't give us). At the end of the step executor being used when `Errored()` is called we try to get the result of the completion source.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works - Added tests for the new promise function `TryResult`, not sure it's that needed to try and write a test for the error case we hit in #14611 now that it's type safe.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
