### PR TITLE
increase the timeout for automation API tests

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -71,7 +71,7 @@ unit_tests:: $(TEST_ALL_DEPS)
 	yarn run nyc -s mocha 'bin/tests_with_mocks/**/*.spec.js'
 
 test_auto:: $(TEST_ALL_DEPS)
-	yarn run nyc -s mocha --timeout 220000 'bin/tests/automation/**/*.spec.js'
+	yarn run nyc -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
 
 TSC_SUPPORTED_VERSIONS = ~3.7.3 ^3 ^4
 


### PR DESCRIPTION
These tests are pretty close to hitting the timeout during regular runs (e.g. one successful run I picked randomly took ~194000ms).  The GitHub action runners don't have super reliable performance, so we can easily get pushed over this limit.

To make matters worse here, if we hit this timeout just at the right time, the test doesn't exit cleanly (potentially related to https://github.com/pulumi/pulumi-dotnet/issues/134), as I've seen a `pulumi preview` process stick around in that case, preventing the tests from shutting down).  This means we have to wait until the CI job times out after an hour until the failure is reported.

I'm not sure if we only got close to this timeout recently, or if this is a longer standing issue, but it reproduces well for me locally. Ideally of course the tests would be faster, but this is still "only" ~5min which is much faster than other tests, and should hopefully reduce the amount of times we need to go through the merge queue, saving a lot of time there.

Fixes https://github.com/pulumi/pulumi/issues/14842

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
