### PR TITLE
[auto] Fixes event stream lag on windows runtime

### DIFF
--- a/changelog/pending/20231127--auto-go--fixes-event-stream-lag-on-windows-runtime.yaml
+++ b/changelog/pending/20231127--auto-go--fixes-event-stream-lag-on-windows-runtime.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fixes event stream lag on windows runtime

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1233,6 +1233,7 @@ type fileWatcher struct {
 func watchFile(path string, receivers []chan<- events.EngineEvent) (*fileWatcher, error) {
 	t, err := tail.TailFile(path, tail.Config{
 		Follow: true,
+		Poll:   runtime.GOOS == "windows", // on Windows poll for file changes instead of using the default inotify
 		Logger: tail.DiscardingLogger,
 	})
 	if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Hey guys, first PR at Pulumi.

On windows (Windows 11) I have been getting event streaming lag using `optup.EventStreams` for the go automation sdk, basically I get no events until the file has stopped writing. This does not occur on other platforms.

We can fix this by polling on windows instead of using the default inotify within watchFile.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
