### PR TITLE
[ci] Re-enable code coverage and rebuild release binaries without coverage

### DIFF
--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -82,11 +82,17 @@ jobs:
           mv ./artifacts.tmp/artifacts-*/* ./artifacts
 
       - name: Ensure coverage not enabled on release
-        working-directory: artifacts
         run: |
-          if ./pulumi version 2>&1 | grep coverage; then
+          # Extract pulumi binary to bintest rather than pollute artifacts directory.
+          mkdir './bintest' && tar -xvf ./artifacts/pulumi-*-linux-x64.tar.gz -C './bintest/.'
+
+          # Ensure pulumi binary exists.
+          stat './bintest/pulumi/pulumi' || exit 1
+
+          # Check binary not built with coverage.
+          if ./bintest/pulumi/pulumi version 2>&1 | grep coverage; then
             echo 'Aborting! Pulumi binary built with coverage data.'
-            exit 1
+            exit 2
           else
             echo 'Pulumi binary OK!'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,3 +391,24 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+  build-release-binaries:
+    # This overwrites the previously built testing binaries with versions without coverage.
+    name: Rebuild binaries
+    needs: [matrix, unit-test, integration-test, acceptance-test]
+    if: ${{ inputs.enable-coverage }}
+    strategy:
+      # To avoid tying up macOS runners:
+      # If using IDE, ignore yaml-schema error: 'Incorrect type. Expected "boolean"'
+      fail-fast: ${{ contains(needs.matrix.outputs.build-targets, 'macos') }}
+      matrix:
+        target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
+    uses: ./.github/workflows/ci-build-binaries.yml
+    with:
+      ref: ${{ inputs.ref }}
+      version: ${{ inputs.version }}
+      os: ${{ matrix.target.os }}
+      arch: ${{ matrix.target.arch }}
+      build-platform: ${{ matrix.target.build-platform }}
+      version-set: ${{ needs.matrix.outputs.version-set }}
+      enable-coverage: false
+    secrets: inherit

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -39,6 +39,7 @@ jobs:
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
+      enable-coverage: true
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
Fixes #14817 

As a follow-up to #14804, we need to re-enable code coverage without releases being built with coverage. #14804 includes a test in the release job to catch `pulumi` being released with coverage data.

Also fixes the test to check that the pulumi binary is not built with coverage.

Background:
Coverage was disabled on merge jobs in order to fix [pulumi/pulumi#14799].
[pulumi/pulumi#14716] removed nightly coverage workflows in favor of collecting coverage on merges [pulumi/pulumi#14727].
The binaries built with coverage were used in the downstream prepare-release job causing a noticable bug [pulumi/pulumi#14799].