### PR TITLE
Extended tests for property paths and ignoreChanges

### DIFF
--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1260,7 +1260,12 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 		},
 		"d": []interface{}{1},
 		"e": []interface{}{1},
-	}), []string{"a", "b.c", "d", "e[0]"}, []display.StepOp{deploy.OpCreate})
+		"f": map[string]interface{}{
+			"g": map[string]interface{}{
+				"h": "bar",
+			},
+		},
+	}), []string{"a", "b.c", "d", "e[0]", "f.g[\"h\"]"}, []display.StepOp{deploy.OpCreate})
 
 	// Ensure that a change to an ignored property results in an OpSame
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -1270,7 +1275,12 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 		},
 		"d": []interface{}{2},
 		"e": []interface{}{2},
-	}), []string{"a", "b.c", "d", "e[0]"}, []display.StepOp{deploy.OpSame})
+		"f": map[string]interface{}{
+			"g": map[string]interface{}{
+				"h": "baz",
+			},
+		},
+	}), []string{"a", "b.c", "d", "e[0]", "f.g[\"h\"]"}, []display.StepOp{deploy.OpSame})
 
 	// Ensure that a change to an un-ignored property results in an OpUpdate
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -1280,12 +1290,17 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 		},
 		"d": []interface{}{3},
 		"e": []interface{}{3},
+		"f": map[string]interface{}{
+			"g": map[string]interface{}{
+				"h": "qux",
+			},
+		},
 	}), nil, []display.StepOp{deploy.OpUpdate})
 
 	// Ensure that a removing an ignored property results in an OpSame
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"e": []interface{}{},
-	}), []string{"a", "b", "d", "e"}, []display.StepOp{deploy.OpSame})
+	}), []string{"a", "b", "d", "e", "f"}, []display.StepOp{deploy.OpSame})
 
 	// Ensure that a removing an un-ignored property results in an OpUpdate
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -1300,13 +1315,13 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 		},
 		"d": []interface{}{4},
 		"e": []interface{}{},
-	}), []string{"a", "b", "d", "e[0]"}, []display.StepOp{deploy.OpSame})
+	}), []string{"a", "b", "d", "e[0]", "f"}, []display.StepOp{deploy.OpSame})
 
 	// Ensure that adding an un-ignored property results in an OpUpdate
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"e": []interface{}{},
-		"f": 4,
-	}), []string{"a", "b", "d", "e"}, []display.StepOp{deploy.OpUpdate})
+		"i": 4,
+	}), []string{"a", "b", "d", "e", "f"}, []display.StepOp{deploy.OpUpdate})
 
 	// Ensure that sub-elements of arrays can be ignored, first reset to a simple state
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -77,6 +77,58 @@ func TestIgnoreChanges(t *testing.T) {
 			ignoreChanges: []string{"a.b"},
 		},
 		{
+			name: "Present in old and new sets, using [\"\"]",
+			oldInputs: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "foo",
+					},
+				},
+			},
+			newInputs: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "bar",
+					},
+				},
+				"c": 42,
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "foo",
+					},
+				},
+				"c": 42,
+			},
+			ignoreChanges: []string{"a.b[\"c\"]"},
+		},
+		{
+			name: "Missing in new sets, using [\"\"]",
+			oldInputs: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "foo",
+					},
+				},
+			},
+			newInputs: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{},
+				},
+				"c": 42,
+			},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "foo",
+					},
+				},
+				"c": 42,
+			},
+			ignoreChanges: []string{"a.b[\"c\"]"},
+		},
+		{
 			name:      "Missing in old deletes",
 			oldInputs: map[string]interface{}{},
 			newInputs: map[string]interface{}{


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Issue #9054 described a problem with `ignoreChanges` not working correctly when using square bracket notation.

- This PR extends some tests that verify property paths and the ignoreChanges mechanism.
- These tests demonstrate that the code exhibits the required behavior
- The behavior described in the issue does not currently reproduce with the scenario described in the issue report. This has been verified manually, and I have closed the issue as **can't repo**

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
