### PR TITLE
Use EqualError/ErrorContains instead of Error

### DIFF
--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -179,8 +179,7 @@ func TestCompilationErrorGo(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsCompilationError(err))
+	assert.True(t, IsCompilationError(err), "%v is not a compilation error", err)
 
 	// -- pulumi destroy --
 
@@ -209,8 +208,7 @@ func TestSelectStack404Error(t *testing.T) {
 
 	// attempt to select stack that has not been created.
 	_, err = SelectStack(ctx, stackName, w)
-	assert.Error(t, err)
-	assert.True(t, IsSelectStack404Error(err))
+	assert.True(t, IsSelectStack404Error(err), "%v is not a 404 error", err)
 }
 
 func TestCreateStack409Error(t *testing.T) {
@@ -244,8 +242,7 @@ func TestCreateStack409Error(t *testing.T) {
 
 	// attempt to create a dupe stack.
 	_, err = NewStack(ctx, stackName, w)
-	assert.Error(t, err)
-	assert.True(t, IsCreateStack409Error(err))
+	assert.True(t, IsCreateStack409Error(err), "%v is not a 409 error", err)
 }
 
 func TestCompilationErrorDotnet(t *testing.T) {
@@ -270,8 +267,7 @@ func TestCompilationErrorDotnet(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsCompilationError(err))
+	assert.True(t, IsCompilationError(err), "%v is not a compilation error", err)
 
 	// -- pulumi destroy --
 
@@ -313,8 +309,7 @@ func TestCompilationErrorTypescript(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsCompilationError(err))
+	assert.True(t, IsCompilationError(err), "%v is not a compilation error", err)
 
 	// -- pulumi destroy --
 
@@ -349,8 +344,7 @@ func TestRuntimeErrorGo(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsRuntimeError(err))
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 
 	// -- pulumi destroy --
 
@@ -384,10 +378,7 @@ func TestRuntimeErrorInlineGo(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	if !assert.True(t, IsRuntimeError(err)) {
-		t.Logf("%v is not a runtime error", err)
-	}
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 
 	// -- pulumi destroy --
 
@@ -446,8 +437,7 @@ func TestRuntimeErrorPython(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsRuntimeError(err), "%+v", err)
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 	assert.Contains(t, fmt.Sprintf("%v", err), "IndexError: list index out of range")
 
 	// -- pulumi destroy --
@@ -490,8 +480,7 @@ func TestRuntimeErrorJavascript(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsRuntimeError(err))
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 
 	// -- pulumi destroy --
 
@@ -533,8 +522,7 @@ func TestRuntimeErrorTypescript(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsRuntimeError(err))
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 
 	// -- pulumi destroy --
 
@@ -567,8 +555,7 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 	}()
 
 	_, err = s.Up(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsRuntimeError(err))
+	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
 
 	// -- pulumi destroy --
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -209,8 +209,7 @@ func TestRemoveWithForce(t *testing.T) {
 
 	// to make sure stack was removed
 	err = s.Workspace().SelectStack(ctx, s.Name())
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no stack named"))
+	assert.ErrorContains(t, err, "no stack named")
 }
 
 //nolint:paralleltest // mutates environment variables
@@ -1083,8 +1082,7 @@ func TestNestedStackFails(t *testing.T) {
 
 	t.Log(result)
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "nested stack operations are not supported")
+	assert.ErrorContains(t, err, "nested stack operations are not supported")
 
 	// -- pulumi destroy --
 
@@ -2137,8 +2135,7 @@ func TestMinimumVersion(t *testing.T) {
 			_, err := parseAndValidatePulumiVersion(minVersion, tt.currentVersion, tt.optOut)
 
 			if tt.expectedError != "" {
-				assert.Error(t, err)
-				assert.Regexp(t, tt.expectedError, err.Error())
+				assert.ErrorContains(t, err, tt.expectedError)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -566,7 +566,7 @@ func TestInvalidPathArchive(t *testing.T) {
 
 	// Attempt to construct a PathArchive with the temp file.
 	_, err = NewPathArchive(fileName)
-	assert.Error(t, err)
+	assert.EqualError(t, err, fmt.Sprintf("'%s' is neither a recognized archive type nor a directory", fileName))
 }
 
 func validateTestDirArchive(t *testing.T, arch *Archive, expected int) {

--- a/sdk/go/common/resource/config/key_test.go
+++ b/sdk/go/common/resource/config/key_test.go
@@ -36,10 +36,14 @@ func TestParseKey(t *testing.T) {
 	assert.Equal(t, "key", k.name)
 
 	_, err = ParseKey("foo")
-	assert.Error(t, err)
+	assert.ErrorContains(t, err,
+		"could not parse foo as a configuration key "+
+			"(configuration keys should be of the form `<namespace>:<name>`)")
 
 	_, err = ParseKey("test:data:key")
-	assert.Error(t, err)
+	assert.ErrorContains(t, err,
+		"could not parse test:data:key as a configuration key "+
+			"(configuration keys should be of the form `<namespace>:<name>`)")
 }
 
 func TestMarshalKeyJSON(t *testing.T) {

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -534,10 +534,12 @@ func TestGetFail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		Key string
+		Key           string
+		ExpectedError string
 	}{
 		{
-			Key: `my:["foo`,
+			Key:           `my:["foo`,
+			ExpectedError: "invalid config key path: missing closing quote in property name",
 		},
 	}
 
@@ -554,7 +556,7 @@ func TestGetFail(t *testing.T) {
 
 			_, found, err := config.Get(key, true /*path*/)
 			assert.False(t, found)
-			assert.Error(t, err)
+			assert.EqualError(t, err, test.ExpectedError)
 		})
 	}
 }
@@ -705,18 +707,21 @@ func TestRemoveFail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		Key    string
-		Config Map
+		Key           string
+		Config        Map
+		ExpectedError string
 	}{
 		{
-			Key:    `my:["foo`,
-			Config: Map{},
+			Key:           `my:["foo`,
+			Config:        Map{},
+			ExpectedError: "invalid config key path: missing closing quote in property name",
 		},
 		{
 			Key: `my:foo.bar`,
 			Config: Map{
 				MustMakeKey("my", "foo"): NewObjectValue(`{"bar":"baz","secure":"myvalue"}`),
 			},
+			ExpectedError: "bar.bar: maps with the single key \"secure\" are reserved",
 		},
 	}
 
@@ -730,7 +735,7 @@ func TestRemoveFail(t *testing.T) {
 			assert.NoError(t, err)
 
 			err = test.Config.Remove(key, true /*path*/)
-			assert.Error(t, err)
+			assert.EqualError(t, err, test.ExpectedError)
 		})
 	}
 }
