### PR TITLE
Fix handling of delete failures for targeted destroys

### DIFF
--- a/changelog/pending/20231204--engine--fix-handling-of-delete-failures-for-targeted-destroys.yaml
+++ b/changelog/pending/20231204--engine--fix-handling-of-delete-failures-for-targeted-destroys.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix handling of delete failures for targeted destroys

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -75,7 +75,7 @@ func TestRebuildBaseState(t *testing.T) {
 
 		ex := nl.Executor()
 
-		ex.rebuildBaseState(nl.AsRefreshSteps(), true)
+		ex.rebuildBaseState(nl.AsRefreshSteps())
 
 		assert.EqualValues(t, map[resource.URN]*resource.State{
 			"B": {URN: "B"},
@@ -97,7 +97,7 @@ func TestRebuildBaseState(t *testing.T) {
 
 		ex := nl.Executor()
 
-		ex.rebuildBaseState(nl.AsRefreshSteps(), true)
+		ex.rebuildBaseState(nl.AsRefreshSteps())
 
 		assert.EqualValues(t, map[resource.URN]*resource.State{
 			"A": {URN: "A"},


### PR DESCRIPTION
When doing a targeted destroy, if a delete operation for a resource fails, the resource was still being removed from the state. Instead, if the delete operation for a resource fails, it should remain in the state.

Fixes #8164
Fixes #14416