### PR TITLE
Add `--suppress-progresss` flag to CLI

### DIFF
--- a/changelog/pending/20231129--cli-display--add-suppress-progress-option-to-not-print-dots.yaml
+++ b/changelog/pending/20231129--cli-display--add-suppress-progress-option-to-not-print-dots.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Add --suppress-progress option to not print dots

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -53,7 +53,7 @@ func ShowDiffEvents(op string, events <-chan engine.Event, done chan<- bool, opt
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
 	if stdout == os.Stdout && stderr == os.Stderr {
-		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
+		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/, opts.SuppressProgress)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/backend/display/jsonmessage.go
+++ b/pkg/backend/display/jsonmessage.go
@@ -108,7 +108,7 @@ func newInteractiveMessageRenderer(term terminal.Terminal, opts Options) progres
 func newNonInteractiveRenderer(stdout io.Writer, op string, opts Options) progressRenderer {
 	spinner, ticker := cmdutil.NewSpinnerAndTicker(
 		fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
-		nil, opts.Color, 1 /*timesPerSecond*/)
+		nil, opts.Color, 1 /*timesPerSecond*/, opts.SuppressProgress)
 	ticker.Stop()
 
 	r := newMessageRenderer(stdout, opts, false)

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -56,6 +56,7 @@ type Options struct {
 	Stdout                 io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
 	Stderr                 io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
 	SuppressTimings        bool                // true to suppress displaying timings of resource actions
+	SuppressProgress       bool                // true to suppress displaying progress spinner.
 
 	// testing-only options
 	term                terminal.Terminal

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -36,7 +36,7 @@ func ShowQueryEvents(op string, events <-chan engine.Event,
 	var ticker *time.Ticker
 
 	if opts.IsInteractive {
-		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
+		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/, opts.SuppressProgress)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1602,7 +1602,7 @@ func (b *cloudBackend) waitForUpdate(ctx context.Context, actionLabel string, up
 
 func displayEvents(action string, events <-chan displayEvent, done chan<- bool, opts display.Options) {
 	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action)
-	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
+	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/, opts.SuppressProgress)
 
 	defer func() {
 		spinner.Reset()

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -62,6 +62,7 @@ func newDestroyCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var suppressPermalink string
 	var yes bool
 	var targets *[]string
@@ -120,6 +121,7 @@ func newDestroyCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      suppressOutputs,
+				SuppressProgress:     suppressProgress,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
@@ -371,6 +373,9 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -527,6 +527,7 @@ func newImportCmd() *cobra.Command {
 	var showConfig bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var suppressPermalink string
 	var yes bool
 	var protectResources bool
@@ -763,13 +764,14 @@ func newImportCmd() *cobra.Command {
 			}
 
 			opts.Display = display.Options{
-				Color:           cmdutil.GetGlobalColorization(),
-				ShowConfig:      showConfig,
-				SuppressOutputs: suppressOutputs,
-				IsInteractive:   interactive,
-				Type:            displayType,
-				EventLogPath:    eventLogPath,
-				Debug:           debug,
+				Color:            cmdutil.GetGlobalColorization(),
+				ShowConfig:       showConfig,
+				SuppressOutputs:  suppressOutputs,
+				SuppressProgress: suppressProgress,
+				IsInteractive:    interactive,
+				Type:             displayType,
+				EventLogPath:     eventLogPath,
+				Debug:            debug,
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -1005,6 +1007,9 @@ func newImportCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -64,6 +64,7 @@ func newPreviewCmd() *cobra.Command {
 	var showSames bool
 	var showReads bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var suppressPermalink string
 	var targets []string
 	var replaces []string
@@ -107,6 +108,7 @@ func newPreviewCmd() *cobra.Command {
 				ShowSameResources:      showSames,
 				ShowReads:              showReads,
 				SuppressOutputs:        suppressOutputs,
+				SuppressProgress:       suppressProgress,
 				IsInteractive:          cmdutil.Interactive(),
 				Type:                   displayType,
 				JSONDisplay:            jsonDisplay,
@@ -367,7 +369,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
-
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -59,6 +59,7 @@ func newRefreshCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var suppressPermalink string
 	var yes bool
 	var targets *[]string
@@ -117,6 +118,7 @@ func newRefreshCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      suppressOutputs,
+				SuppressProgress:     suppressProgress,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
@@ -331,6 +333,9 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -41,6 +41,7 @@ func newReplayEventsCmd() *cobra.Command {
 	var showSames bool
 	var showReads bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var debug bool
 
 	var delay time.Duration
@@ -89,6 +90,7 @@ func newReplayEventsCmd() *cobra.Command {
 				ShowSameResources:    showSames,
 				ShowReads:            showReads,
 				SuppressOutputs:      suppressOutputs,
+				SuppressProgress:     suppressProgress,
 				IsInteractive:        cmdutil.Interactive(),
 				Type:                 displayType,
 				JSONDisplay:          jsonDisplay,
@@ -150,6 +152,9 @@ func newReplayEventsCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 
 	cmd.PersistentFlags().DurationVar(&delay, "delay", time.Duration(0),
 		"Delay display by the given duration. Useful for attaching a debugger.")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -75,6 +75,7 @@ func newUpCmd() *cobra.Command {
 	var skipPreview bool
 	var showFullOutput bool
 	var suppressOutputs bool
+	var suppressProgress bool
 	var suppressPermalink string
 	var yes bool
 	var secretsProvider string
@@ -463,6 +464,7 @@ func newUpCmd() *cobra.Command {
 				ShowSameResources:      showSames,
 				ShowReads:              showReads,
 				SuppressOutputs:        suppressOutputs,
+				SuppressProgress:       suppressProgress,
 				TruncateOutput:         !showFullOutput,
 				IsInteractive:          interactive,
 				Type:                   displayType,
@@ -605,6 +607,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressProgress, "suppress-progress", false,
+		"Suppress display of periodic progress dots")
 	cmd.PersistentFlags().BoolVar(
 		&showFullOutput, "show-full-output", true,
 		"Display full length of stack outputs")

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -79,6 +79,7 @@ func newWatchCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      true,
+				SuppressProgress:     true,
 				SuppressPermalink:    true,
 				IsInteractive:        false,
 				Type:                 display.DisplayWatch,

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -29,6 +29,7 @@ import (
 // slowly.
 func NewSpinnerAndTicker(prefix string, ttyFrames []string,
 	color colors.Colorization, timesPerSecond time.Duration,
+	suppressProgress bool,
 ) (Spinner, *time.Ticker) {
 	if ttyFrames == nil {
 		// If explicit tick frames weren't specified, default to unicode for Mac and ASCII for Windows/Linux.
@@ -39,17 +40,20 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string,
 		}
 	}
 
+	if suppressProgress {
+		return &noopSpinner{}, time.NewTicker(time.Second * 20)
+	}
+
 	if Interactive() {
 		return &ttySpinner{
 			prefix: prefix,
 			frames: ttyFrames,
 		}, time.NewTicker(time.Second / timesPerSecond)
 	}
-
 	return &dotSpinner{
 		color:  color,
 		prefix: prefix,
-	}, time.NewTicker(time.Second * 20)
+	}, time.NewTicker(time.Second / timesPerSecond)
 }
 
 // Spinner represents a very simple progress reporter.
@@ -128,3 +132,8 @@ func (spin *dotSpinner) Reset() {
 	}
 	spin.hasWritten = false
 }
+
+type noopSpinner struct{}
+
+func (spin *noopSpinner) Tick()  {}
+func (spin *noopSpinner) Reset() {}

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -53,7 +53,7 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string,
 	return &dotSpinner{
 		color:  color,
 		prefix: prefix,
-	}, time.NewTicker(time.Second / timesPerSecond)
+	}, time.NewTicker(time.Second * 20)
 }
 
 // Spinner represents a very simple progress reporter.


### PR DESCRIPTION
Adds support for suppressing the periodic "..." printing that can disrupt normal output stream.  This output is still deemed necessary to include by default for CI systems that might otherwise cancel an update that goes for a long time without printing anything.  But we now have an option to turn this off.

Notes:
1. We want to expose this via Automtation API, and may even want to default to off via Automation API?

Fixes https://github.com/pulumi/pulumi/issues/14069.
Related https://github.com/pulumi/pulumi/issues/11139.