### PR TITLE
[schema] Fix package get-schema marking resource properties as plain

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1231,7 +1231,7 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 		}
 
 		propertyType := pkg.marshalType(typ, plain)
-		propertyType.Plain = plain || p.Plain
+		propertyType.Plain = p.Plain
 		specs[p.Name] = PropertySpec{
 			TypeSpec:             propertyType,
 			Description:          p.Comment,

--- a/pkg/codegen/testing/test/testdata/plain-properties-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/plain-properties-1.0.0.json
@@ -8,6 +8,9 @@
         "exampleProperty": {
           "type": "string",
           "plain": true
+        },
+        "nonPlainProperty": {
+          "type": "string"
         }
       }
     }
@@ -17,6 +20,10 @@
       "type": "object",
       "properties": {
         "exampleProperty": {
+          "type": "string",
+          "plain": true
+        },
+        "nonPlainProperty": {
           "type": "string"
         }
       },
@@ -24,6 +31,9 @@
         "exampleProperty": {
           "type": "string",
           "plain": true
+        },
+        "nonPlainProperty": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
# Description

Follow up for #14648 because when I tried it against existing providers as follows:
```
~/.pulumi-dev/bin/pulumi package get-schema random
```
It marks all resource properties as plain even when they are not. This PR fixes it and extends the unit test to assert both plain and non-plain properties of resources and object types

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
