### PR TITLE
Enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - unconvert
     - unused
     - paralleltest
+    - perfsprint
 
 linters-settings:
   nakedret:

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -206,7 +206,7 @@ func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 
 	// The message may span multiple lines, so we massage it so it will be indented properly.
 	message := strings.TrimSuffix(payload.Message, "\n")
-	message = strings.ReplaceAll(message, "\n", fmt.Sprintf("\n%s", linePrefix))
+	message = strings.ReplaceAll(message, "\n", "\n"+linePrefix)
 	policyLine = fmt.Sprintf("%s%s%s", policyLine, linePrefix, message)
 	return opts.Color.Colorize(policyLine + "\n")
 }

--- a/pkg/backend/display/internal/terminal/info.go
+++ b/pkg/backend/display/internal/terminal/info.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -26,7 +27,7 @@ type termInfo interface {
 type noTermInfo int // canary used when no terminfo.
 
 func (ti noTermInfo) Parse(attr string, params ...interface{}) (string, error) {
-	return "", fmt.Errorf("noTermInfo")
+	return "", errors.New("noTermInfo")
 }
 
 type info struct {

--- a/pkg/backend/display/jsonmessage.go
+++ b/pkg/backend/display/jsonmessage.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
@@ -268,7 +269,7 @@ func (r *messageRenderer) render(display *ProgressDisplay, done bool) {
 	removeInfoColumnIfUnneeded(rows)
 
 	for i, row := range rows {
-		r.renderRow(display, fmt.Sprintf("%v", i), row, maxColumnLengths)
+		r.renderRow(display, strconv.Itoa(i), row, maxColumnLengths)
 	}
 
 	systemID := len(rows)
@@ -285,18 +286,18 @@ func (r *messageRenderer) render(display *ProgressDisplay, done bool) {
 		if !printedHeader {
 			printedHeader = true
 			r.colorizeAndWriteProgress(makeActionProgress(
-				fmt.Sprintf("%v", systemID), " "))
+				strconv.Itoa(systemID), " "))
 			systemID++
 
 			r.colorizeAndWriteProgress(makeActionProgress(
-				fmt.Sprintf("%v", systemID),
+				strconv.Itoa(systemID),
 				colors.Yellow+"System Messages"+colors.Reset))
 			systemID++
 		}
 
 		for _, line := range lines {
 			r.colorizeAndWriteProgress(makeActionProgress(
-				fmt.Sprintf("%v", systemID), fmt.Sprintf("  %s", line)))
+				strconv.Itoa(systemID), "  "+line))
 			systemID++
 		}
 	}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -653,7 +653,7 @@ func (display *ProgressDisplay) printPolicies() bool {
 			for _, remediationEvent := range info.RemediationEvents {
 				// Print the individual policy event.
 				remediationLine := renderDiffPolicyRemediationEvent(
-					remediationEvent, fmt.Sprintf("%s- ", subItemIndent), false, display.opts)
+					remediationEvent, subItemIndent+"- ", false, display.opts)
 				remediationLine = strings.TrimSuffix(remediationLine, "\n")
 				if remediationLine != "" {
 					display.println(remediationLine)
@@ -695,7 +695,7 @@ func (display *ProgressDisplay) printPolicies() bool {
 		for _, policyEvent := range info.ViolationEvents {
 			// Print the individual policy event.
 			policyLine := renderDiffPolicyViolationEvent(
-				policyEvent, fmt.Sprintf("%s- ", subItemIndent), subItemIndent+"  ", display.opts)
+				policyEvent, subItemIndent+"- ", subItemIndent+"  ", display.opts)
 			policyLine = strings.TrimSuffix(policyLine, "\n")
 			display.println(policyLine)
 		}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -562,7 +562,7 @@ func Login(ctx context.Context, d diag.Sink, url string, project *workspace.Proj
 func (b *localBackend) getReference(ref backend.StackReference) (*localBackendReference, error) {
 	stackRef, ok := ref.(*localBackendReference)
 	if !ok {
-		return nil, fmt.Errorf("bad stack reference type")
+		return nil, errors.New("bad stack reference type")
 	}
 	return stackRef, stackRef.Validate()
 }
@@ -589,19 +589,19 @@ func (b *localBackend) SetCurrentProject(project *workspace.Project) {
 func (b *localBackend) GetPolicyPack(ctx context.Context, policyPack string,
 	d diag.Sink,
 ) (backend.PolicyPack, error) {
-	return nil, fmt.Errorf("File state backend does not support resource policy")
+	return nil, errors.New("File state backend does not support resource policy")
 }
 
 func (b *localBackend) ListPolicyGroups(ctx context.Context, orgName string, _ backend.ContinuationToken) (
 	apitype.ListPolicyGroupsResponse, backend.ContinuationToken, error,
 ) {
-	return apitype.ListPolicyGroupsResponse{}, nil, fmt.Errorf("File state backend does not support resource policy")
+	return apitype.ListPolicyGroupsResponse{}, nil, errors.New("File state backend does not support resource policy")
 }
 
 func (b *localBackend) ListPolicyPacks(ctx context.Context, orgName string, _ backend.ContinuationToken) (
 	apitype.ListPolicyPacksResponse, backend.ContinuationToken, error,
 ) {
-	return apitype.ListPolicyPacksResponse{}, nil, fmt.Errorf("File state backend does not support resource policy")
+	return apitype.ListPolicyPacksResponse{}, nil, errors.New("File state backend does not support resource policy")
 }
 
 func (b *localBackend) SupportsTags() bool {

--- a/pkg/backend/filestate/backend_legacy_test.go
+++ b/pkg/backend/filestate/backend_legacy_test.go
@@ -3,7 +3,6 @@ package filestate
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -349,7 +348,7 @@ func TestLocalBackendRejectsStackInitOptions_legacy(t *testing.T) {
 
 	// • Create a mock local backend
 	tmpDir := markLegacyStore(t, t.TempDir())
-	dirURI := fmt.Sprintf("file://%s", filepath.ToSlash(tmpDir))
+	dirURI := "file://" + filepath.ToSlash(tmpDir)
 	local, err := New(context.Background(), diagtest.LogSink(t), dirURI, nil)
 	assert.NoError(t, err)
 	ctx := context.Background()

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -562,7 +562,7 @@ func TestLocalBackendRejectsStackInitOptions(t *testing.T) {
 
 	// • Create a mock local backend
 	tmpDir := t.TempDir()
-	dirURI := fmt.Sprintf("file://%s", filepath.ToSlash(tmpDir))
+	dirURI := "file://" + filepath.ToSlash(tmpDir)
 	local, err := New(context.Background(), diagtest.LogSink(t), dirURI, nil)
 	assert.NoError(t, err)
 	ctx := context.Background()

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -2,7 +2,6 @@ package filestate
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -79,7 +78,7 @@ func TestWrappedBucket(t *testing.T) {
 
 		// Write some data.
 		for _, filename := range filenames {
-			key := fmt.Sprintf(`.pulumi\bucket-test\%s`, filename)
+			key := ".pulumi\\bucket-test\\" + filename
 			err := wrappedBucket.WriteAll(ctx, key, randomData, &blob.WriterOptions{})
 			mustNotHaveError(t, "WriteAll", err)
 		}

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -174,7 +174,7 @@ func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendRe
 	if project == "" {
 		currentProject := p.currentProject()
 		if currentProject == nil {
-			return nil, fmt.Errorf("if you're using the --stack flag, " +
+			return nil, errors.New("if you're using the --stack flag, " +
 				"pass the fully qualified name (organization/project/stack)")
 		}
 
@@ -197,7 +197,7 @@ func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendRe
 
 func (p *projectReferenceStore) ValidateReference(ref *localBackendReference) error {
 	if ref.project == "" {
-		return fmt.Errorf("bad stack reference, project was not set")
+		return errors.New("bad stack reference, project was not set")
 	}
 	return nil
 }
@@ -364,7 +364,7 @@ func (p *legacyReferenceStore) ParseReference(stackRef string) (*localBackendRef
 
 func (p *legacyReferenceStore) ValidateReference(ref *localBackendReference) error {
 	if ref.project != "" {
-		return fmt.Errorf("bad stack reference, project was set")
+		return errors.New("bad stack reference, project was set")
 	}
 	return nil
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -355,7 +355,7 @@ func (m defaultLoginManager) Current(
 	if err != nil {
 		return nil, err
 	} else if !valid {
-		return nil, fmt.Errorf("invalid access token")
+		return nil, errors.New("invalid access token")
 	}
 
 	// Save them.
@@ -430,7 +430,7 @@ func (m defaultLoginManager) Login(
 			}
 		}
 	} else {
-		line3 := fmt.Sprintf("Enter your access token from %s", accountLink)
+		line3 := "Enter your access token from " + accountLink
 		line3len := len(line3)
 		line3 = colors.Highlight(line3, "access token", colors.BrightCyan+colors.Bold)
 		line3 = colors.Highlight(line3, accountLink, colors.BrightBlue+colors.Underline+colors.Bold)
@@ -465,7 +465,7 @@ func (m defaultLoginManager) Login(
 	if err != nil {
 		return nil, err
 	} else if !valid {
-		return nil, fmt.Errorf("invalid access token")
+		return nil, errors.New("invalid access token")
 	}
 
 	// Save them.
@@ -690,7 +690,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 
 	if qualifiedName.Project == "" {
 		if b.currentProject == nil {
-			return nil, fmt.Errorf("If you're using the --stack flag, " +
+			return nil, errors.New("If you're using the --stack flag, " +
 				"pass the fully qualified name (org/project/stack)")
 		}
 
@@ -1868,7 +1868,7 @@ func (c httpstateBackendClient) GetStackOutputs(ctx context.Context, name string
 	// When using the cloud backend, require that stack references are fully qualified so they
 	// look like "<org>/<project>/<stack>"
 	if strings.Count(name, "/") != 2 {
-		return nil, fmt.Errorf("a stack reference's name should be of the form " +
+		return nil, errors.New("a stack reference's name should be of the form " +
 			"'<organization>/<project>/<stack>'. See https://pulumi.io/help/stack-reference for more information.")
 	}
 

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -454,7 +454,7 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 			// Return the raw bytes of the response body.
 			*respObj = respBody
 		case []byte:
-			return fmt.Errorf("Can't unmarshal response body to []byte. Try *[]byte")
+			return errors.New("Can't unmarshal response body to []byte. Try *[]byte")
 		default:
 			// Else, unmarshal as JSON.
 			if err = json.Unmarshal(respBody, respObj); err != nil {

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -15,7 +15,6 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -62,7 +61,7 @@ func getEndpointName(method, path string) string {
 		return "unknown"
 	}
 
-	return fmt.Sprintf("api/%s", match.Route.GetName())
+	return "api/" + match.Route.GetName()
 }
 
 // routes is the canonical muxer we use to determine friendly names for Pulumi APIs.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -738,7 +738,7 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 	// is in use, which does not provide  a version tag.
 	var versionMsg string
 	if analyzerInfo.Version != "" {
-		versionMsg = fmt.Sprintf(" - version %s", analyzerInfo.Version)
+		versionMsg = " - version " + analyzerInfo.Version
 	}
 	fmt.Printf("Publishing %q%s to %q\n", analyzerInfo.Name, versionMsg, orgName)
 
@@ -930,7 +930,7 @@ func (pc *Client) GetUpdateEvents(ctx context.Context, update UpdateIdentifier,
 ) (apitype.UpdateResults, error) {
 	path := getUpdatePath(update)
 	if continuationToken != nil {
-		path += fmt.Sprintf("?continuationToken=%s", *continuationToken)
+		path += "?continuationToken=" + *continuationToken
 	}
 
 	var results apitype.UpdateResults
@@ -1059,7 +1059,7 @@ func (pc *Client) GetUpdateEngineEvents(ctx context.Context, update UpdateIdenti
 ) (apitype.GetUpdateEventsResponse, error) {
 	path := getUpdatePath(update, "events")
 	if continuationToken != nil {
-		path += fmt.Sprintf("?continuationToken=%s", *continuationToken)
+		path += "?continuationToken=" + *continuationToken
 	}
 
 	var resp apitype.GetUpdateEventsResponse
@@ -1115,7 +1115,7 @@ func (pc *Client) CreateDeployment(ctx context.Context, stack StackIdentifier,
 func (pc *Client) GetDeploymentLogs(ctx context.Context, stack StackIdentifier, id,
 	token string,
 ) (*apitype.DeploymentLogs, error) {
-	path := getDeploymentPath(stack, id, fmt.Sprintf("logs?continuationToken=%s", token))
+	path := getDeploymentPath(stack, id, "logs?continuationToken="+token)
 	var resp apitype.DeploymentLogs
 	err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp)
 	if err != nil {

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -71,7 +72,7 @@ func (dds *deploymentDiffState) ShouldDiff(new deployment) bool {
 
 func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment) (deploymentDiff, error) {
 	if !dds.CanDiff() {
-		return deploymentDiff{}, fmt.Errorf("Diff() cannot be called before Saved()")
+		return deploymentDiff{}, errors.New("Diff() cannot be called before Saved()")
 	}
 
 	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "Diff")

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -252,7 +252,7 @@ func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("creating plugin root: %w", err)
 	}
 
-	tempDir, err := os.MkdirTemp(filepath.Dir(finalDir), fmt.Sprintf("%s.tmp", filepath.Base(finalDir)))
+	tempDir, err := os.MkdirTemp(filepath.Dir(finalDir), filepath.Base(finalDir)+".tmp")
 	if err != nil {
 		return fmt.Errorf("creating plugin directory %s: %w", tempDir, err)
 	}

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -16,6 +16,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -199,11 +200,11 @@ func GetEnvironmentTagsForCurrentStack(root string,
 	if has {
 		configTagInterface, err := configTags.ToObject()
 		if err != nil {
-			return nil, fmt.Errorf("pulumi:tags must be an object of strings")
+			return nil, errors.New("pulumi:tags must be an object of strings")
 		}
 		configTagObject, ok := configTagInterface.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("pulumi:tags must be an object of strings")
+			return nil, errors.New("pulumi:tags must be an object of strings")
 		}
 
 		for name, value := range configTagObject {

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -173,7 +174,7 @@ func getWatchUtil() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Could not locate pulumi-watch binary")
+	return "", errors.New("Could not locate pulumi-watch binary")
 }
 
 func stdoutToChannel(scanner *bufio.Scanner, out chan string) {

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -147,7 +147,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 
 			lang, err := pluginContext.Host.LanguageRuntime(projinfo.Root, pwd, proj.Runtime.Name(), proj.Runtime.Options())
 			if err != nil {
-				addError(err, fmt.Sprintf("Failed to load language plugin %s", proj.Runtime.Name()))
+				addError(err, "Failed to load language plugin "+proj.Runtime.Name())
 			} else {
 				aboutResponse, err := lang.About()
 				if err != nil {
@@ -336,10 +336,10 @@ func (b backendAbout) String() string {
 	if b.TokenInformation != nil {
 		var tokenType string
 		if b.TokenInformation.Team != "" {
-			tokenType = fmt.Sprintf("team: %s", b.TokenInformation.Team)
+			tokenType = "team: " + b.TokenInformation.Team
 		} else {
 			contract.Assertf(b.TokenInformation.Organization != "", "token must have an organization or team")
-			tokenType = fmt.Sprintf("organization: %s", b.TokenInformation.Organization)
+			tokenType = "organization: " + b.TokenInformation.Organization
 		}
 		rows = append(rows, []string{"Token type", tokenType})
 		rows = append(rows, []string{"Token type", b.TokenInformation.Name})
@@ -569,7 +569,7 @@ func (runtime projectRuntimeAbout) String() string {
 	}
 	paramString := ""
 	if len(params) > 0 {
-		paramString = fmt.Sprintf(": %s", strings.Join(params, " "))
+		paramString = ": " + strings.Join(params, " ")
 	}
 	return fmt.Sprintf("This project is written in %s%s\n",
 		runtime.Language, paramString)

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -101,7 +101,7 @@ func (cmd *aiWebCmd) Run(ctx context.Context, args []string) error {
 	}
 	if !cmd.disableAutoSubmit {
 		if len(args) == 0 {
-			return fmt.Errorf("prompt must be provided when auto-submit is enabled")
+			return errors.New("prompt must be provided when auto-submit is enabled")
 		}
 		query.Set("autoSubmit", "true")
 	}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -748,7 +748,7 @@ func parseKeyValuePair(pair string) (config.Key, string, error) {
 	firstChar := string([]rune(pair)[0])
 	if firstChar == "\"" || firstChar == "'" {
 		pair = strings.TrimPrefix(pair, firstChar)
-		splitArg = strings.SplitN(pair, fmt.Sprintf("%s=", firstChar), 2)
+		splitArg = strings.SplitN(pair, firstChar+"=", 2)
 	}
 
 	if len(splitArg) < 2 {

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -221,7 +221,7 @@ func generatorWrapper(generator projectGeneratorFunc, targetLanguage string) pro
 			return diagnostics, fmt.Errorf("failed to bind program: %w", err)
 		} else if program == nil {
 			// We've already printed the diagnostics above
-			return diagnostics, fmt.Errorf("failed to bind program")
+			return diagnostics, errors.New("failed to bind program")
 		}
 		return diagnostics, generator(targetDirectory, *proj, program)
 	}
@@ -405,7 +405,7 @@ func runConvert(
 		if resp.Diagnostics.HasErrors() {
 			// If we've got error diagnostics then program generation failed, we've printed the error above so
 			// just return a plain message here.
-			return fmt.Errorf("conversion failed")
+			return errors.New("conversion failed")
 		}
 	}
 
@@ -439,7 +439,7 @@ func runConvert(
 			return fmt.Errorf("could not generate output program: %w", err)
 		}
 
-		return fmt.Errorf("could not generate output program")
+		return errors.New("could not generate output program")
 	}
 
 	if err != nil {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -59,12 +59,12 @@ import (
 func parseResourceSpec(spec string) (string, resource.URN, error) {
 	equals := strings.Index(spec, "=")
 	if equals == -1 {
-		return "", "", fmt.Errorf("spec must be of the form name=URN")
+		return "", "", errors.New("spec must be of the form name=URN")
 	}
 
 	name, urn := spec[:equals], resource.URN(spec[equals+1:])
 	if name == "" || urn == "" {
-		return "", "", fmt.Errorf("spec must be of the form name=URN")
+		return "", "", errors.New("spec must be of the form name=URN")
 	}
 
 	if !urn.IsValid() {

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -143,7 +143,7 @@ func newLoginCmd() *cobra.Command {
 			if filestate.IsFileStateBackendURL(cloudURL) {
 				be, err = filestate.Login(ctx, cmdutil.Diag(), cloudURL, project)
 				if defaultOrg != "" {
-					return fmt.Errorf("unable to set default org for this type of backend")
+					return errors.New("unable to set default org for this type of backend")
 				}
 			} else {
 				be, err = loginToCloud(ctx, cloudURL, project, insecure, displayOptions)

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -766,7 +766,7 @@ func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOn
 			cd = fmt.Sprintf("\"%s\"", cd)
 		}
 
-		cd = fmt.Sprintf("cd %s", cd)
+		cd = "cd " + cd
 		commands = append(commands, cd)
 	}
 

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -17,7 +17,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -79,8 +79,8 @@ func TestSearch_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), name)
 	assert.Contains(t, buff.String(), typ)
 	assert.Contains(t, buff.String(), program)
-	assert.Contains(t, buff.String(), fmt.Sprintf("Results are also visible in Pulumi Cloud:\n%s", searchURL))
-	assert.Contains(t, buff.String(), fmt.Sprint(total))
+	assert.Contains(t, buff.String(), "Results are also visible in Pulumi Cloud:\n"+searchURL)
+	assert.Contains(t, buff.String(), strconv.FormatInt(total, 10))
 }
 
 func TestSearchNoOrgName_cmd(t *testing.T) {
@@ -131,8 +131,8 @@ func TestSearchNoOrgName_cmd(t *testing.T) {
 	assert.Contains(t, buff.String(), name)
 	assert.Contains(t, buff.String(), typ)
 	assert.Contains(t, buff.String(), program)
-	assert.Contains(t, buff.String(), fmt.Sprintf("Results are also visible in Pulumi Cloud:\n%s", searchURL))
-	assert.Contains(t, buff.String(), fmt.Sprint(total))
+	assert.Contains(t, buff.String(), "Results are also visible in Pulumi Cloud:\n"+searchURL)
+	assert.Contains(t, buff.String(), strconv.FormatInt(total, 10))
 }
 
 type stubHTTPBackend struct {

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -165,7 +166,7 @@ func genSDK(language, out string, pkg *schema.Package, overlays string) error {
 			if diags.HasErrors() {
 				// If we've got error diagnostics then package generation failed, we've printed the error above so
 				// just return a plain message here.
-				return fmt.Errorf("generation failed")
+				return errors.New("generation failed")
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin_install_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/blang/semver"
@@ -50,7 +50,7 @@ func TestBundledDev(t *testing.T) {
 			getLatestVersionCalled = true
 			assert.Equal(t, "nodejs", ps.Name)
 			assert.Equal(t, workspace.LanguagePlugin, ps.Kind)
-			return nil, fmt.Errorf("404 HTTP error fetching plugin")
+			return nil, errors.New("404 HTTP error fetching plugin")
 		},
 	}
 

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -63,7 +64,7 @@ func newPluginRmCmd() *cobra.Command {
 				}
 				kind = workspace.PluginKind(args[0])
 			} else if !all {
-				return fmt.Errorf("please pass --all if you'd like to remove all plugins")
+				return errors.New("please pass --all if you'd like to remove all plugins")
 			}
 			if len(args) > 1 {
 				name = args[1]

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -134,7 +134,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	} else if len(templates) == 1 {
 		template = templates[0]
 	} else if !opts.IsInteractive {
-		return fmt.Errorf("a template must be provided when running in non-interactive mode")
+		return errors.New("a template must be provided when running in non-interactive mode")
 	} else {
 		if template, err = choosePolicyPackTemplate(templates, opts); err != nil {
 			return err
@@ -271,7 +271,7 @@ func printPolicyPackNextSteps(proj *workspace.PolicyPackProject, root string, ge
 	usageCommandPreambles := []string{
 		"run the Policy Pack against a Pulumi program, in the directory of the Pulumi program run",
 	}
-	usageCommands := []string{fmt.Sprintf("pulumi up --policy-pack %s", root)}
+	usageCommands := []string{"pulumi up --policy-pack " + root}
 
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") || strings.EqualFold(proj.Runtime.Name(), "python") {
 		usageCommandPreambles = append(usageCommandPreambles, "publish the Policy Pack, run")

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -88,7 +88,7 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, args []string) error {
 	if strings.Contains(orgName, "/") {
 		return errors.New("organization name must not contain slashes")
 	}
-	policyPackRef := fmt.Sprintf("%s/", orgName)
+	policyPackRef := orgName + "/"
 
 	//
 	// Obtain current PolicyPack, tied to the Pulumi Cloud backend.

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -201,8 +201,7 @@ func newRefreshCmd() *cobra.Command {
 			}
 
 			if skipPendingCreates && clearPendingCreates {
-				return result.FromError(fmt.Errorf(
-					"cannot set both --skip-pending-creates and --clear-pending-creates"))
+				return result.FromError(errors.New("cannot set both --skip-pending-creates and --clear-pending-creates"))
 			}
 
 			// First we handle explicit create->imports we were given
@@ -381,7 +380,7 @@ func filterMapPendingCreates(
 		var pending []resource.Operation
 		for _, op := range snap.PendingOperations {
 			if op.Resource == nil {
-				return fmt.Errorf("found operation without resource")
+				return errors.New("found operation without resource")
 			}
 			if op.Type != resource.OperationTypeCreating {
 				pending = append(pending, op)

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -255,7 +255,7 @@ func getNewResourceName() (tokens.QName, error) {
 			if tokens.IsQName(ans.(string)) {
 				return nil
 			}
-			return fmt.Errorf("resource names may only contain alphanumerics, underscores, hyphens, dots, and slashes")
+			return errors.New("resource names may only contain alphanumerics, underscores, hyphens, dots, and slashes")
 		}))
 	if err != nil {
 		return "", err

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ func (cmd *stateEditCmd) Run(s backend.Stack) error {
 		return err
 	}
 	if snap == nil {
-		return fmt.Errorf("old snapshot expected to be non-nil")
+		return errors.New("old snapshot expected to be non-nil")
 	}
 
 	sf := &jsonSnapshotEncoder{
@@ -195,7 +196,7 @@ func (cmd *stateEditCmd) Run(s backend.Stack) error {
 			}
 			continue
 		default:
-			return fmt.Errorf("confirmation cancelled, not proceeding with the state edit")
+			return errors.New("confirmation cancelled, not proceeding with the state edit")
 		}
 	}
 }
@@ -231,7 +232,7 @@ func (cmd *stateEditCmd) validateAndPrintState(f *snapshotBuffer) (*deploy.Snaps
 func openInEditor(filename string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
-		return fmt.Errorf("no EDITOR environment variable set")
+		return errors.New("no EDITOR environment variable set")
 	}
 	return openInEditorInternal(editor, filename)
 }

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -83,7 +84,7 @@ func unprotectAllResources(ctx context.Context, stackName string, showPrompt boo
 	err := runTotalStateEdit(ctx, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot) error {
 		// Protects against Panic when a user tries to unprotect non-existing resources
 		if snap == nil {
-			return fmt.Errorf("no resources found to unprotect")
+			return errors.New("no resources found to unprotect")
 		}
 
 		for _, res := range snap.Resources {

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -110,9 +110,9 @@ func (cmd *whoAmICmd) Run(ctx context.Context) error {
 		if tokenInfo != nil {
 			tokenType := "unknown"
 			if tokenInfo.Team != "" {
-				tokenType = fmt.Sprintf("team: %s", tokenInfo.Team)
+				tokenType = "team: " + tokenInfo.Team
 			} else if tokenInfo.Organization != "" {
-				tokenType = fmt.Sprintf("organization: %s", tokenInfo.Organization)
+				tokenType = "organization: " + tokenInfo.Organization
 			}
 			fmt.Fprintf(cmd.Stdout, "Token type: %s\n", tokenType)
 			fmt.Fprintf(cmd.Stdout, "Token name: %s\n", tokenInfo.Name)

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -19,7 +19,6 @@
 package docs
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/pgavlin/goldmark/ast"
@@ -170,7 +169,7 @@ func (dctx *docGenContext) decomposeDocstring(docstring string) docInfo {
 
 	// When we split the description above, the main part of the description is always part[0]
 	// the description must have a blank line after it to render the examples correctly
-	description = fmt.Sprintf("%s\n", parts[0])
+	description = parts[0] + "\n"
 
 	return docInfo{
 		description:   description,

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -844,7 +844,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			DefaultValue: " = null",
 			Type: propertyType{
 				Name: optsType,
-				Link: docLangHelper.GetDocLinkForPulumiType(def, fmt.Sprintf("Pulumi.%s", optsType)),
+				Link: docLangHelper.GetDocLinkForPulumiType(def, "Pulumi."+optsType),
 			},
 			Comment: ctorOptsArgComment,
 		},
@@ -935,11 +935,11 @@ func (mod *modContext) genConstructorPython(r *schema.Resource, argsOptional, ar
 		// Determine whether we need to use the alternate args class name (e.g. `<Resource>InitArgs` instead of
 		// `<Resource>Args`) due to an input type with the same name as the resource in the same module.
 		resName := resourceName(r)
-		resArgsName := fmt.Sprintf("%sArgs", resName)
+		resArgsName := resName + "Args"
 		for _, inputType := range mod.inputTypes {
 			inputTypeName := strings.Title(tokenToName(inputType.Token))
 			if resName == inputTypeName {
-				resArgsName = fmt.Sprintf("%sInitArgs", resName)
+				resArgsName = resName + "InitArgs"
 			}
 		}
 
@@ -1935,7 +1935,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 	// assume top level package index page when formatting title tags otherwise, if contains modules, assume modules
 	// top level page when generating title tags.
 	if len(modules) > 0 {
-		modTitleTag = fmt.Sprintf("%s Package", getPackageDisplayName(modTitle))
+		modTitleTag = getPackageDisplayName(modTitle) + " Package"
 	} else {
 		modTitleTag = fmt.Sprintf("%s.%s", mod.pkg.Name(), modTitle)
 		packageDescription = fmt.Sprintf("Explore the resources and functions of the %s.%s module.",

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -97,7 +97,7 @@ func (mod *modContext) getFunctionResourceInfo(f *schema.Function, outputVersion
 		case "go":
 			resultTypeName = docLangHelper.GetResourceFunctionResultName(mod.mod, f)
 			if outputVersion {
-				resultTypeName = fmt.Sprintf("%sOutput", resultTypeName)
+				resultTypeName = resultTypeName + "Output"
 			}
 		case "csharp":
 			namespace := title(mod.pkg.Name(), lang)

--- a/pkg/codegen/docs/gen_method.go
+++ b/pkg/codegen/docs/gen_method.go
@@ -74,7 +74,7 @@ func (mod *modContext) genMethod(r *schema.Resource, m *schema.Method) methodDoc
 				return name == "__self__"
 			}
 			props := mod.getPropertiesWithIDPrefixAndExclude(f.Inputs.Properties, lang, true, false, false,
-				fmt.Sprintf("%s_arg_", m.Name), exclude)
+				m.Name+"_arg_", exclude)
 			if len(props) > 0 {
 				inputProps[lang] = props
 			}
@@ -82,7 +82,7 @@ func (mod *modContext) genMethod(r *schema.Resource, m *schema.Method) methodDoc
 		if f.ReturnType != nil {
 			if objectType, ok := f.ReturnType.(*schema.ObjectType); ok && objectType != nil {
 				outputProps[lang] = mod.getPropertiesWithIDPrefixAndExclude(objectType.Properties, lang, false, false, false,
-					fmt.Sprintf("%s_result_", m.Name), nil)
+					m.Name+"_result_", nil)
 			}
 		}
 	}

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -178,7 +178,7 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	var displayName string
 	var link string
 	if modName == "" {
-		displayName = fmt.Sprintf("Pulumi.%s", namespaceName(d.Namespaces, pkg.Name))
+		displayName = "Pulumi." + namespaceName(d.Namespaces, pkg.Name)
 	} else {
 		displayName = fmt.Sprintf("Pulumi.%s.%s", namespaceName(d.Namespaces, pkg.Name), modName)
 	}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -407,7 +407,7 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			typ = qualifier
 		}
 		if typ == "Inputs" && mod.fullyQualifiedInputs {
-			typ = fmt.Sprintf("%s.Inputs", mod.namespaceName)
+			typ = mod.namespaceName + ".Inputs"
 		}
 		if typ != "" {
 			typ += "."
@@ -668,7 +668,7 @@ func (pt *plainType) genInputTypeWithFlags(w io.Writer, level int, generateInput
 
 	var suffix string
 	if pt.baseClass != "" {
-		suffix = fmt.Sprintf(" : global::Pulumi.%s", pt.baseClass)
+		suffix = " : global::Pulumi." + pt.baseClass
 	}
 
 	fmt.Fprintf(w, "%spublic %sclass %s%s\n", indent, sealed, pt.name, suffix)
@@ -1002,7 +1002,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	if !r.IsProvider && !r.IsComponent {
 		stateParam, stateRef := "", "null"
 		if r.StateInputs != nil {
-			stateParam, stateRef = fmt.Sprintf("%sState? state = null, ", className), "state"
+			stateParam, stateRef = className+"State? state = null, ", "state"
 		}
 
 		fmt.Fprintf(w, "\n")
@@ -1102,7 +1102,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 
 		stateParam, stateRef := "", ""
 		if r.StateInputs != nil {
-			stateParam, stateRef = fmt.Sprintf("%sState? state = null, ", className), "state, "
+			stateParam, stateRef = className+"State? state = null, ", "state, "
 			fmt.Fprintf(w, "        /// <param name=\"state\">Any extra arguments used during the lookup.</param>\n")
 		}
 
@@ -1140,7 +1140,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 				fieldName := mod.propertyName(objectReturnType.Properties[0])
 				lift = fmt.Sprintf(".Apply(v => v.%s)", fieldName)
 			} else {
-				returnType = fmt.Sprintf("global::Pulumi.Output%s", typeParameter)
+				returnType = "global::Pulumi.Output" + typeParameter
 			}
 		}
 
@@ -1355,7 +1355,7 @@ func (mod *modContext) functionReturnType(fun *schema.Function) string {
 		if _, ok := fun.ReturnType.(*schema.ObjectType); ok && fun.InlineObjectAsReturnType {
 			// for object return types, assume a Result type is generated in the same class as it's function
 			// and reference it from here directly
-			return fmt.Sprintf("%sResult", className)
+			return className + "Result"
 		}
 
 		// otherwise, the object type is a reference to an output type
@@ -1528,7 +1528,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 
 func functionOutputVersionArgsTypeName(fun *schema.Function) string {
 	className := tokenToFunctionName(fun.Token)
-	return fmt.Sprintf("%sInvokeArgs", className)
+	return className + "InvokeArgs"
 }
 
 // Generates `${fn}Output(..)` version lifted to work on

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -293,7 +293,7 @@ func GenerateProject(
 			continue
 		}
 
-		packageName := fmt.Sprintf("Pulumi.%s", namespaceName(map[string]string{}, p.Name))
+		packageName := "Pulumi." + namespaceName(map[string]string{}, p.Name)
 		if langInfo, found := p.Language["csharp"]; found {
 			csharpInfo, ok := langInfo.(CSharpPackageInfo)
 			if ok {
@@ -670,7 +670,7 @@ func (g *generator) genComponentPreamble(w io.Writer, componentName string, comp
 						switch configType.ElementType.(type) {
 						case *model.ObjectType:
 							objectTypeName := configObjectTypeName(configVar.Name())
-							inputType = fmt.Sprintf("%s[]", objectTypeName)
+							inputType = objectTypeName + "[]"
 						}
 					case *model.MapType:
 						// for map(T) where T is an object type, generate Dictionary<string, T>
@@ -734,7 +734,7 @@ func (g *generator) genComponentPreamble(w io.Writer, componentName string, comp
 				g.Fprintf(w, "        %s\n\n", preambleHelperMethodBody)
 			}
 
-			token := fmt.Sprintf("components:index:%s", componentName)
+			token := "components:index:" + componentName
 			if len(configVars) == 0 {
 				// There is no args class
 				g.Fgenf(w, "%spublic %s(string name, ComponentResourceOptions? opts = null)\n",
@@ -986,7 +986,7 @@ func (g *generator) resourceArgsTypeName(r *pcl.Resource) string {
 	rootNamespace := namespaceName(namespaces, pkg)
 	namespace := namespaceName(namespaces, module)
 	if g.compatibilities[pkg] == "kubernetes20" && module != "" {
-		namespace = fmt.Sprintf("Types.Inputs.%s", namespace)
+		namespace = "Types.Inputs." + namespace
 	}
 
 	if namespace != "" {
@@ -1338,7 +1338,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 // genComponent handles the generation of instantiations of non-builtin resources.
 func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
 	componentName := r.DeclarationName()
-	qualifiedMemberName := fmt.Sprintf("Components.%s", componentName)
+	qualifiedMemberName := "Components." + componentName
 
 	name := r.LogicalName()
 	variableName := makeValidIdentifier(r.Name())
@@ -1437,7 +1437,7 @@ func computeConfigTypeParam(configName string, configType model.Type) string {
 			return typeName
 		case *model.ListType:
 			elementType := computeConfigTypeParam(configName, complexType.ElementType)
-			return fmt.Sprintf("%s[]", elementType)
+			return elementType + "[]"
 		case *model.MapType:
 			elementType := computeConfigTypeParam(configName, complexType.ElementType)
 			return fmt.Sprintf("Dictionary<string, %s>", elementType)
@@ -1517,7 +1517,7 @@ func (g *generator) genLocalVariable(w io.Writer, localVariable *pcl.LocalVariab
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
-	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
+	message := "not yet implemented: " + fmt.Sprintf(reason, vs...)
 	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
 		Severity: hcl.DiagWarning,
 		Summary:  message,

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -939,7 +939,7 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 		if _, isConfig := configVars[expr.RootName]; isConfig {
 			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
-				rootName = fmt.Sprintf("args.%s", Title(expr.RootName))
+				rootName = "args." + Title(expr.RootName)
 			}
 		}
 	}

--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -1,7 +1,6 @@
 package dotnet
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -120,7 +119,7 @@ func dotnetDependencies(deps codegen.StringSet) []dep {
 		case "random":
 			result[i] = dep{"Pulumi.Random", test.RandomSchema}
 		default:
-			result[i] = dep{fmt.Sprintf("Pulumi.%s", Title(d)), ""}
+			result[i] = dep{"Pulumi." + Title(d), ""}
 		}
 	}
 	return result

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -43,7 +43,7 @@ func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName
 	version := pulumiSDKVersion
 	if info, ok := pkg.Language["go"].(GoPackageInfo); ok {
 		if info.PulumiSDKVersion == 1 {
-			return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#%s", typeName)
+			return "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#" + typeName
 		}
 		if info.PulumiSDKVersion != 0 {
 			version = fmt.Sprintf("v%d", info.PulumiSDKVersion)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -318,7 +318,7 @@ func (pkg *pkgContext) tokenToResource(tok string) string {
 
 	// Is it a provider resource?
 	if components[0] == "pulumi" && components[1] == "providers" {
-		return fmt.Sprintf("%s.Provider", components[2])
+		return components[2] + ".Provider"
 	}
 
 	mod, name := pkg.tokenToPackage(tok), components[2]
@@ -473,13 +473,13 @@ func (pkg *pkgContext) genericInputTypeImpl(t schema.Type) string {
 		return pkg.resolveEnumType(t)
 	case *schema.ArrayType:
 		elementType := pkg.genericInputTypeImpl(t.ElementType)
-		return fmt.Sprintf("[]%s", elementType)
+		return "[]" + elementType
 	case *schema.MapType:
 		elementType := pkg.genericInputTypeImpl(t.ElementType)
-		return fmt.Sprintf("map[string]%s", elementType)
+		return "map[string]" + elementType
 	case *schema.ObjectType:
 		elementType := pkg.resolveObjectType(t)
-		return fmt.Sprintf("*%s", elementType)
+		return "*" + elementType
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying
 		// type for the input instead
@@ -979,10 +979,10 @@ func (pkg *pkgContext) genericElementType(schemaType schema.Type) (string, bool)
 			return pkg.genericElementType(schemaType.UnderlyingType)
 		case *schema.ArrayType:
 			elementType, _ := pkg.genericElementType(schemaType.ElementType)
-			return fmt.Sprintf("[]%s", elementType), false
+			return "[]" + elementType, false
 		case *schema.MapType:
 			elementType, _ := pkg.genericElementType(schemaType.ElementType)
-			return fmt.Sprintf("map[string]%s", elementType), false
+			return "map[string]" + elementType, false
 		case *schema.UnionType:
 			for _, e := range schemaType.ElementTypes {
 				if enumType, ok := e.(*schema.EnumType); ok {
@@ -1138,7 +1138,7 @@ func printCommentWithDeprecationMessage(w io.Writer, comment, deprecationMessage
 		if lines > 0 {
 			fmt.Fprintf(w, "//\n")
 		}
-		printComment(w, fmt.Sprintf("Deprecated: %s", deprecationMessage), indent)
+		printComment(w, "Deprecated: "+deprecationMessage, indent)
 	}
 }
 
@@ -2039,15 +2039,15 @@ func (pkg *pkgContext) setDefaultValue(
 	parser, typ := "nil", "string"
 	switch codegen.UnwrapType(t).(type) {
 	case *schema.ArrayType:
-		parser, typ = fmt.Sprintf("%s.ParseEnvStringArray", pkg.internalModuleName), "pulumi.StringArray"
+		parser, typ = pkg.internalModuleName+".ParseEnvStringArray", "pulumi.StringArray"
 	}
 	switch t {
 	case schema.BoolType:
-		parser, typ = fmt.Sprintf("%s.ParseEnvBool", pkg.internalModuleName), "bool"
+		parser, typ = pkg.internalModuleName+".ParseEnvBool", "bool"
 	case schema.IntType:
-		parser, typ = fmt.Sprintf("%s.ParseEnvInt", pkg.internalModuleName), "int"
+		parser, typ = pkg.internalModuleName+".ParseEnvInt", "int"
 	case schema.NumberType:
-		parser, typ = fmt.Sprintf("%s.ParseEnvFloat", pkg.internalModuleName), "float64"
+		parser, typ = pkg.internalModuleName+".ParseEnvFloat", "float64"
 	}
 
 	if val == "" {
@@ -2885,12 +2885,12 @@ func (pkg *pkgContext) functionName(f *schema.Function) string {
 
 func (pkg *pkgContext) functionArgsTypeName(f *schema.Function) string {
 	name := pkg.functionName(f)
-	return fmt.Sprintf("%sArgs", name)
+	return name + "Args"
 }
 
 func (pkg *pkgContext) functionResultTypeName(f *schema.Function) string {
 	name := pkg.functionName(f)
-	return fmt.Sprintf("%sResult", name)
+	return name + "Result"
 }
 
 func genericTypeNeedsExplicitCasting(outputType string) bool {
@@ -2905,7 +2905,7 @@ func (pkg *pkgContext) genFunctionOutputGenericVersion(w io.Writer, f *schema.Fu
 	originalName := pkg.functionName(f)
 	name := originalName + "Output"
 	originalResultTypeName := pkg.functionResultTypeName(f)
-	resultTypeName := fmt.Sprintf("%sOutput", originalResultTypeName)
+	resultTypeName := originalResultTypeName + "Output"
 
 	code := ""
 
@@ -4173,7 +4173,7 @@ func generatePackageContextMap(tool string, pkg schema.PackageReference, goInfo 
 		}
 
 		if !canGenerate {
-			panic(fmt.Sprintf("unable to generate Go SDK, schema has unresolvable overlapping resource: %s", rawResourceName(r)))
+			panic("unable to generate Go SDK, schema has unresolvable overlapping resource: " + rawResourceName(r))
 		}
 
 		names := getNames(suffix)
@@ -4253,7 +4253,7 @@ func generatePackageContextMap(tool string, pkg schema.PackageReference, goInfo 
 			}
 
 			if !canGenerate {
-				panic(fmt.Sprintf("unable to generate Go SDK, schema has unresolvable overlapping type: %s", name))
+				panic("unable to generate Go SDK, schema has unresolvable overlapping type: " + name)
 			}
 
 			names := getNames(name, suffix)
@@ -4298,7 +4298,7 @@ func generatePackageContextMap(tool string, pkg schema.PackageReference, goInfo 
 			}
 
 			if !canGenerate {
-				panic(fmt.Sprintf("unable to generate Go SDK, schema has unresolvable overlapping type: %s", name))
+				panic("unable to generate Go SDK, schema has unresolvable overlapping type: " + name)
 			}
 
 			names := getNames(name, suffix)
@@ -4585,7 +4585,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 				return nil, err
 			}
 
-			versionFilePath := fmt.Sprintf("%s/pulumiVersion.go", pkg.internalModuleName)
+			versionFilePath := pkg.internalModuleName + "/pulumiVersion.go"
 			setFile(path.Join(mod, versionFilePath), versionBuf.String())
 			if emitOnlyGenericVariant {
 				setGenericVariantFile(path.Join(mod, versionFilePath), versionBuf.String())
@@ -4811,7 +4811,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 				return nil, err
 			}
 
-			utilFilePath := fmt.Sprintf("%s/pulumiUtilities.go", pkg.internalModuleName)
+			utilFilePath := pkg.internalModuleName + "/pulumiUtilities.go"
 			setFile(path.Join(mod, utilFilePath), buffer.String())
 			if emitOnlyGenericVariant {
 				setGenericVariantFile(path.Join(mod, utilFilePath), buffer.String())

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -195,10 +195,10 @@ func componentInputType(pclType model.Type) string {
 	switch pclType := pclType.(type) {
 	case *model.ListType:
 		elementType := componentInputElementType(pclType.ElementType)
-		return fmt.Sprintf("[]%s", elementType)
+		return "[]" + elementType
 	case *model.MapType:
 		elementType := componentInputElementType(pclType.ElementType)
-		return fmt.Sprintf("map[string]%s", elementType)
+		return "map[string]" + elementType
 	default:
 		return componentInputElementType(pclType)
 	}
@@ -244,14 +244,14 @@ func (g *generator) genComponentArgs(w io.Writer, componentName string, componen
 				switch configType.ElementType.(type) {
 				case *model.ObjectType:
 					objectTypeName := configObjectTypeName(config.Name())
-					inputType = fmt.Sprintf("[]*%s", objectTypeName)
+					inputType = "[]*" + objectTypeName
 				}
 			case *model.MapType:
 				// for map(T) where T is an object type, generate Dictionary<string, T>
 				switch configType.ElementType.(type) {
 				case *model.ObjectType:
 					objectTypeName := configObjectTypeName(config.Name())
-					inputType = fmt.Sprintf("map[string]*%s", objectTypeName)
+					inputType = "map[string]*" + objectTypeName
 				}
 			}
 			g.Fgenf(w, "%s %s\n", fieldName, inputType)
@@ -293,7 +293,7 @@ func (g *generator) genComponentDefinition(w io.Writer, componentName string, co
 
 	g.Indented(func() {
 		g.Fgenf(w, "%svar componentResource %s\n", g.Indent, componentTypeName)
-		token := fmt.Sprintf("components:index:%s", componentTypeName)
+		token := "components:index:" + componentTypeName
 		g.Fgenf(w, "%serr := ctx.RegisterComponentResource(\"%s\", ", g.Indent, token)
 		g.Fgenf(w, "name, &componentResource, opts...)\n")
 		g.Fgenf(w, "%sif err != nil {\n", g.Indent)
@@ -557,7 +557,7 @@ require (
 
 		version := ""
 		if p.Version != nil {
-			version = fmt.Sprintf("v%s", p.Version.String())
+			version = "v" + p.Version.String()
 		}
 		if packageName != "" {
 			fmt.Fprintf(&gomod, "	%s %s\n", packageName, version)
@@ -1314,7 +1314,7 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			g.Fgenf(w, "%s = %.v\n", t.Name, t.Value.FalseResult)
 			g.Fgenf(w, "}\n")
 		case *spillTemp:
-			bytesVar := fmt.Sprintf("tmp%s", strings.ToUpper(t.Variable.Name))
+			bytesVar := "tmp" + strings.ToUpper(t.Variable.Name)
 			g.Fgenf(w, "%s, err := json.Marshal(", bytesVar)
 			args := t.Value.(*model.FunctionCallExpression).Args[0]
 			g.Fgenf(w, "%.v)\n", args)
@@ -1337,10 +1337,10 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 				g.Fgenf(w, "return err\n")
 			}
 			g.Fgenf(w, "}\n")
-			namesVar := fmt.Sprintf("fileNames%s", tmpSuffix)
+			namesVar := "fileNames" + tmpSuffix
 			g.Fgenf(w, "%s := make([]string, len(%s))\n", namesVar, t.Name)
-			iVar := fmt.Sprintf("key%s", tmpSuffix)
-			valVar := fmt.Sprintf("val%s", tmpSuffix)
+			iVar := "key" + tmpSuffix
+			valVar := "val" + tmpSuffix
 			g.Fgenf(w, "for %s, %s := range %s {\n", iVar, valVar, t.Name)
 			g.Fgenf(w, "%s[%s] = %s.Name()\n", namesVar, iVar, valVar)
 			g.Fgenf(w, "}\n")

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -376,7 +377,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 func outputVersionFunctionArgTypeName(t model.Type, cache *Cache) (string, error) {
 	schemaType, ok := pcl.GetSchemaForType(t)
 	if !ok {
-		return "", fmt.Errorf("No schema.Type type found for the given model.Type")
+		return "", errors.New("No schema.Type type found for the given model.Type")
 	}
 
 	objType, ok := schemaType.(*schema.ObjectType)
@@ -397,7 +398,7 @@ func outputVersionFunctionArgTypeName(t model.Type, cache *Cache) (string, error
 		ty = pkg.tokenToType(objType.Token)
 	}
 
-	return fmt.Sprintf("%sOutputArgs", strings.TrimSuffix(ty, "Args")), nil
+	return strings.TrimSuffix(ty, "Args") + "OutputArgs", nil
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
@@ -859,7 +860,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 				elmType = valType
 			}
 			if allSameType && elmType != "" {
-				return fmt.Sprintf("%sMap", elmType)
+				return elmType + "Map"
 			}
 			return "pulumi.Map"
 		}
@@ -872,16 +873,16 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 			}
 			return fmt.Sprintf("pulumi.%sMap", Title(valType))
 		}
-		return fmt.Sprintf("map[string]%s", valType)
+		return "map[string]" + valType
 	case *model.ListType:
 		argTypeName := g.argumentTypeName(nil, destType.ElementType, isInput)
 		if strings.HasPrefix(argTypeName, "pulumi.") && argTypeName != "pulumi.Resource" {
 			if argTypeName == "pulumi.Any" {
 				return "pulumi.Array"
 			}
-			return fmt.Sprintf("%sArray", argTypeName)
+			return argTypeName + "Array"
 		}
-		return fmt.Sprintf("[]%s", argTypeName)
+		return "[]" + argTypeName
 	case *model.TupleType:
 		// attempt to collapse tuple types. intentionally does not use model.UnifyTypes
 		// correct go code requires all types to match, or use of interface{}
@@ -907,9 +908,9 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 				if argTypeName == "pulumi.Any" {
 					return "pulumi.Array"
 				}
-				return fmt.Sprintf("%sArray", argTypeName)
+				return argTypeName + "Array"
 			}
-			return fmt.Sprintf("[]%s", argTypeName)
+			return "[]" + argTypeName
 		}
 
 		if isInput {
@@ -1042,7 +1043,7 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type) (
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
-	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
+	message := "not yet implemented: " + fmt.Sprintf(reason, vs...)
 	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
 		Severity: hcl.DiagWarning,
 		Summary:  message,

--- a/pkg/codegen/go/gen_program_inline_invoke.go
+++ b/pkg/codegen/go/gen_program_inline_invoke.go
@@ -45,7 +45,7 @@ func (spiller *inlineInvokeSpiller) spillExpression(
 			_, _, fn, _ := g.functionName(expr.Args[0])
 			tempName := fmt.Sprintf("invoke%s%d", fn, spiller.count)
 			if spiller.count == 0 {
-				tempName = fmt.Sprintf("invoke%s", fn)
+				tempName = "invoke" + fn
 			}
 			temp := &inlineInvokeTemp{
 				Name:  tempName,

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -143,7 +143,7 @@ func typeCheckGeneratedPackage(t *testing.T, codeDir string) {
 		t.Logf("Found an existing go.mod, leaving as is")
 	} else {
 		test.RunCommand(t, "go_mod_init", codeDir, goExe, "mod", "init", inferModuleName(codeDir))
-		replacement := fmt.Sprintf("github.com/pulumi/pulumi/sdk/v3=%s", sdk)
+		replacement := "github.com/pulumi/pulumi/sdk/v3=" + sdk
 		test.RunCommand(t, "go_mod_edit", codeDir, goExe, "mod", "edit", "-replace", replacement)
 	}
 
@@ -155,7 +155,7 @@ func testGeneratedPackage(t *testing.T, codeDir string) {
 	goExe, err := executable.FindExecutable("go")
 	require.NoError(t, err)
 
-	test.RunCommand(t, "go-test", codeDir, goExe, "test", fmt.Sprintf("%s/...", inferModuleName(codeDir)))
+	test.RunCommand(t, "go-test", codeDir, goExe, "test", inferModuleName(codeDir)+"/...")
 }
 
 func TestGenerateTypeNames(t *testing.T) {

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -114,7 +114,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 
 	// Add the type to the name to disambiguate constants used for enum values
 	if strings.Contains(safeName, "_") && !strings.HasPrefix(safeName, "_") {
-		safeName = fmt.Sprintf("_%s", safeName)
+		safeName = "_" + safeName
 	}
 
 	safeName = typeName + safeName

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1295,7 +1295,7 @@ func literalText(value cty.Value, rawBytes []byte, escaped, quoted bool) string 
 		bf := value.AsBigFloat()
 		i, acc := bf.Int64()
 		if acc == big.Exact {
-			return fmt.Sprintf("%v", i)
+			return strconv.FormatInt(i, 10)
 		}
 		d, _ := bf.Float64()
 		return fmt.Sprintf("%g", d)

--- a/pkg/codegen/hcl2/model/pretty/display.go
+++ b/pkg/codegen/hcl2/model/pretty/display.go
@@ -388,7 +388,7 @@ func (o *Object) String() string {
 
 func (o *Object) hash(seen map[Formatter]bool) string {
 	if seen[o] {
-		return fmt.Sprintf("%d", len(seen))
+		return strconv.Itoa(len(seen))
 	}
 	defer func() { seen[o] = false }()
 	seen[o] = true
@@ -522,7 +522,7 @@ func (l *List) String() string {
 
 func (l *List) hash(seen map[Formatter]bool) string {
 	if seen[l] {
-		return fmt.Sprintf("%d", len(seen))
+		return strconv.Itoa(len(seen))
 	}
 	defer func() { seen[l] = false }()
 	seen[l] = true

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
@@ -50,7 +49,7 @@ func (t *ConstType) pretty(seenFormatters map[Type]pretty.Formatter) pretty.Form
 	case cty.String:
 		return pretty.FromString(strconv.Quote(t.Value.AsString()))
 	case cty.Bool:
-		return pretty.FromString(fmt.Sprintf("%v", t.Value.True()))
+		return pretty.FromString(strconv.FormatBool(t.Value.True()))
 	case cty.Number:
 		return pretty.FromStringer(t.Value.AsBigFloat())
 	}

--- a/pkg/codegen/hcl2/syntax/tokens.go
+++ b/pkg/codegen/hcl2/syntax/tokens.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"strconv"
 	"unicode"
 	"unicode/utf8"
 
@@ -860,7 +861,7 @@ func rawLiteralValueToken(value cty.Value) hclsyntax.Token {
 		bf := value.AsBigFloat()
 		i, acc := bf.Int64()
 		if acc == big.Exact {
-			rawText = fmt.Sprintf("%v", i)
+			rawText = strconv.FormatInt(i, 10)
 		} else {
 			d, _ := bf.Float64()
 			rawText = fmt.Sprintf("%g", d)

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -34,7 +34,7 @@ var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 // GetDocLinkForPulumiType returns the NodeJS API doc link for a Pulumi type.
 func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
 	typeName = strings.ReplaceAll(typeName, "?", "")
-	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/pulumi/#%s", typeName)
+	return "/docs/reference/pkg/nodejs/pulumi/pulumi/#" + typeName
 }
 
 // GetDocLinkForResourceType returns the NodeJS API doc for a type belonging to a resource provider.
@@ -151,7 +151,7 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	var displayName string
 	var link string
 	if modName == "" {
-		displayName = fmt.Sprintf("@pulumi/%s", pkg.Name)
+		displayName = "@pulumi/" + pkg.Name
 	} else {
 		displayName = fmt.Sprintf("@pulumi/%s/%s", pkg.Name, strings.ToLower(modName))
 	}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -127,7 +127,7 @@ func pascal(s string) string {
 // externalModuleName Formats the name of package to comply with an external
 // module.
 func externalModuleName(s string) string {
-	return fmt.Sprintf("pulumi%s", pascal(s))
+	return "pulumi" + pascal(s)
 }
 
 type modContext struct {
@@ -248,7 +248,7 @@ func (mod *modContext) resourceType(r *schema.ResourceType) string {
 			pkgName = externalModuleName(pkgName)
 		}
 
-		return fmt.Sprintf("%s.Provider", pkgName)
+		return pkgName + ".Provider"
 	}
 
 	pkg := mod.pkg
@@ -669,7 +669,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	fmt.Fprintf(w, "            return false;\n")
 	fmt.Fprintf(w, "        }\n")
 
-	typeExpression := fmt.Sprintf("%s.__pulumiType", name)
+	typeExpression := name + ".__pulumiType"
 	if r.IsProvider {
 		// We pass __pulumiType to the ProviderResource constructor as the "type" for this provider, the
 		// ProviderResource constructor in the SDK then prefixes "pulumi:providers:" to that token and passes that
@@ -767,7 +767,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 				return arg
 			}
 
-			argValue := applyDefaults(fmt.Sprintf("args.%s", prop.Name))
+			argValue := applyDefaults("args." + prop.Name)
 			if prop.Secret {
 				arg = fmt.Sprintf("args?.%[1]s ? pulumi.secret(%[2]s) : undefined", prop.Name, argValue)
 			} else {
@@ -1223,7 +1223,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) (functionF
 	if fun.Inputs != nil {
 		for _, p := range fun.Inputs.Properties {
 			// Pass the argument to the invocation.
-			body := fmt.Sprintf("args.%s", p.Name)
+			body := "args." + p.Name
 			if fun.MultiArgumentInputs {
 				body = p.Name
 			}
@@ -1292,10 +1292,10 @@ func (mod *modContext) genFunctionOutputVersion(
 	}
 
 	originalName := tokenToFunctionName(fun.Token)
-	fnOutput := fmt.Sprintf("%sOutput", originalName)
+	fnOutput := originalName + "Output"
 	returnType := mod.functionReturnType(fun)
 	info.functionOutputVersionName = fnOutput
-	argTypeName := fmt.Sprintf("%sArgs", title(fnOutput))
+	argTypeName := title(fnOutput) + "Args"
 
 	argsig := ""
 	if fun.Inputs != nil && len(fun.Inputs.Properties) > 0 {
@@ -2153,7 +2153,7 @@ func (mod *modContext) genIndex(exports []fileInfo) string {
 			if path.Base(rel) == "." {
 				rel = path.Dir(rel)
 			}
-			importPath := fmt.Sprintf(`./%s`, strings.TrimSuffix(rel, ".ts"))
+			importPath := "./" + strings.TrimSuffix(rel, ".ts")
 			ll.genReexport(w, exp, importPath)
 		}
 	}
@@ -2177,7 +2177,7 @@ func (mod *modContext) genIndex(exports []fileInfo) string {
 			if mod.mod == "" {
 				filePath = ""
 			} else {
-				filePath = fmt.Sprintf("/%s", mod.mod)
+				filePath = "/" + mod.mod
 			}
 			fmt.Fprintf(w, "export * from \"%s/types/enums%s\";\n", rel, filePath)
 		}
@@ -2375,7 +2375,7 @@ type npmPackage struct {
 func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 	packageName := info.PackageName
 	if packageName == "" {
-		packageName = fmt.Sprintf("@pulumi/%s", pkg.Name)
+		packageName = "@pulumi/" + pkg.Name
 	}
 
 	devDependencies := map[string]string{}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -459,7 +459,7 @@ func componentElementType(pclType model.Type) string {
 		switch pclType := pclType.(type) {
 		case *model.ListType:
 			elementType := componentElementType(pclType.ElementType)
-			return fmt.Sprintf("%s[]", elementType)
+			return elementType + "[]"
 		case *model.MapType:
 			elementType := componentElementType(pclType.ElementType)
 			return fmt.Sprintf("Record<string, pulumi.Input<%s>>", elementType)
@@ -616,7 +616,7 @@ func (g *generator) genComponentResourceDefinition(w io.Writer, componentName st
 			g.Fgenf(w, "public %s: %s;\n", output.Name(), outputType)
 		}
 
-		token := fmt.Sprintf("components:index:%s", componentName)
+		token := "components:index:" + componentName
 
 		if len(configVars) == 0 {
 			g.Fgenf(w, "%s", g.Indent)
@@ -1252,7 +1252,7 @@ func (g *generator) genOutputVariable(w io.Writer, v *pcl.OutputVariable) {
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
-	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
+	message := "not yet implemented: " + fmt.Sprintf(reason, vs...)
 	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  message,

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -2,6 +2,7 @@ package nodejs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -303,7 +304,7 @@ func (g *generator) getFunctionImports(x *model.FunctionCallExpression) []string
 func enumName(enum *model.EnumType) (string, error) {
 	e, ok := pcl.GetSchemaForType(enum)
 	if !ok {
-		return "", fmt.Errorf("Could not get associated enum")
+		return "", errors.New("Could not get associated enum")
 	}
 	pkgRef := e.(*schema.EnumType).PackageReference
 	return enumNameWithPackage(enum.Token, pkgRef)
@@ -424,7 +425,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		isOut := pcl.IsOutputVersionInvokeCall(expr)
 		name := fmt.Sprintf("%s%s.%s", makeValidIdentifier(pkg), module, fn)
 		if isOut {
-			name = fmt.Sprintf("%sOutput", name)
+			name = name + "Output"
 		}
 		g.Fprintf(w, "%s(", name)
 		if len(expr.Args) >= 2 {
@@ -679,7 +680,7 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 		if _, isConfig := configVars[expr.RootName]; isConfig {
 			if _, configReference := expr.Parts[0].(*pcl.ConfigVariable); configReference {
-				rootName = fmt.Sprintf("args.%s", expr.RootName)
+				rootName = "args." + expr.RootName
 			}
 		}
 	}

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -2,7 +2,6 @@ package nodejs
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,7 +84,7 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
 func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
 	result := make(map[string]string, len(deps))
 	for _, d := range deps.SortedValues() {
-		pkgName := fmt.Sprintf("@pulumi/%s", d)
+		pkgName := "@pulumi/" + d
 		set := func(pkgVersion string) {
 			result[pkgName] = "^" + pkgVersion
 		}

--- a/pkg/codegen/nodejs/tstypes/tstypes_test.go
+++ b/pkg/codegen/nodejs/tstypes/tstypes_test.go
@@ -15,6 +15,7 @@
 package tstypes
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -94,7 +95,7 @@ func (p *typeScriptTypeParser) parse(tokens []typeToken) (TypeAst, error) {
 		return nil, err
 	}
 	if len(rest) > 0 {
-		return nil, fmt.Errorf("Unexpected trailing tokens")
+		return nil, errors.New("Unexpected trailing tokens")
 	}
 	return e, nil
 }
@@ -105,7 +106,7 @@ func (p *typeScriptTypeParser) parseType(tokens []typeToken) (TypeAst, []typeTok
 
 func (p *typeScriptTypeParser) parseType1(tokens []typeToken) (TypeAst, []typeToken, error) {
 	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf("Expect more tokens")
+		return nil, nil, errors.New("Expect more tokens")
 	}
 
 	switch tokens[0].kind {
@@ -115,7 +116,7 @@ func (p *typeScriptTypeParser) parseType1(tokens []typeToken) (TypeAst, []typeTo
 			return nil, nil, err
 		}
 		if len(rest) == 0 || rest[0].kind != closeParen {
-			return nil, nil, fmt.Errorf("Expect `)`")
+			return nil, nil, errors.New("Expect `)`")
 		}
 		return t, rest[1:], nil
 	case openMap:
@@ -124,7 +125,7 @@ func (p *typeScriptTypeParser) parseType1(tokens []typeToken) (TypeAst, []typeTo
 			return nil, nil, err
 		}
 		if len(rest) == 0 {
-			return nil, nil, fmt.Errorf("Expect `}`, but got nothing")
+			return nil, nil, errors.New("Expect `}`, but got nothing")
 		}
 		if rest[0].kind != closeMap {
 			return nil, nil, fmt.Errorf("Expect `}`, but got %s", toLiteral(rest))

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -55,7 +55,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modNam
 		path = modName
 		fqdnTypeName = fmt.Sprintf("%s.%s", modName, typeName)
 	case pkg.Name != "" && modName == "":
-		path = fmt.Sprintf("pulumi_%s", pkg.Name)
+		path = "pulumi_" + pkg.Name
 		fqdnTypeName = fmt.Sprintf("pulumi_%s.%s", pkg.Name, typeName)
 	}
 
@@ -154,6 +154,6 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	} else {
 		displayName = fmt.Sprintf("%s/%s", pyPack(pkg.Name), strings.ToLower(modName))
 	}
-	link = fmt.Sprintf("/docs/reference/pkg/python/%s", displayName)
+	link = "/docs/reference/pkg/python/" + displayName
 	return displayName, link
 }

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -790,7 +790,7 @@ func (mod *modContext) genUtilitiesImport() string {
 
 func (mod *modContext) importObjectType(t *schema.ObjectType, input bool) string {
 	if !codegen.PkgEquals(t.PackageReference, mod.pkg) {
-		return fmt.Sprintf("import %s", pyPack(t.PackageReference.Name()))
+		return "import " + pyPack(t.PackageReference.Name())
 	}
 
 	tok := t.Token
@@ -821,7 +821,7 @@ func (mod *modContext) importObjectType(t *schema.ObjectType, input bool) string
 
 func (mod *modContext) importEnumType(e *schema.EnumType) string {
 	if !codegen.PkgEquals(e.PackageReference, mod.pkg) {
-		return fmt.Sprintf("import %s", pyPack(e.PackageReference.Name()))
+		return "import " + pyPack(e.PackageReference.Name())
 	}
 
 	modName := mod.tokenToModule(e.Token)
@@ -841,7 +841,7 @@ func (mod *modContext) importEnumType(e *schema.EnumType) string {
 
 func (mod *modContext) importResourceType(r *schema.ResourceType) string {
 	if r.Resource != nil && !codegen.PkgEquals(r.Resource.PackageReference, mod.pkg) {
-		return fmt.Sprintf("import %s", pyPack(r.Resource.PackageReference.Name()))
+		return "import " + pyPack(r.Resource.PackageReference.Name())
 	}
 
 	tok := r.Token
@@ -850,7 +850,7 @@ func (mod *modContext) importResourceType(r *schema.ResourceType) string {
 
 	// If it's a provider resource, import the top-level package.
 	if parts[0] == "pulumi" && parts[1] == "providers" {
-		return fmt.Sprintf("import pulumi_%s", parts[2])
+		return "import pulumi_" + parts[2]
 	}
 
 	modName := mod.tokenToResource(tok)
@@ -1180,7 +1180,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 
 	name := resourceName(res)
 
-	resourceArgsName := fmt.Sprintf("%sArgs", name)
+	resourceArgsName := name + "Args"
 	// Some providers (e.g. Kubernetes) have types with the same name as resources (e.g. StorageClass in Kubernetes).
 	// We've already shipped the input type (e.g. StorageClassArgs) in the same module as the resource, so we can't use
 	// the same name for the resource's args class. When an input type exists that would conflict with the name of the
@@ -1703,7 +1703,7 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 		if retTypeNameQualified != "" {
 			// Pass along the private output_type we generated, so any nested output classes are instantiated by
 			// the call.
-			typ = fmt.Sprintf(", typ=%s", retTypeNameQualified)
+			typ = ", typ=" + retTypeNameQualified
 		}
 
 		if fun.ReturnTypePlain {
@@ -1814,7 +1814,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	if returnType != nil {
 		// Pass along the private output_type we generated, so any nested outputs classes are instantiated by
 		// the call to invoke.
-		typ = fmt.Sprintf(", typ=%s", baseName)
+		typ = ", typ=" + baseName
 	}
 	fmt.Fprintf(w, "    __ret__ = pulumi.runtime.invoke('%s', __args__, opts=opts%s).value\n", fun.Token, typ)
 	fmt.Fprintf(w, "\n")
@@ -1932,7 +1932,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 	}
 
 	originalName := PyName(tokenToName(fun.Token))
-	outputSuffixedName := fmt.Sprintf("%s_output", originalName)
+	outputSuffixedName := originalName + "_output"
 
 	var args []*schema.Property
 	if fun.Inputs != nil {
@@ -2698,7 +2698,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 	// determine whether to use the default Python package name
 	pyPkgName := info.PackageName
 	if pyPkgName == "" {
-		pyPkgName = fmt.Sprintf("pulumi_%s", strings.ReplaceAll(pkg.Name, "-", "_"))
+		pyPkgName = "pulumi_" + strings.ReplaceAll(pkg.Name, "-", "_")
 	}
 
 	// group resources, types, and functions into modules

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -214,13 +214,13 @@ func (g *generator) genComponentDefinition(w io.Writer, component *pcl.Component
 		g.Fgen(w, "\n")
 	}
 
-	componentToken := fmt.Sprintf("components:index:%s", componentName)
+	componentToken := "components:index:" + componentName
 	g.Fgenf(w, "class %s(pulumi.ComponentResource):\n", componentName)
 	g.Indented(func() {
 		if hasAnyInputVariables {
 			g.Fgenf(w, "%sdef __init__(self, name: str, args: %s, opts:Optional[pulumi.ResourceOptions] = None):\n",
 				g.Indent,
-				fmt.Sprintf("%sArgs", componentName))
+				componentName+"Args")
 
 			g.Fgenf(w, "%s%ssuper().__init__(\"%s\", name, args, opts)\n",
 				g.Indent,
@@ -519,7 +519,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 		if control.ImportAs {
 			imports = append(imports, fmt.Sprintf("import %s as %s", pkg, EnsureKeywordSafe(control.Pkg)))
 		} else {
-			imports = append(imports, fmt.Sprintf("import %s", pkg))
+			imports = append(imports, "import "+pkg)
 		}
 	}
 
@@ -792,7 +792,7 @@ func (g *generator) genResourceDeclaration(w io.Writer, r *pcl.Resource, needsDe
 			} else {
 				g.Fgenf(w, "%s%s = []\n", g.Indent, nameVar)
 			}
-			localFuncName := fmt.Sprintf("create_%s", PyName(r.LogicalName()))
+			localFuncName := "create_" + PyName(r.LogicalName())
 
 			// Generate a local definition which actually creates the resources
 			g.Fgenf(w, "def %s(range_body):\n", localFuncName)
@@ -1092,7 +1092,7 @@ func (g *generator) genOutputVariable(w io.Writer, v *pcl.OutputVariable) {
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {
-	message := fmt.Sprintf("not yet implemented: %s", fmt.Sprintf(reason, vs...))
+	message := "not yet implemented: " + fmt.Sprintf(reason, vs...)
 	g.diagnostics = append(g.diagnostics, &hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  message,

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -316,7 +316,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		isOut := pcl.IsOutputVersionInvokeCall(expr)
 		if isOut {
-			name = fmt.Sprintf("%s_output", name)
+			name = name + "_output"
 		}
 
 		if len(expr.Args) == 1 {

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -17,6 +17,7 @@ package python
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -164,7 +165,7 @@ func buildVirtualEnv(ctx context.Context) error {
 	}
 
 	if !gotSdk {
-		return fmt.Errorf("This test requires Python SDK to be built; please `cd sdk/python && make ensure build install`")
+		return errors.New("This test requires Python SDK to be built; please `cd sdk/python && make ensure build install`")
 	}
 
 	// install Pulumi Python SDK from the current source tree, -e means no-copy, ref directly

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -17,7 +17,6 @@ package schema
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/url"
 	"os"
@@ -50,7 +49,7 @@ func readSchemaFile(file string) (pkgSpec PackageSpec) {
 			panic(err)
 		}
 	} else {
-		panic(fmt.Sprintf("unknown schema file extension while parsing %s", file))
+		panic("unknown schema file extension while parsing " + file)
 	}
 
 	return pkgSpec

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -213,7 +213,7 @@ func RewriteFilesWhenPulumiAccept(t *testing.T, dir, lang string, actual map[str
 // folder if present.
 func CopyExtraFiles(t *testing.T, dir, lang string) {
 	codeDir := filepath.Join(dir, lang)
-	extrasDir := filepath.Join(dir, fmt.Sprintf("%s-extras", lang))
+	extrasDir := filepath.Join(dir, lang+"-extras")
 	gotExtras, err := PathExists(extrasDir)
 
 	if !gotExtras {

--- a/pkg/codegen/testing/test/program_driver_test.go
+++ b/pkg/codegen/testing/test/program_driver_test.go
@@ -1,9 +1,9 @@
 package test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -14,7 +14,7 @@ func TestBatches(t *testing.T) {
 	t.Parallel()
 	for _, n := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} {
 		n := n
-		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+		t.Run(strconv.Itoa(n), func(t *testing.T) {
 			t.Parallel()
 
 			var combined []ProgramTest

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,8 +51,8 @@ func (tt *SDKTest) ShouldSkipTest(language, test string) bool {
 	// Obey SkipCompileCheck to skip compile and test targets.
 	if tt.SkipCompileCheck != nil &&
 		tt.SkipCompileCheck.Has(language) &&
-		(test == fmt.Sprintf("%s/compile", language) ||
-			test == fmt.Sprintf("%s/test", language)) {
+		(test == language+"/compile" ||
+			test == language+"/test") {
 		return true
 	}
 

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -383,7 +383,7 @@ func checkTargets(targetUrns deploy.UrnTargets, snap *deploy.Snapshot) error {
 		return nil
 	}
 	if snap == nil {
-		return fmt.Errorf("targets specified, but snapshot was nil")
+		return errors.New("targets specified, but snapshot was nil")
 	}
 	urns := map[resource.URN]struct{}{}
 	for _, res := range snap.Resources {

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -2,7 +2,6 @@ package lifecycletest
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/blang/semver"
@@ -938,7 +937,7 @@ func TestImportIntoParent(t *testing.T) {
 				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
 					preview bool,
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
-					return "", news, resource.StatusUnknown, fmt.Errorf("not implemented")
+					return "", news, resource.StatusUnknown, errors.New("not implemented")
 				},
 				ReadF: func(urn resource.URN, id resource.ID,
 					inputs, state resource.PropertyMap,
@@ -997,7 +996,7 @@ func TestImportComponent(t *testing.T) {
 				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
 					preview bool,
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
-					return "", nil, resource.StatusUnknown, fmt.Errorf("not implemented")
+					return "", nil, resource.StatusUnknown, errors.New("not implemented")
 				},
 				ReadF: func(urn resource.URN, id resource.ID,
 					inputs, state resource.PropertyMap,
@@ -1071,7 +1070,7 @@ func TestImportRemoteComponent(t *testing.T) {
 				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
 					preview bool,
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
-					return "", nil, resource.StatusUnknown, fmt.Errorf("not implemented")
+					return "", nil, resource.StatusUnknown, errors.New("not implemented")
 				},
 				ReadF: func(urn resource.URN, id resource.ID,
 					inputs, state resource.PropertyMap,

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -103,7 +104,7 @@ func ExpectDiagMessage(t *testing.T, messagePattern string) ValidateFunc {
 				return fmt.Errorf("Unexpected diag message: %s", payload.Message)
 			}
 		}
-		return fmt.Errorf("Expected a diagnostic message, got none")
+		return errors.New("Expected a diagnostic message, got none")
 	}
 	return validate
 }
@@ -365,11 +366,11 @@ type brokenDecrypter struct {
 }
 
 func (b brokenDecrypter) DecryptValue(_ context.Context, _ string) (string, error) {
-	return "", fmt.Errorf(b.ErrorMessage)
+	return "", errors.New(b.ErrorMessage)
 }
 
 func (b brokenDecrypter) BulkDecrypt(_ context.Context, _ []string) (map[string]string, error) {
-	return nil, fmt.Errorf(b.ErrorMessage)
+	return nil, errors.New(b.ErrorMessage)
 }
 
 // Tests that the engine presents a reasonable error message when a decrypter fails to decrypt a config value.
@@ -872,7 +873,7 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 				return fmt.Errorf("Unexpected warning diag message: %s", payload.Message)
 			}
 		}
-		return fmt.Errorf("Expected a diagnostic message, got none")
+		return errors.New("Expected a diagnostic message, got none")
 	}
 
 	new, _ := op.Run(project, target, options, false, nil, validate)
@@ -3721,7 +3722,7 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 				}
 			}
 		}
-		return fmt.Errorf("Expected a diagnostic message, got none")
+		return errors.New("Expected a diagnostic message, got none")
 	}
 	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate)
 	assert.NoError(t, err)
@@ -3825,10 +3826,10 @@ func TestPendingDeleteOrder(t *testing.T) {
 					preview bool,
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
 					if strings.Contains(string(urn), "typB") && failCreationOfTypB {
-						return "", nil, resource.StatusOK, fmt.Errorf("Could not create typB")
+						return "", nil, resource.StatusOK, errors.New("Could not create typB")
 					}
 
-					id := resource.ID(fmt.Sprintf("%d", len(cloudState)))
+					id := resource.ID(strconv.Itoa(len(cloudState)))
 					if !preview {
 						cloudState[id] = news
 					}
@@ -3972,7 +3973,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
 					id := resource.ID("")
 					if !preview {
-						id = resource.ID(fmt.Sprintf("%d", cloudID))
+						id = resource.ID(strconv.Itoa(cloudID))
 						cloudID = cloudID + 1
 						cloudState[id] = news
 					}
@@ -3991,7 +3992,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 					}
 
 					if strings.Contains(string(urn), "typB") && failDeletionOfTypB {
-						return resource.StatusOK, fmt.Errorf("Could not delete typB")
+						return resource.StatusOK, errors.New("Could not delete typB")
 					}
 
 					delete(cloudState, id)

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -15,6 +15,7 @@
 package importer
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -602,7 +603,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 
 	switch {
 	case value.IsArchive():
-		return nil, fmt.Errorf("NYI: archives")
+		return nil, errors.New("NYI: archives")
 	case value.IsArray():
 		elementType := schema.AnyType
 		if typ, ok := typ.(*schema.ArrayType); ok {
@@ -623,13 +624,13 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 			Expressions: exprs,
 		}, nil
 	case value.IsAsset():
-		return nil, fmt.Errorf("NYI: assets")
+		return nil, errors.New("NYI: assets")
 	case value.IsBool():
 		return &model.LiteralValueExpression{
 			Value: cty.BoolVal(value.BoolValue()),
 		}, nil
 	case value.IsComputed() || value.IsOutput():
-		return nil, fmt.Errorf("cannot define computed values")
+		return nil, errors.New("cannot define computed values")
 	case value.IsNull():
 		return model.VariableReference(Null), nil
 	case value.IsNumber():

--- a/pkg/resource/analyzer/config.go
+++ b/pkg/resource/analyzer/config.go
@@ -218,7 +218,7 @@ func ValidatePolicyPackConfig(schemaMap map[string]apitype.PolicyConfigSchema,
 			for i, e := range result.Errors() {
 				resultErrs[i] = e.Description()
 			}
-			msg := fmt.Sprintf("policy pack configuration is invalid: %s", strings.Join(resultErrs, ", "))
+			msg := "policy pack configuration is invalid: " + strings.Join(resultErrs, ", ")
 			return errors.New(msg)
 		}
 	}

--- a/pkg/resource/analyzer/config_test.go
+++ b/pkg/resource/analyzer/config_test.go
@@ -205,7 +205,7 @@ func TestParsePolicyPackConfigFail(t *testing.T) {
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
 	for _, test := range tests {
 		test := test
-		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+		t.Run(test, func(t *testing.T) {
 			t.Parallel()
 
 			result, err := parsePolicyPackConfig([]byte(test))

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -230,13 +230,13 @@ func (p *builtinProvider) StreamInvoke(
 	tok tokens.ModuleMember, args resource.PropertyMap,
 	onNext func(resource.PropertyMap) error,
 ) ([]plugin.CheckFailure, error) {
-	return nil, fmt.Errorf("the builtin provider does not implement streaming invokes")
+	return nil, errors.New("the builtin provider does not implement streaming invokes")
 }
 
 func (p *builtinProvider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
 	options plugin.CallOptions,
 ) (plugin.CallResult, error) {
-	return plugin.CallResult{}, fmt.Errorf("the builtin provider does not implement call")
+	return plugin.CallResult{}, errors.New("the builtin provider does not implement call")
 }
 
 func (p *builtinProvider) GetPluginInfo() (workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -17,7 +17,6 @@ package deploytest
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/blang/semver"
@@ -116,23 +115,23 @@ func (p *languageRuntime) GetProgramDependencies(
 }
 
 func (p *languageRuntime) RunPlugin(info plugin.RunPluginInfo) (io.Reader, io.Reader, context.CancelFunc, error) {
-	return nil, nil, nil, fmt.Errorf("inline plugins are not currently supported")
+	return nil, nil, nil, errors.New("inline plugins are not currently supported")
 }
 
 func (p *languageRuntime) GenerateProject(string, string, string,
 	bool, string, map[string]string,
 ) (hcl.Diagnostics, error) {
-	return nil, fmt.Errorf("GenerateProject is not supported")
+	return nil, errors.New("GenerateProject is not supported")
 }
 
 func (p *languageRuntime) GeneratePackage(string, string, map[string][]byte, string) (hcl.Diagnostics, error) {
-	return nil, fmt.Errorf("GeneratePackage is not supported")
+	return nil, errors.New("GeneratePackage is not supported")
 }
 
 func (p *languageRuntime) GenerateProgram(map[string]string, string) (map[string][]byte, hcl.Diagnostics, error) {
-	return nil, nil, fmt.Errorf("GenerateProgram is not supported")
+	return nil, nil, errors.New("GenerateProgram is not supported")
 }
 
 func (p *languageRuntime) Pack(string, semver.Version, string) (string, error) {
-	return "", fmt.Errorf("Pack is not supported")
+	return "", errors.New("Pack is not supported")
 }

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -492,7 +492,7 @@ func (host *pluginHost) ResolvePlugin(
 
 	match := workspace.SelectCompatiblePlugin(plugins, kind, name, semverRange)
 	if match == nil {
-		return nil, fmt.Errorf("could not locate a compatible plugin in deploytest, the makefile and " +
+		return nil, errors.New("could not locate a compatible plugin in deploytest, the makefile and " +
 			"& constructor of the plugin host must define the location of the schema")
 	}
 	return match, nil

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -16,7 +16,7 @@ package deploytest
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
@@ -221,7 +221,7 @@ func (prov *Provider) StreamInvoke(
 	tok tokens.ModuleMember, args resource.PropertyMap,
 	onNext func(resource.PropertyMap) error,
 ) ([]plugin.CheckFailure, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (prov *Provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -17,6 +17,7 @@ package deploy
 import (
 	"context"
 	cryptorand "crypto/rand"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -215,7 +216,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		}
 
 		if imp.Type.Package() == "" {
-			return nil, false, fmt.Errorf("incorrect package type specified")
+			return nil, false, errors.New("incorrect package type specified")
 		}
 		req := providers.NewProviderRequest(imp.Version, imp.Type.Package(), imp.PluginDownloadURL, imp.PluginChecksums)
 		typ, name := providers.MakeProviderType(req.Package()), req.Name()
@@ -244,7 +245,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 	})
 	for idx, req := range defaultProviderRequests {
 		if req.Package() == "" {
-			return nil, false, fmt.Errorf("incorrect package type specified")
+			return nil, false, errors.New("incorrect package type specified")
 		}
 
 		typ, name := providers.MakeProviderType(req.Package()), req.Name()

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -1,8 +1,10 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -522,7 +524,7 @@ func (rp *ResourcePlan) checkGoal(
 
 	if rp.Goal == nil {
 		// If the plan goal is nil it expected a delete
-		return fmt.Errorf("resource unexpectedly not deleted")
+		return errors.New("resource unexpectedly not deleted")
 	}
 
 	// Check that either both resources are custom resources or both are component resources.
@@ -573,7 +575,7 @@ func (rp *ResourcePlan) checkGoal(
 	default:
 		expected := "no value"
 		if rp.Goal.DeleteBeforeReplace != nil {
-			expected = fmt.Sprintf("%v", *rp.Goal.DeleteBeforeReplace)
+			expected = strconv.FormatBool(*rp.Goal.DeleteBeforeReplace)
 		}
 		return fmt.Errorf("deleteBeforeReplace changed (expected %v)", expected)
 	}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -590,7 +590,7 @@ func (r *Registry) StreamInvoke(
 	tok tokens.ModuleMember, args resource.PropertyMap,
 	onNext func(resource.PropertyMap) error,
 ) ([]plugin.CheckFailure, error) {
-	return nil, fmt.Errorf("the provider registry does not implement streaming invokes")
+	return nil, errors.New("the provider registry does not implement streaming invokes")
 }
 
 func (r *Registry) Call(tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -15,6 +15,7 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -129,7 +130,7 @@ func (snap *Snapshot) VerifyIntegrity() error {
 	if snap != nil {
 		// Ensure the magic cookie checks out.
 		if snap.Manifest.Magic != snap.Manifest.NewMagic() {
-			return fmt.Errorf("magic cookie mismatch; possible tampering/corruption detected")
+			return errors.New("magic cookie mismatch; possible tampering/corruption detected")
 		}
 
 		// Now check the resources.  For now, we just verify that parents come before children, and that there aren't

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -17,6 +17,7 @@ package deploy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -453,7 +454,7 @@ func (d *defaultProviders) shouldDenyRequest(req providers.ProviderRequest) (boo
 	if value, ok := pConfig["disable-default-providers"]; ok {
 		array := []interface{}{}
 		if !value.IsString() {
-			return true, fmt.Errorf("Unexpected encoding of pulumi:disable-default-providers")
+			return true, errors.New("Unexpected encoding of pulumi:disable-default-providers")
 		}
 		if value.StringValue() == "" {
 			// If the list is provided but empty, we don't encode a empty json
@@ -1104,7 +1105,7 @@ func (s *sourcePositions) parseSourcePosition(raw *pulumirpc.SourcePosition) (st
 
 	file := filepath.FromSlash(posURL.Path)
 	if !filepath.IsAbs(file) {
-		return "", fmt.Errorf("source positions must include absolute paths")
+		return "", errors.New("source positions must include absolute paths")
 	}
 	rel, err := filepath.Rel(s.projectRoot, file)
 	if err != nil {

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -16,6 +16,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -517,14 +518,14 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 func (rm *queryResmon) ReadResource(ctx context.Context,
 	req *pulumirpc.ReadResourceRequest,
 ) (*pulumirpc.ReadResourceResponse, error) {
-	return nil, fmt.Errorf("Query mode does not support reading resources")
+	return nil, errors.New("Query mode does not support reading resources")
 }
 
 // RegisterResource is invoked by a language process when a new resource has been allocated.
 func (rm *queryResmon) RegisterResource(ctx context.Context,
 	req *pulumirpc.RegisterResourceRequest,
 ) (*pulumirpc.RegisterResourceResponse, error) {
-	return nil, fmt.Errorf("Query mode does not support creating, updating, or deleting resources")
+	return nil, errors.New("Query mode does not support creating, updating, or deleting resources")
 }
 
 // RegisterResourceOutputs records some new output properties for a resource that have arrived after its initial
@@ -532,7 +533,7 @@ func (rm *queryResmon) RegisterResource(ctx context.Context,
 func (rm *queryResmon) RegisterResourceOutputs(ctx context.Context,
 	req *pulumirpc.RegisterResourceOutputsRequest,
 ) (*pbempty.Empty, error) {
-	return nil, fmt.Errorf("Query mode does not support registering resource operations")
+	return nil, errors.New("Query mode does not support registering resource operations")
 }
 
 // SupportsFeature the query resmon is able to have secrets passed to it, which may be arguments to invoke calls.

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -16,7 +16,7 @@ package deploy
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	pbempty "github.com/golang/protobuf/ptypes/empty"
@@ -49,7 +49,7 @@ func TestQuerySource_Trivial_Wait(t *testing.T) {
 	// Failure case.
 	resmon2 := mockQueryResmon{}
 	qs2, _ := newTestQuerySource(&resmon2, func(*querySource) error {
-		return fmt.Errorf("failed")
+		return errors.New("failed")
 	})
 
 	qs2.forkRun()

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -259,7 +259,7 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		}
 
 		if !preview && id == "" {
-			return resourceStatus, nil, fmt.Errorf("provider did not return an ID from Create")
+			return resourceStatus, nil, errors.New("provider did not return an ID from Create")
 		}
 
 		// Copy any of the default and output properties on the live object state.
@@ -849,7 +849,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 			// 2. Make sure the initialization errors are persisted in the state, so that the next
 			//    `pulumi up` will surface them to the user.
 			err = nil
-			msg := fmt.Sprintf("Refreshed resource is in an unhealthy state:\n* %s", strings.Join(initErrors, "\n* "))
+			msg := "Refreshed resource is in an unhealthy state:\n* " + strings.Join(initErrors, "\n* ")
 			s.Deployment().Diag().Warningf(diag.RawMessage(s.URN(), msg))
 		}
 	}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -16,6 +16,7 @@ package deploy
 
 import (
 	cryptorand "crypto/rand"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -1008,7 +1009,7 @@ func (sg *stepGenerator) generateStepsFromDiff(
 				if sg.deployment.preview {
 					sg.deployment.ctx.Diag.Warningf(diag.StreamMessage(urn, message, 0))
 				} else {
-					return nil, fmt.Errorf(message)
+					return nil, errors.New(message)
 				}
 			}
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -51,11 +51,11 @@ const (
 var (
 	// ErrDeploymentSchemaVersionTooOld is returned from `DeserializeDeployment` if the
 	// untyped deployment being deserialized is too old to understand.
-	ErrDeploymentSchemaVersionTooOld = fmt.Errorf("this stack's deployment is too old")
+	ErrDeploymentSchemaVersionTooOld = errors.New("this stack's deployment is too old")
 
 	// ErrDeploymentSchemaVersionTooNew is returned from `DeserializeDeployment` if the
 	// untyped deployment being deserialized is too new to understand.
-	ErrDeploymentSchemaVersionTooNew = fmt.Errorf("this stack's deployment version is too new")
+	ErrDeploymentSchemaVersionTooNew = errors.New("this stack's deployment version is too new")
 )
 
 var (
@@ -510,7 +510,7 @@ func DeserializeResource(res apitype.ResourceV3, dec config.Decrypter, enc confi
 	}
 
 	if res.URN == "" {
-		return nil, fmt.Errorf("resource missing required 'urn' field")
+		return nil, errors.New("resource missing required 'urn' field")
 	}
 
 	if res.Type == "" {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -738,7 +738,7 @@ func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
 	// Disable stack backups for tests to avoid filling up ~/.pulumi/backups with unnecessary
 	// backups of test stacks.
 	disableCheckpointBackups := env.SelfManagedDisableCheckpointBackups.Var().Name()
-	opts.Env = append(opts.Env, fmt.Sprintf("%s=1", disableCheckpointBackups))
+	opts.Env = append(opts.Env, disableCheckpointBackups+"=1")
 
 	// We want tests to default into being ran in parallel, hence the odd double negative.
 	if !opts.NoParallel && !opts.DestroyOnCleanup {
@@ -883,7 +883,7 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 // MakeTempBackend creates a temporary backend directory which will clean up on test exit.
 func MakeTempBackend(t *testing.T) string {
 	tempDir := t.TempDir()
-	return fmt.Sprintf("file://%s", filepath.ToSlash(tempDir))
+	return "file://" + filepath.ToSlash(tempDir)
 }
 
 func (pt *ProgramTester) getBin() (string, error) {
@@ -2306,7 +2306,7 @@ func getVirtualenvBinPath(cwd, bin string, pt *ProgramTester) (string, error) {
 	}
 	virtualenvBinPath := filepath.Join(virtualEnvBasePath, "bin", bin)
 	if runtime.GOOS == windowsOS {
-		virtualenvBinPath = filepath.Join(virtualEnvBasePath, "Scripts", fmt.Sprintf("%s.exe", bin))
+		virtualenvBinPath = filepath.Join(virtualEnvBasePath, "Scripts", bin+".exe")
 	}
 	if info, err := os.Stat(virtualenvBinPath); err != nil || info.IsDir() {
 		return "", fmt.Errorf("Expected %s to exist in virtual environment at %q", bin, virtualenvBinPath)
@@ -2409,7 +2409,7 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 	if pt.opts.RunBuild {
 		outBin := filepath.Join(gopath, "bin", string(projinfo.Proj.Name))
 		if runtime.GOOS == windowsOS {
-			outBin = fmt.Sprintf("%s.exe", outBin)
+			outBin = outBin + ".exe"
 		}
 		err = pt.runCommand("go-build", []string{goBin, "build", "-o", outBin, "."}, cwd)
 		if err != nil {

--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -31,7 +30,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 	e.RunCommand("git", "init")
 
 	contents := "name: pulumi-test\ndescription: a test\nruntime: nodejs\n"
-	filePath := fmt.Sprintf("%s.yaml", workspace.ProjectFile)
+	filePath := workspace.ProjectFile + ".yaml"
 	filePath = path.Join(e.CWD, filePath)
 	err := os.WriteFile(filePath, []byte(contents), os.ModePerm)
 	assert.NoError(e, err, "writing %s file", filePath)
@@ -42,7 +41,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 // Returns the repo owner and name used.
 func CreatePulumiRepo(e *testing.Environment, projectFileContent string) {
 	e.RunCommand("git", "init")
-	filePath := path.Join(e.CWD, fmt.Sprintf("%s.yaml", workspace.ProjectFile))
+	filePath := path.Join(e.CWD, workspace.ProjectFile+".yaml")
 	err := os.WriteFile(filePath, []byte(projectFileContent), os.ModePerm)
 	assert.NoError(e, err, "writing %s file", filePath)
 }

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -186,7 +186,7 @@ func AssertHTTPResultWithRetry(
 		return false
 	}
 	if !(strings.HasPrefix(hostname, "http://") || strings.HasPrefix(hostname, "https://")) {
-		hostname = fmt.Sprintf("http://%s", hostname)
+		hostname = "http://" + hostname
 	}
 	var err error
 	var resp *http.Response

--- a/pkg/util/rpcdebug/interceptors.go
+++ b/pkg/util/rpcdebug/interceptors.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -48,7 +49,7 @@ type LogOptions struct {
 // Each LogFile should have a unique instance of DebugInterceptor for proper locking.
 func NewDebugInterceptor(opts DebugInterceptorOptions) (*DebugInterceptor, error) {
 	if opts.LogFile == "" {
-		return nil, fmt.Errorf("logFile cannot be empty")
+		return nil, errors.New("logFile cannot be empty")
 	}
 	i := &DebugInterceptor{logFile: opts.LogFile}
 

--- a/pkg/util/rpcdebug/interceptors_test.go
+++ b/pkg/util/rpcdebug/interceptors_test.go
@@ -16,7 +16,7 @@ package rpcdebug
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +43,7 @@ func TestClientInterceptorCatchesErrors(t *testing.T) {
 
 	ctx := context.Background()
 
-	giveErr := fmt.Errorf("oops")
+	giveErr := errors.New("oops")
 
 	var inner grpc.UnaryInvoker = func(
 		ctx context.Context,

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -38,7 +38,7 @@ type InstallPluginError struct {
 func (err *InstallPluginError) Error() string {
 	var server string
 	if err.Spec.PluginDownloadURL != "" {
-		server = fmt.Sprintf(" --server %s", err.Spec.PluginDownloadURL)
+		server = " --server " + err.Spec.PluginDownloadURL
 	}
 
 	if err.Spec.Version != nil {
@@ -70,7 +70,7 @@ func InstallPlugin(pluginSpec workspace.PluginSpec, log func(sev diag.Severity, 
 
 	wrapper := func(stream io.ReadCloser, size int64) io.ReadCloser {
 		// Log at info but to stderr so we don't pollute stdout for commands like `package get-schema`
-		log(diag.Infoerr, fmt.Sprintf("Downloading provider: %s", pluginSpec.Name))
+		log(diag.Infoerr, "Downloading provider: "+pluginSpec.Name)
 		return stream
 	}
 

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -17,7 +17,6 @@ package auto
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -438,7 +437,7 @@ func TestRuntimeErrorPython(t *testing.T) {
 
 	_, err = s.Up(ctx)
 	assert.True(t, IsRuntimeError(err), "%v is not a runtime error", err)
-	assert.Contains(t, fmt.Sprintf("%v", err), "IndexError: list index out of range")
+	assert.ErrorContains(t, err, "IndexError: list index out of range")
 
 	// -- pulumi destroy --
 

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -1279,7 +1279,7 @@ const pulumiHomeEnv = "PULUMI_HOME"
 
 func readProjectSettingsFromDir(ctx context.Context, workDir string) (*workspace.Project, error) {
 	for _, ext := range settingsExtensions {
-		projectPath := filepath.Join(workDir, fmt.Sprintf("Pulumi%s", ext))
+		projectPath := filepath.Join(workDir, "Pulumi"+ext)
 		if _, err := os.Stat(projectPath); err == nil {
 			proj, err := workspace.LoadProject(projectPath)
 			if err != nil {

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -948,7 +948,7 @@ func TestUpsertStackInlineSourceParallel(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		// Verify that shared context doesn't affect result
 		ctx := context.Background()
-		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			sName := randomStackName()
 			stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -167,8 +167,8 @@ func testRemoteStackGitSource(
 	// initialize
 	s, err := fn(ctx, stackName, repo,
 		RemotePreRunCommands(
-			fmt.Sprintf("pulumi config set bar abc --stack %s", stackName),
-			fmt.Sprintf("pulumi config set --secret buzz secret --stack %s", stackName)),
+			"pulumi config set bar abc --stack "+stackName,
+			"pulumi config set --secret buzz secret --stack "+stackName),
 		RemoteSkipInstallDependencies(true))
 	if err != nil {
 		t.Errorf("failed to initialize stack, err: %v", err)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -105,6 +105,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -229,16 +230,16 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, "--diff")
 	}
 	for _, rURN := range preOpts.Replace {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace=%s", rURN))
+		sharedArgs = append(sharedArgs, "--replace="+rURN)
 	}
 	for _, tURN := range preOpts.Target {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
+		sharedArgs = append(sharedArgs, "--target="+tURN)
 	}
 	for _, pack := range preOpts.PolicyPacks {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack=%s", pack))
+		sharedArgs = append(sharedArgs, "--policy-pack="+pack)
 	}
 	for _, packConfig := range preOpts.PolicyPackConfigs {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack-config=%s", packConfig))
+		sharedArgs = append(sharedArgs, "--policy-pack-config="+packConfig)
 	}
 	if preOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
@@ -247,13 +248,13 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
 	if preOpts.UserAgent != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", preOpts.UserAgent))
+		sharedArgs = append(sharedArgs, "--exec-agent="+preOpts.UserAgent)
 	}
 	if preOpts.Color != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%s", preOpts.Color))
+		sharedArgs = append(sharedArgs, "--color="+preOpts.Color)
 	}
 	if preOpts.Plan != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--save-plan=%s", preOpts.Plan))
+		sharedArgs = append(sharedArgs, "--save-plan="+preOpts.Plan)
 	}
 
 	// Apply the remote args, if needed.
@@ -270,7 +271,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		kind, args = constant.ExecKindAutoInline, append(args, "--client="+server.address)
 	}
 
-	args = append(args, fmt.Sprintf("--exec-kind=%s", kind))
+	args = append(args, "--exec-kind="+kind)
 	args = append(args, sharedArgs...)
 
 	var summaryEvents []apitype.SummaryEvent
@@ -351,16 +352,16 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, "--diff")
 	}
 	for _, rURN := range upOpts.Replace {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace=%s", rURN))
+		sharedArgs = append(sharedArgs, "--replace="+rURN)
 	}
 	for _, tURN := range upOpts.Target {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
+		sharedArgs = append(sharedArgs, "--target="+tURN)
 	}
 	for _, pack := range upOpts.PolicyPacks {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack=%s", pack))
+		sharedArgs = append(sharedArgs, "--policy-pack="+pack)
 	}
 	for _, packConfig := range upOpts.PolicyPackConfigs {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack-config=%s", packConfig))
+		sharedArgs = append(sharedArgs, "--policy-pack-config="+packConfig)
 	}
 	if upOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
@@ -369,13 +370,13 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
 	}
 	if upOpts.UserAgent != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", upOpts.UserAgent))
+		sharedArgs = append(sharedArgs, "--exec-agent="+upOpts.UserAgent)
 	}
 	if upOpts.Color != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%s", upOpts.Color))
+		sharedArgs = append(sharedArgs, "--color="+upOpts.Color)
 	}
 	if upOpts.Plan != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--plan=%s", upOpts.Plan))
+		sharedArgs = append(sharedArgs, "--plan="+upOpts.Plan)
 	}
 
 	// Apply the remote args, if needed.
@@ -391,7 +392,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 
 		kind, args = constant.ExecKindAutoInline, append(args, "--client="+server.address)
 	}
-	args = append(args, fmt.Sprintf("--exec-kind=%s", kind))
+	args = append(args, "--exec-kind="+kind)
 
 	if len(upOpts.EventStreams) > 0 {
 		eventChannels := upOpts.EventStreams
@@ -462,22 +463,22 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		args = append(args, "--expect-no-changes")
 	}
 	for _, tURN := range refreshOpts.Target {
-		args = append(args, fmt.Sprintf("--target=%s", tURN))
+		args = append(args, "--target="+tURN)
 	}
 	if refreshOpts.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", refreshOpts.Parallel))
 	}
 	if refreshOpts.UserAgent != "" {
-		args = append(args, fmt.Sprintf("--exec-agent=%s", refreshOpts.UserAgent))
+		args = append(args, "--exec-agent="+refreshOpts.UserAgent)
 	}
 	if refreshOpts.Color != "" {
-		args = append(args, fmt.Sprintf("--color=%s", refreshOpts.Color))
+		args = append(args, "--color="+refreshOpts.Color)
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {
 		execKind = constant.ExecKindAutoInline
 	}
-	args = append(args, fmt.Sprintf("--exec-kind=%s", execKind))
+	args = append(args, "--exec-kind="+execKind)
 
 	if len(refreshOpts.EventStreams) > 0 {
 		eventChannels := refreshOpts.EventStreams
@@ -547,7 +548,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		args = append(args, fmt.Sprintf("--message=%q", destroyOpts.Message))
 	}
 	for _, tURN := range destroyOpts.Target {
-		args = append(args, fmt.Sprintf("--target=%s", tURN))
+		args = append(args, "--target="+tURN)
 	}
 	if destroyOpts.TargetDependents {
 		args = append(args, "--target-dependents")
@@ -556,16 +557,16 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		args = append(args, fmt.Sprintf("--parallel=%d", destroyOpts.Parallel))
 	}
 	if destroyOpts.UserAgent != "" {
-		args = append(args, fmt.Sprintf("--exec-agent=%s", destroyOpts.UserAgent))
+		args = append(args, "--exec-agent="+destroyOpts.UserAgent)
 	}
 	if destroyOpts.Color != "" {
-		args = append(args, fmt.Sprintf("--color=%s", destroyOpts.Color))
+		args = append(args, "--color="+destroyOpts.Color)
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {
 		execKind = constant.ExecKindAutoInline
 	}
-	args = append(args, fmt.Sprintf("--exec-kind=%s", execKind))
+	args = append(args, "--exec-kind="+execKind)
 
 	if len(destroyOpts.EventStreams) > 0 {
 		eventChannels := destroyOpts.EventStreams
@@ -645,7 +646,7 @@ func (s *Stack) History(ctx context.Context,
 		if page < 1 {
 			page = 1
 		}
-		args = append(args, "--page-size", fmt.Sprintf("%d", pageSize), "--page", fmt.Sprintf("%d", page))
+		args = append(args, "--page-size", strconv.Itoa(pageSize), "--page", strconv.Itoa(page))
 	}
 
 	stdout, stderr, errCode, err := s.runPulumiCmdSync(
@@ -1013,30 +1014,30 @@ func (s *Stack) remoteArgs() []string {
 			args = append(args, repo.URL)
 		}
 		if repo.Branch != "" {
-			args = append(args, fmt.Sprintf("--remote-git-branch=%s", repo.Branch))
+			args = append(args, "--remote-git-branch="+repo.Branch)
 		}
 		if repo.CommitHash != "" {
-			args = append(args, fmt.Sprintf("--remote-git-commit=%s", repo.CommitHash))
+			args = append(args, "--remote-git-commit="+repo.CommitHash)
 		}
 		if repo.ProjectPath != "" {
-			args = append(args, fmt.Sprintf("--remote-git-repo-dir=%s", repo.ProjectPath))
+			args = append(args, "--remote-git-repo-dir="+repo.ProjectPath)
 		}
 		if repo.Auth != nil {
 			if repo.Auth.PersonalAccessToken != "" {
-				args = append(args, fmt.Sprintf("--remote-git-auth-access-token=%s", repo.Auth.PersonalAccessToken))
+				args = append(args, "--remote-git-auth-access-token="+repo.Auth.PersonalAccessToken)
 			}
 			if repo.Auth.SSHPrivateKey != "" {
-				args = append(args, fmt.Sprintf("--remote-git-auth-ssh-private-key=%s", repo.Auth.SSHPrivateKey))
+				args = append(args, "--remote-git-auth-ssh-private-key="+repo.Auth.SSHPrivateKey)
 			}
 			if repo.Auth.SSHPrivateKeyPath != "" {
 				args = append(args,
-					fmt.Sprintf("--remote-git-auth-ssh-private-key-path=%s", repo.Auth.SSHPrivateKeyPath))
+					"--remote-git-auth-ssh-private-key-path="+repo.Auth.SSHPrivateKeyPath)
 			}
 			if repo.Auth.Password != "" {
-				args = append(args, fmt.Sprintf("--remote-git-auth-password=%s", repo.Auth.Password))
+				args = append(args, "--remote-git-auth-password="+repo.Auth.Password)
 			}
 			if repo.Auth.Username != "" {
-				args = append(args, fmt.Sprintf("--remote-git-auth-username=%s", repo.Auth.Username))
+				args = append(args, "--remote-git-auth-username="+repo.Auth.Username)
 			}
 		}
 	}
@@ -1050,7 +1051,7 @@ func (s *Stack) remoteArgs() []string {
 	}
 
 	for _, command := range preRunCommands {
-		args = append(args, fmt.Sprintf("--remote-pre-run-command=%s", command))
+		args = append(args, "--remote-pre-run-command="+command)
 	}
 
 	if skipInstallDependencies {

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -16,7 +16,6 @@ package auto
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestGetPermalink(t *testing.T) {
 		want   string
 		err    error
 	}{
-		"successful parsing": {testee: fmt.Sprintf("%s\n", testPermalink), want: "https://gotest"},
+		"successful parsing": {testee: testPermalink + "\n", want: "https://gotest"},
 		"failed parsing":     {testee: testPermalink, err: ErrParsePermalinkFailed},
 	}
 

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -546,7 +546,7 @@ func TestGetFail(t *testing.T) {
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
 	for _, test := range tests {
 		test := test
-		t.Run(fmt.Sprintf("%v", test.Key), func(t *testing.T) {
+		t.Run(test.Key, func(t *testing.T) {
 			t.Parallel()
 
 			config := make(Map)

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver"
@@ -97,7 +98,7 @@ func NewPolicyAnalyzer(
 	// All other languages have the runtime appended, e.g. "policy-<runtime>".
 	policyAnalyzerName := "policy"
 	if !strings.EqualFold(proj.Runtime.Name(), "nodejs") {
-		policyAnalyzerName = fmt.Sprintf("policy-%s", proj.Runtime.Name())
+		policyAnalyzerName = "policy-" + proj.Runtime.Name()
 	}
 
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
@@ -343,7 +344,7 @@ func (a *analyzer) Remediate(r AnalyzerResource) ([]Remediation, error) {
 
 // GetAnalyzerInfo returns metadata about the policies contained in this analyzer plugin.
 func (a *analyzer) GetAnalyzerInfo() (AnalyzerInfo, error) {
-	label := fmt.Sprintf("%s.GetAnalyzerInfo()", a.label())
+	label := a.label() + ".GetAnalyzerInfo()"
 	logging.V(7).Infof("%s executing", label)
 	resp, err := a.client.GetAnalyzerInfo(a.ctx.Request(), &pbempty.Empty{})
 	if err != nil {
@@ -421,7 +422,7 @@ func (a *analyzer) GetAnalyzerInfo() (AnalyzerInfo, error) {
 
 // GetPluginInfo returns this plugin's information.
 func (a *analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
-	label := fmt.Sprintf("%s.GetPluginInfo()", a.label())
+	label := a.label() + ".GetPluginInfo()"
 	logging.V(7).Infof("%s executing", label)
 	resp, err := a.client.GetPluginInfo(a.ctx.Request(), &pbempty.Empty{})
 	if err != nil {
@@ -448,7 +449,7 @@ func (a *analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
 }
 
 func (a *analyzer) Configure(policyConfig map[string]AnalyzerPolicyConfig) error {
-	label := fmt.Sprintf("%s.Configure(...)", a.label())
+	label := a.label() + ".Configure(...)"
 	logging.V(7).Infof("%s executing", label)
 
 	if len(policyConfig) == 0 {
@@ -778,13 +779,13 @@ func constructEnv(opts *PolicyAnalyzerOptions, runtime string) ([]string, error)
 			maybeAppendEnv("PULUMI_NODEJS_ORGANIZATION", opts.Organization)
 			maybeAppendEnv("PULUMI_NODEJS_PROJECT", opts.Project)
 			maybeAppendEnv("PULUMI_NODEJS_STACK", opts.Stack)
-			maybeAppendEnv("PULUMI_NODEJS_DRY_RUN", fmt.Sprintf("%v", opts.DryRun))
+			maybeAppendEnv("PULUMI_NODEJS_DRY_RUN", strconv.FormatBool(opts.DryRun))
 		}
 
 		maybeAppendEnv("PULUMI_ORGANIZATION", opts.Organization)
 		maybeAppendEnv("PULUMI_PROJECT", opts.Project)
 		maybeAppendEnv("PULUMI_STACK", opts.Stack)
-		maybeAppendEnv("PULUMI_DRY_RUN", fmt.Sprintf("%v", opts.DryRun))
+		maybeAppendEnv("PULUMI_DRY_RUN", strconv.FormatBool(opts.DryRun))
 	}
 
 	return env, nil

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -105,7 +105,7 @@ func (c *converter) Close() error {
 }
 
 func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) (*ConvertStateResponse, error) {
-	label := fmt.Sprintf("%s.ConvertState", c.label())
+	label := c.label() + ".ConvertState"
 	logging.V(7).Infof("%s executing", label)
 
 	resp, err := c.clientRaw.ConvertState(ctx, &pulumirpc.ConvertStateRequest{
@@ -143,7 +143,7 @@ func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) 
 }
 
 func (c *converter) ConvertProgram(ctx context.Context, req *ConvertProgramRequest) (*ConvertProgramResponse, error) {
-	label := fmt.Sprintf("%s.ConvertProgram", c.label())
+	label := c.label() + ".ConvertProgram"
 	logging.V(7).Infof("%s executing", label)
 
 	resp, err := c.clientRaw.ConvertProgram(ctx, &pulumirpc.ConvertProgramRequest{

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -120,7 +120,7 @@ func buildArgsForNewPlugin(host Host, root string, options map[string]interface{
 		args = append(args, fmt.Sprintf("-%s=%v", k, v))
 	}
 
-	args = append(args, fmt.Sprintf("-root=%s", filepath.Clean(root)))
+	args = append(args, "-root="+filepath.Clean(root))
 
 	// NOTE: positional argument for the server addresss must come last
 	args = append(args, host.ServerAddr())

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +31,6 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -117,12 +117,12 @@ var errRunPolicyModuleNotFound = errors.New("pulumi SDK does not support policy 
 var errPluginNotFound = errors.New("plugin not found")
 
 func dialPlugin(portNum int, bin, prefix string, dialOptions []grpc.DialOption) (*grpc.ClientConn, error) {
-	port := fmt.Sprintf("%d", portNum)
+	port := strconv.Itoa(portNum)
 
 	// Now that we have the port, go ahead and create a gRPC client connection to it.
 	conn, err := grpc.Dial("127.0.0.1:"+port, dialOptions...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not dial plugin [%v] over RPC", bin)
+		return nil, fmt.Errorf("could not dial plugin [%v] over RPC: %w", bin, err)
 	}
 
 	// Now wait for the gRPC connection to the plugin to become ready.
@@ -157,13 +157,13 @@ func dialPlugin(portNum int, bin, prefix string, dialOptions []grpc.DialOption) 
 				}
 
 				// Unexpected error; get outta dodge.
-				return nil, errors.Wrapf(err, "%v plugin [%v] did not come alive", prefix, bin)
+				return nil, fmt.Errorf("%v plugin [%v] did not come alive: %w", prefix, bin, err)
 			}
 			break
 		}
 		// Not ready yet; ask the gRPC client APIs to block until the state transitions again so we can retry.
 		if !conn.WaitForStateChange(timeout, s) {
-			return nil, errors.Errorf("%v plugin [%v] did not begin responding to RPC connections", prefix, bin)
+			return nil, fmt.Errorf("%v plugin [%v] did not begin responding to RPC connections: %w", prefix, bin, err)
 		}
 	}
 
@@ -199,7 +199,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 	// Try to execute the binary.
 	plug, err := execPlugin(ctx, bin, prefix, kind, args, pwd, env)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load plugin %s", bin)
+		return nil, fmt.Errorf("failed to load plugin %s: %w", bin, err)
 	}
 	contract.Assertf(plug != nil, "plugin %v canot be nil", bin)
 
@@ -271,10 +271,10 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 
 			// Fall back to a generic, opaque error.
 			if portString == "" {
-				return nil, errors.Wrapf(readerr, "could not read plugin [%v] stdout", bin)
+				return nil, fmt.Errorf("could not read plugin [%v] stdout: %w", bin, readerr)
 			}
-			return nil, errors.Wrapf(readerr, "failure reading plugin [%v] stdout (read '%v')",
-				bin, portString)
+			return nil, fmt.Errorf("failure reading plugin [%v] stdout (read '%v'): %w",
+				bin, portString, readerr)
 		}
 		if n > 0 && b[0] == '\n' {
 			break
@@ -290,8 +290,8 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 	if port, err = strconv.Atoi(portString); err != nil {
 		killerr := plug.Kill()
 		contract.IgnoreError(killerr) // ignoring the error because the existing one trumps it.
-		return nil, errors.Wrapf(
-			err, "%v plugin [%v] wrote a non-numeric port to stdout ('%v')", prefix, bin, port)
+		return nil, fmt.Errorf(
+			"%v plugin [%v] wrote a non-numeric port to stdout ('%v'): %w", prefix, bin, port, err)
 	}
 
 	// After reading the port number, set up a tracer on stdout just so other output doesn't disappear.
@@ -340,14 +340,14 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 			}
 			runtimeInfo = proj.Runtime
 		} else {
-			return nil, fmt.Errorf("language plugins must be executable binaries")
+			return nil, errors.New("language plugins must be executable binaries")
 		}
 
 		logging.V(9).Infof("Launching plugin '%v' from '%v' via runtime '%s'", prefix, pluginDir, runtimeInfo.Name())
 
 		runtime, err := ctx.Host.LanguageRuntime(pluginDir, pluginDir, runtimeInfo.Name(), runtimeInfo.Options())
 		if err != nil {
-			return nil, errors.Wrap(err, "loading runtime")
+			return nil, fmt.Errorf("loading runtime: %w", err)
 		}
 
 		stdout, stderr, kill, err := runtime.RunPlugin(RunPluginInfo{

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,7 +30,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -141,7 +141,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 			env = append(env, fmt.Sprintf("PULUMI_RUNTIME_%s=%v", strings.ToUpper(k), v))
 		}
 		if jsonConfig != "" {
-			env = append(env, fmt.Sprintf("PULUMI_CONFIG=%s", jsonConfig))
+			env = append(env, "PULUMI_CONFIG="+jsonConfig)
 		}
 		plug, err = newPlugin(ctx, ctx.Pwd, path, prefix,
 			workspace.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, pkg, ""))
@@ -300,7 +300,7 @@ func (p *provider) CheckConfig(urn resource.URN, olds,
 	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(olds), len(news))
 
 	molds, err := MarshalProperties(olds, MarshalOptions{
-		Label:        fmt.Sprintf("%s.olds", label),
+		Label:        label + ".olds",
 		KeepUnknowns: allowUnknowns,
 	})
 	if err != nil {
@@ -308,7 +308,7 @@ func (p *provider) CheckConfig(urn resource.URN, olds,
 	}
 
 	mnews, err := MarshalProperties(news, MarshalOptions{
-		Label:        fmt.Sprintf("%s.news", label),
+		Label:        label + ".news",
 		KeepUnknowns: allowUnknowns,
 	})
 	if err != nil {
@@ -337,7 +337,7 @@ func (p *provider) CheckConfig(urn resource.URN, olds,
 	var inputs resource.PropertyMap
 	if ins := resp.GetInputs(); ins != nil {
 		inputs, err = UnmarshalProperties(ins, MarshalOptions{
-			Label:          fmt.Sprintf("%s.inputs", label),
+			Label:          label + ".inputs",
 			KeepUnknowns:   allowUnknowns,
 			RejectUnknowns: !allowUnknowns,
 			KeepSecrets:    true,
@@ -403,7 +403,7 @@ func (p *provider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs
 		label, len(oldInputs), len(oldOutputs), len(newInputs))
 
 	mOldInputs, err := MarshalProperties(oldInputs, MarshalOptions{
-		Label:        fmt.Sprintf("%s.oldInputs", label),
+		Label:        label + ".oldInputs",
 		KeepUnknowns: true,
 	})
 	if err != nil {
@@ -411,7 +411,7 @@ func (p *provider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs
 	}
 
 	mOldOutputs, err := MarshalProperties(oldOutputs, MarshalOptions{
-		Label:        fmt.Sprintf("%s.oldOutputs", label),
+		Label:        label + ".oldOutputs",
 		KeepUnknowns: true,
 	})
 	if err != nil {
@@ -419,7 +419,7 @@ func (p *provider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs
 	}
 
 	mNewInputs, err := MarshalProperties(newInputs, MarshalOptions{
-		Label:        fmt.Sprintf("%s.newInputs", label),
+		Label:        label + ".newInputs",
 		KeepUnknowns: true,
 	})
 	if err != nil {
@@ -649,7 +649,7 @@ func restoreElidedAssetContents(original resource.PropertyMap, transformed resou
 
 // Configure configures the resource provider with "globals" that control its behavior.
 func (p *provider) Configure(inputs resource.PropertyMap) error {
-	label := fmt.Sprintf("%s.Configure()", p.label())
+	label := p.label() + ".Configure()"
 	logging.V(7).Infof("%s executing (#vars=%d)", label, len(inputs))
 
 	// Convert the inputs to a config map. If any are unknown, do not configure the underlying plugin: instead, leave
@@ -673,7 +673,7 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 		if _, isString := mapped.(string); !isString {
 			marshalled, err := json.Marshal(mapped)
 			if err != nil {
-				err := errors.Wrapf(err, "marshaling configuration property '%v'", k)
+				err := fmt.Errorf("marshaling configuration property '%v': %w", k, err)
 				p.configSource.MustReject(err)
 				return err
 			}
@@ -686,13 +686,13 @@ func (p *provider) Configure(inputs resource.PropertyMap) error {
 	}
 
 	minputs, err := MarshalProperties(inputs, MarshalOptions{
-		Label:         fmt.Sprintf("%s.inputs", label),
+		Label:         label + ".inputs",
 		KeepUnknowns:  true,
 		KeepSecrets:   true,
 		KeepResources: true,
 	})
 	if err != nil {
-		err := errors.Wrapf(err, "marshaling provider inputs")
+		err := fmt.Errorf("marshaling provider inputs: %w", err)
 		p.configSource.MustReject(err)
 		return err
 	}
@@ -750,7 +750,7 @@ func (p *provider) Check(urn resource.URN,
 	}
 
 	molds, err := MarshalProperties(olds, MarshalOptions{
-		Label:         fmt.Sprintf("%s.olds", label),
+		Label:         label + ".olds",
 		KeepUnknowns:  allowUnknowns,
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
@@ -759,7 +759,7 @@ func (p *provider) Check(urn resource.URN,
 		return nil, nil, err
 	}
 	mnews, err := MarshalProperties(news, MarshalOptions{
-		Label:         fmt.Sprintf("%s.news", label),
+		Label:         label + ".news",
 		KeepUnknowns:  allowUnknowns,
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
@@ -784,7 +784,7 @@ func (p *provider) Check(urn resource.URN,
 	var inputs resource.PropertyMap
 	if ins := resp.GetInputs(); ins != nil {
 		inputs, err = UnmarshalProperties(ins, MarshalOptions{
-			Label:          fmt.Sprintf("%s.inputs", label),
+			Label:          label + ".inputs",
 			KeepUnknowns:   allowUnknowns,
 			RejectUnknowns: !allowUnknowns,
 			KeepSecrets:    true,
@@ -845,7 +845,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	}
 
 	mOldInputs, err := MarshalProperties(oldInputs, MarshalOptions{
-		Label:              fmt.Sprintf("%s.oldInputs", label),
+		Label:              label + ".oldInputs",
 		ElideAssetContents: true,
 		KeepUnknowns:       allowUnknowns,
 		KeepSecrets:        pcfg.acceptSecrets,
@@ -856,7 +856,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	}
 
 	mOldOutputs, err := MarshalProperties(oldOutputs, MarshalOptions{
-		Label:              fmt.Sprintf("%s.oldOutputs", label),
+		Label:              label + ".oldOutputs",
 		ElideAssetContents: true,
 		KeepUnknowns:       allowUnknowns,
 		KeepSecrets:        pcfg.acceptSecrets,
@@ -867,7 +867,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	}
 
 	mNewInputs, err := MarshalProperties(newInputs, MarshalOptions{
-		Label:              fmt.Sprintf("%s.newInputs", label),
+		Label:              label + ".newInputs",
 		ElideAssetContents: true,
 		KeepUnknowns:       allowUnknowns,
 		KeepSecrets:        pcfg.acceptSecrets,
@@ -964,7 +964,7 @@ func (p *provider) Create(urn resource.URN, props resource.PropertyMap, timeout 
 	contract.Assertf(pcfg.known, "Create cannot be called if the configuration is unknown")
 
 	mprops, err := MarshalProperties(props, MarshalOptions{
-		Label:         fmt.Sprintf("%s.inputs", label),
+		Label:         label + ".inputs",
 		KeepUnknowns:  preview,
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
@@ -998,11 +998,11 @@ func (p *provider) Create(urn resource.URN, props resource.PropertyMap, timeout 
 
 	if id == "" && !preview {
 		return "", nil, resource.StatusUnknown,
-			errors.Errorf("plugin for package '%v' returned empty resource.ID from create '%v'", p.pkg, urn)
+			fmt.Errorf("plugin for package '%v' returned empty resource.ID from create '%v'", p.pkg, urn)
 	}
 
 	outs, err := UnmarshalProperties(liveObject, MarshalOptions{
-		Label:          fmt.Sprintf("%s.outputs", label),
+		Label:          label + ".outputs",
 		RejectUnknowns: !preview,
 		KeepUnknowns:   preview,
 		KeepSecrets:    true,
@@ -1109,7 +1109,7 @@ func (p *provider) Read(urn resource.URN, id resource.ID,
 
 	// Finally, unmarshal the resulting state properties and return them.
 	newState, err := UnmarshalProperties(liveObject, MarshalOptions{
-		Label:          fmt.Sprintf("%s.outputs", label),
+		Label:          label + ".outputs",
 		RejectUnknowns: true,
 		KeepSecrets:    true,
 		KeepResources:  true,
@@ -1200,7 +1200,7 @@ func (p *provider) Update(urn resource.URN, id resource.ID,
 	contract.Assertf(pcfg.known, "Update cannot be called if the configuration is unknown")
 
 	mOldInputs, err := MarshalProperties(oldInputs, MarshalOptions{
-		Label:              fmt.Sprintf("%s.oldInputs", label),
+		Label:              label + ".oldInputs",
 		ElideAssetContents: true,
 		KeepSecrets:        pcfg.acceptSecrets,
 		KeepResources:      pcfg.acceptResources,
@@ -1209,7 +1209,7 @@ func (p *provider) Update(urn resource.URN, id resource.ID,
 		return nil, resource.StatusOK, err
 	}
 	mOldOutputs, err := MarshalProperties(oldOutputs, MarshalOptions{
-		Label:              fmt.Sprintf("%s.oldOutputs", label),
+		Label:              label + ".oldOutputs",
 		ElideAssetContents: true,
 		KeepSecrets:        pcfg.acceptSecrets,
 		KeepResources:      pcfg.acceptResources,
@@ -1218,7 +1218,7 @@ func (p *provider) Update(urn resource.URN, id resource.ID,
 		return nil, resource.StatusOK, err
 	}
 	mNewInputs, err := MarshalProperties(newInputs, MarshalOptions{
-		Label:         fmt.Sprintf("%s.newInputs", label),
+		Label:         label + ".newInputs",
 		KeepUnknowns:  preview,
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
@@ -1253,7 +1253,7 @@ func (p *provider) Update(urn resource.URN, id resource.ID,
 	}
 
 	outs, err := UnmarshalProperties(liveObject, MarshalOptions{
-		Label:          fmt.Sprintf("%s.outputs", label),
+		Label:          label + ".outputs",
 		RejectUnknowns: !preview,
 		KeepUnknowns:   preview,
 		KeepSecrets:    true,
@@ -1357,17 +1357,16 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name string, p
 	// If the provider is not fully configured, we need to error. We can't support unknown URNs but if the
 	// provider isn't configured we can't call into it to get the URN.
 	if !pcfg.known {
-		return ConstructResult{}, fmt.Errorf(
-			"cannot construct components if the provider is configured with unknown values")
+		return ConstructResult{}, errors.New("cannot construct components if the provider is configured with unknown values")
 	}
 
 	if !pcfg.acceptSecrets {
-		return ConstructResult{}, fmt.Errorf("plugins that can construct components must support secrets")
+		return ConstructResult{}, errors.New("plugins that can construct components must support secrets")
 	}
 
 	// Marshal the input properties.
 	minputs, err := MarshalProperties(inputs, MarshalOptions{
-		Label:         fmt.Sprintf("%s.inputs", label),
+		Label:         label + ".inputs",
 		KeepUnknowns:  true,
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
@@ -1449,7 +1448,7 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name string, p
 	}
 
 	outputs, err := UnmarshalProperties(resp.GetState(), MarshalOptions{
-		Label:         fmt.Sprintf("%s.outputs", label),
+		Label:         label + ".outputs",
 		KeepUnknowns:  info.DryRun,
 		KeepSecrets:   true,
 		KeepResources: true,
@@ -1497,7 +1496,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 	}
 
 	margs, err := MarshalProperties(args, MarshalOptions{
-		Label:         fmt.Sprintf("%s.args", label),
+		Label:         label + ".args",
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
 	})
@@ -1517,7 +1516,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 
 	// Unmarshal any return values.
 	ret, err := UnmarshalProperties(resp.GetReturn(), MarshalOptions{
-		Label:          fmt.Sprintf("%s.returns", label),
+		Label:          label + ".returns",
 		RejectUnknowns: true,
 		KeepSecrets:    true,
 		KeepResources:  true,
@@ -1561,7 +1560,7 @@ func (p *provider) StreamInvoke(
 	}
 
 	margs, err := MarshalProperties(args, MarshalOptions{
-		Label:         fmt.Sprintf("%s.args", label),
+		Label:         label + ".args",
 		KeepSecrets:   pcfg.acceptSecrets,
 		KeepResources: pcfg.acceptResources,
 	})
@@ -1591,7 +1590,7 @@ func (p *provider) StreamInvoke(
 
 		// Unmarshal response.
 		ret, err := UnmarshalProperties(in.GetReturn(), MarshalOptions{
-			Label:          fmt.Sprintf("%s.returns", label),
+			Label:          label + ".returns",
 			RejectUnknowns: true,
 			KeepSecrets:    true,
 			KeepResources:  true,
@@ -1639,7 +1638,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 	}
 
 	margs, err := MarshalProperties(args, MarshalOptions{
-		Label:         fmt.Sprintf("%s.args", label),
+		Label:         label + ".args",
 		KeepUnknowns:  true,
 		KeepSecrets:   true,
 		KeepResources: true,
@@ -1686,7 +1685,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 
 	// Unmarshal any return values.
 	ret, err := UnmarshalProperties(resp.GetReturn(), MarshalOptions{
-		Label:         fmt.Sprintf("%s.returns", label),
+		Label:         label + ".returns",
 		KeepUnknowns:  info.DryRun,
 		KeepSecrets:   true,
 		KeepResources: true,
@@ -1716,7 +1715,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 
 // GetPluginInfo returns this plugin's information.
 func (p *provider) GetPluginInfo() (workspace.PluginInfo, error) {
-	label := fmt.Sprintf("%s.GetPluginInfo()", p.label())
+	label := p.label() + ".GetPluginInfo()"
 	logging.V(7).Infof("%s executing", label)
 
 	// Calling GetPluginInfo happens immediately after loading, and does not require configuration to proceed.
@@ -1753,7 +1752,7 @@ func (p *provider) GetPluginInfo() (workspace.PluginInfo, error) {
 
 // Attach attaches this plugin to the engine
 func (p *provider) Attach(address string) error {
-	label := fmt.Sprintf("%s.Attach()", p.label())
+	label := p.label() + ".Attach()"
 	logging.V(7).Infof("%s executing", label)
 
 	// Calling Attach happens immediately after loading, and does not require configuration to proceed.
@@ -1917,7 +1916,7 @@ func decorateProviderSpans(span opentracing.Span, method string, req, resp inter
 
 // GetMapping fetches the conversion mapping (if any) for this resource provider.
 func (p *provider) GetMapping(key, provider string) ([]byte, string, error) {
-	label := fmt.Sprintf("%s.GetMapping", p.label())
+	label := p.label() + ".GetMapping"
 	logging.V(7).Infof("%s executing: key=%s, provider=%s", label, key, provider)
 
 	resp, err := p.clientRaw.GetMapping(p.requestContext(), &pulumirpc.GetMappingRequest{
@@ -1942,7 +1941,7 @@ func (p *provider) GetMapping(key, provider string) ([]byte, string, error) {
 }
 
 func (p *provider) GetMappings(key string) ([]string, error) {
-	label := fmt.Sprintf("%s.GetMappings", p.label())
+	label := p.label() + ".GetMappings"
 	logging.V(7).Infof("%s executing: key=%s", label, key)
 
 	resp, err := p.clientRaw.GetMappings(p.requestContext(), &pulumirpc.GetMappingsRequest{

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -663,7 +664,7 @@ func TestKubernetesDiffError(t *testing.T) {
 
 	diffErr := status.Errorf(codes.Unknown, "failed to parse kubeconfig: %s",
 		fmt.Errorf("couldn't get version/kind; json parse error: %w",
-			fmt.Errorf("json: cannot unmarshal string into Go value of type struct "+
+			errors.New("json: cannot unmarshal string into Go value of type struct "+
 				"{ APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }")))
 
 	client := &stubClient{

--- a/sdk/go/common/resource/urn.go
+++ b/sdk/go/common/resource/urn.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -57,7 +58,7 @@ const (
 // ParseURN attempts to parse a string into a URN returning an error if it's not valid.
 func ParseURN(s string) (URN, error) {
 	if s == "" {
-		return "", fmt.Errorf("missing required URN")
+		return "", errors.New("missing required URN")
 	}
 
 	urn := URN(s)

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -243,10 +243,10 @@ func (e *Environment) GetCommandResultsIn(dir string, command string, args ...st
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", pulumiCredentialsPathEnvVar, e.RootPath))
 	cmd.Env = append(cmd.Env, "PULUMI_DEBUG_COMMANDS=true")
 	if !e.NoPassphrase {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("PULUMI_CONFIG_PASSPHRASE=%s", passphrase))
+		cmd.Env = append(cmd.Env, "PULUMI_CONFIG_PASSPHRASE="+passphrase)
 	}
 	if e.Backend != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("PULUMI_BACKEND_URL=%s", e.Backend))
+		cmd.Env = append(cmd.Env, "PULUMI_BACKEND_URL="+e.Backend)
 	}
 	// According to https://pkg.go.dev/os/exec#Cmd.Env:
 	//     If Env contains duplicate environment keys, only the last

--- a/sdk/go/common/tokens/stack_name.go
+++ b/sdk/go/common/tokens/stack_name.go
@@ -15,6 +15,7 @@
 package tokens
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -58,10 +59,10 @@ func ParseStackName(s string) (StackName, error) {
 	}
 
 	if s == "" {
-		return StackName{}, fmt.Errorf("a stack name may not be empty")
+		return StackName{}, errors.New("a stack name may not be empty")
 	}
 	if len(s) > 100 {
-		return StackName{}, fmt.Errorf("a stack name cannot exceed 100 characters")
+		return StackName{}, errors.New("a stack name cannot exceed 100 characters")
 	}
 
 	failure := -1

--- a/sdk/go/common/util/executable/executable.go
+++ b/sdk/go/common/util/executable/executable.go
@@ -17,7 +17,7 @@ const unableToFindProgramTemplate = "unable to find program: %s"
 // filesystem, eventually resorting to searching in $PATH.
 func FindExecutable(program string) (string, error) {
 	if runtime.GOOS == "windows" && !strings.HasSuffix(program, ".exe") {
-		program = fmt.Sprintf("%s.exe", program)
+		program = program + ".exe"
 	}
 	// look in the same directory
 	cwd, err := os.Getwd()

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -250,7 +250,7 @@ func newGitlabSource(url *url.URL, name string, kind PluginKind) (*gitlabSource,
 func (source *gitlabSource) newHTTPRequest(url, accept string) (*http.Request, error) {
 	var authorization string
 	if source.token != "" {
-		authorization = fmt.Sprintf("Bearer %s", source.token)
+		authorization = "Bearer " + source.token
 	}
 
 	req, err := buildHTTPRequest(url, authorization)
@@ -384,7 +384,7 @@ func newGithubSource(url *url.URL, name string, kind PluginKind) (*githubSource,
 func (source *githubSource) newHTTPRequest(url, accept string) (*http.Request, error) {
 	var authorization string
 	if source.token != "" {
-		authorization = fmt.Sprintf("token %s", source.token)
+		authorization = "token " + source.token
 	}
 
 	req, err := buildHTTPRequest(url, authorization)
@@ -766,7 +766,7 @@ func (spec PluginSpec) LockFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.lock", dir), nil
+	return dir + ".lock", nil
 }
 
 // PartialFilePath returns the full path to the plugin's partial file used during installation
@@ -776,7 +776,7 @@ func (spec PluginSpec) PartialFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s.partial", dir), nil
+	return dir + ".partial", nil
 }
 
 func (spec PluginSpec) String() string {
@@ -824,8 +824,8 @@ func (info *PluginInfo) Delete() error {
 	}
 	// Attempt to delete any leftover .partial or .lock files.
 	// Don't fail the operation if we can't delete these.
-	contract.IgnoreError(os.Remove(fmt.Sprintf("%s.partial", dir)))
-	contract.IgnoreError(os.Remove(fmt.Sprintf("%s.lock", dir)))
+	contract.IgnoreError(os.Remove(dir + ".partial"))
+	contract.IgnoreError(os.Remove(dir + ".lock"))
 	return nil
 }
 
@@ -1051,7 +1051,7 @@ func (spec PluginSpec) installLock() (unlock func(), err error) {
 	if err != nil {
 		return nil, err
 	}
-	lockFilePath := fmt.Sprintf("%s.lock", finalDir)
+	lockFilePath := finalDir + ".lock"
 
 	if err := os.MkdirAll(filepath.Dir(lockFilePath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating plugin root: %w", err)
@@ -1639,7 +1639,7 @@ func getPlugins(dir string, skipMetadata bool) ([]PluginInfo, error) {
 				Version: &version,
 				Path:    path,
 			}
-			if _, err := os.Stat(fmt.Sprintf("%s.partial", path)); err == nil {
+			if _, err := os.Stat(path + ".partial"); err == nil {
 				// Skip it if the partial file exists, meaning the plugin is not fully installed.
 				continue
 			} else if !os.IsNotExist(err) {

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -18,7 +18,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -267,11 +266,11 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, nil)
 
 	// Leftover temp dirs.
-	tempDir1, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir1, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
-	tempDir2, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir2, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
-	tempDir3, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir3, err := os.MkdirTemp(dir, plugin.Dir()+".tmp")
 	assert.NoError(t, err)
 
 	// Leftover partial file.

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -485,7 +485,7 @@ func TestPluginDownload(t *testing.T) {
 		require.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.32.0" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -504,7 +504,7 @@ func TestPluginDownload(t *testing.T) {
 			}
 
 			assert.Equal(t, "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456", req.URL.String())
-			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+			assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
@@ -533,7 +533,7 @@ func TestPluginDownload(t *testing.T) {
 			}
 
 			if req.URL.String() == "https://api.git.org/repos/ourorg/mock/releases/tags/v4.32.0" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -552,7 +552,7 @@ func TestPluginDownload(t *testing.T) {
 			}
 
 			assert.Equal(t, "https://api.git.org/repos/ourorg/mock/releases/assets/123456", req.URL.String())
-			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+			assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
@@ -676,7 +676,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t,
 				"https://gitlab.com/api/v4/projects/278964/releases/v1.23.4/downloads/"+
 					"pulumi-resource-mock-gitlab-v1.23.4-windows-arm64.tar.gz", req.URL.String())
-			assert.Equal(t, fmt.Sprintf("Bearer %s", token), req.Header.Get("Authorization"))
+			assert.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
@@ -752,7 +752,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		require.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mock-private/releases/latest" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -778,7 +778,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.git.org/repos/ourorg/mock/releases/latest" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "token "+token, req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -804,7 +804,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		require.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://gitlab.com/api/v4/projects/278964/releases/permalink/latest" {
-				assert.Equal(t, fmt.Sprintf("Bearer %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 
 				// Minimal JSON from the releases API to get the test to pass

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -130,7 +130,7 @@ func TestRetrieveZIPTemplates(t *testing.T) {
 		writer := zip.NewWriter(buf)
 		data := []byte("foo")
 		fileDirPathParts := strings.Split(fileDirName, "/")
-		_, err := writer.Create(fmt.Sprintf("%s/", strings.Join(fileDirPathParts[:len(fileDirPathParts)-1], "/")))
+		_, err := writer.Create(strings.Join(fileDirPathParts[:len(fileDirPathParts)-1], "/") + "/")
 		if err != nil {
 			t.Errorf("Failed to create directory in zip archive: %s", err)
 		}
@@ -166,7 +166,7 @@ func TestRetrieveZIPTemplates(t *testing.T) {
 	}{
 		{
 			testName:    "valid_zip_url",
-			templateURL: fmt.Sprintf("%s/foo.zip", server.URL),
+			templateURL: server.URL + "/foo.zip",
 		},
 		{
 			testName:    "invalid_zip_url",

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -849,8 +850,8 @@ func (host *goLanguageHost) constructEnv(req *pulumirpc.RunRequest) ([]string, e
 	maybeAppendEnv(pulumi.EnvStack, req.GetStack())
 	maybeAppendEnv(pulumi.EnvConfig, config)
 	maybeAppendEnv(pulumi.EnvConfigSecretKeys, configSecretKeys)
-	maybeAppendEnv(pulumi.EnvDryRun, fmt.Sprintf("%v", req.GetDryRun()))
-	maybeAppendEnv(pulumi.EnvParallel, fmt.Sprint(req.GetParallel()))
+	maybeAppendEnv(pulumi.EnvDryRun, strconv.FormatBool(req.GetDryRun()))
+	maybeAppendEnv(pulumi.EnvParallel, strconv.Itoa(int(req.GetParallel())))
 	maybeAppendEnv(pulumi.EnvMonitor, req.GetMonitorAddress())
 	maybeAppendEnv(pulumi.EnvEngine, host.engineAddress)
 

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -16,7 +16,7 @@ package pulumi
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -349,7 +349,7 @@ func TestMergeProviders(t *testing.T) {
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
 	for i, tt := range tests {
 		i, tt := i, tt
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
 			err := RunErr(func(ctx *Context) error {

--- a/sdk/go/pulumi/generate/templates/types_builtins.go.template
+++ b/sdk/go/pulumi/generate/templates/types_builtins.go.template
@@ -19,7 +19,7 @@ package pulumi
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
@@ -104,7 +104,7 @@ func (in {{.InputType}}) To{{.Name}}PtrOutputWithContext(ctx context.Context) {{
 type {{.Name}}Output struct { *OutputState }
 
 func ({{.Name}}Output) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o {{.Name}}Output) ToOutput(ctx context.Context) pulumix.Output[{{.ElementType}}] {

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -528,7 +528,7 @@ func copyToMap(ctx *Context, v resource.PropertyValue, typ reflect.Type, dest re
 
 	keyType, elemType := typ.Key(), typ.Elem()
 	if keyType.Kind() != reflect.String {
-		return fmt.Errorf("map keys must be assignable from type string")
+		return errors.New("map keys must be assignable from type string")
 	}
 
 	result := reflect.MakeMap(typ)

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -304,7 +304,7 @@ func marshalInputImpl(v interface{},
 		switch v := v.(type) {
 		case *asset:
 			if v.invalid {
-				return resource.PropertyValue{}, nil, fmt.Errorf("invalid asset")
+				return resource.PropertyValue{}, nil, errors.New("invalid asset")
 			}
 			return resource.NewAssetProperty(&resource.Asset{
 				Path: v.Path(),
@@ -313,7 +313,7 @@ func marshalInputImpl(v interface{},
 			}), deps, nil
 		case *archive:
 			if v.invalid {
-				return resource.PropertyValue{}, nil, fmt.Errorf("invalid archive")
+				return resource.PropertyValue{}, nil, errors.New("invalid archive")
 			}
 
 			var assets map[string]interface{}
@@ -721,7 +721,7 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 
 		keyType, elemType := dest.Type().Key(), dest.Type().Elem()
 		if keyType.Kind() != reflect.String {
-			return false, fmt.Errorf("map keys must be assignable from type string")
+			return false, errors.New("map keys must be assignable from type string")
 		}
 
 		result := reflect.MakeMap(dest.Type())

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -478,7 +479,7 @@ func TestRemoteComponent(t *testing.T) {
 			case "pkg:index:Instance":
 				return "i-1234567890abcdef0", resource.PropertyMap{}, nil
 			case "pkg:index:MyRemoteComponent":
-				outprop := resource.NewStringProperty(fmt.Sprintf("output: %s", args.Inputs["inprop"].StringValue()))
+				outprop := resource.NewStringProperty("output: " + args.Inputs["inprop"].StringValue())
 				return args.Name + "_id", resource.PropertyMap{
 					"inprop":  args.Inputs["inprop"],
 					"outprop": outprop,
@@ -836,7 +837,7 @@ func TestWaitRecursiveApply(t *testing.T) {
 
 		var res testResource2
 		err := ctx.RegisterResource("test:resource:type", fmt.Sprintf("res%d", n), &testResource2Inputs{
-			Foo: String(fmt.Sprintf("%d", n)),
+			Foo: String(strconv.Itoa(n)),
 		}, &res)
 		assert.NoError(t, err)
 

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -18,6 +18,7 @@ package pulumi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -253,7 +254,7 @@ type AnyOutput struct{ *OutputState }
 var _ pulumix.Input[any] = AnyOutput{}
 
 func (AnyOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("outputs can not be marshaled to JSON")
+	return nil, errors.New("outputs can not be marshaled to JSON")
 }
 
 func (AnyOutput) ElementType() reflect.Type {
@@ -329,7 +330,7 @@ type ResourceOutput struct{ *OutputState }
 var _ pulumix.Input[Resource] = ResourceOutput{}
 
 func (ResourceOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 // ElementType returns the element type of this Output (Resource).
@@ -412,7 +413,7 @@ type ResourceArrayOutput struct{ *OutputState }
 var _ pulumix.Input[[]Resource] = ResourceArrayOutput{}
 
 func (ResourceArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 // ElementType returns the element type of this Output ([]Resource).

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -19,7 +19,7 @@ package pulumi
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
@@ -67,7 +67,7 @@ func (in *archive) ToAssetOrArchiveOutputWithContext(ctx context.Context) AssetO
 type ArchiveOutput struct{ *OutputState }
 
 func (ArchiveOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveOutput) ToOutput(ctx context.Context) pulumix.Output[Archive] {
@@ -135,7 +135,7 @@ func (in ArchiveArray) ToArchiveArrayOutputWithContext(ctx context.Context) Arch
 type ArchiveArrayOutput struct{ *OutputState }
 
 func (ArchiveArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Archive] {
@@ -223,7 +223,7 @@ func (in ArchiveMap) ToArchiveMapOutputWithContext(ctx context.Context) ArchiveM
 type ArchiveMapOutput struct{ *OutputState }
 
 func (ArchiveMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]Archive] {
@@ -304,7 +304,7 @@ func (in ArchiveArrayMap) ToArchiveArrayMapOutputWithContext(ctx context.Context
 type ArchiveArrayMapOutput struct{ *OutputState }
 
 func (ArchiveArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]Archive] {
@@ -385,7 +385,7 @@ func (in ArchiveMapArray) ToArchiveMapArrayOutputWithContext(ctx context.Context
 type ArchiveMapArrayOutput struct{ *OutputState }
 
 func (ArchiveMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]Archive] {
@@ -473,7 +473,7 @@ func (in ArchiveMapMap) ToArchiveMapMapOutputWithContext(ctx context.Context) Ar
 type ArchiveMapMapOutput struct{ *OutputState }
 
 func (ArchiveMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]Archive] {
@@ -554,7 +554,7 @@ func (in ArchiveArrayArray) ToArchiveArrayArrayOutputWithContext(ctx context.Con
 type ArchiveArrayArrayOutput struct{ *OutputState }
 
 func (ArchiveArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArchiveArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]Archive] {
@@ -647,7 +647,7 @@ func (in *asset) ToAssetOrArchiveOutputWithContext(ctx context.Context) AssetOrA
 type AssetOutput struct{ *OutputState }
 
 func (AssetOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOutput) ToOutput(ctx context.Context) pulumix.Output[Asset] {
@@ -715,7 +715,7 @@ func (in AssetArray) ToAssetArrayOutputWithContext(ctx context.Context) AssetArr
 type AssetArrayOutput struct{ *OutputState }
 
 func (AssetArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]Asset] {
@@ -803,7 +803,7 @@ func (in AssetMap) ToAssetMapOutputWithContext(ctx context.Context) AssetMapOutp
 type AssetMapOutput struct{ *OutputState }
 
 func (AssetMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]Asset] {
@@ -884,7 +884,7 @@ func (in AssetArrayMap) ToAssetArrayMapOutputWithContext(ctx context.Context) As
 type AssetArrayMapOutput struct{ *OutputState }
 
 func (AssetArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]Asset] {
@@ -965,7 +965,7 @@ func (in AssetMapArray) ToAssetMapArrayOutputWithContext(ctx context.Context) As
 type AssetMapArrayOutput struct{ *OutputState }
 
 func (AssetMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]Asset] {
@@ -1053,7 +1053,7 @@ func (in AssetMapMap) ToAssetMapMapOutputWithContext(ctx context.Context) AssetM
 type AssetMapMapOutput struct{ *OutputState }
 
 func (AssetMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]Asset] {
@@ -1134,7 +1134,7 @@ func (in AssetArrayArray) ToAssetArrayArrayOutputWithContext(ctx context.Context
 type AssetArrayArrayOutput struct{ *OutputState }
 
 func (AssetArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]Asset] {
@@ -1200,7 +1200,7 @@ type AssetOrArchiveInput interface {
 type AssetOrArchiveOutput struct{ *OutputState }
 
 func (AssetOrArchiveOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveOutput) ToOutput(ctx context.Context) pulumix.Output[AssetOrArchive] {
@@ -1258,7 +1258,7 @@ func (in AssetOrArchiveArray) ToAssetOrArchiveArrayOutputWithContext(ctx context
 type AssetOrArchiveArrayOutput struct{ *OutputState }
 
 func (AssetOrArchiveArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]AssetOrArchive] {
@@ -1330,7 +1330,7 @@ func (in AssetOrArchiveMap) ToAssetOrArchiveMapOutputWithContext(ctx context.Con
 type AssetOrArchiveMapOutput struct{ *OutputState }
 
 func (AssetOrArchiveMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]AssetOrArchive] {
@@ -1395,7 +1395,7 @@ func (in AssetOrArchiveArrayMap) ToAssetOrArchiveArrayMapOutputWithContext(ctx c
 type AssetOrArchiveArrayMapOutput struct{ *OutputState }
 
 func (AssetOrArchiveArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]AssetOrArchive] {
@@ -1460,7 +1460,7 @@ func (in AssetOrArchiveMapArray) ToAssetOrArchiveMapArrayOutputWithContext(ctx c
 type AssetOrArchiveMapArrayOutput struct{ *OutputState }
 
 func (AssetOrArchiveMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]AssetOrArchive] {
@@ -1532,7 +1532,7 @@ func (in AssetOrArchiveMapMap) ToAssetOrArchiveMapMapOutputWithContext(ctx conte
 type AssetOrArchiveMapMapOutput struct{ *OutputState }
 
 func (AssetOrArchiveMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]AssetOrArchive] {
@@ -1597,7 +1597,7 @@ func (in AssetOrArchiveArrayArray) ToAssetOrArchiveArrayArrayOutputWithContext(c
 type AssetOrArchiveArrayArrayOutput struct{ *OutputState }
 
 func (AssetOrArchiveArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o AssetOrArchiveArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]AssetOrArchive] {
@@ -1680,7 +1680,7 @@ func (in Bool) ToBoolPtrOutputWithContext(ctx context.Context) BoolPtrOutput {
 type BoolOutput struct{ *OutputState }
 
 func (BoolOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolOutput) ToOutput(ctx context.Context) pulumix.Output[bool] {
@@ -1758,7 +1758,7 @@ func (in *boolPtr) ToBoolPtrOutputWithContext(ctx context.Context) BoolPtrOutput
 type BoolPtrOutput struct{ *OutputState }
 
 func (BoolPtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*bool] {
@@ -1827,7 +1827,7 @@ func (in BoolArray) ToBoolArrayOutputWithContext(ctx context.Context) BoolArrayO
 type BoolArrayOutput struct{ *OutputState }
 
 func (BoolArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]bool] {
@@ -1915,7 +1915,7 @@ func (in BoolMap) ToBoolMapOutputWithContext(ctx context.Context) BoolMapOutput 
 type BoolMapOutput struct{ *OutputState }
 
 func (BoolMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]bool] {
@@ -1996,7 +1996,7 @@ func (in BoolArrayMap) ToBoolArrayMapOutputWithContext(ctx context.Context) Bool
 type BoolArrayMapOutput struct{ *OutputState }
 
 func (BoolArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]bool] {
@@ -2077,7 +2077,7 @@ func (in BoolMapArray) ToBoolMapArrayOutputWithContext(ctx context.Context) Bool
 type BoolMapArrayOutput struct{ *OutputState }
 
 func (BoolMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]bool] {
@@ -2165,7 +2165,7 @@ func (in BoolMapMap) ToBoolMapMapOutputWithContext(ctx context.Context) BoolMapM
 type BoolMapMapOutput struct{ *OutputState }
 
 func (BoolMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]bool] {
@@ -2246,7 +2246,7 @@ func (in BoolArrayArray) ToBoolArrayArrayOutputWithContext(ctx context.Context) 
 type BoolArrayArrayOutput struct{ *OutputState }
 
 func (BoolArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o BoolArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]bool] {
@@ -2345,7 +2345,7 @@ func (in Float64) ToFloat64PtrOutputWithContext(ctx context.Context) Float64PtrO
 type Float64Output struct{ *OutputState }
 
 func (Float64Output) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64Output) ToOutput(ctx context.Context) pulumix.Output[float64] {
@@ -2423,7 +2423,7 @@ func (in *float64Ptr) ToFloat64PtrOutputWithContext(ctx context.Context) Float64
 type Float64PtrOutput struct{ *OutputState }
 
 func (Float64PtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64PtrOutput) ToOutput(ctx context.Context) pulumix.Output[*float64] {
@@ -2492,7 +2492,7 @@ func (in Float64Array) ToFloat64ArrayOutputWithContext(ctx context.Context) Floa
 type Float64ArrayOutput struct{ *OutputState }
 
 func (Float64ArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64ArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]float64] {
@@ -2580,7 +2580,7 @@ func (in Float64Map) ToFloat64MapOutputWithContext(ctx context.Context) Float64M
 type Float64MapOutput struct{ *OutputState }
 
 func (Float64MapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64MapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]float64] {
@@ -2661,7 +2661,7 @@ func (in Float64ArrayMap) ToFloat64ArrayMapOutputWithContext(ctx context.Context
 type Float64ArrayMapOutput struct{ *OutputState }
 
 func (Float64ArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64ArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]float64] {
@@ -2742,7 +2742,7 @@ func (in Float64MapArray) ToFloat64MapArrayOutputWithContext(ctx context.Context
 type Float64MapArrayOutput struct{ *OutputState }
 
 func (Float64MapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64MapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]float64] {
@@ -2830,7 +2830,7 @@ func (in Float64MapMap) ToFloat64MapMapOutputWithContext(ctx context.Context) Fl
 type Float64MapMapOutput struct{ *OutputState }
 
 func (Float64MapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64MapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]float64] {
@@ -2911,7 +2911,7 @@ func (in Float64ArrayArray) ToFloat64ArrayArrayOutputWithContext(ctx context.Con
 type Float64ArrayArrayOutput struct{ *OutputState }
 
 func (Float64ArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o Float64ArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]float64] {
@@ -3015,7 +3015,7 @@ func (in ID) ToIDPtrOutputWithContext(ctx context.Context) IDPtrOutput {
 type IDOutput struct{ *OutputState }
 
 func (IDOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDOutput) ToOutput(ctx context.Context) pulumix.Output[ID] {
@@ -3103,7 +3103,7 @@ func (in *idPtr) ToIDPtrOutputWithContext(ctx context.Context) IDPtrOutput {
 type IDPtrOutput struct{ *OutputState }
 
 func (IDPtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*ID] {
@@ -3172,7 +3172,7 @@ func (in IDArray) ToIDArrayOutputWithContext(ctx context.Context) IDArrayOutput 
 type IDArrayOutput struct{ *OutputState }
 
 func (IDArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]ID] {
@@ -3260,7 +3260,7 @@ func (in IDMap) ToIDMapOutputWithContext(ctx context.Context) IDMapOutput {
 type IDMapOutput struct{ *OutputState }
 
 func (IDMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]ID] {
@@ -3341,7 +3341,7 @@ func (in IDArrayMap) ToIDArrayMapOutputWithContext(ctx context.Context) IDArrayM
 type IDArrayMapOutput struct{ *OutputState }
 
 func (IDArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]ID] {
@@ -3422,7 +3422,7 @@ func (in IDMapArray) ToIDMapArrayOutputWithContext(ctx context.Context) IDMapArr
 type IDMapArrayOutput struct{ *OutputState }
 
 func (IDMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]ID] {
@@ -3510,7 +3510,7 @@ func (in IDMapMap) ToIDMapMapOutputWithContext(ctx context.Context) IDMapMapOutp
 type IDMapMapOutput struct{ *OutputState }
 
 func (IDMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]ID] {
@@ -3591,7 +3591,7 @@ func (in IDArrayArray) ToIDArrayArrayOutputWithContext(ctx context.Context) IDAr
 type IDArrayArrayOutput struct{ *OutputState }
 
 func (IDArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IDArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]ID] {
@@ -3679,7 +3679,7 @@ func (in Array) ToArrayOutputWithContext(ctx context.Context) ArrayOutput {
 type ArrayOutput struct{ *OutputState }
 
 func (ArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]interface{}] {
@@ -3767,7 +3767,7 @@ func (in Map) ToMapOutputWithContext(ctx context.Context) MapOutput {
 type MapOutput struct{ *OutputState }
 
 func (MapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o MapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]interface{}] {
@@ -3848,7 +3848,7 @@ func (in ArrayMap) ToArrayMapOutputWithContext(ctx context.Context) ArrayMapOutp
 type ArrayMapOutput struct{ *OutputState }
 
 func (ArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]interface{}] {
@@ -3929,7 +3929,7 @@ func (in MapArray) ToMapArrayOutputWithContext(ctx context.Context) MapArrayOutp
 type MapArrayOutput struct{ *OutputState }
 
 func (MapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o MapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]interface{}] {
@@ -4017,7 +4017,7 @@ func (in MapMap) ToMapMapOutputWithContext(ctx context.Context) MapMapOutput {
 type MapMapOutput struct{ *OutputState }
 
 func (MapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o MapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]interface{}] {
@@ -4098,7 +4098,7 @@ func (in ArrayArray) ToArrayArrayOutputWithContext(ctx context.Context) ArrayArr
 type ArrayArrayOutput struct{ *OutputState }
 
 func (ArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]interface{}] {
@@ -4186,7 +4186,7 @@ func (in ArrayArrayMap) ToArrayArrayMapOutputWithContext(ctx context.Context) Ar
 type ArrayArrayMapOutput struct{ *OutputState }
 
 func (ArrayArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o ArrayArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][][]interface{}] {
@@ -4278,7 +4278,7 @@ func (in Int) ToIntPtrOutputWithContext(ctx context.Context) IntPtrOutput {
 type IntOutput struct{ *OutputState }
 
 func (IntOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntOutput) ToOutput(ctx context.Context) pulumix.Output[int] {
@@ -4356,7 +4356,7 @@ func (in *intPtr) ToIntPtrOutputWithContext(ctx context.Context) IntPtrOutput {
 type IntPtrOutput struct{ *OutputState }
 
 func (IntPtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*int] {
@@ -4425,7 +4425,7 @@ func (in IntArray) ToIntArrayOutputWithContext(ctx context.Context) IntArrayOutp
 type IntArrayOutput struct{ *OutputState }
 
 func (IntArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]int] {
@@ -4513,7 +4513,7 @@ func (in IntMap) ToIntMapOutputWithContext(ctx context.Context) IntMapOutput {
 type IntMapOutput struct{ *OutputState }
 
 func (IntMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]int] {
@@ -4594,7 +4594,7 @@ func (in IntArrayMap) ToIntArrayMapOutputWithContext(ctx context.Context) IntArr
 type IntArrayMapOutput struct{ *OutputState }
 
 func (IntArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]int] {
@@ -4675,7 +4675,7 @@ func (in IntMapArray) ToIntMapArrayOutputWithContext(ctx context.Context) IntMap
 type IntMapArrayOutput struct{ *OutputState }
 
 func (IntMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]int] {
@@ -4763,7 +4763,7 @@ func (in IntMapMap) ToIntMapMapOutputWithContext(ctx context.Context) IntMapMapO
 type IntMapMapOutput struct{ *OutputState }
 
 func (IntMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]int] {
@@ -4844,7 +4844,7 @@ func (in IntArrayArray) ToIntArrayArrayOutputWithContext(ctx context.Context) In
 type IntArrayArrayOutput struct{ *OutputState }
 
 func (IntArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o IntArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]int] {
@@ -4943,7 +4943,7 @@ func (in String) ToStringPtrOutputWithContext(ctx context.Context) StringPtrOutp
 type StringOutput struct{ *OutputState }
 
 func (StringOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringOutput) ToOutput(ctx context.Context) pulumix.Output[string] {
@@ -5021,7 +5021,7 @@ func (in *stringPtr) ToStringPtrOutputWithContext(ctx context.Context) StringPtr
 type StringPtrOutput struct{ *OutputState }
 
 func (StringPtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*string] {
@@ -5090,7 +5090,7 @@ func (in StringArray) ToStringArrayOutputWithContext(ctx context.Context) String
 type StringArrayOutput struct{ *OutputState }
 
 func (StringArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]string] {
@@ -5178,7 +5178,7 @@ func (in StringMap) ToStringMapOutputWithContext(ctx context.Context) StringMapO
 type StringMapOutput struct{ *OutputState }
 
 func (StringMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]string] {
@@ -5259,7 +5259,7 @@ func (in StringArrayMap) ToStringArrayMapOutputWithContext(ctx context.Context) 
 type StringArrayMapOutput struct{ *OutputState }
 
 func (StringArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]string] {
@@ -5340,7 +5340,7 @@ func (in StringMapArray) ToStringMapArrayOutputWithContext(ctx context.Context) 
 type StringMapArrayOutput struct{ *OutputState }
 
 func (StringMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]string] {
@@ -5428,7 +5428,7 @@ func (in StringMapMap) ToStringMapMapOutputWithContext(ctx context.Context) Stri
 type StringMapMapOutput struct{ *OutputState }
 
 func (StringMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]string] {
@@ -5509,7 +5509,7 @@ func (in StringArrayArray) ToStringArrayArrayOutputWithContext(ctx context.Conte
 type StringArrayArrayOutput struct{ *OutputState }
 
 func (StringArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o StringArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]string] {
@@ -5613,7 +5613,7 @@ func (in URN) ToURNPtrOutputWithContext(ctx context.Context) URNPtrOutput {
 type URNOutput struct{ *OutputState }
 
 func (URNOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNOutput) ToOutput(ctx context.Context) pulumix.Output[URN] {
@@ -5701,7 +5701,7 @@ func (in *urnPtr) ToURNPtrOutputWithContext(ctx context.Context) URNPtrOutput {
 type URNPtrOutput struct{ *OutputState }
 
 func (URNPtrOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNPtrOutput) ToOutput(ctx context.Context) pulumix.Output[*URN] {
@@ -5770,7 +5770,7 @@ func (in URNArray) ToURNArrayOutputWithContext(ctx context.Context) URNArrayOutp
 type URNArrayOutput struct{ *OutputState }
 
 func (URNArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]URN] {
@@ -5858,7 +5858,7 @@ func (in URNMap) ToURNMapOutputWithContext(ctx context.Context) URNMapOutput {
 type URNMapOutput struct{ *OutputState }
 
 func (URNMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]URN] {
@@ -5939,7 +5939,7 @@ func (in URNArrayMap) ToURNArrayMapOutputWithContext(ctx context.Context) URNArr
 type URNArrayMapOutput struct{ *OutputState }
 
 func (URNArrayMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNArrayMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string][]URN] {
@@ -6020,7 +6020,7 @@ func (in URNMapArray) ToURNMapArrayOutputWithContext(ctx context.Context) URNMap
 type URNMapArrayOutput struct{ *OutputState }
 
 func (URNMapArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNMapArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[]map[string]URN] {
@@ -6108,7 +6108,7 @@ func (in URNMapMap) ToURNMapMapOutputWithContext(ctx context.Context) URNMapMapO
 type URNMapMapOutput struct{ *OutputState }
 
 func (URNMapMapOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNMapMapOutput) ToOutput(ctx context.Context) pulumix.Output[map[string]map[string]URN] {
@@ -6189,7 +6189,7 @@ func (in URNArrayArray) ToURNArrayArrayOutputWithContext(ctx context.Context) UR
 type URNArrayArrayOutput struct{ *OutputState }
 
 func (URNArrayArrayOutput) MarshalJSON() ([]byte, error) {
-	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+	return nil, errors.New("Outputs can not be marshaled to JSON")
 }
 
 func (o URNArrayArrayOutput) ToOutput(ctx context.Context) pulumix.Output[[][]URN] {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -39,6 +39,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -729,8 +730,8 @@ func (host *nodeLanguageHost) constructArguments(
 		args = append(args, "--dry-run")
 	}
 
-	maybeAppendArg("query-mode", fmt.Sprint(req.GetQueryMode()))
-	maybeAppendArg("parallel", fmt.Sprint(req.GetParallel()))
+	maybeAppendArg("query-mode", strconv.FormatBool(req.GetQueryMode()))
+	maybeAppendArg("parallel", strconv.Itoa(int(req.GetParallel())))
 	maybeAppendArg("tracing", host.tracing)
 
 	// The engine should always pass a name for entry point, even if its just "." for the program directory.

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -35,6 +35,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -771,8 +772,8 @@ func (host *pythonLanguageHost) constructArguments(req *pulumirpc.RunRequest) []
 	maybeAppendArg("project", req.GetProject())
 	maybeAppendArg("stack", req.GetStack())
 	maybeAppendArg("pwd", req.GetPwd())
-	maybeAppendArg("dry_run", fmt.Sprintf("%v", req.GetDryRun()))
-	maybeAppendArg("parallel", fmt.Sprint(req.GetParallel()))
+	maybeAppendArg("dry_run", strconv.FormatBool(req.GetDryRun()))
+	maybeAppendArg("parallel", strconv.Itoa(int(req.GetParallel())))
 	maybeAppendArg("tracing", host.tracing)
 	maybeAppendArg("organization", req.GetOrganization())
 

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -145,7 +145,7 @@ func resolveWindowsExecutionAlias(pythonCmds []string) (string, string, error) {
 // directory.
 func VirtualEnvCommand(virtualEnvDir, name string, arg ...string) *exec.Cmd {
 	if runtime.GOOS == windows {
-		name = fmt.Sprintf("%s.exe", name)
+		name = name + ".exe"
 	}
 	cmdPath := filepath.Join(virtualEnvDir, virtualEnvBinDirName(), name)
 	return exec.Command(cmdPath, arg...)
@@ -155,7 +155,7 @@ func VirtualEnvCommand(virtualEnvDir, name string, arg ...string) *exec.Cmd {
 func IsVirtualEnv(dir string) bool {
 	pyBin := filepath.Join(dir, virtualEnvBinDirName(), "python")
 	if runtime.GOOS == windows {
-		pyBin = fmt.Sprintf("%s.exe", pyBin)
+		pyBin = pyBin + ".exe"
 	}
 	if info, err := os.Stat(pyBin); err == nil && !info.IsDir() {
 		return true
@@ -213,7 +213,7 @@ func ActivateVirtualEnv(environ []string, virtualEnvDir string) []string {
 		}
 	}
 	if !hasPath {
-		path := fmt.Sprintf("PATH=%s", virtualEnvBin)
+		path := "PATH=" + virtualEnvBin
 		result = append(result, path)
 	}
 	return result

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -64,7 +64,7 @@ func TestActivateVirtualEnv(t *testing.T) {
 		},
 		{
 			input:    []string{"PYTHONHOME=foo", "FOO=blah"},
-			expected: []string{"FOO=blah", fmt.Sprintf("PATH=%s", venvDir)},
+			expected: []string{"FOO=blah", "PATH=" + venvDir},
 		},
 		{
 			input:    []string{"PythonHome=foo", "Path=bar"},


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Prompted by a comment in another review:
https://github.com/pulumi/pulumi/pull/14654#discussion_r1419995945

This lints that we don't use `fmt.Errorf` when `errors.New` will suffice, it also covers a load of other cases where `Sprintf` is sub-optimal.

Most of these edits were made by running `perfsprint --fix`.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
