### PR TITLE
Fix datarace in setupGitRepo

### DIFF
--- a/changelog/pending/20231122--auto-go--fix-a-datarace-in-cloning-git-repos.yaml
+++ b/changelog/pending/20231122--auto-go--fix-a-datarace-in-cloning-git-repos.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fix a datarace in cloning git repos.

--- a/sdk/go/auto/git.go
+++ b/sdk/go/auto/git.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -29,6 +30,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 )
+
+var transportMutex sync.Mutex
 
 func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (string, error) {
 	cloneOptions := &git.CloneOptions{
@@ -118,25 +121,34 @@ func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (strin
 		cloneOptions.ReferenceName = refName
 	}
 
-	// Azure DevOps requires multi_ack and multi_ack_detailed capabilities, which go-git doesn't
-	// implement. But: it's possible to do a full clone by saying it's _not_ _un_supported, in which
-	// case the library happily functions so long as it doesn't _actually_ get a multi_ack packet. See
+	// Azure DevOps requires multi_ack and multi_ack_detailed capabilities, which go-git doesn't implement.
+	// But: it's possible to do a full clone by saying it's _not_ _un_supported, in which case the library
+	// happily functions so long as it doesn't _actually_ get a multi_ack packet. See
 	// https://github.com/go-git/go-git/blob/v5.5.1/_examples/azure_devops/main.go.
-	oldUnsupportedCaps := transport.UnsupportedCapabilities
-	// This check is crude, but avoids having another dependency to parse the git URL.
-	if strings.Contains(repoArgs.URL, "dev.azure.com") {
-		transport.UnsupportedCapabilities = []capability.Capability{
-			capability.ThinPack,
-		}
-	}
+	repo, err := func() (*git.Repository, error) {
+		// Because transport.UnsupportedCapabilities is a global variable, we need a global lock around the
+		// use of this.
+		transportMutex.Lock()
+		defer transportMutex.Unlock()
 
-	// clone
-	repo, err := git.PlainCloneContext(ctx, workDir, false, cloneOptions)
+		oldUnsupportedCaps := transport.UnsupportedCapabilities
+		// This check is crude, but avoids having another dependency to parse the git URL.
+		if strings.Contains(repoArgs.URL, "dev.azure.com") {
+			transport.UnsupportedCapabilities = []capability.Capability{
+				capability.ThinPack,
+			}
+		}
+
+		// clone
+		repo, err := git.PlainCloneContext(ctx, workDir, false, cloneOptions)
+
+		// Regardless of error we need to restore the UnsupportedCapabilities
+		transport.UnsupportedCapabilities = oldUnsupportedCaps
+		return repo, err
+	}()
 	if err != nil {
 		return "", fmt.Errorf("unable to clone repo: %w", err)
 	}
-
-	transport.UnsupportedCapabilities = oldUnsupportedCaps
 
 	if repoArgs.CommitHash != "" {
 		// ensure that the commit has been fetched


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes a datarace in setupGitRepo seen in CI:

```
=== FAIL: go/auto TestNewStackRemoteSource (44.69s)
==================
WARNING: DATA RACE
Read at 0x000002d35650 by goroutine 103:
  github.com/pulumi/pulumi/sdk/v3/go/auto.setupGitRepo()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/git.go:125 +0xf78
  github.com/pulumi/pulumi/sdk/v3/go/auto.NewLocalWorkspace()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace.go:778 +0x435
  github.com/pulumi/pulumi/sdk/v3/go/auto.NewStackRemoteSource()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace.go:1114 +0x2c4
  github.com/pulumi/pulumi/sdk/v3/go/auto.TestNewStackRemoteSource()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace_test.go:465 +0x326
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x44

Previous write at 0x000002d35650 by goroutine 104:
  github.com/pulumi/pulumi/sdk/v3/go/auto.setupGitRepo()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/git.go:139 +0x11d1
  github.com/pulumi/pulumi/sdk/v3/go/auto.NewLocalWorkspace()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace.go:778 +0x435
  github.com/pulumi/pulumi/sdk/v3/go/auto.UpsertStackRemoteSource()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace.go:1133 +0x2c4
  github.com/pulumi/pulumi/sdk/v3/go/auto.TestUpsertStackRemoteSource()
      /Users/runner/work/pulumi/pulumi/sdk/go/auto/local_workspace_test.go:559 +0x326
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x44

Goroutine 103 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x82a
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:2052 +0x896
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1925 +0xb57
  main.main()
      _testmain.go:159 +0x2e4

Goroutine 104 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x82a
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:2052 +0x896
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1925 +0xb57
  main.main()
      _testmain.go:159 +0x2e4
==================
    testing.go:1465: race detected during execution of test
```

Pretty clear culprit of mutating a global variable in the go-git module. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - This was caught be existing tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
