### PR TITLE
[ci] enable coverage on merge job

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -39,6 +39,7 @@ jobs:
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
+      enable-coverage: true
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
CodeCov was skipped on https://github.com/pulumi/pulumi/actions/runs/7081061983

On further inspection, `enable-coverage` was not set to true on the on-merge job.