### PR TITLE
[cli/import] Minimize logical name changes

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2
 	github.com/natefinch/atomic v1.0.1
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e
+	github.com/pgavlin/fx v0.1.6
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/esc v0.6.1-0.20231111193429-44b746a5b3b5
@@ -92,6 +93,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5
 	go.pennock.tech/tabular v1.1.3
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/mod v0.14.0
 	golang.org/x/term v0.14.0
 	google.golang.org/protobuf v1.31.0
@@ -225,7 +227,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e // indirect
-	github.com/pgavlin/fx v0.1.6 // indirect
 	github.com/pgavlin/text v0.0.0-20230428184845-84c285f11d2f // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
@@ -255,7 +256,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect


### PR DESCRIPTION
The trickiest job we do while parsing the import file is name disambiguation.

The name of an import serves as both the logical name of the imported resource (e.g. "foo" in `new aws.s3.Bucket("foo")`) and as the name of the resource's definition (e.g. `foo_1` in
`const foo_1 = new aws.s3.Bucket("foo")`). The logical name of the resource need only be unique within its qualified type--that is, two resources may have the same logical name if they are of different types or have different ancestors--but the name of the resource's definition must always be unique.

Other systems that serve as input for import (notably Terraform) also have this sort of peculiar type-based namespacing. We often see overlapping names when importing from these systems. In order to make `pulumi import` cooperate nicely with `pulumi convert`, we need the logical names of the imported resource to agree with the logical name of the corresponding converted resource.

To address this:
- We only change the logical name of a resource if not doing so would cause it to conflict with another resource (i.e. because they end up with the same URN)
- We change the definition name of a resource if not doing so would cause its definition in the generated source to conflict with another resource

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
