### PR TITLE
[esc] Add a command to create an ESC env from stack config

### DIFF
--- a/changelog/pending/20231122--cli-config--add-a-command-to-create-an-esc-environment-from-stack-config.yaml
+++ b/changelog/pending/20231122--cli-config--add-a-command-to-create-an-esc-environment-from-stack-config.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Add a command to create an ESC environment from stack config

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -220,6 +220,13 @@ type Backend interface {
 
 // EnvironmentsBackend is an interface that defines an optional capability for a backend to work with environments.
 type EnvironmentsBackend interface {
+	CreateEnvironment(
+		ctx context.Context,
+		org string,
+		name string,
+		yaml []byte,
+	) (apitype.EnvironmentDiagnostics, error)
+
 	CheckYAMLEnvironment(
 		ctx context.Context,
 		org string,

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -377,6 +377,13 @@ var _ = EnvironmentsBackend((*MockEnvironmentsBackend)(nil))
 type MockEnvironmentsBackend struct {
 	MockBackend
 
+	CreateEnvironmentF func(
+		ctx context.Context,
+		org string,
+		name string,
+		yaml []byte,
+	) (apitype.EnvironmentDiagnostics, error)
+
 	CheckYAMLEnvironmentF func(
 		ctx context.Context,
 		org string,
@@ -389,6 +396,18 @@ type MockEnvironmentsBackend struct {
 		yaml []byte,
 		duration time.Duration,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
+}
+
+func (be *MockEnvironmentsBackend) CreateEnvironment(
+	ctx context.Context,
+	org string,
+	name string,
+	yaml []byte,
+) (apitype.EnvironmentDiagnostics, error) {
+	if be.CreateEnvironmentF != nil {
+		return be.CreateEnvironmentF(ctx, org, name, yaml)
+	}
+	panic("not implemented")
 }
 
 func (be *MockEnvironmentsBackend) CheckYAMLEnvironment(

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -47,10 +47,12 @@ func newConfigEnvCmd(stackRef *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Manage ESC environments for a stack",
-		Long:  "Manages the ESC environment associated with a specific stack.",
-		Args:  cmdutil.NoArgs,
+		Long: "Manages the ESC environment associated with a specific stack. To create a new environment\n" +
+			"from a stack's configuration, use `pulumi config env init`.",
+		Args: cmdutil.NoArgs,
 	}
 
+	cmd.AddCommand(newConfigEnvInitCmd(&impl))
 	cmd.AddCommand(newConfigEnvAddCmd(&impl))
 	cmd.AddCommand(newConfigEnvRmCmd(&impl))
 

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -1,0 +1,346 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"text/template"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/erikgeiser/promptkit/confirmation"
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/eval"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvInitCmd{
+		parent:     parent,
+		newCrypter: newConfigEnvInitCrypter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Creates an environment for a stack",
+		Long: "Creates an environment for a specific stack based on the stack's configuration values,\n" +
+			"then replaces the stack's configuration values with a reference to that environment.\n" +
+			"The environment will be created in the same organization as the stack.",
+		Args: cmdutil.NoArgs,
+		Run:  cmdutil.RunFunc(impl.run),
+	}
+
+	cmd.Flags().StringVar(
+		&impl.envName, "env", "",
+		`The name of the environment to create. Defaults to "<project name>-<stack name>"`)
+	cmd.Flags().BoolVar(
+		&impl.showSecrets, "show-secrets", false,
+		"Show secret values in plaintext instead of ciphertext")
+	cmd.Flags().BoolVar(
+		&impl.keepConfig, "keep-config", false,
+		"Do not remove configuration values from the stack after creating the environment")
+	cmd.Flags().BoolVarP(
+		&impl.yes, "yes", "y", false,
+		"True to save the created environment without prompting")
+
+	return cmd
+}
+
+var envPreviewTemplate = template.Must(template.New("env-preview").Parse("# Value\n" +
+	"```json\n" +
+	"{{.Preview}}\n" +
+	"```\n" +
+	"# Definition\n" +
+	"```yaml\n" +
+	"{{.Definition}}\n" +
+	"```\n"))
+
+type configEnvInitCmd struct {
+	parent *configEnvCmd
+
+	newCrypter func() (evalCrypter, error)
+
+	envName     string
+	showSecrets bool
+	keepConfig  bool
+	yes         bool
+}
+
+func (cmd *configEnvInitCmd) run(_ *cobra.Command, args []string) error {
+	if !cmd.yes && !cmd.parent.interactive {
+		return errors.New("--yes must be passed in to proceed when running in non-interactive mode")
+	}
+
+	ctx := cmd.parent.ctx
+
+	opts := display.Options{Color: cmd.parent.color}
+
+	project, _, err := cmd.parent.readProject()
+	if err != nil {
+		return err
+	}
+
+	stack, err := cmd.parent.requireStack(ctx, *cmd.parent.stackRef, stackOfferNew|stackSetCurrent, opts)
+	if err != nil {
+		return err
+	}
+
+	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+
+	orgName := stack.(interface{ OrgName() string }).OrgName()
+
+	if cmd.envName == "" {
+		cmd.envName = fmt.Sprintf("%v-%v", project.Name, stack.Ref().Name())
+	}
+
+	fmt.Fprintf(cmd.parent.stdout, "Creating environment %v for stack %v...\n", cmd.envName, stack.Ref().Name())
+
+	projectStack, config, err := cmd.getStackConfig(ctx, project, stack)
+	if err != nil {
+		return err
+	}
+
+	crypter, err := cmd.newCrypter()
+	if err != nil {
+		return err
+	}
+
+	yaml, err := cmd.renderEnvironmentDefinition(ctx, cmd.envName, crypter, config, cmd.showSecrets)
+	if err != nil {
+		return err
+	}
+
+	preview, err := cmd.renderPreview(ctx, envBackend, orgName, cmd.envName, yaml, cmd.showSecrets)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(cmd.parent.stdout, preview)
+
+	if !cmd.yes {
+		save, err := confirmation.New("Save?", confirmation.Yes).RunPrompt()
+		if err != nil {
+			return err
+		}
+		if !save {
+			return errors.New("canceled")
+		}
+	}
+
+	if !cmd.showSecrets {
+		yaml, err = eval.DecryptSecrets(ctx, cmd.envName, yaml, crypter)
+		if err != nil {
+			return err
+		}
+	}
+
+	diags, err := envBackend.CreateEnvironment(ctx, orgName, cmd.envName, yaml)
+	if err != nil {
+		return fmt.Errorf("creating environment: %w", err)
+	}
+	if len(diags) != 0 {
+		return fmt.Errorf("internal error creating environment: %w", diags)
+	}
+
+	projectStack.Environment = projectStack.Environment.Append(cmd.envName)
+	if !cmd.keepConfig {
+		projectStack.Config = nil
+	}
+	if err = cmd.parent.saveProjectStack(stack, projectStack); err != nil {
+		return fmt.Errorf("saving stack config: %w", err)
+	}
+	return nil
+}
+
+func (cmd *configEnvInitCmd) getStackConfig(
+	ctx context.Context,
+	project *workspace.Project,
+	stack backend.Stack,
+) (*workspace.ProjectStack, resource.PropertyMap, error) {
+	ps, err := cmd.parent.loadProjectStack(project, stack)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	decrypter, needsSave, err := getStackDecrypter(stack, ps)
+	if err != nil {
+		return nil, nil, err
+	}
+	// This may have setup the stack's secrets provider, so save the stack if needed.
+	if needsSave {
+		if err = cmd.parent.saveProjectStack(stack, ps); err != nil {
+			return nil, nil, fmt.Errorf("saving stack config: %w", err)
+		}
+	}
+
+	m, err := ps.Config.AsDecryptedPropertyMap(ctx, decrypter)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ps, m, nil
+}
+
+func (cmd *configEnvInitCmd) render(v resource.PropertyValue) any {
+	switch {
+	case v.IsBool():
+		return v.BoolValue()
+	case v.IsNumber():
+		return v.NumberValue()
+	case v.IsString():
+		return v.StringValue()
+	case v.IsArray():
+		arrV := v.ArrayValue()
+		rendered := make([]any, len(arrV))
+		for i, v := range arrV {
+			rendered[i] = cmd.render(v)
+		}
+		return rendered
+	case v.IsObject():
+		objV := v.ObjectValue()
+		rendered := make(map[string]any, len(objV))
+		for k, v := range objV {
+			rendered[string(k)] = cmd.render(v)
+		}
+		return rendered
+	case v.IsSecret():
+		return map[string]any{
+			"fn::secret": cmd.render(v.SecretValue().Element),
+		}
+	default:
+		return nil
+	}
+}
+
+func (cmd *configEnvInitCmd) renderEnvironmentDefinition(
+	ctx context.Context,
+	envName string,
+	encrypter eval.Encrypter,
+	config resource.PropertyMap,
+	showSecrets bool,
+) ([]byte, error) {
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	err := enc.Encode(map[string]any{
+		"values": map[string]any{
+			"pulumiConfig": cmd.render(resource.NewObjectProperty(config)),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	yaml := b.Bytes()
+	if !showSecrets {
+		yaml, err = eval.EncryptSecrets(ctx, envName, yaml, encrypter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return yaml, nil
+}
+
+func (cmd *configEnvInitCmd) renderPreview(
+	ctx context.Context,
+	b backend.EnvironmentsBackend,
+	org string,
+	name string,
+	yaml []byte,
+	showSecrets bool,
+) (string, error) {
+	env, diags, err := b.CheckYAMLEnvironment(ctx, org, yaml)
+	if err != nil {
+		return "", err
+	}
+	if len(diags) != 0 {
+		return "", fmt.Errorf("internal error: %w", diags)
+	}
+
+	envJSON, err := json.MarshalIndent(esc.NewValue(env.Properties).ToJSON(!showSecrets), "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encoding value: %w", err)
+	}
+
+	var markdown bytes.Buffer
+	err = envPreviewTemplate.Execute(&markdown, map[string]any{
+		"Preview":    string(envJSON),
+		"Definition": string(yaml),
+	})
+	if err != nil {
+		return "", fmt.Errorf("rendering preview: %w", err)
+	}
+
+	if !cmdutil.InteractiveTerminal() {
+		return markdown.String(), nil
+	}
+
+	renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithWordWrap(0))
+	if err != nil {
+		return "", fmt.Errorf("internal error: creating renderer: %w", err)
+	}
+	rendered, err := renderer.Render(markdown.String())
+	if err != nil {
+		rendered = markdown.String()
+	}
+
+	return rendered, nil
+}
+
+type evalCrypter interface {
+	eval.Decrypter
+	eval.Encrypter
+}
+
+type configEnvInitCrypter struct {
+	crypter config.Crypter
+}
+
+func newConfigEnvInitCrypter() (evalCrypter, error) {
+	key := make([]byte, config.SymmetricCrypterKeyBytes)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generating key: %w", err)
+	}
+	return &configEnvInitCrypter{crypter: config.NewSymmetricCrypter(key)}, nil
+}
+
+func (c configEnvInitCrypter) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	ciphertext, err := c.crypter.EncryptValue(ctx, string(plaintext))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(ciphertext), nil
+}
+
+func (c configEnvInitCrypter) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	plaintext, err := c.crypter.DecryptValue(ctx, string(ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(plaintext), nil
+}

--- a/pkg/cmd/pulumi/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config_env_init_test.go
@@ -1,0 +1,329 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type base64EvalCrypter struct{}
+
+func newBase64EvalCrypter() (evalCrypter, error) {
+	return base64EvalCrypter{}, nil
+}
+
+func (c base64EvalCrypter) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	ciphertext, err := config.Base64Crypter.EncryptValue(ctx, string(plaintext))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(ciphertext), nil
+}
+
+func (c base64EvalCrypter) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	plaintext, err := config.Base64Crypter.DecryptValue(ctx, string(ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(plaintext), nil
+}
+
+func TestConfigEnvInit(t *testing.T) {
+	t.Parallel()
+
+	projectYAML := `name: test
+runtime: yaml`
+
+	t.Run("no config", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		var newStackYAML string
+		stdin := strings.NewReader("y")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, "", &newStackYAML, envDefMap{})
+		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, yes: true}
+		err := init.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+			"# Value\n" +
+			"```json\n" +
+			"{\n" +
+			"  \"pulumiConfig\": {}\n" +
+			"}\n" +
+			"```\n" +
+			"# Definition\n" +
+			"```yaml\n" +
+			"values:\n" +
+			"  pulumiConfig: {}\n" +
+			"\n" +
+			"```\n" +
+			""
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+
+		const expectedYAML = `environment:
+  - test-stack
+`
+
+		assert.Equal(t, expectedYAML, newStackYAML)
+	})
+
+	t.Run("some config", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		plaintext := map[string]config.Plaintext{
+			"aws:region":   config.NewPlaintext("us-west-2"),
+			"app:password": config.NewSecurePlaintext("hunter2"),
+			"app:tags": config.NewPlaintext(map[string]config.Plaintext{
+				"env": config.NewPlaintext("testing"),
+				"owners": config.NewPlaintext([]config.Plaintext{
+					config.NewPlaintext("alice"),
+					config.NewPlaintext("bob"),
+				}),
+			}),
+		}
+		cfg := make(config.Map)
+		for k, v := range plaintext {
+			cv, err := v.Encrypt(ctx, config.Base64Crypter)
+			require.NoError(t, err)
+			ns, name, _ := strings.Cut(k, ":")
+			cfg[config.MustMakeKey(ns, name)] = cv
+		}
+
+		stackYAML, err := encoding.YAML.Marshal(workspace.ProjectStack{Config: cfg})
+		require.NoError(t, err)
+
+		var newStackYAML string
+		stdin := strings.NewReader("y")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
+		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, yes: true}
+		err = init.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+			"# Value\n" +
+			"```json\n" +
+			"{\n" +
+			"  \"pulumiConfig\": {\n" +
+			"    \"app:password\": \"[secret]\",\n" +
+			"    \"app:tags\": {\n" +
+			"      \"env\": \"testing\",\n" +
+			"      \"owners\": [\n" +
+			"        \"alice\",\n" +
+			"        \"bob\"\n" +
+			"      ]\n" +
+			"    },\n" +
+			"    \"aws:region\": \"us-west-2\"\n" +
+			"  }\n" +
+			"}\n" +
+			"```\n" +
+			"# Definition\n" +
+			"```yaml\n" +
+			"values:\n" +
+			"  pulumiConfig:\n" +
+			"    app:password:\n" +
+			"      fn::secret:\n" +
+			"        ciphertext: ZXNjeAAAAAFhSFZ1ZEdWeU1nPT2+gKwa\n" +
+			"    app:tags:\n" +
+			"      env: testing\n" +
+			"      owners:\n" +
+			"        - alice\n" +
+			"        - bob\n" +
+			"    aws:region: us-west-2\n" +
+			"\n" +
+			"```\n" +
+			""
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+
+		const expectedYAML = `environment:
+  - test-stack
+`
+		assert.Equal(t, expectedYAML, newStackYAML)
+	})
+
+	t.Run("some config, show secrets", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		plaintext := map[string]config.Plaintext{
+			"aws:region":   config.NewPlaintext("us-west-2"),
+			"app:password": config.NewSecurePlaintext("hunter2"),
+			"app:tags": config.NewPlaintext(map[string]config.Plaintext{
+				"env": config.NewPlaintext("testing"),
+				"owners": config.NewPlaintext([]config.Plaintext{
+					config.NewPlaintext("alice"),
+					config.NewPlaintext("bob"),
+				}),
+			}),
+		}
+		cfg := make(config.Map)
+		for k, v := range plaintext {
+			cv, err := v.Encrypt(ctx, config.Base64Crypter)
+			require.NoError(t, err)
+			ns, name, _ := strings.Cut(k, ":")
+			cfg[config.MustMakeKey(ns, name)] = cv
+		}
+
+		stackYAML, err := encoding.YAML.Marshal(workspace.ProjectStack{Config: cfg})
+		require.NoError(t, err)
+
+		var newStackYAML string
+		stdin := strings.NewReader("y")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
+		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, showSecrets: true, yes: true}
+		err = init.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+			"# Value\n" +
+			"```json\n" +
+			"{\n" +
+			"  \"pulumiConfig\": {\n" +
+			"    \"app:password\": \"hunter2\",\n" +
+			"    \"app:tags\": {\n" +
+			"      \"env\": \"testing\",\n" +
+			"      \"owners\": [\n" +
+			"        \"alice\",\n" +
+			"        \"bob\"\n" +
+			"      ]\n" +
+			"    },\n" +
+			"    \"aws:region\": \"us-west-2\"\n" +
+			"  }\n" +
+			"}\n" +
+			"```\n" +
+			"# Definition\n" +
+			"```yaml\n" +
+			"values:\n" +
+			"  pulumiConfig:\n" +
+			"    app:password:\n" +
+			"      fn::secret: hunter2\n" +
+			"    app:tags:\n" +
+			"      env: testing\n" +
+			"      owners:\n" +
+			"        - alice\n" +
+			"        - bob\n" +
+			"    aws:region: us-west-2\n" +
+			"\n" +
+			"```\n" +
+			""
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+
+		const expectedYAML = `environment:
+  - test-stack
+`
+		assert.Equal(t, expectedYAML, newStackYAML)
+	})
+
+	t.Run("other env, some config, show secrets", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		plaintext := map[string]config.Plaintext{
+			"aws:region":   config.NewPlaintext("us-west-2"),
+			"app:password": config.NewSecurePlaintext("hunter2"),
+			"app:tags": config.NewPlaintext(map[string]config.Plaintext{
+				"env": config.NewPlaintext("testing"),
+				"owners": config.NewPlaintext([]config.Plaintext{
+					config.NewPlaintext("alice"),
+					config.NewPlaintext("bob"),
+				}),
+			}),
+		}
+		cfg := make(config.Map)
+		for k, v := range plaintext {
+			cv, err := v.Encrypt(ctx, config.Base64Crypter)
+			require.NoError(t, err)
+			ns, name, _ := strings.Cut(k, ":")
+			cfg[config.MustMakeKey(ns, name)] = cv
+		}
+
+		stackYAML, err := encoding.YAML.Marshal(workspace.ProjectStack{
+			Environment: workspace.NewEnvironment([]string{"env"}),
+			Config:      cfg,
+		})
+		require.NoError(t, err)
+
+		var newStackYAML string
+		stdin := strings.NewReader("y")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{
+			"env": `{"values": {"pulumiConfig": {"app:tags": {"name": "project"}}}}`,
+		})
+		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, showSecrets: true, yes: true}
+		err = init.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "Creating environment test-stack for stack stack...\n" +
+			"# Value\n" +
+			"```json\n" +
+			"{\n" +
+			"  \"pulumiConfig\": {\n" +
+			"    \"app:password\": \"hunter2\",\n" +
+			"    \"app:tags\": {\n" +
+			"      \"env\": \"testing\",\n" +
+			"      \"owners\": [\n" +
+			"        \"alice\",\n" +
+			"        \"bob\"\n" +
+			"      ]\n" +
+			"    },\n" +
+			"    \"aws:region\": \"us-west-2\"\n" +
+			"  }\n" +
+			"}\n" +
+			"```\n" +
+			"# Definition\n" +
+			"```yaml\n" +
+			"values:\n" +
+			"  pulumiConfig:\n" +
+			"    app:password:\n" +
+			"      fn::secret: hunter2\n" +
+			"    app:tags:\n" +
+			"      env: testing\n" +
+			"      owners:\n" +
+			"        - alice\n" +
+			"        - bob\n" +
+			"    aws:region: us-west-2\n" +
+			"\n" +
+			"```\n" +
+			""
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+
+		const expectedYAML = `environment:
+  - env
+  - test-stack
+`
+		assert.Equal(t, expectedYAML, newStackYAML)
+	})
+}

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -16,11 +16,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
 	"github.com/acarl005/stripansi"
 	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/eval"
