### PR TITLE
[template zip] only copy over valid pulumi projects

### DIFF
--- a/changelog/pending/20231211--sdk-go--template-zip-only-copy-over-valid-pulumi-projects.yaml
+++ b/changelog/pending/20231211--sdk-go--template-zip-only-copy-over-valid-pulumi-projects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: "[template zip] only copy over valid pulumi projects"

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -150,6 +150,18 @@ func TestRetrieveZIPTemplates(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to write nested file to zip archive: %s", err)
 		}
+
+		if req.URL.Path != "/no-pulumi-yaml/foo.zip" {
+			fileHandle, err := writer.Create("Pulumi.yaml")
+			if err != nil {
+				t.Errorf("Failed to create Pulumi.yaml file in zip archive: %s", err)
+			}
+			pulumiProj := "name: foo\nruntime: nodejs"
+			_, err = fileHandle.Write([]byte(pulumiProj))
+			if err != nil {
+				t.Errorf("Failed to write to zip file: %s", err)
+			}
+		}
 		writer.Close()
 		rw.Header().Set("Content-Type", "application/zip")
 		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.zip", fileName))
@@ -168,6 +180,11 @@ func TestRetrieveZIPTemplates(t *testing.T) {
 			testName:    "valid_zip_url",
 			templateURL: fmt.Sprintf("%s/foo.zip", server.URL),
 			shouldFail:  false,
+		},
+		{
+			testName:    "invalid_zip_template",
+			templateURL: fmt.Sprintf("%s/no-pulumi-yaml/foo.zip", server.URL),
+			shouldFail:  true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

add validation to the `RetrieveZIPTemplateFolder` function to ensure the template contains a `Pulumi.yaml` file before copying the contents over. @kpitzen let me know what you think about this. It looks like we are always copying over the archive at the moment which is probably validated later. I also understand if we don't want to make this change since it is breaking the current behavior that will retrieve any zip folder (even if it's not a valid template).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
