### PR TITLE
Add LogicalName to import system

### DIFF
--- a/changelog/pending/20231122--cli-import--import-can-now-distinguish-between-logical-names-and-source-names.yaml
+++ b/changelog/pending/20231122--cli-import--import-can-now-distinguish-between-logical-names-and-source-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Import can now distinguish between logical names and source names.

--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -5,6 +19,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/importer"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
@@ -230,6 +247,60 @@ func TestParseImportFile_errors(t *testing.T) {
 	}
 }
 
+func TestParseImportFileJustLogicalName(t *testing.T) {
+	t.Parallel()
+	f := importFile{
+		Resources: []importSpec{
+			{
+				LogicalName: "thing",
+				ID:          "thing",
+				Type:        "foo:bar:bar",
+			},
+		},
+	}
+	imports, names, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
+	assert.NoError(t, err)
+	assert.Equal(t, []deploy.Import{
+		{
+			Type: "foo:bar:bar",
+			Name: "thing",
+			ID:   "thing",
+		},
+	}, imports)
+	assert.Equal(t, importer.NameTable{
+		"urn:pulumi:stack::proj::foo:bar:bar::thing": "thing",
+	}, names)
+}
+
+func TestParseImportFileLogicalName(t *testing.T) {
+	t.Parallel()
+	f := importFile{
+		Resources: []importSpec{
+			{
+				Name:        "thing",
+				LogicalName: "different logical name",
+				ID:          "thing",
+				Type:        "foo:bar:bar",
+				Version:     "0.0.0",
+			},
+		},
+	}
+	imports, names, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
+	assert.NoError(t, err)
+	v := semver.MustParse("0.0.0")
+	assert.Equal(t, []deploy.Import{
+		{
+			Type:    "foo:bar:bar",
+			Name:    "different logical name",
+			ID:      "thing",
+			Version: &v,
+		},
+	}, imports)
+	assert.Equal(t, importer.NameTable{
+		"urn:pulumi:stack::proj::foo:bar:bar::different logical name": "thing",
+	}, names)
+}
+
 func TestParseImportFileSameName(t *testing.T) {
 	t.Parallel()
 	f := importFile{
@@ -248,61 +319,45 @@ func TestParseImportFileSameName(t *testing.T) {
 			},
 		},
 	}
-	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
-	assert.NoError(t, err)
-	resourceNames := map[string]struct{}{}
-	for _, imp := range imports {
-		_, exists := resourceNames[imp.Name]
-		assert.False(t, exists, "name %s should not have been seen already", imp.Name)
-		resourceNames[imp.Name] = struct{}{}
-	}
-
-	// Check expected names are present.
-	for _, name := range []string{"thing", "thing_1"} {
-		_, exists := resourceNames[name]
-		assert.True(t, exists, "expected resource with name '%v' to be in the imports", name)
-	}
+	_, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
+	assert.ErrorContains(t, err,
+		"resource 'thing' of type 'foo:bar:bar' has an ambiguous URN, set name (or logical name) to be unique")
 }
 
-func TestParseImportFileRenameNoClash(t *testing.T) {
+func TestParseImportFileSameNameDifferentType(t *testing.T) {
 	t.Parallel()
 	f := importFile{
 		Resources: []importSpec{
 			{
-				Name:    "thing",
-				ID:      "thing",
-				Type:    "foo:bar:a",
-				Version: "0.0.0",
+				Name: "thing",
+				ID:   "thing",
+				Type: "foo:bar:bar",
 			},
 			{
-				Name:    "thing",
-				ID:      "thing",
-				Type:    "foo:bar:a",
-				Version: "0.0.0",
-			},
-			{
-				Name:    "thing_1",
-				ID:      "thing",
-				Type:    "foo:bar:a",
-				Version: "0.0.0",
+				Name: "thing",
+				ID:   "thing",
+				Type: "foo:bar:baz",
 			},
 		},
 	}
-	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
+	imports, names, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false)
 	assert.NoError(t, err)
-	resourceNames := map[string]struct{}{}
-	// Check resource names are unique.
-	for _, imp := range imports {
-		_, exists := resourceNames[imp.Name]
-		assert.False(t, exists, "name %s should not have been seen already", imp.Name)
-		resourceNames[imp.Name] = struct{}{}
-	}
-
-	// Check expected names are present.
-	for _, name := range []string{"thing", "thing_1", "thing_2"} {
-		_, exists := resourceNames[name]
-		assert.True(t, exists, "expected resource with name '%v' to be in the imports", name)
-	}
+	assert.Equal(t, []deploy.Import{
+		{
+			Type: "foo:bar:bar",
+			Name: "thing",
+			ID:   "thing",
+		},
+		{
+			Type: "foo:bar:baz",
+			Name: "thing",
+			ID:   "thing",
+		},
+	}, imports)
+	assert.Equal(t, importer.NameTable{
+		"urn:pulumi:stack::proj::foo:bar:bar::thing": "thing",
+		"urn:pulumi:stack::proj::foo:bar:baz::thing": "thing",
+	}, names)
 }
 
 // Test that if we're using the name for another resource in the import file for a parent that we don't need

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -95,6 +95,7 @@ require (
 	go.pennock.tech/tabular v1.1.3
 	golang.org/x/mod v0.14.0
 	golang.org/x/term v0.14.0
+	golang.org/x/text v0.14.0
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -259,7 +260,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -373,10 +373,14 @@ func TestPreviewImportFile(t *testing.T) {
 
 	expectedResources := []interface{}{
 		map[string]interface{}{
-			"id":      "<PLACEHOLDER>",
-			"name":    "username",
-			"type":    "random:index/randomPet:RandomPet",
-			"version": "4.12.0",
+			"id": "<PLACEHOLDER>",
+			// This isn't ideal, we don't really need to change the "name" here because it isn't used as a
+			// parent, but currently we generate unique names for all resources rather than just unique names
+			// for all parent resources.
+			"name":        "usernameRandomPet",
+			"logicalName": "username",
+			"type":        "random:index/randomPet:RandomPet",
+			"version":     "4.12.0",
 		},
 		map[string]interface{}{
 			"name":      "component",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14618.

This adds a new field to the import file "logicalName", which if set is used as the logical name (https://www.pulumi.com/docs/concepts/resources/names/#logicalname) of the resource. The original "name" field is then used just for codegen purposes (i.e. the source name).

If either field is not set then the other field is used to fill it in. If neither field is set it's an error.

Further the import system _no longer_ renames resources to try and make unique names, but it also no longer errors just because two resources of different types have the same name. The rules for uniqueness now match what's valid when writing a Pulumi program, but it is the users responsibility to make names unique and the import system will error if you try to import two resources that would end up with the same URN.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
