### PR TITLE
langhost test: retry if the langhost is unavailable

### DIFF
--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1924,26 +1924,26 @@ function mockRun(
         runReq.setInfo(info);
 
         runReq.setDryrun(dryrun);
-        // Sometimes it takes a little bit until the engine is ready to accept connections.  We'll
-        // retry a few times to make sure we don't fail spuriously.
-        for (let i = 0; i < 20; i++) {
-            let retry = false;
-            langHostClient.run(runReq, (err: Error, res: any) => {
-                if (err) {
-                    if (err.message.indexOf("UNAVAILABLE") !== 0) {
-                        retry = true;
-                    } else {
-                        reject(err);
-                    }
-                } else {
-                    // The response has a single field, the error, if any, that occurred (blank means success).
-                    resolve([res.getError(), res.getBail()]);
-                }
-            });
-            if (!retry) {
-                break;
+        langHostClient.run(runReq, (err: Error, res: any) => {
+            if (err && err.message.indexOf("UNAVAILABLE") !== 0) {
+                // Sometimes it takes a little bit until the engine is ready to accept connections.  We'll
+                // retry after a short delay.
+                setTimeout(() => {
+                    langHostClient.run(runReq, (err: Error, res: any) => {
+                        if (err) {
+                            reject(err)
+                        } else {
+                            resolve([res.getError(), res.getBail()]);
+                        }
+                    })
+                }, 200);
+            } else if (err) {
+                reject(err);
+            } else {
+                // The response has a single field, the error, if any, that occurred (blank means success).
+                resolve([res.getError(), res.getBail()]);
             }
-        }
+        });
     });
 }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1929,13 +1929,13 @@ function mockRun(
                 // Sometimes it takes a little bit until the engine is ready to accept connections.  We'll
                 // retry after a short delay.
                 setTimeout(() => {
-                    langHostClient.run(runReq, (err: Error, res: any) => {
-                        if (err) {
-                            reject(err)
+                    langHostClient.run(runReq, (e: Error, r: any) => {
+                        if (e) {
+                            reject(e);
                         } else {
-                            resolve([res.getError(), res.getBail()]);
+                            resolve([r.getError(), r.getBail()]);
                         }
-                    })
+                    });
                 }, 200);
             } else if (err) {
                 reject(err);


### PR DESCRIPTION
This test is racy, as the langhost can sometimes take a little bit too long to be ready to accept connections successfully.  Just retry a few times in this case, to make sure it's ready to have the test run against it.

I haven't been able to reliable reproduce the flakyness locally, so there's no guarantee that this will actually do what it says successfully.  I think it's still worth a try and we can monitor CI to verify if this fixed the issue, and revert this PR if the same issue appears again.

Fixes https://github.com/pulumi/pulumi/issues/14841
