### PR TITLE
Recover after a failed automatation run

### DIFF
--- a/changelog/pending/20231130--sdk-nodejs--use-local-storage-to-track-per-stack-error-log-count.yaml
+++ b/changelog/pending/20231130--sdk-nodejs--use-local-storage-to-track-per-stack-error-log-count.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Use local storage to track per stack error log count

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -16,9 +16,9 @@
 
 import * as resourceTypes from "../resource";
 import { getEngine, rpcKeepAlive } from "../runtime/settings";
+import { getStore } from "../runtime/state";
 const engproto = require("../proto/engine_pb.js");
 
-let errcnt = 0;
 let lastLog: Promise<any> = Promise.resolve();
 
 const messageLevels = {
@@ -32,7 +32,7 @@ const messageLevels = {
  * hasErrors returns true if any errors have occurred in the program.
  */
 export function hasErrors(): boolean {
-    return errcnt > 0;
+    return getStore().logErrorCount > 0;
 }
 
 /**
@@ -77,7 +77,7 @@ export function warn(msg: string, resource?: resourceTypes.Resource, streamId?: 
  * error logs a fatal condition. Consider raising an exception after calling error to stop the Pulumi program.
  */
 export function error(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
-    errcnt++; // remember the error so we can suppress leaks.
+    getStore().logErrorCount++; // remember the error so we can suppress leaks.
 
     const engine: Object | undefined = getEngine();
     if (engine) {

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -69,6 +69,7 @@ export interface Store {
     config: Record<string, string>;
     stackResource?: Stack;
     leakCandidates: Set<Promise<any>>;
+    logErrorCount: number;
 }
 
 /** @internal */
@@ -100,6 +101,8 @@ export class LocalStore implements Store {
      * leakCandidates tracks the list of potential leak candidates.
      */
     leakCandidates = new Set<Promise<any>>();
+
+    logErrorCount = 0;
 }
 
 /** Get the root stack resource for the current stack deployment

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -959,7 +959,7 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
-    it(`can run successfully after a previous failure`, async () => {
+    it(`runs successfully after a previous failure`, async () => {
         let shouldFail = true;
         const program = async () => {
             if (shouldFail) {
@@ -974,7 +974,7 @@ describe("LocalWorkspace", () => {
         // pulumi up rejects the first time
         await assert.rejects(stack.up());
 
-        // pulumi up the 2nd time succeeds
+        // pulumi up succeeds the 2nd time
         shouldFail = false;
         await assert.doesNotReject(stack.up());
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12521

The log module for the nodejs SDK keeps track of an error count in a global, this should be stored in the stack's local store.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
