### PR TITLE
fix: docs generator

### DIFF
--- a/changelog/pending/20231211--docs--fix-docs-generator-panic-with-nested-modules-and-invalid-package-tree.yaml
+++ b/changelog/pending/20231211--docs--fix-docs-generator-panic-with-nested-modules-and-invalid-package-tree.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Fix docs generator panic with nested modules and invalid package tree

--- a/pkg/codegen/docs/package_tree.go
+++ b/pkg/codegen/docs/package_tree.go
@@ -32,8 +32,6 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 	size := numResources + numFunctions + 1
 	packageTree := slice.Prealloc[PackageTreeItem](size)
 
-	conflictResolver := rootMod.docGenContext.newModuleConflictResolver()
-
 	for _, m := range rootMod.children {
 		modName := m.getModuleFileName()
 		displayName := modFilenameToDisplayName(modName)
@@ -43,14 +41,10 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 			return nil, fmt.Errorf("generating children for module %s (mod token: %s): %w", displayName, m.mod, err)
 		}
 
-		safeName := conflictResolver.getSafeName(displayName, m)
-		if safeName == "" {
-			continue // unresolved conflict
-		}
 		ti := PackageTreeItem{
 			Name:     displayName,
 			Type:     entryTypeModule,
-			Link:     getModuleLink(safeName),
+			Link:     getModuleLink(m.mod),
 			Children: children,
 		}
 
@@ -62,14 +56,10 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 
 	for _, r := range rootMod.resources {
 		name := resourceName(r)
-		safeName := conflictResolver.getSafeName(name, r)
-		if safeName == "" {
-			continue // unresolved conflict
-		}
 		ti := PackageTreeItem{
 			Name:     name,
 			Type:     entryTypeResource,
-			Link:     getResourceLink(safeName),
+			Link:     getResourceLink("res-" + name),
 			Children: nil,
 		}
 
@@ -87,14 +77,10 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 
 	for _, f := range rootMod.functions {
 		name := tokenToName(f.Token)
-		safeName := conflictResolver.getSafeName(name, f)
-		if safeName == "" {
-			continue // unresolved conflict
-		}
 		ti := PackageTreeItem{
 			Name:     name,
 			Type:     entryTypeFunction,
-			Link:     getFunctionLink(safeName),
+			Link:     getFunctionLink("fn-" + name),
 			Children: nil,
 		}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR contains fixes to solve two issues with the docs generator.

Fixes #14820
Fixes #14821

To fix #14820 the moduleConflictResolver has been completely removed from the docs generator and has been replaced with a strategy to always add a prefix `res-` to a directory for a resource and a `fn-` prefix for a directory of a function. This will effectively prevent name collisions without the overhead of moduleConflictResolver which tried to solve this problem in some dynamic way.

The new implementation has been tested by using `registrygen gen docs` with the following Pulumi providers: Azure Classic, GCP, AWS, Docker, Kubernetes and the result yielded only changes to the folder names of all resources and functions, what was expected.

To fix #14821 the code at `getMod` has been changed so that `parentName := path.Dir(modName)` has been removed and the `modName` is passed directly to the recursive call of `dctx.getMod` because `pkg.TokenToModule` always removes the last element of the module name and thus `path.Dir(modName)` prematurely shortened the path so that the recursive call of `dctx.getMod`  didn't return the parent module but the next but one module in the hierarchy.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change

