### PR TITLE
Fix optional handling on nested props

### DIFF
--- a/changelog/pending/20231121--sdk-go--Fix-optional-handling-on-nested-props.yaml
+++ b/changelog/pending/20231121--sdk-go--Fix-optional-handling-on-nested-props.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix optional handling on nested props

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -564,6 +564,7 @@ func copyToStruct(ctx *Context, v resource.PropertyValue, typ reflect.Type, dest
 		}
 
 		tag := typ.Field(i).Tag.Get("pulumi")
+		tag = strings.Split(tag, ",")[0] // tagName,flag => tagName
 		if tag == "" {
 			continue
 		}

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -226,7 +226,7 @@ type NestedMapOutputArgs struct {
 
 type Nested struct {
 	Foo string `pulumi:"foo"`
-	Bar int    `pulumi:"bar"`
+	Bar int    `pulumi:"bar,optional"`
 }
 
 type NestedOutput struct {

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/blang/semver"
@@ -155,6 +156,7 @@ func marshalInputs(props Input) (resource.PropertyMap, map[string][]URN, []URN, 
 		for i := 0; i < numFields; i++ {
 			destField, _ := getMappedField(reflect.Value{}, i)
 			tag := destField.Tag.Get("pulumi")
+			tag = strings.Split(tag, ",")[0] // tagName,flag => tagName
 			if tag == "" {
 				continue
 			}
@@ -448,6 +450,7 @@ func marshalInputImpl(v interface{},
 			for i := 0; i < typ.NumField(); i++ {
 				destField, _ := getMappedField(reflect.Value{}, i)
 				tag := destField.Tag.Get("pulumi")
+				tag = strings.Split(tag, ",")[0] // tagName,flag => tagName
 				if tag == "" {
 					continue
 				}
@@ -789,6 +792,7 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 			}
 
 			tag := typ.Field(i).Tag.Get("pulumi")
+			tag = strings.Split(tag, ",")[0] // tagName,flag => tagName
 			if tag == "" {
 				continue
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
When you had a provider that accepted a nested struct that had optional props. Those props were always empty. Example: https://github.com/MMartyn/pulumi-foo/tree/repro/optional-bug/examples/optional

From walking through the execution the tags weren't stripping the `,optional` out before looking up the property so it wasn't finding them and copying the values.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
