### PR TITLE
[ci] improve test logging on retries

### DIFF
--- a/scripts/retry
+++ b/scripts/retry
@@ -35,6 +35,7 @@ run_tests() {
     done
 
     success=true
+    echo "::info Tests successful.. failures refer to test flakes that were successfully re-run."
 }
 
 run_tests "${@}"


### PR DESCRIPTION
CI added log output to clarify success despite test failure output.
- `run tests` may end with a failing test being the last thing printed, but it was retried and passed.