### PR TITLE
Sets the `main` project setting to the cwd for inline programs

### DIFF
--- a/changelog/pending/20231201--auto-python--ensures-that-the-project_settings-has-a-main-directory-for-inline-programs-in-python.yaml
+++ b/changelog/pending/20231201--auto-python--ensures-that-the-project_settings-has-a-main-directory-for-inline-programs-in-python.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: Ensures that the project_settings has a main directory for inline programs in python

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -725,11 +725,18 @@ def _inline_source_stack_helper(
         work_dir = workspace_options.work_dir
         if work_dir:
             try:
+                # This attempts to load the project settings, and if it
+                # succeeds, then discards them. This is ok because the
+                # LocalWorkspace will load them when it needs to. This is simply
+                # establishing whether there is an appropritate file in
+                # `work_dir`
                 _load_project_settings(work_dir)
             except FileNotFoundError:
                 workspace_options.project_settings = default_project(project_name)
         else:
             workspace_options.project_settings = default_project(project_name)
+    elif workspace_options.project_settings.main is None:
+        workspace_options.project_settings.main = os.getcwd()
 
     ws = LocalWorkspace(**workspace_options.__dict__)
     return init_fn(stack_name, ws)

--- a/sdk/python/lib/test/automation/test_errors.py
+++ b/sdk/python/lib/test/automation/test_errors.py
@@ -23,7 +23,7 @@ from pulumi.automation import (
     RuntimeError,
     CompilationError,
 )
-from .test_local_workspace import stack_namer, test_path
+from .test_local_workspace import stack_namer, get_test_path
 
 compilation_error_project = "compilation_error"
 runtime_error_project = "runtime_error"
@@ -50,7 +50,7 @@ class TestErrors(unittest.TestCase):
     def test_runtime_errors(self):
         for lang in ["python", "go", "dotnet", "javascript", "typescript"]:
             stack_name = stack_namer(runtime_error_project)
-            project_dir = test_path("errors", runtime_error_project, lang)
+            project_dir = get_test_path("errors", runtime_error_project, lang)
 
             if lang in ["javascript", "typescript"]:
                 subprocess.run(["npm", "install"], check=True, cwd=project_dir, capture_output=True)
@@ -73,7 +73,7 @@ class TestErrors(unittest.TestCase):
 
     def test_compilation_error_go(self):
         stack_name = stack_namer(compilation_error_project)
-        project_dir = test_path("errors", compilation_error_project, "go")
+        project_dir = get_test_path("errors", compilation_error_project, "go")
         stack = create_stack(stack_name, work_dir=project_dir)
 
         try:
@@ -84,7 +84,7 @@ class TestErrors(unittest.TestCase):
 
     def test_compilation_error_dotnet(self):
         stack_name = stack_namer(compilation_error_project)
-        project_dir = test_path("errors", compilation_error_project, "dotnet")
+        project_dir = get_test_path("errors", compilation_error_project, "dotnet")
         stack = create_stack(stack_name, work_dir=project_dir)
 
         try:
@@ -98,7 +98,7 @@ class TestErrors(unittest.TestCase):
     @pytest.mark.skipif(sys.platform == "win32", reason="skipping on windows")
     def test_compilation_error_typescript(self):
         stack_name = stack_namer(compilation_error_project)
-        project_dir = test_path("errors", compilation_error_project, "typescript")
+        project_dir = get_test_path("errors", compilation_error_project, "typescript")
         subprocess.run(["npm", "install"], check=True, cwd=project_dir, capture_output=True)
         stack = create_stack(stack_name, work_dir=project_dir)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Currently if no project settings are provided this is the default value for `main`, but if the caller providers a project_settings object without this set it will cause a module load issue if the inline program depends on other local python files. The current work-around is to put all the code in one file or set `work_dir`.

Fixes #7960

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
