### PR TITLE
[typescrypt/program-gen] Fix generated readFile function so that it includes the encoding

### DIFF
--- a/changelog/pending/20231122--programgen-nodejs--fix-generated-readfile-function-so-that-it-includes-the-encoding-and-returns-a-string.yaml
+++ b/changelog/pending/20231122--programgen-nodejs--fix-generated-readfile-function-so-that-it-includes-the-encoding-and-returns-a-string.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix generated readFile function so that it includes the encoding and returns a string

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -459,7 +459,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "range":
 		g.genRange(w, expr, false)
 	case "readFile":
-		g.Fgenf(w, "fs.readFileSync(%v)", expr.Args[0])
+		g.Fgenf(w, "fs.readFileSync(%v, \"utf8\")", expr.Args[0])
 	case "readDir":
 		g.Fgenf(w, "fs.readdirSync(%v)", expr.Args[0])
 	case "secret":

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -110,6 +110,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "AWS IAM Policy",
 	},
 	{
+		Directory:   "read-file-func",
+		Description: "ReadFile function translation works",
+	},
+	{
 		Directory:   "python-regress-10914",
 		Description: "Python regression test for #10914",
 		Skip:        allProgLanguages.Except("python"),

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/dotnet/read-file-func.cs
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/dotnet/read-file-func.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Pulumi;
 
 return await Deployment.RunAsync(() => 

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/nodejs/read-file-func.ts
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/nodejs/read-file-func.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 
-const key = fs.readFileSync("key.pub");
+const key = fs.readFileSync("key.pub", "utf8");
 export const result = key;

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/readme-pp/nodejs/readme.ts
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/readme-pp/nodejs/readme.ts
@@ -6,4 +6,4 @@ export const arrVar = [
     "fizz",
     "buzz",
 ];
-export const readme = fs.readFileSync("./Pulumi.README.md");
+export const readme = fs.readFileSync("./Pulumi.README.md", "utf8");


### PR DESCRIPTION
# Description

Small fix for generated `readFile` function so that it includes the encoding and returns a string

Fixes #14630

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
