### PR TITLE
[testing] Add integration tests for regressions in property name parsing

### DIFF
--- a/tests/integration/valid-property-names/step1/.gitignore
+++ b/tests/integration/valid-property-names/step1/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/tests/integration/valid-property-names/step1/Pulumi.yaml
+++ b/tests/integration/valid-property-names/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: props
+description: A program that exercises Pulumi property names.
+runtime: nodejs

--- a/tests/integration/valid-property-names/step1/index.ts
+++ b/tests/integration/valid-property-names/step1/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+import * as pulumi from "@pulumi/pulumi";
+import { Resource } from "./resource";
+
+
+let config = new pulumi.Config();
+export const a = new Resource("a", {
+    state: {
+        // Driven by table tests in steps_test.go.
+        [config.require("propertyName")]: "foo",
+    }
+});

--- a/tests/integration/valid-property-names/step1/package.json
+++ b/tests/integration/valid-property-names/step1/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "props",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/valid-property-names/step1/resource.ts
+++ b/tests/integration/valid-property-names/step1/resource.ts
@@ -1,0 +1,35 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    constructor() {}
+
+    public async create(inputs: any) {
+        return {
+            id: (currentID++).toString(),
+            outs: inputs,
+        };
+    }
+
+    public async delete(id: pulumi.ID, props: any) {}
+
+    public async diff(id: pulumi.ID, olds: any, news: any) { return {}; }
+
+    public async update(id: pulumi.ID, olds: any, news: any) {
+        return news;
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}
+
+export interface ResourceProps {
+    state?: any; // arbitrary state bag that can be updated without replacing.
+}

--- a/tests/integration/valid-property-names/step2/index.ts
+++ b/tests/integration/valid-property-names/step2/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+import { Resource } from "./resource";
+
+export const a = new Resource("a", {
+    state: {
+        template: {
+            metadata: {
+                annotations: {},
+            },
+        },
+    }
+});

--- a/tests/integration/valid-property-names/steps_test.go
+++ b/tests/integration/valid-property-names/steps_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+//go:build (nodejs || all) && !xplatform_acceptance
+
+package ints
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func getResource(stackInfo integration.RuntimeValidationStackInfo, name string) (apitype.ResourceV3, error) {
+	for _, res := range stackInfo.Deployment.Resources {
+		if res.URN.Name() == name {
+			return res, nil
+		}
+	}
+	return apitype.ResourceV3{}, fmt.Errorf("resource with name `%s` not found", name)
+}
+
+// TestPropertyNameDiffs checks that property names that look like invalid property paths
+// do not break diff generation.
+func TestPropertyNameDiffs(t *testing.T) {
+	t.Parallel()
+
+	validPropertyNames := []string{
+		"foo",
+		"example.com",
+		".",
+
+		".[0]",                      // Regression         v3.90.1
+		"foo.[0].bar",               // Regression         v3.90.1
+		`.["Hello, World!"]`,        // Regression         v3.90.1
+		"[",                         // Regression v3.89.0 v3.90.1
+		".[]",                       // Regression v3.89.0 v3.90.1
+		"[]",                        // Regression v3.89.0 v3.90.1
+		".[Hello, Unquoted World!]", // Regression v3.89.0 v3.90.1
+		`.H[ello, World!"]`,         // Regression v3.89.0 v3.90.1
+	}
+	//nolint:paralleltest // ProgramTest calls t.Parallel()
+	for _, propName := range validPropertyNames {
+		propName := propName
+		t.Run("validate path "+propName, func(t *testing.T) {
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Dir:          "step1",
+				Dependencies: []string{"@pulumi/pulumi"},
+				Config: map[string]string{
+					"propertyName": propName,
+				},
+				Quick: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					require.NotNil(t, stackInfo.Deployment)
+					res, err := getResource(stackInfo, "a")
+					assert.NoError(t, err)
+					state := res.Outputs["state"].(map[string]interface{})
+					assert.Equal(t, "foo", state[propName])
+				},
+				EditDirs: []integration.EditDir{
+					{
+						Dir:      "step2",
+						Additive: true,
+						ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+							require.NotNil(t, stackInfo.Deployment)
+							_, err := getResource(stackInfo, "a")
+							assert.NoError(t, err)
+						},
+					},
+				},
+			})
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #14571
    
Adds integration tests that check that resource property names that are
invalid property paths do not trigger errors in diff logic.
    
Internal Postmortem: https://docs.google.com/document/d/1kMcw3RUZZ98Aq5Na-f-oLNVWlDsdPAl8EdQmEVoQv1I

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