+	"github.com/pulumi/esc/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -43,6 +46,43 @@ func newConfigEnvCmdForTest(
 	projectStackYAML string,
 	env *esc.Environment,
 	diags apitype.EnvironmentDiagnostics,
+	newStackYAML *string,
+) *configEnvCmd {
+	return newConfigEnvCmdForTestWithCheckYAMLEnvironment(
+		ctx,
+		stdin,
+		stdout,
+		projectYAML,
+		projectStackYAML,
+		nil,
+		func(
+			ctx context.Context,
+			org string,
+			yaml []byte,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			return env, diags, nil
+		},
+		newStackYAML,
+	)
+}
+
+func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
+	ctx context.Context,
+	stdin io.Reader,
+	stdout io.Writer,
+	projectYAML string,
+	projectStackYAML string,
+	createEnvironment func(
+		ctx context.Context,
+		org string,
+		name string,
+		yaml []byte,
+	) (apitype.EnvironmentDiagnostics, error),
+	checkYAMLEnvironment func(
+		ctx context.Context,
+		org string,
+		yaml []byte,
+	) (*esc.Environment, apitype.EnvironmentDiagnostics, error),
 	newStackYAML *string,
 ) *configEnvCmd {
 	stackRef := "stack"
@@ -79,13 +119,8 @@ func newConfigEnvCmdForTest(
 				},
 				BackendF: func() backend.Backend {
 					return &backend.MockEnvironmentsBackend{
-						CheckYAMLEnvironmentF: func(
-							ctx context.Context,
-							org string,
-							yaml []byte,
-						) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
-							return env, diags, nil
-						},
+						CreateEnvironmentF:    createEnvironment,
+						CheckYAMLEnvironmentF: checkYAMLEnvironment,
 					}
 				},
 				DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