@@ -1247,30 +1252,56 @@ func TestSetFail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		Key    string
-		Config Map
+		Key           string
+		Config        Map
+		ExpectedError string
 	}{
 		// Syntax errors.
-		{Key: "my:root["},
-		{Key: `my:root["nested]`},
-		{Key: "my:root.array[abc]"},
+		{
+			Key:           "my:root[",
+			ExpectedError: "invalid config key path: missing closing bracket in array index",
+		},
+		{
+			Key:           `my:root["nested]`,
+			ExpectedError: "invalid config key path: missing closing quote in property name",
+		},
+		{
+			Key:           "my:root.array[abc]",
+			ExpectedError: "invalid config key path: invalid array index: strconv.ParseInt: parsing \"abc\": invalid syntax",
+		},
 
 		// First path component must be a string.
-		{Key: `my:[""]`},
-		{Key: "my:[0]"},
+		{
+			Key:           `my:[""]`,
+			ExpectedError: "config key is empty",
+		},
+		{
+			Key:           "my:[0]",
+			ExpectedError: "first path segement of config key must be a string",
+		},
 
 		// Index out of range.
-		{Key: `my:name[-1]`},
+		{
+			Key:           `my:name[-1]`,
+			ExpectedError: "name[-1]: array index out of range",
+		},
 		{
 			Key: `my:name[4]`,
 			Config: Map{
 				MustMakeKey("my", "name"): NewObjectValue(`["a","b","c"]`),
 			},
+			ExpectedError: "name[4]: array index out of range",
 		},
 
 		// A "secure" key that is a map with a single string value is reserved by the system.
-		{Key: `my:key.secure`},
-		{Key: `my:super.nested.map.secure`},
+		{
+			Key:           `my:key.secure`,
+			ExpectedError: "maps with the single key \"secure\" are reserved",
+		},
+		{
+			Key:           `my:super.nested.map.secure`,
+			ExpectedError: "maps with the single key \"secure\" are reserved",
+		},
 
 		// Type mismatches.
 		{
@@ -1278,24 +1309,28 @@ func TestSetFail(t *testing.T) {
 			Config: Map{
 				MustMakeKey("my", "outer"): NewObjectValue("[1,2,3]"),
 			},
+			ExpectedError: "outer.inner: key for an array must be an int",
 		},
 		{
 			Key: `my:array[0]`,
 			Config: Map{
 				MustMakeKey("my", "array"): NewObjectValue(`{"inner":"value"}`),
 			},
+			ExpectedError: "array[0]: key for a map must be a string",
 		},
 		{
 			Key: `my:outer.inner.nested`,
 			Config: Map{
 				MustMakeKey("my", "outer"): NewObjectValue(`{"inner":"value"}`),
 			},
+			ExpectedError: "outer.inner: expected a map",
 		},
 		{
 			Key: `my:outer.inner[0]`,
 			Config: Map{
 				MustMakeKey("my", "outer"): NewObjectValue(`{"inner":"value"}`),
 			},
+			ExpectedError: "outer.inner: expected an array",
 		},
 	}
 
@@ -1313,7 +1348,7 @@ func TestSetFail(t *testing.T) {
 			assert.NoError(t, err)
 
 			err = test.Config.Set(key, NewValue("value"), true /*path*/)
-			assert.Error(t, err)
+			assert.EqualError(t, err, test.ExpectedError)
 		})
 	}
 }

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -678,7 +678,7 @@ func TestKubernetesDiffError(t *testing.T) {
 		resource.NewURN("org/proj/dev", "foo", "", "pulumi:provider:azure", "qux"),
 		resource.PropertyMap{}, resource.PropertyMap{}, resource.PropertyMap{},
 		false, nil)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse kubeconfig")
 
 	// Test that the error from 14529 is ignored if reported by kubernetes
 	k8s := NewProviderWithClient(newTestContext(t), "kubernetes", client, false /* disablePreview */)
