### PR TITLE
[program-gen] Fix duplicated import statements when instantiating a component multiple times

### DIFF
--- a/changelog/pending/20231212--programgen-nodejs-python--fix-duplicated-import-statements-when-instantiating-a-component-multiple-times.yaml
+++ b/changelog/pending/20231212--programgen-nodejs-python--fix-duplicated-import-statements-when-instantiating-a-component-multiple-times.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs,python
+  description: Fix duplicated import statements when instantiating a component multiple times

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -365,6 +365,7 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 	var componentImports []string
 
 	npmToPuPkgName := make(map[string]string)
+	seenComponentImports := map[string]bool{}
 	for _, n := range program.Nodes {
 		switch n := n.(type) {
 		case *pcl.Resource:
@@ -385,8 +386,12 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 		case *pcl.Component:
 			componentDir := filepath.Base(n.DirPath())
 			componentName := n.DeclarationName()
-			importStatement := fmt.Sprintf("import { %s } from \"./%s\";", componentName, componentDir)
-			componentImports = append(componentImports, importStatement)
+			dirAndName := componentDir + "-" + componentName
+			if _, ok := seenComponentImports[dirAndName]; !ok {
+				importStatement := fmt.Sprintf("import { %s } from \"./%s\";", componentName, componentDir)
+				componentImports = append(componentImports, importStatement)
+				seenComponentImports[dirAndName] = true
+			}
 		}
 		diags := n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
 			if call, ok := n.(*model.FunctionCallExpression); ok {

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -529,11 +529,16 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 		imports = append(imports, "from pulumi import Input")
 	}
 
+	seenComponentImports := map[string]bool{}
 	for _, node := range program.Nodes {
 		if component, ok := node.(*pcl.Component); ok {
 			componentPath := strings.ReplaceAll(filepath.Base(component.DirPath()), "-", "_")
 			componentName := component.DeclarationName()
-			imports = append(imports, fmt.Sprintf("from %s import %s", componentPath, componentName))
+			pathAndName := componentPath + "-" + componentName
+			if _, ok := seenComponentImports[pathAndName]; !ok {
+				imports = append(imports, fmt.Sprintf("from %s import %s", componentPath, componentName))
+				seenComponentImports[pathAndName] = true
+			}
 		}
 	}
 

--- a/pkg/codegen/testing/test/testdata/components-pp/components.pp
+++ b/pkg/codegen/testing/test/testdata/components-pp/components.pp
@@ -1,5 +1,11 @@
 component simpleComponent "./simpleComponent" {}
 
+component multipleSimpleComponents "./simpleComponent" {
+    options {
+        range = 10
+    }
+}
+
 component anotherComponent "./another-component" {}
 
 component exampleComponent "./exampleComponent" {

--- a/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
+++ b/pkg/codegen/testing/test/testdata/components-pp/dotnet/components.cs
@@ -6,6 +6,12 @@ return await Deployment.RunAsync(() =>
 {
     var simpleComponent = new Components.SimpleComponent("simpleComponent");
 
+    var multipleSimpleComponents = new List<Components.SimpleComponent>();
+    for (var rangeIndex = 0; rangeIndex < 10; rangeIndex++)
+    {
+        var range = new { Value = rangeIndex };
+        multipleSimpleComponents.Add(new Components.SimpleComponent($"multipleSimpleComponents-{range.Value}"));
+    }
     var anotherComponent = new Components.AnotherComponent("anotherComponent");
 
     var exampleComponent = new Components.ExampleComponent("exampleComponent", new()

--- a/pkg/codegen/testing/test/testdata/components-pp/go/components.go
+++ b/pkg/codegen/testing/test/testdata/components-pp/go/components.go
@@ -10,6 +10,16 @@ func main() {
 		if err != nil {
 			return err
 		}
+		var multipleSimpleComponents []*SimpleComponent
+		for index := 0; index < 10; index++ {
+			key0 := index
+			_ := index
+			__res, err := NewSimpleComponent(ctx, fmt.Sprintf("multipleSimpleComponents-%v", key0), nil)
+			if err != nil {
+				return err
+			}
+			multipleSimpleComponents = append(multipleSimpleComponents, __res)
+		}
 		_, err = NewAnotherComponent(ctx, "anotherComponent", nil)
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
+++ b/pkg/codegen/testing/test/testdata/components-pp/nodejs/components.ts
@@ -4,6 +4,10 @@ import { ExampleComponent } from "./exampleComponent";
 import { SimpleComponent } from "./simpleComponent";
 
 const simpleComponent = new SimpleComponent("simpleComponent");
+const multipleSimpleComponents: SimpleComponent[] = [];
+for (const range = {value: 0}; range.value < 10; range.value++) {
+    multipleSimpleComponents.push(new SimpleComponent(`multipleSimpleComponents-${range.value}`));
+}
 const anotherComponent = new AnotherComponent("anotherComponent");
 const exampleComponent = new ExampleComponent("exampleComponent", {
     input: "doggo",

--- a/pkg/codegen/testing/test/testdata/components-pp/python/components.py
+++ b/pkg/codegen/testing/test/testdata/components-pp/python/components.py
@@ -4,6 +4,9 @@ from exampleComponent import ExampleComponent
 from simpleComponent import SimpleComponent
 
 simple_component = SimpleComponent("simpleComponent")
+multiple_simple_components = []
+for range in [{"value": i} for i in range(0, 10)]:
+    multiple_simple_components.append(SimpleComponent(f"multipleSimpleComponents-{range['value']}"))
 another_component = AnotherComponent("anotherComponent")
 example_component = ExampleComponent("exampleComponent", {
     'input': "doggo", 


### PR DESCRIPTION
# Description

This PR extends the `components` test program in PCL so that it instantiates a component with `options { range = <expr> }` to test that it is generating the right thing and increase code coverage in program-gen which has a special handling for the `range` option. Found a small bug where we duplicate imports for components if they are instantiated multiple times in the program and fixed it as well

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
