### PR TITLE
Just call plugin install directly in tests

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -68,10 +68,7 @@ func TestYamlConvertSmoke(t *testing.T) {
 	e.ImportDirectory("testdata/random_yaml")
 
 	// Make sure random is installed
-	out, _ := e.RunCommand("pulumi", "plugin", "ls")
-	if !strings.Contains(out, "random  resource  4.13.0") {
-		e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
-	}
+	e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
 
 	e.RunCommand(
 		"pulumi", "convert", "--strict",
@@ -105,10 +102,7 @@ func TestLanguageConvertSmoke(t *testing.T) {
 			e.ImportDirectory("testdata/random_pp")
 
 			// Make sure random is installed
-			out, _ := e.RunCommand("pulumi", "plugin", "ls")
-			if !strings.Contains(out, "random  resource  4.13.0") {
-				e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
-			}
+			e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
 
 			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 			e.RunCommand(
@@ -139,10 +133,7 @@ func TestLanguageConvertLenientSmoke(t *testing.T) {
 			e.ImportDirectory("testdata/bad_random_pp")
 
 			// Make sure random is installed
-			out, _ := e.RunCommand("pulumi", "plugin", "ls")
-			if !strings.Contains(out, "random  resource  4.13.0") {
-				e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
-			}
+			e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
 
 			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 			e.RunCommand(
@@ -175,10 +166,7 @@ func TestLanguageConvertComponentSmoke(t *testing.T) {
 			e.ImportDirectory("testdata/component_pp")
 
 			// Make sure random is installed
-			out, _ := e.RunCommand("pulumi", "plugin", "ls")
-			if !strings.Contains(out, "random  resource  4.13.0") {
-				e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
-			}
+			e.RunCommand("pulumi", "plugin", "install", "resource", "random", "4.13.0")
 
 			e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 			e.RunCommand("pulumi", "convert", "--language", Languages[runtime], "--from", "pcl", "--out", "out")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Pointed out in another PR https://github.com/pulumi/pulumi/pull/14548#discussion_r1411431491.  

No need to check if a plugin is already installed with `plugin ls`, `install` will return success if the plugin is already present.
