### PR TITLE
feat: enable imports from nodejs provider resources

### DIFF
--- a/changelog/pending/20231129--sdk-nodejs--enable-resource-imports-for-nodejs-providers.yaml
+++ b/changelog/pending/20231129--sdk-nodejs--enable-resource-imports-for-nodejs-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Enable resource imports for nodejs providers

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -95,6 +95,10 @@ export interface ReadResult {
      * The current property state read from the live environment.
      */
     readonly props?: any;
+    /**
+     * The inputs that would lead to the current resource state when importing it.
+     */
+    readonly inputs?: any;
 }
 
 /**

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -219,6 +219,7 @@ class Server implements grpc.UntypedServiceImplementation {
                 const result: any = await this.provider.read(id, req.getUrn(), props);
                 resp.setId(result.id);
                 resp.setProperties(structproto.Struct.fromJavaScript(result.props));
+                resp.setInputs(structproto.Struct.fromJavaScript(result.props));
             } else {
                 // In the event of a missing read, simply return back the input state.
                 resp.setId(id);

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -219,7 +219,7 @@ class Server implements grpc.UntypedServiceImplementation {
                 const result: any = await this.provider.read(id, req.getUrn(), props);
                 resp.setId(result.id);
                 resp.setProperties(structproto.Struct.fromJavaScript(result.props));
-                resp.setInputs(structproto.Struct.fromJavaScript(result.props));
+                resp.setInputs(structproto.Struct.fromJavaScript(result.inputs));
             } else {
                 // In the event of a missing read, simply return back the input state.
                 resp.setId(id);


### PR DESCRIPTION
# Description
I was writing a typescript resource provider, but got errors that the the plugin didn't support imports, while the `read` method was implemented on the provider.
This PR also sets the `Inputs` on the `ReadResponse`, so imports will be supported.

Fixes # (issue)
Could not find existing issue

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
- [ ] I have formatted my code using `gofumpt`
(None of the above, since the change is in js code)

- [ ] I have added tests that prove my fix is effective or that my feature works
There are no existing tests for the `server.ts` file. If really required for merging I could maybe take a look at a test for this use-case.

- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
