### PR TITLE
[test] increase code coverage of `pkg/resource/deploy`

### DIFF
--- a/pkg/engine/lifecycletest/source_query_test.go
+++ b/pkg/engine/lifecycletest/source_query_test.go
@@ -1,0 +1,146 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunQuery_nocreate(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ReadF: func(
+					urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+				) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{Outputs: resource.PropertyMap{}}, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true)
+		assert.ErrorContains(t, err, "Query mode does not support creating, updating, or deleting resources")
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
+		assert.ErrorContains(t, err, "Query mode does not support creating, updating, or deleting resources")
+
+		_, _, err = monitor.ReadResource("pkgA:m:typA", "resA", "read-id", "", nil, "", "", "")
+		assert.ErrorContains(t, err, "Query mode does not support reading resources")
+		return nil
+	})
+
+	plugCtx, err := plugin.NewContext(
+		diagtest.LogSink(t), diagtest.LogSink(t),
+		deploytest.NewPluginHostF(nil, nil, programF, loaders...)(),
+		nil, "", nil, false, nil)
+	assert.NoError(t, err)
+
+	src, err := deploy.NewQuerySource(context.Background(), plugCtx, &deploytest.BackendClient{}, &deploy.EvalRunInfo{
+		Proj: &workspace.Project{
+			Name: "query-program",
+		},
+	}, nil, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, src.Wait())
+}
+
+func TestRunQuery_call_invoke(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				InvokeF: func(
+					tok tokens.ModuleMember, inputs resource.PropertyMap,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					name := inputs["name"]
+					ret := "unexpected"
+					if name.IsString() {
+						ret = "Hello, " + name.StringValue() + "!"
+					}
+
+					return resource.NewPropertyMapFromMap(map[string]interface{}{
+						"message": ret,
+					}), nil, nil
+				},
+				CallF: func(monitor *deploytest.ResourceMonitor, tok tokens.ModuleMember,
+					args resource.PropertyMap, info plugin.CallInfo, options plugin.CallOptions,
+				) (plugin.CallResult, error) {
+					ret := "unexpected"
+					if args["name"].IsString() {
+						ret = "Hello, " + args["name"].StringValue() + "!"
+					}
+
+					return plugin.CallResult{
+						Return: resource.NewPropertyMapFromMap(map[string]interface{}{
+							"message": ret,
+						}),
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		outs, _, _, err := monitor.Call("pkgA:m:typA/methodA", resource.PropertyMap{
+			"name": resource.NewStringProperty("bar"),
+		}, "", "")
+		assert.NoError(t, err)
+		assert.Equal(t, (resource.PropertyMap{
+			"message": resource.NewStringProperty("Hello, bar!"),
+		}), outs, "outs was %v", outs)
+
+		outs, _, err = monitor.Invoke("pkgA:m:invokeA", resource.PropertyMap{
+			"name": resource.NewStringProperty("bar"),
+		}, "", "")
+		assert.NoError(t, err)
+		assert.Equal(t, (resource.PropertyMap{
+			"message": resource.NewStringProperty("Hello, bar!"),
+		}), outs, "outs was %v", outs)
+
+		return nil
+	})
+
+	plugCtx, err := plugin.NewContext(
+		diagtest.LogSink(t), diagtest.LogSink(t),
+		deploytest.NewPluginHostF(nil, nil, programF, loaders...)(),
+		nil, "", nil, false, nil)
+	require.NoError(t, err)
+
+	src, err := deploy.NewQuerySource(context.Background(), plugCtx, &deploytest.BackendClient{}, &deploy.EvalRunInfo{
+		Proj: &workspace.Project{
+			Name: "query-program",
+		},
+	}, nil, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, src.Wait())
+}

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blang/semver"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -135,4 +136,233 @@ func TestSecretMasked(t *testing.T) {
 	if snap != nil {
 		assert.True(t, snap.Resources[1].Outputs["shouldBeSecret"].IsSecret())
 	}
