### PR TITLE
Don't set inputs to empty if inputs was undefined

### DIFF
--- a/changelog/pending/20231211--sdk-nodejs--fix-a-bug-in-nodejs-providers-returning-empty-inputs-on-read.yaml
+++ b/changelog/pending/20231211--sdk-nodejs--fix-a-bug-in-nodejs-providers-returning-empty-inputs-on-read.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix a bug in nodejs providers returning empty inputs on read.

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -218,7 +218,9 @@ class Server implements grpc.UntypedServiceImplementation {
                 const result: any = await this.provider.read(id, req.getUrn(), props);
                 resp.setId(result.id);
                 resp.setProperties(structproto.Struct.fromJavaScript(result.props));
-                resp.setInputs(structproto.Struct.fromJavaScript(result.inputs));
+                resp.setInputs(
+                    result.inputs === undefined ? undefined : structproto.Struct.fromJavaScript(result.inputs),
+                );
             } else {
                 // In the event of a missing read, simply return back the input state.
                 resp.setId(id);


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/14819.

NodeJS providers started returning empty inputs rather than unknown inputs from Read.