### PR TITLE
Don't validate URNs

### DIFF
--- a/changelog/pending/20231204--engine--dont-validate-urns-this-was-causing-issues-with-unexpected-data-from-filestate-backends.yaml
+++ b/changelog/pending/20231204--engine--dont-validate-urns-this-was-causing-issues-with-unexpected-data-from-filestate-backends.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Don't validate URNs, this was causing issues with unexpected data from filestate backends.

--- a/sdk/go/common/resource/urn.go
+++ b/sdk/go/common/resource/urn.go
@@ -107,22 +107,10 @@ func (urn URN) IsValid() bool {
 		return false
 	}
 
-	urn = urn[len(URNPrefix):]
-
 	split := strings.SplitN(string(urn), URNNameDelimiter, 4)
-	if len(split) != 4 {
-		return false
-	}
-
-	stack := split[0]
-	if !tokens.IsName(stack) {
-		return false
-	}
-
-	project := split[1]
-	return tokens.IsName(project)
-
-	// TODO: We should validate the type tokens in split[2] here
+	return len(split) == 4
+	// TODO: We should validate the stack, project and type tokens here, but currently those fields might not
+	// actually be "valid" (e.g. spaces in project names, custom component types, etc).
 }
 
 // URNName returns the URN name part of a URN (i.e., strips off the prefix).

--- a/sdk/go/common/resource/urn_test.go
+++ b/sdk/go/common/resource/urn_test.go
@@ -78,6 +78,7 @@ func TestIsValid(t *testing.T) {
 		"urn:pulumi:stack-name::project-name::my:customtype$aws:s3/bucket:Bucket::bob",
 		"urn:pulumi:stack::project::type::",
 		"urn:pulumi:stack::project::type::some really ::^&\n*():: crazy name",
+		"urn:pulumi:stack::project with whitespace::type::some name",
 	}
 	for _, str := range goodUrns {
 		urn := URN(str)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix an issue with users with spaces in project names. They aren't technically `token.Name`s so this method was failing them, but they've happened to work up till now.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
