### PR TITLE
[ci] Consolidate CodeCov Upload

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -93,6 +93,23 @@ jobs:
     timeout-minutes: 60
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
+      # Create a coverage file to register a testing job was started.
+      # This artifact will be overwritten with "OK" at the end of the job.
+      - name: Write test started file
+        shell: bash
+        run: |
+          HASH=$(echo '${{ inputs.test-name }}' | git hash-object --literally --stdin | awk '{ print $1 }')
+          echo "TEST_HASH_ID=${HASH}" >> "$GITHUB_ENV"
+          echo "TEST_STATUS_FILE=status/test-${HASH}.txt" >> "$GITHUB_ENV"
+      # Consume env.TEST_STATUS_FILE to ensure it's able to be successfully used later.
+      - shell: bash
+        run: |
+          mkdir status
+          echo "incomplete" > "${{ env.TEST_STATUS_FILE }}"
+      - name: Register test started.
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.TEST_STATUS_FILE }}
       - name: "Windows cache workaround"
         # https://github.com/actions/cache/issues/752#issuecomment-1222415717
         # but only modify the path by adding tar.exe
@@ -333,14 +350,20 @@ jobs:
             go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration.$TS.cov"
           fi
       - name: Upload code coverage
+        uses: actions/upload-artifact@v2
         if: ${{ inputs.enable-coverage }}
-        uses: codecov/codecov-action@v3
         with:
-          directory: coverage
-          files: "*,!.gitkeep"
-          fail_ci_if_error: false
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-${{ env.TEST_HASH_ID }}
+          path: |
+            coverage/*
+            !coverage/.gitkeep
+      - name: Register test OK.
+        shell: bash
+        run: mkdir status; echo "OK" > "${{ env.TEST_STATUS_FILE }}"
+      - name: Register test successful.
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.TEST_STATUS_FILE }}
       - name: Summarize Test Time by Package
         continue-on-error: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ on:
       PULUMI_PROD_ACCESS_TOKEN:
         required: false
         description: "Pulumi access token, required to run tests against the service"
+      CODECOV_TOKEN:
+        required: false
+        description: "CodeCov token, required to publish CodeCov coverage data"
 
 jobs:
   matrix:
@@ -354,3 +357,37 @@ jobs:
         run: |
           ls -lhR test-results
           find test-results -mindepth 1 -name '*.json' -mtime +7 -delete
+  test-collect-coverage:
+    needs: [unit-test, integration-test, acceptance-test]
+    if: ${{ inputs.enable-coverage }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve code coverage statuses
+        uses: actions/download-artifact@v3
+        with:
+          path: status
+      # Check that there are no incomplete tests.
+      - name: Check tests completed successfully.
+        run: |
+          if test -z "$(grep -rl 'incomplete' ./status)"; then
+              echo "Tests OK!"
+          else
+              echo "Test Failure.. skipping CodeCov upload."
+              exit 1
+          fi
+      # Checkout repository to upload coverage results.
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Retrieve code coverage reports
+        uses: actions/download-artifact@v3
+        with:
+          path: coverage
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: coverage/
+          files: "*,!.gitkeep"
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #13835

Change CodeCov to only upload on completely if all jobs succeed. Consolidates CodeCov upload task in `ci-run-test.yml` to `ci.yml`.

There are extraneous commits that will be squashed before merging to retain commit `55e783c997021d9c5fae2252708ad35f62eb20c6` displaying a successful run for the reviewer.