### PR TITLE
Change reading passphrase from stdin to be explicit

### DIFF
--- a/changelog/pending/20231129--cli-config--change-reading-passphrase-from-stdin-to-be-explicit.yaml
+++ b/changelog/pending/20231129--cli-config--change-reading-passphrase-from-stdin-to-be-explicit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Change reading passphrase from stdin to be explicit

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -196,7 +196,7 @@ func commandContext() context.Context {
 
 func createSecretsManager(
 	ctx context.Context, stack backend.Stack, secretsProvider string,
-	rotateSecretsProvider, creatingStack bool,
+	rotateSecretsProvider, creatingStack, useStdin bool,
 ) error {
 	// As part of creating the stack, we also need to configure the secrets provider for the stack.
 	// We need to do this configuration step for cases where we will be using with the passphrase
@@ -227,7 +227,7 @@ func createSecretsManager(
 	if isDefaultSecretsProvider {
 		_, err = stack.DefaultSecretManager(ps)
 	} else if secretsProvider == passphrase.Type {
-		_, err = passphrase.NewPromptingPassphraseSecretsManager(ps, rotateSecretsProvider)
+		_, err = passphrase.NewPromptingPassphraseSecretsManagerWithStdin(ps, rotateSecretsProvider, useStdin)
 	} else {
 		// All other non-default secrets providers are handled by the cloud secrets provider which
 		// uses a URL schema to identify the provider
@@ -266,7 +266,7 @@ func createStack(ctx context.Context,
 	}
 
 	if err := createSecretsManager(ctx, stack, secretsProvider,
-		false /*rotateSecretsManager*/, true /*creatingStack*/); err != nil {
+		false /*rotateSecretsManager*/, true /*creatingStack*/, false /*useStdin*/); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Require users to pass `--stdin` to:

  `pulumi stack change-secrets-provider passphrase`

Allow passing passphrase through stdin non-interactively also when existing passphrase is not being rotated.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
