### PR TITLE
Pass current context root to Run/GetRequiredPlugins

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -763,7 +763,7 @@ func (eng *languageTestServer) RunLanguageTest(
 
 	// TODO(https://github.com/pulumi/pulumi/issues/13941): We don't capture stdout/stderr from the language
 	// plugin, so we can't show it back to the test.
-	err = languageClient.InstallDependencies(projectDir, ".")
+	err = languageClient.InstallDependencies(projectDir, projectDir, ".")
 	if err != nil {
 		return makeTestResponse(fmt.Sprintf("install dependencies: %v", err)), nil
 	}

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -103,7 +103,10 @@ func (h *L1EmptyLanguageHost) GenerateProject(
 func (h *L1EmptyLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
-	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
 		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
 	}
 	return nil

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -149,7 +149,10 @@ func (h *L2ResourceSimpleLanguageHost) GetRequiredPlugins(
 func (h *L2ResourceSimpleLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
-	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
+		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
 		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
 	}
 	return nil

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -161,7 +161,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 					}
 				}
 
-				progInfo := plugin.ProgInfo{Proj: proj, Pwd: pwd, Program: program}
+				progInfo := plugin.ProgInfo{Root: projinfo.Root, Proj: proj, Pwd: pwd, Program: program}
 				deps, err := lang.GetProgramDependencies(progInfo, transitiveDependencies)
 				if err != nil {
 					addError(err, "Failed to get information about the Pulumi program's dependencies")
@@ -589,6 +589,7 @@ func getProjectPluginsSilently(
 	os.Stdout = w
 
 	return plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
+		Root:    ctx.Root,
 		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -80,12 +80,13 @@ func newInstallCmd() *cobra.Command {
 				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
 			}
 
-			if err = lang.InstallDependencies(pwd, main); err != nil {
+			if err = lang.InstallDependencies(root, pwd, main); err != nil {
 				return fmt.Errorf("installing dependencies: %w", err)
 			}
 
 			// Compute the set of plugins the current project needs.
 			installs, err := lang.GetRequiredPlugins(plugin.ProgInfo{
+				Root:    pctx.Root,
 				Proj:    proj,
 				Pwd:     pwd,
 				Program: main,

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -738,7 +738,7 @@ func installDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 		return fmt.Errorf("failed to load language plugin %s: %w", runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(ctx.Pwd, main); err != nil {
+	if err = lang.InstallDependencies(ctx.Root, ctx.Pwd, main); err != nil {
 		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
 			"then run `pulumi up` to perform an initial deployment: %w", err)
 	}

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -70,6 +70,7 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	plugins, err := plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
+		Root:    projinfo.Root,
 		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -232,7 +232,7 @@ func installPolicyPackDependencies(ctx *plugin.Context,
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(ctx.Pwd, main); err != nil {
+	if err = lang.InstallDependencies(ctx.Root, ctx.Pwd, main); err != nil {
 		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
 			"then run `pulumi up` to perform an initial deployment: %w", err)
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -239,6 +239,7 @@ func installPlugins(ctx context.Context,
 	// In order to get a complete view of the set of plugins that we need for an update or query, we must
 	// consult both sources and merge their results into a list of plugins.
 	languagePlugins, err := gatherPluginsFromProgram(plugctx, plugin.ProgInfo{
+		Root:    plugctx.Root,
 		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -92,7 +92,7 @@ func (p *languageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{Name: "TestLanguage"}, nil
 }
 
-func (p *languageRuntime) InstallDependencies(pwd, main string) error {
+func (p *languageRuntime) InstallDependencies(root, pwd, main string) error {
 	if p.closed {
 		return ErrLanguageRuntimeIsClosed
 	}

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -44,7 +44,7 @@ type LanguageRuntime interface {
 	GetPluginInfo() (workspace.PluginInfo, error)
 
 	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-	InstallDependencies(pwd, main string) error
+	InstallDependencies(root, pwd, main string) error
 
 	// About returns information about the language runtime.
 	About() (AboutInfo, error)
@@ -85,6 +85,7 @@ type AboutInfo struct {
 }
 
 type RunPluginInfo struct {
+	Root    string
 	Pwd     string
 	Program string
 	Args    []string
@@ -94,12 +95,14 @@ type RunPluginInfo struct {
 // ProgInfo contains minimal information about the program to be run.
 type ProgInfo struct {
 	Proj    *workspace.Project // the program project/package.
+	Root    string             // the programs root directory, i.e. where the Pulumi.yaml file is.
 	Pwd     string             // the program's working directory.
 	Program string             // the path to the program to execute.
 }
 
 // RunInfo contains all of the information required to perform a plan or deployment operation.
 type RunInfo struct {
+	Root              string                // the programs root directory, i.e. where the Pulumi.yaml file is.
 	MonitorAddress    string                // the RPC address to the host resource monitor.
 	Project           string                // the project name housing the program being run.
 	Stack             string                // the stack name being evaluated.

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -351,6 +351,7 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 		}
 
 		stdout, stderr, kill, err := runtime.RunPlugin(RunPluginInfo{
+			Root:    ctx.Root,
 			Pwd:     pwd,
 			Program: pluginDir,
 			Args:    pluginArgs,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Next part of fixing root directories for conformance testing. We need the current root for the project, not the root first saved on the language host when it was created. 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