@@ -695,5 +695,5 @@ func TestKubernetesDiffError(t *testing.T) {
 		resource.NewURN("org/proj/dev", "foo", "", "pulumi:provider:kubernetes", "qux"),
 		resource.PropertyMap{}, resource.PropertyMap{}, resource.PropertyMap{},
 		false, nil)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "some other error")
 }

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -56,22 +56,22 @@ func TestAssetSerialize(t *testing.T) {
 	// Ensure that an invalid asset produces an error.
 	setProperty(pk, assetProps, resource.AssetHashProperty, 0)
 	_, err = UnmarshalPropertyValue("", assetProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected asset hash of type float64")
 	setProperty(pk, assetProps, resource.AssetHashProperty, asset.Hash)
 
 	setProperty(pk, assetProps, resource.AssetTextProperty, 0)
 	_, err = UnmarshalPropertyValue("", assetProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected asset text of type float64")
 	setProperty(pk, assetProps, resource.AssetTextProperty, "")
 
 	setProperty(pk, assetProps, resource.AssetPathProperty, 0)
 	_, err = UnmarshalPropertyValue("", assetProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected asset path of type float64")
 	setProperty(pk, assetProps, resource.AssetPathProperty, "")
 
 	setProperty(pk, assetProps, resource.AssetURIProperty, 0)
 	_, err = UnmarshalPropertyValue("", assetProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected asset URI of type float64")
 	setProperty(pk, assetProps, resource.AssetURIProperty, "")
 
 	arch, err := resource.NewAssetArchive(map[string]interface{}{"foo": asset})
@@ -104,22 +104,22 @@ func TestAssetSerialize(t *testing.T) {
 	// Ensure that an invalid archive produces an error.
 	setProperty(pk, archProps, resource.ArchiveHashProperty, 0)
 	_, err = UnmarshalPropertyValue("", archProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected archive hash of type float64")
 	setProperty(pk, archProps, resource.ArchiveHashProperty, arch.Hash)
 
 	setProperty(pk, archProps, resource.ArchiveAssetsProperty, 0)
 	_, err = UnmarshalPropertyValue("", archProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected archive contents of type float64")
 	setProperty(pk, archProps, resource.ArchiveAssetsProperty, nil)
 
 	setProperty(pk, archProps, resource.ArchivePathProperty, 0)
 	_, err = UnmarshalPropertyValue("", archProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected archive path of type float64")
 	setProperty(pk, archProps, resource.ArchivePathProperty, "")
 
 	setProperty(pk, archProps, resource.ArchiveURIProperty, 0)
 	_, err = UnmarshalPropertyValue("", archProps, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unexpected archive URI of type float64")
 	setProperty(pk, archProps, resource.ArchiveURIProperty, "")
 }
 
@@ -183,7 +183,7 @@ func TestComputedReject(t *testing.T) {
 		cprop, err := MarshalPropertyValue(pk,
 			resource.NewComputedProperty(
 				resource.Computed{Element: resource.NewStringProperty("")}), opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected unknown property value for \"pk\"")
 		assert.Nil(t, cprop)
 	}
 	{
@@ -192,7 +192,7 @@ func TestComputedReject(t *testing.T) {
 				resource.Computed{Element: resource.NewStringProperty("")}), MarshalOptions{KeepUnknowns: true})
 		assert.NoError(t, err)
 		cpropU, err := UnmarshalPropertyValue(pk, cprop, opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected unknown property value for \"pk\"")
 		assert.Nil(t, cpropU)
 	}
 }
@@ -210,14 +210,14 @@ func TestAssetReject(t *testing.T) {
 	assert.NoError(t, err)
 	{
 		assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(asset), opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected Asset property value for \"an asset URI\"")
 		assert.Nil(t, assetProps)
 	}
 	{
 		assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(asset), MarshalOptions{})
 		assert.NoError(t, err)
 		assetPropU, err := UnmarshalPropertyValue(pk, assetProps, opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected Asset property value for \"an asset URI\"")
 		assert.Nil(t, assetPropU)
 	}
 
@@ -225,14 +225,14 @@ func TestAssetReject(t *testing.T) {
 	assert.NoError(t, err)
 	{
 		archProps, err := MarshalPropertyValue(pk, resource.NewArchiveProperty(arch), opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected Asset Archive property value for \"an asset URI\"")
 		assert.Nil(t, archProps)
 	}
 	{
 		archProps, err := MarshalPropertyValue(pk, resource.NewArchiveProperty(arch), MarshalOptions{})
 		assert.NoError(t, err)
 		archValue, err := UnmarshalPropertyValue(pk, archProps, opts)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "unexpected Asset property value for \"foo\"")
 		assert.Nil(t, archValue)
 	}
 }
@@ -283,7 +283,7 @@ func TestUnknownSig(t *testing.T) {
 	prop, err := MarshalPropertyValue(pk, rawProp, MarshalOptions{})
 	assert.NoError(t, err)
 	_, err = UnmarshalPropertyValue(pk, prop, MarshalOptions{})
-	assert.Error(t, err)
+	assert.EqualError(t, err, "unrecognized signature 'foobar' in property map for \"pk\"")
 }
 
 func TestSkipInternalKeys(t *testing.T) {

--- a/sdk/go/common/resource/resource_id_test.go
+++ b/sdk/go/common/resource/resource_id_test.go
@@ -53,7 +53,7 @@ func TestNewUniqueHexMaxLen2(t *testing.T) {
 	randlen := 8
 	maxlen := 13
 	_, err := NewUniqueHex(prefix, randlen, maxlen)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "name 'prefix' plus 8 random chars is longer than maximum length 13")
 }
 
 func TestNewUniqueHexEnsureRandomness2(t *testing.T) {
@@ -150,7 +150,7 @@ func TestNewUniqueHexV2MaxLen2(t *testing.T) {
 	randlen := 8
 	maxlen := 13
 	_, err := NewUniqueHexV2(urn, sequenceNumber, prefix, randlen, maxlen)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "name 'prefix' plus 8 random chars is longer than maximum length 13")
 }
 
 func TestNewUniqueHexV2EnsureRandomness2(t *testing.T) {

--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -43,10 +43,9 @@ func TestRunFunc_Bail(t *testing.T) {
 	cmd.Stderr = output
 
 	err = cmd.Run()
-	require.Error(t, err)
-	if exitErr := new(exec.ExitError); assert.ErrorAs(t, err, &exitErr) {
-		assert.NotZero(t, exitErr.ExitCode())
-	}
+	exitErr := new(exec.ExitError)
+	require.ErrorAs(t, err, &exitErr)
+	assert.NotZero(t, exitErr.ExitCode())
 
 	assert.Empty(t, buff.String())
 }

--- a/sdk/go/common/util/goversion/version_test.go
+++ b/sdk/go/common/util/goversion/version_test.go
@@ -1,11 +1,9 @@
 package goversion
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_checkMinimumGoVersion(t *testing.T) {
@@ -14,7 +12,7 @@ func Test_checkMinimumGoVersion(t *testing.T) {
 	tests := []struct {
 		name            string
 		goVersionOutput string
-		err             error
+		err             string
 	}{
 		{
 			name:            "ExactVersion",
@@ -31,17 +29,17 @@ func Test_checkMinimumGoVersion(t *testing.T) {
 		{
 			name:            "OlderGoVersion",
 			goVersionOutput: "go version go1.13.8 linux/amd64",
-			err:             errors.New("go version must be 1.14.0 or higher (1.13.8 detected)"),
+			err:             "go version must be 1.14.0 or higher (1.13.8 detected)",
 		},
 		{
 			name:            "MalformedVersion",
 			goVersionOutput: "go version xyz",
-			err:             errors.New("parsing go version: Malformed version: xyz"),
+			err:             "parsing go version: Malformed version: xyz",
 		},
 		{
 			name:            "GarbageVersionOutput",
 			goVersionOutput: "gobble gobble",
-			err:             errors.New("unexpected format for go version output: \"gobble gobble\""),
+			err:             "unexpected format for go version output: \"gobble gobble\"",
 		},
 	}
 	for _, tt := range tests {
@@ -50,12 +48,11 @@ func Test_checkMinimumGoVersion(t *testing.T) {
 			t.Parallel()
 
 			err := checkMinimumGoVersion(tt.goVersionOutput)
-			if err != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, tt.err.Error())
-				return
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
 			}
-			require.NoError(t, err)
 		})
 	}
 }

--- a/sdk/go/common/util/mapper/mapper_test.go
+++ b/sdk/go/common/util/mapper/mapper_test.go
@@ -93,15 +93,13 @@ func TestFieldMapper(t *testing.T) {
 	// Try some error conditions; first, wrong type:
 	s.String = "x"
 	err = md.DecodeValue(tree, reflect.TypeOf(bag{}), "b", &s.String, false)
-	assert.Error(t, err)
-	assert.Equal(t, "Field 'b' on 'mapper.bag' must be a 'string'; got 'bool' instead", err.Error())
+	assert.EqualError(t, err, "Field 'b' on 'mapper.bag' must be a 'string'; got 'bool' instead")
 	assert.Equal(t, "x", s.String)
 
 	// Next, missing required field:
 	s.String = "x"
 	err = md.DecodeValue(tree, reflect.TypeOf(bag{}), "missing", &s.String, false)
-	assert.Error(t, err)
-	assert.Equal(t, "Missing required field 'missing' on 'mapper.bag'", err.Error())
+	assert.EqualError(t, err, "Missing required field 'missing' on 'mapper.bag'")
 	assert.Equal(t, "x", s.String)
 }
 
@@ -285,17 +283,15 @@ func TestMapperDecode(t *testing.T) {
 		"s":  true,
 		"sc": "",
 	}, &b3)
-	assert.Error(t, err)
-	assert.Equal(t, "1 failures decoding:\n"+
-		"\ts: Field 's' on 'mapper.bagtag' must be a 'string'; got 'bool' instead", err.Error())
+	assert.EqualError(t, err, "1 failures decoding:\n"+
+		"\ts: Field 's' on 'mapper.bagtag' must be a 'string'; got 'bool' instead")
 	assert.Equal(t, "", b3.String)
 
 	// Next, missing required field:
 	var b4 bagtag
 	err = md.Decode(map[string]interface{}{}, &b4)
-	assert.Error(t, err)
-	assert.Equal(t, "1 failures decoding:\n"+
-		"\ts: Missing required field 's' on 'mapper.bagtag'", err.Error())
+	assert.EqualError(t, err, "1 failures decoding:\n"+
+		"\ts: Missing required field 's' on 'mapper.bagtag'")
 	assert.Equal(t, "", b4.String)
 }
 

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -87,10 +87,9 @@ func TestProjectStackPath(t *testing.T) {
 		"WithBoth",
 		"name: some_project\ndescription: Some project\nruntime: nodejs\nconfig: stacksA\nstackConfigDir: stacksB\n",
 		func(t *testing.T, projectDir, path string, err error) {
-			assert.Error(t, err)
 			errorMsg := "Should not use both config and stackConfigDir to define the stack directory. " +
 				"Use only stackConfigDir instead."
-			assert.Contains(t, err.Error(), errorMsg)
+			assert.EqualError(t, err, errorMsg)
 		},
 	}}
 

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nodejs || python || all
-
 package workspace
 
 import (
@@ -110,8 +108,7 @@ func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginIn
 	assert.False(t, info.IsDir())
 
 	_, err = os.Stat(filepath.Join(dir, plugin.Dir()+".partial"))
-	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	assert.Truef(t, os.IsNotExist(err), "err was not IsNotExists, but was %s", err)
 
 	assert.True(t, HasPlugin(plugin))
 
@@ -149,7 +146,6 @@ func testDeletePlugin(t *testing.T, plugin PluginInfo) {
 
 	for _, path := range paths {
 		_, err := os.Stat(path)
-		assert.Error(t, err)
 		assert.Truef(t, os.IsNotExist(err), "err was not IsNotExists, but was %s", err)
 	}
 }
@@ -291,8 +287,7 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	// Verify leftover files were removed.
 	for _, path := range []string{tempDir1, tempDir2, tempDir3, partialPath} {
 		_, err := os.Stat(path)
-		assert.Error(t, err)
-		assert.True(t, os.IsNotExist(err))
+		assert.Truef(t, os.IsNotExist(err), "err was not IsNotExists, but was %s", err)
 	}
 
 	testDeletePlugin(t, pluginInfo)

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -54,13 +54,11 @@ func TestProjectValidationForNameAndRuntime(t *testing.T) {
 	// Test lack of name
 	proj := Project{}
 	err = proj.Validate()
-	assert.Error(t, err)
-	assert.Equal(t, "project is missing a 'name' attribute", err.Error())
+	assert.EqualError(t, err, "project is missing a 'name' attribute")
 	// Test lack of runtime
 	proj.Name = "a project"
 	err = proj.Validate()
-	assert.Error(t, err)
-	assert.Equal(t, "project is missing a 'runtime' attribute", err.Error())
+	assert.EqualError(t, err, "project is missing a 'runtime' attribute")
 
 	// Test success
 	proj.Runtime = NewProjectRuntimeInfo("test", nil)

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -15,6 +15,7 @@
 package workspace
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +46,7 @@ func TestRetrieveNonExistingTemplate(t *testing.T) {
 			t.Parallel()
 
 			_, err := RetrieveTemplates(templateName, false, tt.templateKind)
-			assert.Error(t, err)
+			assert.EqualError(t, err, fmt.Sprintf("template '%s' not found", templateName))
 		})
 	}
 }
@@ -169,7 +170,7 @@ func TestRetrieveHttpsTemplateOffline(t *testing.T) {
 			t.Parallel()
 
 			_, err := RetrieveTemplates(tt.templateURL, true, tt.templateKind)
-			assert.Error(t, err)
+			assert.EqualError(t, err, fmt.Sprintf("cannot use %s offline", tt.templateURL))
 		})
 	}
 }

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -54,7 +54,7 @@ func TestSanitizeArchivePath(t *testing.T) {
 			t.Parallel()
 			_, err := sanitizeArchivePath(tt.dir, tt.fileName)
 			if tt.shouldFail {
-				assert.Error(t, err)
+				assert.ErrorContains(t, err, "content filepath is tainted")
 			} else {
 				assert.NoError(t, err)
 			}
@@ -160,22 +160,27 @@ func TestRetrieveZIPTemplates(t *testing.T) {
 	}))
 	defer server.Close()
 	tests := []struct {
-		testName    string
-		templateURL string
-		shouldFail  bool
+		testName      string
+		templateURL   string
+		expectedError string
 	}{
 		{
 			testName:    "valid_zip_url",
 			templateURL: fmt.Sprintf("%s/foo.zip", server.URL),
-			shouldFail:  false,
+		},
+		{
+			testName:    "invalid_zip_url",
+			templateURL: "not a url",
+			expectedError: "failed to retrieve zip archive: " +
+				"Get \"not%20a%20url\": unsupported protocol scheme \"\"",
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			_, err := retrieveZIPTemplates(tt.templateURL)
-			if tt.shouldFail {
-				assert.Error(t, err)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/sdk/go/internal/types_test.go
+++ b/sdk/go/internal/types_test.go
@@ -152,8 +152,7 @@ func TestNewApplier_errors(t *testing.T) {
 			t.Parallel()
 
 			_, err := newApplier(tt.give, stringType)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -86,7 +86,7 @@ func TestConfig(t *testing.T) {
 	// malformed key GetObj
 	err = cfg.GetObject("malobj", &testStruct)
 	assert.Equal(t, emptyTestStruct, testStruct)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid character 'o' in literal null (expecting 'u')")
 	testStruct = TestStruct{}
 	// GetObj
 	err = cfg.GetObject("obj", &testStruct)
@@ -139,7 +139,7 @@ func TestConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 42, k3)
 	invalidInt, err := cfg.TryInt("badint")
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unable to cast \"4d2\" of type string to int")
 	assert.Zero(t, invalidInt)
 	k4, err := cfg.TryFloat64("fpfpfp")
 	assert.NoError(t, err)
@@ -151,19 +151,18 @@ func TestConfig(t *testing.T) {
 	testStruct = TestStruct{}
 	// missing TryObject
 	err = cfg.TryObject("missing", &testStruct)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "missing required configuration variable 'testpkg:missing'; run `pulumi config` to set")
 	assert.Equal(t, emptyTestStruct, testStruct)
 	assert.True(t, errors.Is(err, ErrMissingVar))
 	testStruct = TestStruct{}
 	// malformed TryObject
 	err = cfg.TryObject("malobj", &testStruct)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid character 'o' in literal null (expecting 'u')")
 	assert.Equal(t, emptyTestStruct, testStruct)
 	assert.False(t, errors.Is(err, ErrMissingVar))
 	testStruct = TestStruct{}
 	_, err = cfg.Try("missing")
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(),
+	assert.EqualError(t, err,
 		"missing required configuration variable 'testpkg:missing'; run `pulumi config` to set")
 	assert.True(t, errors.Is(err, ErrMissingVar))
 }

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -59,7 +59,7 @@ func TestBasicOutputs(t *testing.T) {
 			reject(errors.New("boom"))
 		}()
 		v, _, _, _, err := await(out)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "boom")
 		assert.Nil(t, v)
 	}
 }

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -849,7 +849,7 @@ func TestInvalidAsset(t *testing.T) {
 	require.True(t, d.(*asset).invalid)
 
 	_, _, err = marshalInput(d, assetType, true)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid asset")
 }
 
 func TestInvalidArchive(t *testing.T) {
@@ -865,7 +865,7 @@ func TestInvalidArchive(t *testing.T) {
 	require.True(t, d.(*archive).invalid)
 
 	_, _, err = marshalInput(d, archiveType, true)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "invalid archive")
 }
 
 func TestDependsOnComponent(t *testing.T) {

--- a/sdk/go/pulumi/stack_reference_test.go
+++ b/sdk/go/pulumi/stack_reference_test.go
@@ -65,35 +65,25 @@ func TestStackReference(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, outputs["numf"], numf)
 		_, _, _, _, err = await(ref1.GetFloat64Output(String("foo")))
-		assert.Error(t, err)
-		assert.Equal(t, fmt.Errorf(
+		assert.EqualError(t, err, fmt.Sprintf(
 			"getting stack reference output \"foo\" on stack \"stack2\", failed to convert %T to float64",
-			outputs["foo"]),
-			err)
+			outputs["foo"]))
 		numi, _, _, _, err := await(ref1.GetIntOutput(String("numi")))
 		assert.NoError(t, err)
 		assert.Equal(t, int(outputs["numi"].(float64)), numi)
 		_, _, _, _, err = await(ref1.GetIntOutput(String("foo")))
-		assert.Error(t, err)
-		assert.Equal(t, fmt.Errorf(
+		assert.EqualError(t, err, fmt.Sprintf(
 			"getting stack reference output \"foo\" on stack \"stack2\", failed to convert %T to int",
-			outputs["foo"]),
-			err)
+			outputs["foo"]))
 		_, _, _, _, err = await(ref1.GetStringOutput(String("doesnotexist")))
-		assert.Error(t, err)
-		assert.Equal(t, fmt.Errorf(
-			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\""),
-			err)
+		assert.EqualError(t, err,
+			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\"")
 		_, _, _, _, err = await(ref1.GetIntOutput(String("doesnotexist")))
-		assert.Error(t, err)
-		assert.Equal(t, fmt.Errorf(
-			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\""),
-			err)
+		assert.EqualError(t, err,
+			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\"")
 		_, _, _, _, err = await(ref1.GetFloat64Output(String("doesnotexist")))
-		assert.Error(t, err)
-		assert.Equal(t, fmt.Errorf(
-			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\""),
-			err)
+		assert.EqualError(t, err,
+			"stack reference output \"doesnotexist\" does not exist on stack \"stack2\"")
 		return nil
 	}, WithMocks("project", "stack", mocks))
 	assert.NoError(t, err)

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -66,7 +66,7 @@ func TestBasicOutputs(t *testing.T) {
 			reject(errors.New("boom"))
 		}()
 		v, _, _, _, err := await(out)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "boom")
 		assert.Nil(t, v)
 	}
 }
