### PR TITLE
Actually save root on plugin.Context

### DIFF
--- a/changelog/pending/20231129--engine--fix-root-directory-passed-to-langauge-plugins-when-starting-pulumi-in-a-subfolder.yaml
+++ b/changelog/pending/20231129--engine--fix-root-directory-passed-to-langauge-plugins-when-starting-pulumi-in-a-subfolder.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix root directory passed to langauge plugins when starting pulumi in a subfolder.

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -107,6 +107,7 @@ func NewContextWithContext(
 		StatusDiag:      statusD,
 		Host:            host,
 		Pwd:             pwd,
+		Root:            root,
 		tracingSpan:     parentSpan,
 		DebugTraceMutex: &sync.Mutex{},
 		cancelLock:      &sync.Mutex{},

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -269,6 +269,12 @@ func TestAutomaticVenvCreation(t *testing.T) {
 
 		t.Logf("Wrote Pulumi.yaml:\n%s\n", string(newYaml))
 
+		// Make a subdir and change to it to ensure paths aren't just relative to the working directory.
+		subdir := filepath.Join(e.RootPath, "subdir")
+		err = os.Mkdir(subdir, 0o755)
+		require.NoError(t, err)
+		e.CWD = subdir
+
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "teststack")
 		e.RunCommand("pulumi", "preview")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Pretty sure this has been broken since forever.

Pretty sure it's only _mostly_ worked because we nearly always run pulumi from the directory with the Pulumi.yaml file and there's a bit of code in `buildArgsForNewPlugin` that calls `filepath.Abs(root)` before passing it to the language plugins. `Abs("")` will just resolve to the working directory, which as above is nearly always the one with the Pulumi.yaml file in it.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
