### PR TITLE
Try a direct build once a day

### DIFF
--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -1,0 +1,18 @@
+name: Direct build
+
+on:
+  schedule:
+  # 1030 UTC every weekday
+  - cron: "30 10 * * 1-5"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
+      - name: Build
+        shell: bash
+        run: GOPROXY=direct make build


### PR DESCRIPTION
We've seen some issues with dependencies being yanked. We'll try a direct build once a day so we get earlier warning of these before they go missing from the go build caches.