@@ -235,7 +235,7 @@ func TestResolveOutputToOutput(t *testing.T) {
 			go func() { rejectOther(errors.New("boom")) }()
 		}()
 		v, _, _, _, err := await(out)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "boom")
 		assert.Nil(t, v)
 	}
 }

--- a/sdk/go/pulumix/types_ext_test.go
+++ b/sdk/go/pulumix/types_ext_test.go
@@ -75,7 +75,6 @@ func TestOutput_ConvertTyped_error(t *testing.T) {
 	stringOut := pulumi.String("bar").ToStringOutput()
 
 	_, err := pulumix.ConvertTyped[int](stringOut)
-	require.Error(t, err)
 	assert.ErrorContains(t, err, "cannot convert string to int")
 }
 

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
-		err      error
+		err      string
 	}{
 		{
 			input:    "0.1",
@@ -48,7 +47,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "",
-			err:   fmt.Errorf("cannot parse empty string"),
+			err:   "cannot parse empty string",
 		},
 		{
 			input:    "4.3.2.1",
@@ -56,7 +55,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: " 1 . 2 . 3 ",
-			err:   fmt.Errorf(`' 1 . 2 . 3 ' still unparsed`),
+			err:   `' 1 . 2 . 3 ' still unparsed`,
 		},
 		{
 			input:    "2.1a123456789",
@@ -76,7 +75,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "1.2.3dev7890",
-			err:   fmt.Errorf("'dev7890' still unparsed"),
+			err:   "'dev7890' still unparsed",
 		},
 		{
 			input:    "1.2.3.dev456",
@@ -84,7 +83,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "1.",
-			err:   fmt.Errorf("'.' still unparsed"),
+			err:   "'.' still unparsed",
 		},
 		{
 			input:    "3.2.post32",
@@ -96,7 +95,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "10!3.2.1",
-			err:   fmt.Errorf("epochs are not supported"),
+			err:   "epochs are not supported",
 		},
 		{
 			input:    "3.2.post1.dev0",
@@ -109,9 +108,8 @@ func TestDeterminePluginVersion(t *testing.T) {
 			t.Parallel()
 
 			result, err := determinePluginVersion(tt.input)
-			if tt.err != nil {
-				assert.Error(t, err)
-				assert.EqualError(t, err, tt.err.Error())
+			if tt.err != "" {
+				assert.EqualError(t, err, tt.err)
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is a pass over all of /sdk to replace asserts that just checked we had an error with asserts for what the error value is.

Just checking for an error is a weak test that can result in error paths being broken and tests not detecting it.
