### PR TITLE
[sdk-gen/go] Fix generated usage documentation for enum input types

### DIFF
--- a/changelog/pending/20231204--sdkgen-go--fix-generated-usage-documentation-for-enum-input-types.yaml
+++ b/changelog/pending/20231204--sdkgen-go--fix-generated-usage-documentation-for-enum-input-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix generated usage documentation for enum input types

--- a/pkg/codegen/testing/test/testdata/array-of-enum-map/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/array-of-enum-map/go/example/pulumiEnums.go
@@ -141,10 +141,15 @@ func (o AnnotationStoreSchemaValueTypePtrOutput) ToStringPtrOutputWithContext(ct
 	}).(pulumi.StringPtrOutput)
 }
 
-// AnnotationStoreSchemaValueTypeInput is an input type that accepts AnnotationStoreSchemaValueTypeArgs and AnnotationStoreSchemaValueTypeOutput values.
-// You can construct a concrete instance of `AnnotationStoreSchemaValueTypeInput` via:
+// AnnotationStoreSchemaValueTypeInput is an input type that accepts values of the AnnotationStoreSchemaValueType enum
+// A concrete instance of `AnnotationStoreSchemaValueTypeInput` can be one of the following:
 //
-//	AnnotationStoreSchemaValueTypeArgs{...}
+//	AnnotationStoreSchemaValueTypeLong
+//	AnnotationStoreSchemaValueTypeInt
+//	AnnotationStoreSchemaValueTypeString
+//	AnnotationStoreSchemaValueTypeFloat
+//	AnnotationStoreSchemaValueTypeDouble
+//	AnnotationStoreSchemaValueTypeBoolean
 type AnnotationStoreSchemaValueTypeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
@@ -144,10 +144,13 @@ func (o CloudAuditOptionsLogNamePtrOutput) ToStringPtrOutputWithContext(ctx cont
 	}).(pulumi.StringPtrOutput)
 }
 
-// CloudAuditOptionsLogNameInput is an input type that accepts CloudAuditOptionsLogNameArgs and CloudAuditOptionsLogNameOutput values.
-// You can construct a concrete instance of `CloudAuditOptionsLogNameInput` via:
+// CloudAuditOptionsLogNameInput is an input type that accepts values of the CloudAuditOptionsLogName enum
+// A concrete instance of `CloudAuditOptionsLogNameInput` can be one of the following:
 //
-//	CloudAuditOptionsLogNameArgs{...}
+//	CloudAuditOptionsLogNameUnspecifiedLogName
+//	CloudAuditOptionsLogNameAdminActivity
+//	CloudAuditOptionsLogNameDataAccess
+//	CloudAuditOptionsLogNameSynthetic
 type CloudAuditOptionsLogNameInput interface {
 	pulumi.Input
 
@@ -314,10 +317,11 @@ func (o ContainerBrightnessPtrOutput) ToFloat64PtrOutputWithContext(ctx context.
 	}).(pulumi.Float64PtrOutput)
 }
 
-// ContainerBrightnessInput is an input type that accepts ContainerBrightnessArgs and ContainerBrightnessOutput values.
-// You can construct a concrete instance of `ContainerBrightnessInput` via:
+// ContainerBrightnessInput is an input type that accepts values of the ContainerBrightness enum
+// A concrete instance of `ContainerBrightnessInput` can be one of the following:
 //
-//	ContainerBrightnessArgs{...}
+//	ContainerBrightnessZeroPointOne
+//	ContainerBrightnessOne
 type ContainerBrightnessInput interface {
 	pulumi.Input
 
@@ -486,10 +490,12 @@ func (o ContainerColorPtrOutput) ToStringPtrOutputWithContext(ctx context.Contex
 	}).(pulumi.StringPtrOutput)
 }
 
