### PR TITLE
Fix a panic in diff display when parsing YAML strings

### DIFF
--- a/changelog/pending/20231201--cli-display--fix-a-panic-in-diff-display-when-parsing-yaml-strings.yaml
+++ b/changelog/pending/20231201--cli-display--fix-a-panic-in-diff-display-when-parsing-yaml-strings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix a panic in diff display when parsing YAML strings

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -1242,7 +1242,8 @@ func (p *propertyPrinter) decodeValue(repr string) (resource.PropertyValue, stri
 			// Make sure _all_ the string was consumed as YAML. Unlike JsonDecoder above, the YamlDecoder
 			// doesn't give an easy way to do this, so our workaround is we ask it to try and decode another
 			// value, and if it fails with io.EOF, then we know we've consumed the whole string.
-			eofErr := yamlDecoder.Decode(nil)
+			var ignored interface{}
+			eofErr := yamlDecoder.Decode(&ignored)
 			if errors.Is(eofErr, io.EOF) {
 				translated, ok := p.translateYAMLValue(object)
 				if !ok {

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -43,6 +43,7 @@ func Test_decodeValue(t *testing.T) {
 		{repr: "[] bar"},
 		{repr: "{} bar"},
 		{repr: "[] \n not yaml"},
+		{repr: "---\n'hello'\n...\n---\ngoodbye\n...\n"},
 
 		// Positive cases
 		{


### PR DESCRIPTION
To make sure all of the string was consumed by the YAML decoder, we'd call `yamlDecoder.Decode(nil)` to see if it returned an `io.EOF` error. However, if it's not EOF, the decoder panics when `nil` is passed-in. Instead, pass in a valid argument for cases that aren't EOF.

Fixes #14558