### PR TITLE
Unskip test

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -92,7 +92,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 }
 
 func TestLanguage(t *testing.T) {
-	t.Skip("Temporarily skipping test to unblock CI - pulumi/pulumi#14781")
 	t.Parallel()
 
 	engineAddress, engine := runTestingHost(t)


### PR DESCRIPTION
This test was skipped because of an issue with `@pulumi/pulumi` v3.96.0. The issue has now been addressed with the release of v3.96.1, so we can unskip the test.