### PR TITLE
Fix fmt.Errorf from 16d9f4c1670404c2cb2f15d2dd095f05dc8eec12

### DIFF
--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -163,7 +163,7 @@ func dialPlugin(portNum int, bin, prefix string, dialOptions []grpc.DialOption) 
 		}
 		// Not ready yet; ask the gRPC client APIs to block until the state transitions again so we can retry.
 		if !conn.WaitForStateChange(timeout, s) {
-			return nil, fmt.Errorf("%v plugin [%v] did not begin responding to RPC connections: %w", prefix, bin, err)
+			return nil, fmt.Errorf("%v plugin [%v] did not begin responding to RPC connections", prefix, bin)
 		}
 	}
 


### PR DESCRIPTION
This incorrectly added `err` as a parameter:
```
-                       return nil, errors.Errorf("%v plugin [%v] did not begin responding to RPC connections", prefix, bin)
+                       return nil, fmt.Errorf("%v plugin [%v] did not begin responding to RPC connections: %w", prefix, bin, err)
```
