### PR TITLE
[ci] Fix Run @actions/setup-go flake

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -160,8 +160,10 @@ jobs:
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"
         run: echo "$CACHE_KEY" > .gocache.tmp
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         id: setup-go
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
           cache: true


### PR DESCRIPTION
Bumps @actions/setup-go to v5.

.github/workflows/ci-run-test.yml uses @actions/setup-go@v3 which uses @actions/cache@v3.

This version suffers from a bug where it will hang forever when downloading a segment and will timeout the job.

According to https://github.com/actions/cache/blob/6a1a45d/tips-and-workarounds.md#cache-segment-restore-timeout v3.0.8 adds SEGMENT_DOWNLOAD_TIMEOUT_MINS with a default of 10 minutes which should alleviate our CI hangs.

Only applying this to `ci-run-test.yml` to limit the scope of the change.