@@ -107,4 +142,99 @@ func newConfigEnvCmdForTest(
 
 		stackRef: &stackRef,
 	}
+}
+
+func mapEvalDiags(diags syntax.Diagnostics) apitype.EnvironmentDiagnostics {
+	if len(diags) == 0 {
+		return nil
+	}
+
+	api := make(apitype.EnvironmentDiagnostics, len(diags))
+	for i, d := range diags {
+		var rng *esc.Range
+		if d.Subject != nil {
+			begin := esc.Pos{
+				Line:   d.Subject.Start.Line,
+				Column: d.Subject.Start.Column,
+				Byte:   d.Subject.Start.Byte,
+			}
+			end := esc.Pos{
+				Line:   d.Subject.End.Line,
+				Column: d.Subject.End.Column,
+				Byte:   d.Subject.End.Byte,
+			}
+			rng = &esc.Range{
+				Environment: d.Subject.Filename,
+				Begin:       begin,
+				End:         end,
+			}
+		}
+		api[i] = apitype.EnvironmentDiagnostic{
+			Range:   rng,
+			Summary: d.Summary,
+		}
+	}
+
+	return api
+}
+
+type envDefMap map[string]string
+
+// LoadEnvironment loads the definition for the environment with the given name.
+func (m envDefMap) LoadEnvironment(ctx context.Context, name string) ([]byte, eval.Decrypter, error) {
+	def, ok := m[name]
+	if !ok {
+		return nil, nil, errors.New("not found")
+	}
+	return []byte(def), nil, nil
+}
+
+func newConfigEnvCmdForInitTest(
+	ctx context.Context,
+	stdin io.Reader,
+	stdout io.Writer,
+	projectYAML string,
+	projectStackYAML string,
+	newStackYAML *string,
+	envs envDefMap,
+) *configEnvCmd {
+	return newConfigEnvCmdForTestWithCheckYAMLEnvironment(
+		ctx,
+		stdin,
+		stdout,
+		projectYAML,
+		projectStackYAML,
+		func(
+			ctx context.Context,
+			org string,
+			name string,
+			yaml []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			decl, diags, err := eval.LoadYAMLBytes(name, yaml)
+			if err != nil {
+				return nil, err
+			}
+			_, checkDiags := eval.CheckEnvironment(ctx, name, decl, nil, envs)
+			diags.Extend(checkDiags...)
+			if len(diags) != 0 {
+				return mapEvalDiags(diags), nil
+			}
+			envs[name] = string(yaml)
+			return nil, nil
+		},
+		func(
+			ctx context.Context,
+			org string,
+			yaml []byte,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			decl, diags, err := eval.LoadYAMLBytes("<yaml>", yaml)
+			if err != nil {
+				return nil, nil, err
+			}
+			env, checkDiags := eval.CheckEnvironment(ctx, "<yaml>", decl, nil, envs)
+			diags.Extend(checkDiags...)
+			return env, mapEvalDiags(diags), nil
+		},
+		newStackYAML,
+	)
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10
+	github.com/charmbracelet/glamour v0.6.0
 	github.com/creack/pty v1.1.17
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/erikgeiser/promptkit v0.9.0
@@ -152,7 +153,6 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/charmbracelet/bubbles v0.16.1 // indirect
 	github.com/charmbracelet/bubbletea v0.24.2 // indirect
-	github.com/charmbracelet/glamour v0.6.0 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect


### PR DESCRIPTION
This change adds a command, `pulumi config env init`, that creates a new environment for a stack based on the stack's configuration values.

From the usage:

* `pulumi config env init`

Creates an environment for a specific stack based on the stack's configuration values, then replaces the stack's configuration values with a reference to that environment. The environment will be created in the same organization as the stack.