### PR TITLE
[ci] Python ProgramTests no longer re-use the same virtualenv.

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -69,7 +69,6 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
-  PULUMI_TEST_PYTHON_SHARED_VENV: "true"
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
   PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
   PYTHON: python


### PR DESCRIPTION
Part of #14765 

Python ProgramTests would flake during preparation, but pass on re-run. Python ProgramTests would use the hash of the `requirements.txt` to determine the directory to use as its virtualenv. When multiple Python ProgramTests `pip install` the same virtualenv, it would cause test failures which would pass on re-run since there would no longer be contention.

These failures typically are re-run in [CI / Integration Test / tests/integration 8/8 on ubuntu-latest/current](https://github.com/pulumi/pulumi/actions/runs/7118443964/job/19381751006?pr=14767#logs)