### PR TITLE
Use DisplayName from template files

### DIFF
--- a/changelog/pending/20231118--cli-new--use-templates-displayname-when-listing-templates.yaml
+++ b/changelog/pending/20231118--cli-new--use-templates-displayname-when-listing-templates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Use templates `DisplayName` when listing templates.

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -226,7 +226,7 @@ func newUpCmd() *cobra.Command {
 		} else if len(templates) == 1 {
 			template = templates[0]
 		} else {
-			if template, err = chooseTemplate(templates, opts.Display); err != nil {
+			if template, err = chooseTemplate(templates, opts.Display, nil); err != nil {
 				return result.FromError(err)
 			}
 		}

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -198,6 +198,7 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 type Template struct {
 	Dir         string                                // The directory containing Pulumi.yaml.
 	Name        string                                // The name of the template.
+	DisplayName string                                // The optional display name of the template.
 	Description string                                // Description of the template.
 	Quickstart  string                                // Optional text to be displayed after template creation.
 	Config      map[string]ProjectTemplateConfigValue // Optional template config.
@@ -469,6 +470,7 @@ func LoadTemplate(path string) (Template, error) {
 		ProjectName: proj.Name.String(),
 	}
 	if proj.Template != nil {
+		template.DisplayName = proj.Template.DisplayName
 		template.Description = proj.Template.Description
 		template.Quickstart = proj.Template.Quickstart
 		template.Config = proj.Template.Config


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Small addition to make use of the DisplayName field added to template files by https://github.com/pulumi/pulumi/pull/14587. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