-// ContainerColorInput is an input type that accepts ContainerColorArgs and ContainerColorOutput values.
-// You can construct a concrete instance of `ContainerColorInput` via:
+// ContainerColorInput is an input type that accepts values of the ContainerColor enum
+// A concrete instance of `ContainerColorInput` can be one of the following:
 //
-//	ContainerColorArgs{...}
+//	ContainerColorRed
+//	ContainerColorBlue
+//	ContainerColorYellow
 type ContainerColorInput interface {
 	pulumi.Input
 
@@ -659,10 +665,11 @@ func (o ContainerSizePtrOutput) ToIntPtrOutputWithContext(ctx context.Context) p
 	}).(pulumi.IntPtrOutput)
 }
 
-// ContainerSizeInput is an input type that accepts ContainerSizeArgs and ContainerSizeOutput values.
-// You can construct a concrete instance of `ContainerSizeInput` via:
+// ContainerSizeInput is an input type that accepts values of the ContainerSize enum
+// A concrete instance of `ContainerSizeInput` can be one of the following:
 //
-//	ContainerSizeArgs{...}
+//	ContainerSizeFourInch
+//	ContainerSizeSixInch
 type ContainerSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o DiameterPtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pu
 	}).(pulumi.Float64PtrOutput)
 }
 
-// DiameterInput is an input type that accepts DiameterArgs and DiameterOutput values.
-// You can construct a concrete instance of `DiameterInput` via:
+// DiameterInput is an input type that accepts values of the Diameter enum
+// A concrete instance of `DiameterInput` can be one of the following:
 //
-//	DiameterArgs{...}
+//	DiameterSixinch
+//	DiameterTwelveinch
 type DiameterInput interface {
 	pulumi.Input
 
@@ -307,10 +308,11 @@ func (o FarmPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.
 	}).(pulumi.StringPtrOutput)
 }
 
-// FarmInput is an input type that accepts FarmArgs and FarmOutput values.
-// You can construct a concrete instance of `FarmInput` via:
+// FarmInput is an input type that accepts values of the Farm enum
+// A concrete instance of `FarmInput` can be one of the following:
 //
-//	FarmArgs{...}
+//	Farm_Pulumi_Planters_Inc_
+//	Farm_Plants_R_Us
 type FarmInput interface {
 	pulumi.Input
 
@@ -482,10 +484,12 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 	}).(pulumi.StringPtrOutput)
 }
 
-// RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.
-// You can construct a concrete instance of `RubberTreeVarietyInput` via:
+// RubberTreeVarietyInput is an input type that accepts values of the RubberTreeVariety enum
+// A concrete instance of `RubberTreeVarietyInput` can be one of the following:
 //
-//	RubberTreeVarietyArgs{...}
+//	RubberTreeVarietyBurgundy
+//	RubberTreeVarietyRuby
+//	RubberTreeVarietyTineke
 type RubberTreeVarietyInput interface {
 	pulumi.Input
 
@@ -698,10 +702,12 @@ func (o TreeSizePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// TreeSizeInput is an input type that accepts TreeSizeArgs and TreeSizeOutput values.
-// You can construct a concrete instance of `TreeSizeInput` via:
+// TreeSizeInput is an input type that accepts values of the TreeSize enum
+// A concrete instance of `TreeSizeInput` can be one of the following:
 //
-//	TreeSizeArgs{...}
+//	TreeSizeSmall
+//	TreeSizeMedium
+//	TreeSizeLarge
 type TreeSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
@@ -151,10 +151,11 @@ func (o ContainerBrightnessPtrOutput) ToFloat64PtrOutputWithContext(ctx context.
 	}).(pulumi.Float64PtrOutput)
 }
 
-// ContainerBrightnessInput is an input type that accepts ContainerBrightnessArgs and ContainerBrightnessOutput values.
-// You can construct a concrete instance of `ContainerBrightnessInput` via:
+// ContainerBrightnessInput is an input type that accepts values of the ContainerBrightness enum
+// A concrete instance of `ContainerBrightnessInput` can be one of the following:
 //
