### PR TITLE
on-merge: add steps to update the latest dev version 

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -87,3 +87,26 @@ jobs:
         run: exit 1
       - name: CI succeeded
         run: exit 0
+
+  update-dev-version:
+    name: update-dev-version
+    needs: [ci-ok]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Install Pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        with:
+          repo: pulumi/pulumictl
+          tag: v0.0.46
+          cache: enable
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v1
+      - name: Dispatch event to docs repo
+        run: |
+          pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version=${{ steps.ghd.outputs.describe }}


### PR DESCRIPTION
If CI succeeds for the merge, we'll want to update the latest dev
version, as we know this is going to be merged, and we published the
binaries to AWS.  Dispatch the correct event to update that file in
the pulumi/docs repository.

/xref https://github.com/pulumi/pulumi/issues/14623

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
