### PR TITLE
[tests] Disable `--rerun-fails` to identify flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           ls -lhR test-results
           find test-results -mindepth 1 -name '*.json' -mtime +7 -delete
   test-collect-coverage:
-    needs: [unit-test, integration-test, acceptance-test]
+    needs: [unit-test, integration-test]
     if: ${{ inputs.enable-coverage }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -72,8 +72,7 @@ jobs:
 
   ci:
     name: CI
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, inspect]
+    needs: [info]
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
@@ -82,29 +81,6 @@ jobs:
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
-      lint: true
-      build-all-targets: ${{ contains(github.event.pull_request.labels.*.name, 'ci/test') }}
-      # codegen tests take quite a while to run.
-      # Run them only if ci/test is set,
-      # or if one of the codegen files changed.
-      test-codegen: >- # No newlines or trailing newline.
-        ${{
-          contains(github.event.pull_request.labels.*.name, 'ci/test') ||
-          (needs.inspect.outputs.test-codegen == 'true')
-        }}
-      test-version-sets: >- # No newlines or trailing newline.
-        ${{
-          contains(github.event.pull_request.labels.*.name, 'ci/test')
-          && 'minimum current'
-          || 'current'
-        }}
-      integration-test-platforms: ubuntu-latest
-      acceptance-test-platforms: >- # No newlines or trailing newline.
-        ${{
-          contains(github.event.pull_request.labels.*.name, 'ci/test')
-          && 'macos-latest windows-latest'
-          || ''
-        }}
       enable-coverage: true
     secrets: inherit
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -105,8 +105,7 @@ jobs:
           && 'macos-latest windows-latest'
           || ''
         }}
-      # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
-      enable-coverage: false
+      enable-coverage: true
     secrets: inherit
 
   prepare-release:

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args


### PR DESCRIPTION
As seen by #14777, side-effects caused by prior tests led to a test failure that was masked by `gotestsum` retrying failures.