-//	ContainerBrightnessArgs{...}
+//	ContainerBrightnessZeroPointOne
+//	ContainerBrightnessOne
 type ContainerBrightnessInput interface {
 	pulumi.Input
 
@@ -323,10 +324,12 @@ func (o ContainerColorPtrOutput) ToStringPtrOutputWithContext(ctx context.Contex
 	}).(pulumi.StringPtrOutput)
 }
 
-// ContainerColorInput is an input type that accepts ContainerColorArgs and ContainerColorOutput values.
-// You can construct a concrete instance of `ContainerColorInput` via:
+// ContainerColorInput is an input type that accepts values of the ContainerColor enum
+// A concrete instance of `ContainerColorInput` can be one of the following:
 //
-//	ContainerColorArgs{...}
+//	ContainerColorRed
+//	ContainerColorBlue
+//	ContainerColorYellow
 type ContainerColorInput interface {
 	pulumi.Input
 
@@ -496,10 +499,11 @@ func (o ContainerSizePtrOutput) ToIntPtrOutputWithContext(ctx context.Context) p
 	}).(pulumi.IntPtrOutput)
 }
 
-// ContainerSizeInput is an input type that accepts ContainerSizeArgs and ContainerSizeOutput values.
-// You can construct a concrete instance of `ContainerSizeInput` via:
+// ContainerSizeInput is an input type that accepts values of the ContainerSize enum
+// A concrete instance of `ContainerSizeInput` can be one of the following:
 //
-//	ContainerSizeArgs{...}
+//	ContainerSizeFourInch
+//	ContainerSizeSixInch
 type ContainerSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o DiameterPtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pu
 	}).(pulumi.Float64PtrOutput)
 }
 
-// DiameterInput is an input type that accepts DiameterArgs and DiameterOutput values.
-// You can construct a concrete instance of `DiameterInput` via:
+// DiameterInput is an input type that accepts values of the Diameter enum
+// A concrete instance of `DiameterInput` can be one of the following:
 //
-//	DiameterArgs{...}
+//	DiameterSixinch
+//	DiameterTwelveinch
 type DiameterInput interface {
 	pulumi.Input
 
@@ -307,10 +308,11 @@ func (o FarmPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.
 	}).(pulumi.StringPtrOutput)
 }
 
-// FarmInput is an input type that accepts FarmArgs and FarmOutput values.
-// You can construct a concrete instance of `FarmInput` via:
+// FarmInput is an input type that accepts values of the Farm enum
+// A concrete instance of `FarmInput` can be one of the following:
 //
-//	FarmArgs{...}
+//	Farm_Pulumi_Planters_Inc_
+//	Farm_Plants_R_Us
 type FarmInput interface {
 	pulumi.Input
 
@@ -482,10 +484,12 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 	}).(pulumi.StringPtrOutput)
 }
 
-// RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.
-// You can construct a concrete instance of `RubberTreeVarietyInput` via:
+// RubberTreeVarietyInput is an input type that accepts values of the RubberTreeVariety enum
+// A concrete instance of `RubberTreeVarietyInput` can be one of the following:
 //
-//	RubberTreeVarietyArgs{...}
+//	RubberTreeVarietyBurgundy
+//	RubberTreeVarietyRuby
+//	RubberTreeVarietyTineke
 type RubberTreeVarietyInput interface {
 	pulumi.Input
 
@@ -698,10 +702,12 @@ func (o TreeSizePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// TreeSizeInput is an input type that accepts TreeSizeArgs and TreeSizeOutput values.
-// You can construct a concrete instance of `TreeSizeInput` via:
+// TreeSizeInput is an input type that accepts values of the TreeSize enum
+// A concrete instance of `TreeSizeInput` can be one of the following:
 //
-//	TreeSizeArgs{...}
+//	TreeSizeSmall
+//	TreeSizeMedium
+//	TreeSizeLarge
 type TreeSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o MyEnumPtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pulu
 	}).(pulumi.Float64PtrOutput)
 }
 