+}
+
+// TestReadReplaceStep creates a resource and then replaces it with a read resource.
+func TestReadReplaceStep(t *testing.T) {
+	t.Parallel()
+
+	// Create resource.
+	newTestBuilder(t, nil).
+		WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+			CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64, preview bool,
+			) (resource.ID, resource.PropertyMap, resource.Status, error) {
+				return "created-id", news, resource.StatusOK, nil
+			},
+		}).
+		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+			assert.NoError(t, err)
+			return nil
+		}).
+		Then(func(snap *deploy.Snapshot, err error) {
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
+
+			assert.Nil(t, snap.VerifyIntegrity())
+			assert.Len(t, snap.Resources, 2)
+			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+			assert.False(t, snap.Resources[1].External)
+
+			// ReadReplace resource.
+			newTestBuilder(t, snap).
+				WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+					ReadF: func(urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{Outputs: resource.PropertyMap{}}, resource.StatusOK, nil
+					},
+				}).
+				RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+					_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", "read-id", "", nil, "", "", "")
+					assert.NoError(t, err)
+					return nil
+				}).
+				Then(func(snap *deploy.Snapshot, err error) {
+					assert.NoError(t, err)
+
+					assert.NotNil(t, snap)
+					assert.Nil(t, snap.VerifyIntegrity())
+					assert.Len(t, snap.Resources, 2)
+					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+					assert.True(t, snap.Resources[1].External)
+				})
+		})
+}
+
+func TestRelinquishStep(t *testing.T) {
+	t.Parallel()
+
+	const resourceID = "my-resource-id"
+	newTestBuilder(t, nil).
+		WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+			CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+				preview bool,
+			) (resource.ID, resource.PropertyMap, resource.Status, error) {
+				// Should match the ReadResource resource ID.
+				return resourceID, news, resource.StatusOK, nil
+			},
+		}).
+		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+			assert.NoError(t, err)
+			return nil
+		}).
+		Then(func(snap *deploy.Snapshot, err error) {
+			assert.NotNil(t, snap)
+			assert.Nil(t, snap.VerifyIntegrity())
+			assert.Len(t, snap.Resources, 2)
+			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+			assert.False(t, snap.Resources[1].External)
+
+			newTestBuilder(t, snap).
+				WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+					ReadF: func(urn resource.URN, id resource.ID,
+						inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{
+							Outputs: resource.PropertyMap{},
+						}, resource.StatusOK, nil
+					},
+				}).
+				RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+					_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", resourceID, "", nil, "", "", "")
+					assert.NoError(t, err)
+					return nil
+				}).
+				Then(func(snap *deploy.Snapshot, err error) {
+					assert.NoError(t, err)
+
+					assert.NotNil(t, snap)
+					assert.Nil(t, snap.VerifyIntegrity())
+					assert.Len(t, snap.Resources, 2)
+					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+					assert.True(t, snap.Resources[1].External)
+				})
+		})
+}
+
+func TestTakeOwnershipStep(t *testing.T) {
+	t.Parallel()
+
+	newTestBuilder(t, nil).
+		WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+			ReadF: func(urn resource.URN, id resource.ID,
+				inputs, state resource.PropertyMap,
+			) (plugin.ReadResult, resource.Status, error) {
+				return plugin.ReadResult{
+					Outputs: resource.PropertyMap{},
+				}, resource.StatusOK, nil
+			},
+		}).
+		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", "my-resource-id", "", nil, "", "", "")
+			assert.NoError(t, err)
+			return nil
+		}).
+		Then(func(snap *deploy.Snapshot, err error) {
+			assert.NoError(t, err)
+
+			assert.NotNil(t, snap)
+			assert.Nil(t, snap.VerifyIntegrity())
+			assert.Len(t, snap.Resources, 2)
+			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+			assert.True(t, snap.Resources[1].External)
+
+			// Create new resource for this snapshot.
+			newTestBuilder(t, snap).
+				WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+					CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+						preview bool,
+					) (resource.ID, resource.PropertyMap, resource.Status, error) {
+						// Should match the ReadF resource ID.
+						return "my-resource-id", news, resource.StatusOK, nil
+					},
+				}).
+				RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+					_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+					assert.NoError(t, err)
+					return nil
+				}).
+				Then(func(snap *deploy.Snapshot, err error) {
+					assert.NoError(t, err)
+
+					assert.NotNil(t, snap)
+					assert.Nil(t, snap.VerifyIntegrity())
+					assert.Len(t, snap.Resources, 2)
+					assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+					assert.False(t, snap.Resources[1].External)
+				})
+		})
+}
+
+func TestInitErrorsStep(t *testing.T) {
+	t.Parallel()
+
+	// Create new resource for this snapshot.
+	newTestBuilder(t, &deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				Type:   "pulumi:providers:pkgA",
+				URN:    "urn:pulumi:test::test::pulumi:providers:pkgA::default",
+				Custom: true,
+				Delete: false,
+				ID:     "935b2216-aec5-4810-96fd-5f6eae57ac88",
+			},
+			{
+				Type:     "pkgA:m:typA",
+				URN:      "urn:pulumi:test::test::pkgA:m:typA::resA",
+				Custom:   true,
+				ID:       "my-resource-id",
+				Provider: "urn:pulumi:test::test::pulumi:providers:pkgA::default::935b2216-aec5-4810-96fd-5f6eae57ac88",
+				InitErrors: []string{
+					`errors should yield an empty update to "continue" awaiting initialization.`,
+				},
+			},
+		},
+	}).
+		WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+			CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+				preview bool,
+			) (resource.ID, resource.PropertyMap, resource.Status, error) {
+				return "my-resource-id", news, resource.StatusOK, nil
+			},
+		}).
+		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+			assert.NoError(t, err)
+			return nil
+		}).
+		Then(func(snap *deploy.Snapshot, err error) {
+			assert.NoError(t, err)
+
+			assert.NotNil(t, snap)
+			assert.Nil(t, snap.VerifyIntegrity())
+			assert.Len(t, snap.Resources, 2)
+			assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), snap.Resources[1].URN)
+			assert.Empty(t, snap.Resources[1].InitErrors)
+		})
+}
+
+func TestReadNilOutputs(t *testing.T) {
+	t.Parallel()
+
+	const resourceID = "my-resource-id"
+	newTestBuilder(t, nil).
+		WithProvider("pkgA", "1.0.0", &deploytest.Provider{
+			ReadF: func(urn resource.URN, id resource.ID,
+				inputs, state resource.PropertyMap,
+			) (plugin.ReadResult, resource.Status, error) {
+				return plugin.ReadResult{}, resource.StatusOK, nil
+			},
+		}).
+		RunUpdate(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", resourceID, "", nil, "", "", "")
+			assert.ErrorContains(t, err, "resource 'my-resource-id' does not exist")
+
+			return nil
+		}).
+		Then(func(snap *deploy.Snapshot, err error) {
+			assert.ErrorContains(t, err,
+				"BAIL: step executor errored: step application failed: resource 'my-resource-id' does not exist")
+		})
 }


### PR DESCRIPTION
Moves coverage from 72% to 76% for `pkg/resource/deploy`.

Has temporary CI and test skip changes to enable more reliable coverage numbers.