### PR TITLE
[schema] Fixes marshalling the "plain" flag from object or resource properties

### DIFF
--- a/changelog/pending/20231123--sdkgen--fixes-marshalling-the-plain-flag-from-object-or-resource-properties.yaml
+++ b/changelog/pending/20231123--sdkgen--fixes-marshalling-the-plain-flag-from-object-or-resource-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: Fixes marshalling the "plain" flag from object or resource properties

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1230,8 +1230,10 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 			return nil, nil, fmt.Errorf("property '%v': %w", p.Name, err)
 		}
 
+		propertyType := pkg.marshalType(typ, plain)
+		propertyType.Plain = plain || p.Plain
 		specs[p.Name] = PropertySpec{
-			TypeSpec:             pkg.marshalType(typ, plain),
+			TypeSpec:             propertyType,
 			Description:          p.Comment,
 			Const:                p.ConstValue,
 			Default:              defaultValue,

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -132,6 +132,48 @@ func TestRoundtripEnum(t *testing.T) {
 	assertEnum(t, pkg)
 }
 
+func TestRoundtripPlainProperties(t *testing.T) {
+	t.Parallel()
+
+	assertPlainPropertyFromType := func(t *testing.T, pkg *Package) {
+		exampleType, ok := pkg.GetType("plain-properties:index:ExampleType")
+		assert.True(t, ok)
+		exampleObjectType, ok := exampleType.(*ObjectType)
+		assert.True(t, ok)
+		// assert that the property is plain
+		assert.Equal(t, 1, len(exampleObjectType.Properties))
+		assert.True(t, exampleObjectType.Properties[0].Plain)
+	}
+
+	assertPlainPropertyFromResourceInputs := func(t *testing.T, pkg *Package) {
+		exampleResource, ok := pkg.GetResource("plain-properties:index:ExampleResource")
+		assert.True(t, ok)
+		// assert that the property is plain
+		assert.Equal(t, 1, len(exampleResource.InputProperties))
+		assert.True(t, exampleResource.InputProperties[0].Plain)
+	}
+
+	testdataPath := filepath.Join("..", "testing", "test", "testdata")
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := readSchemaFile("plain-properties-1.0.0.json")
+	pkg, diags, err := BindSpec(pkgSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	assertPlainPropertyFromType(t, pkg)
+	assertPlainPropertyFromResourceInputs(t, pkg)
+
+	newSpec, err := pkg.MarshalSpec()
+	require.NoError(t, err)
+	require.NotNil(t, newSpec)
+
+	// Try and bind again
+	pkg, diags, err = BindSpec(*newSpec, loader)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	assertPlainPropertyFromType(t, pkg)
+	assertPlainPropertyFromResourceInputs(t, pkg)
+}
+
 func TestImportSpec(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/testing/test/testdata/plain-properties-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/plain-properties-1.0.0.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.0.1",
+  "name": "plain-properties",
+  "types": {
+    "plain-properties:index:ExampleType": {
+      "type": "object",
+      "properties": {
+        "exampleProperty": {
+          "type": "string",
+          "plain": true
+        }
+      }
+    }
+  },
+  "resources": {
+    "plain-properties:index:ExampleResource": {
+      "type": "object",
+      "properties": {
+        "exampleProperty": {
+          "type": "string"
+        }
+      },
+      "inputProperties": {
+        "exampleProperty": {
+          "type": "string",
+          "plain": true
+        }
+      }
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -91,5 +91,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"auto-deploy", "0.0.1"},
 		SchemaProvider{"localref", "1.0.0"},
 		SchemaProvider{"enum", "1.0.0"},
+		SchemaProvider{"plain-properties", "1.0.0"},
 	)
 }


### PR DESCRIPTION
# Description

When marshalling a schema that has resources or types with plain properties, the `plain` flag was not preserved. This PR fixes it and adds a roundtrip test for the plain properties. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