-// MyEnumInput is an input type that accepts MyEnumArgs and MyEnumOutput values.
-// You can construct a concrete instance of `MyEnumInput` via:
+// MyEnumInput is an input type that accepts values of the MyEnum enum
+// A concrete instance of `MyEnumInput` can be one of the following:
 //
-//	MyEnumArgs{...}
+//	MyEnumPi
+//	MyEnumSmall
 type MyEnumInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o ExampleEnumPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) 
 	}).(pulumi.StringPtrOutput)
 }
 
-// ExampleEnumInput is an input type that accepts ExampleEnumArgs and ExampleEnumOutput values.
-// You can construct a concrete instance of `ExampleEnumInput` via:
+// ExampleEnumInput is an input type that accepts values of the ExampleEnum enum
+// A concrete instance of `ExampleEnumInput` can be one of the following:
 //
-//	ExampleEnumArgs{...}
+//	ExampleEnumOne
+//	ExampleEnumTwo
 type ExampleEnumInput interface {
 	pulumi.Input
 
@@ -307,10 +308,11 @@ func (o ExampleEnumInputEnumPtrOutput) ToStringPtrOutputWithContext(ctx context.
 	}).(pulumi.StringPtrOutput)
 }
 
-// ExampleEnumInputEnumInput is an input type that accepts ExampleEnumInputEnumArgs and ExampleEnumInputEnumOutput values.
-// You can construct a concrete instance of `ExampleEnumInputEnumInput` via:
+// ExampleEnumInputEnumInput is an input type that accepts values of the ExampleEnumInputEnum enum
+// A concrete instance of `ExampleEnumInputEnumInput` can be one of the following:
 //
-//	ExampleEnumInputEnumArgs{...}
+//	ExampleEnumInputEnumOne
+//	ExampleEnumInputEnumTwo
 type ExampleEnumInputEnumInput interface {
 	pulumi.Input
 
@@ -477,10 +479,11 @@ func (o ResourceTypeEnumPtrOutput) ToStringPtrOutputWithContext(ctx context.Cont
 	}).(pulumi.StringPtrOutput)
 }
 
-// ResourceTypeEnumInput is an input type that accepts ResourceTypeEnumArgs and ResourceTypeEnumOutput values.
-// You can construct a concrete instance of `ResourceTypeEnumInput` via:
+// ResourceTypeEnumInput is an input type that accepts values of the ResourceTypeEnum enum
+// A concrete instance of `ResourceTypeEnumInput` can be one of the following:
 //
-//	ResourceTypeEnumArgs{...}
+//	ResourceTypeEnumHaha
+//	ResourceTypeEnumBusiness
 type ResourceTypeEnumInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
@@ -140,10 +140,11 @@ func (o SupportedFilterTypesPtrOutput) ToStringPtrOutputWithContext(ctx context.
 	}).(pulumi.StringPtrOutput)
 }
 
-// SupportedFilterTypesInput is an input type that accepts SupportedFilterTypesArgs and SupportedFilterTypesOutput values.
-// You can construct a concrete instance of `SupportedFilterTypesInput` via:
+// SupportedFilterTypesInput is an input type that accepts values of the SupportedFilterTypes enum
+// A concrete instance of `SupportedFilterTypesInput` can be one of the following:
 //
-//	SupportedFilterTypesArgs{...}
+//	SupportedFilterTypesShipToCountries
+//	SupportedFilterTypesDoubleEncryptionStatus
 type SupportedFilterTypesInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/pulumiEnums.go
@@ -150,10 +150,12 @@ func (o EnumThingPtrOutput) ToIntPtrOutputWithContext(ctx context.Context) pulum
 	}).(pulumi.IntPtrOutput)
 }
 
