### PR TITLE
Warn if StackReferences are registered instead of read

### DIFF
--- a/changelog/pending/20231128--engine--warn-if-sdks-are-trying-to-use-old-registerresource-style-stackreferences.yaml
+++ b/changelog/pending/20231128--engine--warn-if-sdks-are-trying-to-use-old-registerresource-style-stackreferences.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Warn if SDKs are trying to use old RegisterResource style StackReferences.

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -464,7 +464,7 @@ func NewDeployment(ctx *plugin.Context, target *Target, prev *Snapshot, plan *Pl
 	newResources := &resourceMap{}
 
 	// Create a new builtin provider. This provider implements features such as `getStack`.
-	builtins := newBuiltinProvider(backendClient, newResources)
+	builtins := newBuiltinProvider(backendClient, newResources, ctx.Diag)
 
 	// Create a new provider registry. Although we really only need to pass in any providers that were present in the
 	// old resource list, the registry itself will filter out other sorts of resources when processing the prior state,

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -85,7 +85,7 @@ func NewImportDeployment(ctx *plugin.Context, target *Target, projectName tokens
 	// Create a goal map for the deployment.
 	newGoals := &goalMap{}
 
-	builtins := newBuiltinProvider(nil, nil)
+	builtins := newBuiltinProvider(nil, nil, ctx.Diag)
 
 	// Create a new provider registry.
 	reg := providers.NewRegistry(ctx.Host, preview, builtins)

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -50,7 +50,7 @@ func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client Back
 	provs ProviderSource,
 ) (QuerySource, error) {
 	// Create a new builtin provider. This provider implements features such as `getStack`.
-	builtins := newBuiltinProvider(client, nil)
+	builtins := newBuiltinProvider(client, nil, plugctx.Diag)
 
 	reg := providers.NewRegistry(plugctx.Host, false, builtins)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Noticed this while looking at https://github.com/pulumi/pulumi-yaml/issues/462 with @julienp.

StackReferences only really work properly when 'read'. When registered they don't behave as expected because they don't diff (no input properties change) so they don't update so they don't get the new stack output values.

Looks like all the SDKs but YAML we're doing this correctly, so I've updated the engine test to do a read and will change the check/diff/create methods to log a warning that the user SDKs must be old. At some point we can clean these up to just only allow reading of stack reference types.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
