### PR TITLE
[test] fix `TestCreatingProjectWithEmptyConfig` flakiness

### DIFF
--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -200,7 +200,6 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
 	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
 
-	backendInstance = nil
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 	defaultProjectName := filepath.Base(tempdir)

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -34,6 +34,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockBackendInstance sets the backendInstance for the test and cleans it up after.
+func mockBackendInstance(t *testing.T, b backend.Backend) {
+	t.Cleanup(func() {
+		backendInstance = nil
+	})
+	backendInstance = b
+}
+
 //nolint:paralleltest // changes directory for process
 func TestFailInInteractiveWithoutYes(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
@@ -203,18 +211,18 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 	assert.Equal(t, uniqueProjectName, proj.Name.String())
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
-	}
+	})
 
 	args := newArgs{
 		interactive:       false,
@@ -230,18 +238,18 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "project with this name already exists")
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
-	}
+	})
 
 	args := newArgs{
 		interactive:       true,
@@ -255,18 +263,18 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "Try again")
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-	}
+	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
 	args := newArgs{
@@ -286,18 +294,18 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	assert.Equal(t, projectName, proj.Name.String())
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-	}
+	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
 	args := newArgs{
@@ -354,18 +362,18 @@ func TestCreatingProjectWithEmptyConfig(t *testing.T) {
 	removeStack(t, tempdir, stackName)
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-	}
+	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
 	args := newArgs{
@@ -383,18 +391,18 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "project names may only contain")
 }
 
-//nolint:paralleltest // changes directory for process
+//nolint:paralleltest // changes directory for process, mocks backendInstance
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
-	}
+	})
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
 	err := runNew(context.Background(), newArgs{

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -123,12 +123,11 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 		},
 	}
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		GetStackF: func(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
 			return mockStack, nil
 		},
-	}
-	t.Cleanup(func() { backendInstance = nil })
+	})
 
 	tmpDir := t.TempDir()
 	chdir(t, tmpDir)
@@ -223,12 +222,11 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		},
 	}
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		GetStackF: func(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
 			return mockStack, nil
 		},
-	}
-	t.Cleanup(func() { backendInstance = nil })
+	})
 
 	tmpDir := t.TempDir()
 	chdir(t, tmpDir)

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -139,7 +139,7 @@ func TestListStacksPagination(t *testing.T) {
 		},
 	}
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -148,7 +148,7 @@ func TestListStacksPagination(t *testing.T) {
 			response := cannedResponses[requestIdx]
 			return response.summaries, response.outContToken, nil
 		},
-	}
+	})
 
 	const testOrgName, testProjName = "comprehendingdevice", "website"
 
@@ -193,7 +193,7 @@ func TestListStacksPagination(t *testing.T) {
 func TestListStacksJsonProgress(t *testing.T) {
 	mockTime := time.Unix(1, 0)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -223,7 +223,7 @@ func TestListStacksJsonProgress(t *testing.T) {
 		SupportsProgressF: func() bool {
 			return true
 		},
-	}
+	})
 
 	var buff bytes.Buffer
 	ctx := context.Background()
@@ -258,7 +258,7 @@ func TestListStacksJsonProgress(t *testing.T) {
 func TestListStacksJsonNoProgress(t *testing.T) {
 	mockTime := time.Unix(1, 0)
 
-	backendInstance = &backend.MockBackend{
+	mockBackendInstance(t, &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -281,7 +281,7 @@ func TestListStacksJsonNoProgress(t *testing.T) {
 		SupportsProgressF: func() bool {
 			return false
 		},
-	}
+	})
 
 	var buff bytes.Buffer
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #14756

Flaky tests cause coverage to be rerun and drops coverage data making CodeCov data less reliable/usable.

One of the most commonly flaky tests is `TestCreatingProjectWithEmptyConfig`  in `pkg` which contains a large number of tests.

Moving this test to the top of the file appears to lead to less flakiness.