### PR TITLE
[do-not-merge] test codegen PRs are closed on close.

### DIFF
--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -1,0 +1,19 @@
+name: On PR Close
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+    cleanup:
+      name: Remove Existing Codegen PRs
+      runs-on: ubuntu-latest
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      steps:
+        - name: "Close existing Downstream PRs"
+          run: |
+            for url in $(gh search prs --json url --owner pulumi --state open --match body "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}." | jq -r '.[].url'); do
+                gh pr close "$url"
+            done

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -1,0 +1,139 @@
+name: Downstream Codegen Tests
+on:
+  pull_request:
+    paths:
+    - 'pkg/codegen/**'
+    - '!pkg/codegen/docs/**'
+    - '.github/workflows/pr-test-codegen-downstream.yml'
+
+permissions:
+  contents: read
+
+jobs:
+    cleanup:
+      name: Remove Existing Codegen PRs
+      runs-on: ubuntu-latest
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      steps:
+        - name: "Close existing Downstream PRs"
+          run: |
+            for url in $(gh search prs --json url --owner pulumi --state open --match body "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}." | jq -r '.[].url'); do
+                gh pr close "$url"
+            done
+    bridged:
+      name: Test ${{ matrix.provider }} (bridged)
+      needs: ["cleanup"]
+      timeout-minutes: 240
+      runs-on: ubuntu-latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      strategy:
+        matrix:
+          provider: ["aws", "gcp", "azure", "azuread", "random"]
+        fail-fast: false
+      steps:
+        - name: Trigger upgrade
+          uses: peter-evans/repository-dispatch@v2
+          with:
+            token: ${{ secrets.PULUMI_BOT_TOKEN }}
+            repository: pulumi/pulumi-${{ matrix.provider }}
+            event-type: upgrade-bridge
+            client-payload: |-
+              {
+                 "target-pulumi-version": ${{ toJSON( github.event.pull_request.head.sha ) }},
+                 "target-bridge-version": "",
+                 "pr-reviewers": ${{ toJSON( github.triggering_actor || 'justinvp' ) }},
+                 "pr-description": "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}. (run-id: ${{ github.run_id }})",
+                 "automerge": false
+              }
+        - name: Await PR opened for pulumi-${{ matrix.provider }}
+          run: |
+            echo Await PR opened for pulumi-${{ matrix.provider }}
+            until gh search prs --repo pulumi/pulumi-${{ matrix.provider }} --review-requested ${{ toJSON( github.triggering_actor || 'justinvp' ) }} --match body "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}. (run-id: ${{ github.run_id }})"  --json url | grep url; do sleep 30; done;
+        - name: Await PR codegen tests succeed.
+          run: |
+            echo "Await PR opened for pulumi-${{ matrix.provider }}"
+            number=$(gh search prs --repo pulumi/pulumi-${{ matrix.provider }} --review-requested ${{ toJSON( github.triggering_actor || 'justinvp' ) }} --match body "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}. (run-id: ${{ github.run_id }})"  --json number --jq '.[0].number')
+            # Ensure that expected checks are pending before checking the status passes.
+            # We use 'test' as all workflows have tests.
+            until gh pr checks --repo "pulumi/pulumi-${{ matrix.provider }}" "$number" | grep 'test'; do sleep 30; done;
+            gh pr checks --repo "pulumi/pulumi-${{ matrix.provider }}" "$number" --watch --fail-fast
+# Native Providers
+    awsx:
+      name: Test AWSX
+      needs: ["cleanup"]
+      timeout-minutes: 240
+      runs-on: ubuntu-latest
+      env:
+        GOVERSION: ">=1.19.0" # from awsx: decoupled from version sets, track latest for codegen
+        NODEVERSION: "14.x"
+        PYTHONVERSION: "3.9.x"
+        DOTNETVERSION: "6.x"
+        JAVAVERSION: "11"
+        AWS_REGION: us-west-2
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      steps:
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-region: ${{ env.AWS_REGION }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            role-duration-seconds: 3600
+            role-session-name: awsx@githubActions
+            role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        - name: Setup Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: ${{ env.GOVERSION }}
+            check-latest: true
+        - name: Setup Node
+          uses: actions/setup-node@v1
+          with:
+            node-version: ${{ env.NODEVERSION }}
+        - name: Setup Python
+          uses: actions/setup-python@v3
+          with:
+            python-version: ${{ env.PYTHONVERSION }}
+        - name: Setup DotNet
+          uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: ${{ env.DOTNETVERSION }}
+        - name: Setup Java
+          uses: actions/setup-java@v3
+          with:
+            distribution: temurin
+            java-version: ${{ env.JAVAVERSION }}
+        - name: Install gotestfmt
+          uses: jaxxstorm/action-install-gh-release@v1.7.1
+          with:
+            repo: gotesttools/gotestfmt
+        - name: Install pulumictl
+          uses: jaxxstorm/action-install-gh-release@v1.1.0
+          with:
+            repo: pulumi/pulumictl
+        - name: Check out source code
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ github.event.pull_request.head.sha }}
+            token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        - name: Test Downstream
+          uses: pulumi/action-test-provider-downstream@v0.0.1-beta
+          env:
+            GOPROXY: "https://proxy.golang.org"
+            PULUMI_LOCAL_NUGET: ${{ github.workspace }}/../pulumi-awsx/nuget
+            AWS_REGION: us-west-2
+            PWD: ${{ github.workspace }}/pulumi-awsx
+            PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+            PULUMI_API: https://api.pulumi-staging.io
+            TESTPARALLELISM: 4
+          with:
+            replacements: github.com/pulumi/pulumi/pkg/v3=pulumi/pkg,github.com/pulumi/pulumi/sdk/v3=pulumi/sdk
+            downstream-name: pulumi-awsx
+            downstream-url: https://github.com/pulumi/pulumi-awsx
+            use-provider-dir: true
+            issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+            buildTargets: "build,install_dotnet_sdk"
+            testTargets: "lint,test_nodejs,test_python,test_java,test_go,test_dotnet,test"


### PR DESCRIPTION
Fixes #14530

Adds back downstream codegen tests
- aws
- gcp
- azure
- azuread
- random
- awsx

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
