### PR TITLE
Prefer stable plugin release to pre-releases

### DIFF
--- a/changelog/pending/20231130--engine--engine-now-prefers-stable-plugin-versions-to-pre-releases-when-no-explict-version-is-given.yaml
+++ b/changelog/pending/20231130--engine--engine-now-prefers-stable-plugin-versions-to-pre-releases-when-no-explict-version-is-given.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine now prefers stable plugin versions to pre-releases when no explict version is given.

--- a/pkg/codegen/report/report_test.go
+++ b/pkg/codegen/report/report_test.go
@@ -64,8 +64,7 @@ func TestReportExample(t *testing.T) {
 				GoErrors: map[string]string{
 					"Might not bind": "error: could not locate a compatible plugin in " +
 						"deploytest, the makefile and & constructor of the plugin host " +
-						"must define the location of the schema: failed " +
-						`to locate compatible plugin: "not"`,
+						"must define the location of the schema",
 				},
 				Files: map[string][]report.File{
 					"Might not bind": {{Name: "Might not bind", Body: "resource foo \"not:a:Resource\" { foo: \"bar\" }"}},

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -490,12 +490,12 @@ func (host *pluginHost) ResolvePlugin(
 		semverRange = version.EQ
 	}
 
-	match, err := workspace.SelectCompatiblePlugin(plugins, kind, name, semverRange)
-	if err == nil {
-		return &match, nil
+	match := workspace.SelectCompatiblePlugin(plugins, kind, name, semverRange)
+	if match == nil {
+		return nil, fmt.Errorf("could not locate a compatible plugin in deploytest, the makefile and " +
+			"& constructor of the plugin host must define the location of the schema")
 	}
-	return nil, fmt.Errorf("could not locate a compatible plugin in deploytest, the makefile and "+
-		"& constructor of the plugin host must define the location of the schema: %w", err)
+	return match, nil
 }
 
 func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -312,7 +312,7 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 	assert.False(t, HasPlugin(plugin))
 
 	has, err := HasPluginGTE(plugin)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 
 	skipMetadata := true

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -36,6 +36,87 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLegacyPluginSelection_Prerelease(t *testing.T) {
+	t.Parallel()
+
+	v1 := semver.MustParse("0.1.0")
+	v2 := semver.MustParse("0.2.0")
+	v3 := semver.MustParse("0.3.0-alpha")
+	candidatePlugins := []PluginInfo{
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v1,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v2,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v3,
+		},
+		{
+			Name:    "notmyplugin",
+			Kind:    ResourcePlugin,
+			Version: &v3,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    AnalyzerPlugin,
+			Version: &v3,
+		},
+	}
+
+	result := LegacySelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", nil)
+	assert.NotNil(t, result)
+	assert.Equal(t, "myplugin", result.Name)
+	assert.Equal(t, "0.2.0", result.Version.String())
+}
+
+func TestLegacyPluginSelection_PrereleaseRequested(t *testing.T) {
+	t.Parallel()
+
+	v1 := semver.MustParse("0.1.0")
+	v2 := semver.MustParse("0.2.0-alpha")
+	v3 := semver.MustParse("0.3.0-alpha")
+	candidatePlugins := []PluginInfo{
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v1,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v2,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    ResourcePlugin,
+			Version: &v3,
+		},
+		{
+			Name:    "notmyplugin",
+			Kind:    ResourcePlugin,
+			Version: &v3,
+		},
+		{
+			Name:    "myplugin",
+			Kind:    AnalyzerPlugin,
+			Version: &v3,
+		},
+	}
+
+	v := semver.MustParse("0.2.0")
+	result := LegacySelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", &v)
+	assert.NotNil(t, result)
+	assert.Equal(t, "myplugin", result.Name)
+	assert.Equal(t, "0.3.0-alpha", result.Version.String())
+}
+
 func TestPluginSelection_ExactMatch(t *testing.T) {
 	t.Parallel()
 
@@ -71,8 +152,8 @@ func TestPluginSelection_ExactMatch(t *testing.T) {
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result, err := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
-	assert.NoError(t, err)
+	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
 }
@@ -112,8 +193,8 @@ func TestPluginSelection_ExactMatchNotFound(t *testing.T) {
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	_, err := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
-	assert.Error(t, err)
+	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	assert.Nil(t, result)
 }
 
 func TestPluginSelection_PatchVersionSlide(t *testing.T) {
@@ -157,8 +238,8 @@ func TestPluginSelection_PatchVersionSlide(t *testing.T) {
 	}
 
 	requested := semver.MustParseRange(">=0.2.0 <0.3.0")
-	result, err := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
-	assert.NoError(t, err)
+	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.1", result.Version.String())
 }
@@ -203,8 +284,8 @@ func TestPluginSelection_EmptyVersionNoAlternatives(t *testing.T) {
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result, err := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
-	assert.NoError(t, err)
+	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Nil(t, result.Version)
 }
@@ -254,8 +335,8 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result, err := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
-	assert.NoError(t, err)
+	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
 }


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14680.

Updated the plugin logic (which we still use when no explict version is given) to prefer selecting a stable version over a pre-release version when no explict requested version is given.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
