### PR TITLE
Check qualified type for root stackness

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -185,7 +185,7 @@ func isRootStack(step engine.StepEventMetadata) bool {
 }
 
 func isRootURN(urn resource.URN) bool {
-	return urn != "" && urn.Type() == resource.RootStackType
+	return urn != "" && urn.QualifiedType() == resource.RootStackType
 }
 
 // shouldShow returns true if a step should show in the output.

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -346,7 +346,7 @@ func getResourceOutputsPropertiesString(
 	step engine.StepEventMetadata, indent int, planning, debug, refresh, showSames bool,
 ) string {
 	// During the actual update we always show all the outputs for the stack, even if they are unchanged.
-	if !showSames && !planning && step.URN.Type() == resource.RootStackType {
+	if !showSames && !planning && step.URN.QualifiedType() == resource.RootStackType {
 		showSames = true
 	}
 
@@ -371,7 +371,7 @@ func getResourceOutputsPropertiesString(
 			step.Op == deploy.OpReadReplacement ||
 			step.Op == deploy.OpImport ||
 			step.Op == deploy.OpImportReplacement ||
-			step.URN.Type() == resource.RootStackType
+			step.URN.QualifiedType() == resource.RootStackType
 		if !printOutputDuringPlanning {
 			return ""
 		}
@@ -403,7 +403,7 @@ func getResourceOutputsPropertiesString(
 
 		// If this is the root stack type, we want to strip out any nested resource outputs that are not known if
 		// they have no corresponding output in the old state.
-		if planning && step.URN.Type() == resource.RootStackType {
+		if planning && step.URN.QualifiedType() == resource.RootStackType {
 			massageStackPreviewOutputDiff(outputDiff, false)
 		}
 

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -294,7 +294,7 @@ func renderTree(snap *deploy.Snapshot, showURNs, showIDs bool) ([]cmdutil.TableR
 				nodes[res.Parent] = p
 			}
 			p.children = append(p.children, node)
-		case res.Type == resource.RootStackType:
+		case res.Type == resource.RootStackType && res.Parent == "":
 			root = node
 		default:
 			orphans = append(orphans, node)

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -128,7 +128,7 @@ func appendResourceOption(block *model.Block, name string, value model.Expressio
 
 func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, error) {
 	var resourceOptions *model.Block
-	if state.Parent != "" && state.Parent.Type() != resource.RootStackType {
+	if state.Parent != "" && state.Parent.QualifiedType() != resource.RootStackType {
 		name, ok := names[state.Parent]
 		if !ok {
 			return nil, fmt.Errorf("no name for parent %v", state.Parent)

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -542,7 +542,7 @@ func (d *Deployment) GetProvider(ref providers.Reference) (plugin.Provider, bool
 func (d *Deployment) generateURN(parent resource.URN, ty tokens.Type, name string) resource.URN {
 	// Use the resource goal state name to produce a globally unique URN.
 	parentType := tokens.Type("")
-	if parent != "" && parent.Type() != resource.RootStackType {
+	if parent != "" && parent.QualifiedType() != resource.RootStackType {
 		// Skip empty parents and don't use the root stack type; otherwise, use the full qualified type.
 		parentType = parent.QualifiedType()
 	}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -166,7 +166,7 @@ func (i *importer) getOrCreateStackResource(ctx context.Context) (resource.URN, 
 	// Get or create the root resource.
 	if i.deployment.prev != nil {
 		for _, res := range i.deployment.prev.Resources {
-			if res.Type == resource.RootStackType {
+			if res.Type == resource.RootStackType && res.Parent == "" {
 				return res.URN, false, true
 			}
 		}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -75,7 +75,7 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 		}
 		// If our parent has changed URN, then we need to update our URN as well.
 		if parent, has := aliased[state.Parent]; has {
-			if parent != "" && parent.Type() != resource.RootStackType {
+			if parent != "" && parent.QualifiedType() != resource.RootStackType {
 				aliased[state.URN] = resource.NewURN(
 					state.URN.Stack(), state.URN.Project(),
 					parent.QualifiedType(), state.URN.Type(),

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -998,7 +998,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		if _, ok := s.deployment.olds[s.new.URN]; ok {
 			return resource.StatusOK, nil, fmt.Errorf("resource '%v' already exists", s.new.URN)
 		}
-		if s.new.Parent.Type() != resource.RootStackType {
+		if s.new.Parent.QualifiedType() != resource.RootStackType {
 			_, ok := s.deployment.news.get(s.new.Parent)
 			if !ok {
 				return resource.StatusOK, nil, fmt.Errorf("unknown parent '%v' for resource '%v'",

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -117,46 +117,38 @@ func (sg *stepGenerator) Errored() bool {
 // if there is one.
 func (sg *stepGenerator) checkParent(parent resource.URN, resourceType tokens.Type) (resource.URN, error) {
 	// Some goal settings are based on the parent settings so make sure our parent is correct.
-	if resourceType == resource.RootStackType {
-		// The RootStack must not have a parent set
-		if parent != "" {
-			return "", fmt.Errorf("root stack resource can not have a parent (tried to set it to %v)", parent)
+
+	// TODO(fraser): I think every resource but the RootStack should have a parent, however currently a
+	// number of our tests do not create a RootStack resource, feels odd that it's possible for the engine
+	// to run without a RootStack resource. I feel this ought to be fixed by making the engine always
+	// create the RootStack before running the user program, however that leaves some questions of what to
+	// do if we ever support changing any of the settings (such as the provider map) on the RootStack
+	// resource. For now we set it to the root stack if we can find it, but we don't error on blank parents
+
+	// If it is set check the parent exists.
+	if parent != "" {
+		// The parent for this resource hasn't been registered yet. That's an error and we can't continue.
+		if _, hasParent := sg.urns[parent]; !hasParent {
+			return "", fmt.Errorf("could not find parent resource %v", parent)
 		}
-	} else {
-		// For other resources they may or may not have a parent.
-		//
-		// TODO(fraser): I think every resource but the RootStack should have a parent, however currently a
-		// number of our tests do not create a RootStack resource, feels odd that it's possible for the engine
-		// to run without a RootStack resource. I feel this ought to be fixed by making the engine always
-		// create the RootStack before running the user program, however that leaves some questions of what to
-		// do if we ever support changing any of the settings (such as the provider map) on the RootStack
-		// resource. For now we set it to the root stack if we can find it, but we don't error on blank parents
+	} else { //nolint:staticcheck // https://github.com/pulumi/pulumi/issues/10950
+		// Else try and set it to the root stack
 
-		// If it is set check the parent exists.
-		if parent != "" {
-			// The parent for this resource hasn't been registered yet. That's an error and we can't continue.
-			if _, hasParent := sg.urns[parent]; !hasParent {
-				return "", fmt.Errorf("could not find parent resource %v", parent)
-			}
-		} else { //nolint:staticcheck // https://github.com/pulumi/pulumi/issues/10950
-			// Else try and set it to the root stack
+		// TODO: It looks like this currently has some issues with state ordering (see
+		// https://github.com/pulumi/pulumi/issues/10950). Best I can guess is the stack resource is
+		// hitting the step generator and so saving it's URN to sg.urns and issuing a Create step but not
+		// actually getting to writing it's state to the snapshot. Then in parallel with this something
+		// else is causing a pulumi:providers:pulumi default provider to be created, this picks up the
+		// stack URN from sg.urns and so sets it's parent automatically, but then races the step executor
+		// to write itself to state before the stack resource manages to. Long term we want to ensure
+		// there's always a stack resource present, and so that all resources (except the stack) have a
+		// parent (this will save us some work in each SDK), but for now lets just turn this support off.
 
-			// TODO: It looks like this currently has some issues with state ordering (see
-			// https://github.com/pulumi/pulumi/issues/10950). Best I can guess is the stack resource is
-			// hitting the step generator and so saving it's URN to sg.urns and issuing a Create step but not
-			// actually getting to writing it's state to the snapshot. Then in parallel with this something
-			// else is causing a pulumi:providers:pulumi default provider to be created, this picks up the
-			// stack URN from sg.urns and so sets it's parent automatically, but then races the step executor
-			// to write itself to state before the stack resource manages to. Long term we want to ensure
-			// there's always a stack resource present, and so that all resources (except the stack) have a
-			// parent (this will save us some work in each SDK), but for now lets just turn this support off.
-
-			//for urn := range sg.urns {
-			//	if urn.Type() == resource.RootStackType {
-			//		return urn, nil
-			//	}
-			//}
-		}
+		//for urn := range sg.urns {
+		//	if urn.Type() == resource.RootStackType {
+		//		return urn, nil
+		//	}
+		//}
 	}
 
 	return parent, nil
@@ -381,7 +373,7 @@ func (sg *stepGenerator) collapseAliasToUrn(goal *resource.Goal, alias resource.
 			parent = parentAlias
 		}
 	}
-	parentIsRootStack := parent != "" && parent.Type() == resource.RootStackType
+	parentIsRootStack := parent != "" && parent.QualifiedType() == resource.RootStackType
 	if alias.NoParent || parentIsRootStack {
 		parent = ""
 	}
@@ -634,7 +626,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, err
 		return []Step{NewImportStep(sg.deployment, event, new, goal.IgnoreChanges, randomSeed)}, nil
 	}
 
-	isImplicitlyTargetedResource := providers.IsProviderType(urn.Type()) || urn.Type() == resource.RootStackType
+	isImplicitlyTargetedResource := providers.IsProviderType(urn.Type()) || urn.QualifiedType() == resource.RootStackType
 
 	// Internally managed resources are under Pulumi's control and changes or creations should be invisible to
 	// the user, we also implicitly target providers (both default and explicit, see

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -166,7 +166,7 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.StackName, newProject tok
 
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want
 		// to rename the name portion as well.
-		if u.QualifiedType() == "pulumi:pulumi:Stack" {
+		if u.QualifiedType() == resource.RootStackType {
 			return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), string(tokens.QName(project)+"-"+newName.Q()))
 		}
 

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -148,7 +148,7 @@ func DeserializeCheckpoint(
 func GetRootStackResource(snap *deploy.Snapshot) (*resource.State, error) {
 	if snap != nil {
 		for _, res := range snap.Resources {
-			if res.Type == resource.RootStackType {
+			if res.Type == resource.RootStackType && res.Parent == "" {
 				return res, nil
 			}
 		}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1824,7 +1824,7 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	var rootResource apitype.ResourceV3
 	var outputs map[string]interface{}
 	for _, res := range deployment.Resources {
-		if res.Type == resource.RootStackType {
+		if res.Type == resource.RootStackType && res.Parent == "" {
 			rootResource = res
 			outputs = res.Outputs
 		}

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -72,7 +72,7 @@ type mockMonitor struct {
 
 func (m *mockMonitor) newURN(parent, typ, name string) string {
 	parentType := tokens.Type("")
-	if parentURN := resource.URN(parent); parentURN != "" && parentURN.Type() != resource.RootStackType {
+	if parentURN := resource.URN(parent); parentURN != "" && parentURN.QualifiedType() != resource.RootStackType {
 		parentType = parentURN.QualifiedType()
 	}
 
@@ -206,7 +206,7 @@ func (m *mockMonitor) ReadResource(ctx context.Context, in *pulumirpc.ReadResour
 func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.RegisterResourceRequest,
 	opts ...grpc.CallOption,
 ) (*pulumirpc.RegisterResourceResponse, error) {
-	if in.GetType() == string(resource.RootStackType) {
+	if in.GetType() == string(resource.RootStackType) && in.GetParent() == "" {
 		return &pulumirpc.RegisterResourceResponse{
 			Urn: m.newURN(in.GetParent(), in.GetType(), in.GetName()),
 		}, nil


### PR DESCRIPTION
With the introduction of component programs there will be mulitple "pulumi:pulumi:stack" resources in a program. We should therefore check against the qualified type of resources to see if they are the root stack, not just their direct type.
