### PR TITLE
Add clarifying text for `pulumi stack` command

### DIFF
--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -43,8 +43,8 @@ func newStackCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stack",
-		Short: "Manage stacks",
-		Long: "Manage stacks\n" +
+		Short: "Manage stacks and view stack state",
+		Long: "Manage stacks and view stack state\n" +
 			"\n" +
 			"A stack is a named update target, and a single project may have many of them.\n" +
 			"Each stack has a configuration and update history associated with it, stored in\n" +


### PR DESCRIPTION
# Description

This PR adds text for the `pulumi stack` command to clarify that you can also view the stack of the stack with it.

Fixes [this issue](https://github.com/pulumi/pulumi/issues/9677).