-// EnumThingInput is an input type that accepts EnumThingArgs and EnumThingOutput values.
-// You can construct a concrete instance of `EnumThingInput` via:
+// EnumThingInput is an input type that accepts values of the EnumThing enum
+// A concrete instance of `EnumThingInput` can be one of the following:
 //
-//	EnumThingArgs{...}
+//	EnumThingFour
+//	EnumThingSix
+//	EnumThingEight
 type EnumThingInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o ColorPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi
 	}).(pulumi.StringPtrOutput)
 }
 
-// ColorInput is an input type that accepts ColorArgs and ColorOutput values.
-// You can construct a concrete instance of `ColorInput` via:
+// ColorInput is an input type that accepts values of the Color enum
+// A concrete instance of `ColorInput` can be one of the following:
 //
-//	ColorArgs{...}
+//	ColorBlue
+//	ColorRed
 type ColorInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
@@ -137,10 +137,11 @@ func (o MyEnumPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulum
 	}).(pulumi.StringPtrOutput)
 }
 
-// MyEnumInput is an input type that accepts MyEnumArgs and MyEnumOutput values.
-// You can construct a concrete instance of `MyEnumInput` via:
+// MyEnumInput is an input type that accepts values of the MyEnum enum
+// A concrete instance of `MyEnumInput` can be one of the following:
 //
-//	MyEnumArgs{...}
+//	MyEnumOne
+//	MyEnumTwo
 type MyEnumInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
@@ -157,10 +157,14 @@ func (o CloudAuditOptionsLogNamePtrOutput) ToStringPtrOutputWithContext(ctx cont
 	}).(pulumi.StringPtrOutput)
 }
 
-// CloudAuditOptionsLogNameInput is an input type that accepts CloudAuditOptionsLogNameArgs and CloudAuditOptionsLogNameOutput values.
-// You can construct a concrete instance of `CloudAuditOptionsLogNameInput` via:
+// CloudAuditOptionsLogNameInput is an input type that accepts values of the CloudAuditOptionsLogName enum
+// A concrete instance of `CloudAuditOptionsLogNameInput` can be one of the following:
 //
-//	CloudAuditOptionsLogNameArgs{...}
+//	CloudAuditOptionsLogNameUnspecifiedLogName
+//	CloudAuditOptionsLogNameAdminActivity
+//	CloudAuditOptionsLogNameDataAccess
+//	CloudAuditOptionsLogNameSynthetic
+//	CloudAuditOptionsLogName_NO_NAME
 type CloudAuditOptionsLogNameInput interface {
 	pulumi.Input
 
@@ -339,10 +343,11 @@ func (o ContainerBrightnessPtrOutput) ToFloat64PtrOutputWithContext(ctx context.
 	}).(pulumi.Float64PtrOutput)
 }
 
-// ContainerBrightnessInput is an input type that accepts ContainerBrightnessArgs and ContainerBrightnessOutput values.
-// You can construct a concrete instance of `ContainerBrightnessInput` via:
+// ContainerBrightnessInput is an input type that accepts values of the ContainerBrightness enum
+// A concrete instance of `ContainerBrightnessInput` can be one of the following:
 //
-//	ContainerBrightnessArgs{...}
+//	ContainerBrightnessZeroPointOne
+//	ContainerBrightnessOne
 type ContainerBrightnessInput interface {
 	pulumi.Input
 
@@ -523,10 +528,12 @@ func (o ContainerColorPtrOutput) ToStringPtrOutputWithContext(ctx context.Contex
 	}).(pulumi.StringPtrOutput)
 }
 
-// ContainerColorInput is an input type that accepts ContainerColorArgs and ContainerColorOutput values.
-// You can construct a concrete instance of `ContainerColorInput` via:
+// ContainerColorInput is an input type that accepts values of the ContainerColor enum
+// A concrete instance of `ContainerColorInput` can be one of the following:
 //
