### PR TITLE
Fix test-language to not use the default loader for binding

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -676,7 +676,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal schema for provider %s: %w", pkg, err)
 		}
-		boundSpec, diags, err := schema.BindSpec(spec, nil)
+		boundSpec, diags, err := schema.BindSpec(spec, loader)
 		if err != nil {
 			return nil, fmt.Errorf("bind schema for provider %s: %w", pkg, err)
 		}


### PR DESCRIPTION
Because BindSpec was being passed nil for the loader parameter it was creating a new default plugin host, instead of using the mocked one we create as part of the test-language code.

No real observable effect as yet, but would of been an issue once we start having test schemas that refer to each other.
