### PR TITLE
GenerateHCL2Definition should respect logical names

### DIFF
--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -54,6 +54,23 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 	}
 
 	var items []model.BodyItem
+	name := state.URN.Name()
+	// Check if _this_ urn is in the name table, if so we need to set logicalName and use the mapped name for
+	// the resource block.
+	if mappedName, ok := names[state.URN]; ok {
+		items = append(items, &model.Attribute{
+			Name: "__logicalName",
+			Value: &model.TemplateExpression{
+				Parts: []model.Expression{
+					&model.LiteralValueExpression{
+						Value: cty.StringVal(name),
+					},
+				},
+			},
+		})
+		name = mappedName
+	}
+
 	for _, p := range r.InputProperties {
 		x, err := generatePropertyValue(p, state.Inputs[resource.PropertyKey(p.Name)])
 		if err != nil {
@@ -75,11 +92,11 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 		items = append(items, resourceOptions)
 	}
 
-	typ, name := state.URN.Type(), state.URN.Name()
+	typ := string(state.URN.Type())
 	return &model.Block{
-		Tokens: syntax.NewBlockTokens("resource", name, string(typ)),
+		Tokens: syntax.NewBlockTokens("resource", name, typ),
 		Type:   "resource",
-		Labels: []string{name, string(typ)},
+		Labels: []string{name, typ},
 		Body: &model.Body{
 			Items: items,
 		},

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -45,16 +45,19 @@ var testdataPath = filepath.Join("..", "codegen", "testing", "test", "testdata")
 const (
 	parentName   = "parent"
 	providerName = "provider"
+	logicalName  = "logical"
 )
 
 var (
 	parentURN   = resource.NewURN("stack", "project", "", "my::parent", "parent")
 	providerURN = resource.NewURN("stack", "project", "", providers.MakeProviderType("pkg"), "provider")
+	logicalURN  = resource.NewURN("stack", "project", "", "random:index/randomId:RandomId", "strange logical name")
 )
 
 var names = NameTable{
 	parentURN:   parentName,
 	providerURN: providerName,
+	logicalURN:  logicalName,
 }
 
 func renderExpr(t *testing.T, x model.Expression) resource.PropertyValue {
@@ -209,7 +212,7 @@ func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
 	}
 	return &resource.State{
 		Type:     token,
-		URN:      resource.NewURN("stack", "project", parentType, token, r.Name()),
+		URN:      resource.NewURN("stack", "project", parentType, token, r.LogicalName()),
 		Custom:   true,
 		Inputs:   inputs,
 		Parent:   parent,

--- a/pkg/importer/testdata/cases.json
+++ b/pkg/importer/testdata/cases.json
@@ -1558,6 +1558,14 @@
 				"byteLength": 42,
 				"prefix": "f${oo}ba%{}r"
 			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::strange logical name",
+			"custom": true,
+			"type": "random:index/randomId:RandomId",
+			"inputs": {
+				"byteLength": 42
+			}
 		}
     ]
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

No user visible change here, just laying the groundwork for import to be able to have "logical names" (i.e. what's set in state and the URN) and "program names" (i.e. what the source code and import file use, must be unique).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