-//	ContainerColorArgs{...}
+//	ContainerColorRed
+//	ContainerColorBlue
+//	ContainerColorYellow
 type ContainerColorInput interface {
 	pulumi.Input
 
@@ -708,10 +715,11 @@ func (o ContainerSizePtrOutput) ToIntPtrOutputWithContext(ctx context.Context) p
 	}).(pulumi.IntPtrOutput)
 }
 
-// ContainerSizeInput is an input type that accepts ContainerSizeArgs and ContainerSizeOutput values.
-// You can construct a concrete instance of `ContainerSizeInput` via:
+// ContainerSizeInput is an input type that accepts values of the ContainerSize enum
+// A concrete instance of `ContainerSizeInput` can be one of the following:
 //
-//	ContainerSizeArgs{...}
+//	ContainerSizeFourInch
+//	ContainerSizeSixInch
 type ContainerSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
@@ -149,10 +149,11 @@ func (o DiameterPtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pu
 	}).(pulumi.Float64PtrOutput)
 }
 
-// DiameterInput is an input type that accepts DiameterArgs and DiameterOutput values.
-// You can construct a concrete instance of `DiameterInput` via:
+// DiameterInput is an input type that accepts values of the Diameter enum
+// A concrete instance of `DiameterInput` can be one of the following:
 //
-//	DiameterArgs{...}
+//	DiameterSixinch
+//	DiameterTwelveinch
 type DiameterInput interface {
 	pulumi.Input
 
@@ -331,10 +332,11 @@ func (o FarmPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.
 	}).(pulumi.StringPtrOutput)
 }
 
-// FarmInput is an input type that accepts FarmArgs and FarmOutput values.
-// You can construct a concrete instance of `FarmInput` via:
+// FarmInput is an input type that accepts values of the Farm enum
+// A concrete instance of `FarmInput` can be one of the following:
 //
-//	FarmArgs{...}
+//	Farm_Pulumi_Planters_Inc_
+//	Farm_Plants_R_Us
 type FarmInput interface {
 	pulumi.Input
 
@@ -518,10 +520,12 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 	}).(pulumi.StringPtrOutput)
 }
 
-// RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.
-// You can construct a concrete instance of `RubberTreeVarietyInput` via:
+// RubberTreeVarietyInput is an input type that accepts values of the RubberTreeVariety enum
+// A concrete instance of `RubberTreeVarietyInput` can be one of the following:
 //
-//	RubberTreeVarietyArgs{...}
+//	RubberTreeVarietyBurgundy
+//	RubberTreeVarietyRuby
+//	RubberTreeVarietyTineke
 type RubberTreeVarietyInput interface {
 	pulumi.Input
 
@@ -758,10 +762,12 @@ func (o TreeSizePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pul
 	}).(pulumi.StringPtrOutput)
 }
 
-// TreeSizeInput is an input type that accepts TreeSizeArgs and TreeSizeOutput values.
-// You can construct a concrete instance of `TreeSizeInput` via:
+// TreeSizeInput is an input type that accepts values of the TreeSize enum
+// A concrete instance of `TreeSizeInput` can be one of the following:
 //
-//	TreeSizeArgs{...}
+//	TreeSizeSmall
+//	TreeSizeMedium
+//	TreeSizeLarge
 type TreeSizeInput interface {
 	pulumi.Input
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
@@ -252,10 +252,12 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 	}).(pulumi.StringPtrOutput)
 }
 
-// RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.
-// You can construct a concrete instance of `RubberTreeVarietyInput` via:
+// RubberTreeVarietyInput is an input type that accepts values of the RubberTreeVariety enum
+// A concrete instance of `RubberTreeVarietyInput` can be one of the following:
 //
-//	RubberTreeVarietyArgs{...}
+//	RubberTreeVarietyBurgundy
+//	RubberTreeVarietyRuby
+//	RubberTreeVarietyTineke
 type RubberTreeVarietyInput interface {
 	pulumi.Input
 


### PR DESCRIPTION
# Description

Fixes #13821 (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
