### PR TITLE
Ensure that pulumi config cp also copies the environments from the source stack

### DIFF
--- a/changelog/pending/20231213--cli-config--fixes-config-copy-command-to-also-copy-environments-from-the-source-stack.yaml
+++ b/changelog/pending/20231213--cli-config--fixes-config-copy-command-to-also-copy-environments-from-the-source-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fixes config copy command to also copy environments from the source stack

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -278,15 +278,7 @@ func copyEntireConfigMap(currentStack backend.Stack,
 	}
 
 	if currentEnvironments != nil && len(currentEnvironments.Imports()) > 0 {
-		if destinationProjectStack.Environment != nil {
-			imports := currentEnvironments.Imports()
-			for _, env := range imports {
-				destinationProjectStack.Environment.Append(env)
-			}
-		} else {
-			destinationProjectStack.Environment = currentEnvironments
-		}
-
+		destinationProjectStack.Environment = currentEnvironments
 		requiresSaving = true
 	}
 

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -161,7 +161,11 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 					destinationProjectStack)
 			}
 
-			requiresSaving, err := copyEntireConfigMap(currentStack, currentProjectStack, destinationStack, destinationProjectStack)
+			requiresSaving, err := copyEntireConfigMap(
+				currentStack,
+				currentProjectStack,
+				destinationStack,
+				destinationProjectStack)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -161,7 +161,21 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 					destinationProjectStack)
 			}
 
-			return copyEntireConfigMap(currentStack, currentProjectStack, destinationStack, destinationProjectStack)
+			requiresSaving, err := copyEntireConfigMap(currentStack, currentProjectStack, destinationStack, destinationProjectStack)
+			if err != nil {
+				return err
+			}
+
+			// The use of `requiresSaving` here ensures that there was actually some config
+			// that needed saved, otherwise it's an unnecessary save call
+			if requiresSaving {
+				err := saveProjectStack(destinationStack, destinationProjectStack)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
 		}),
 	}
 
@@ -224,13 +238,15 @@ func copySingleConfigKey(configKey string, path bool, currentStack backend.Stack
 func copyEntireConfigMap(currentStack backend.Stack,
 	currentProjectStack *workspace.ProjectStack, destinationStack backend.Stack,
 	destinationProjectStack *workspace.ProjectStack,
-) error {
+) (bool, error) {
 	var decrypter config.Decrypter
 	currentConfig := currentProjectStack.Config
+	currentEnvironments := currentProjectStack.Environment
+
 	if currentConfig.HasSecureValue() {
 		dec, needsSave, decerr := getStackDecrypter(currentStack, currentProjectStack)
 		if decerr != nil {
-			return decerr
+			return false, decerr
 		}
 		contract.Assertf(!needsSave, "We're reading a secure value so the encryption information must be present already")
 		decrypter = dec
@@ -240,33 +256,37 @@ func copyEntireConfigMap(currentStack backend.Stack,
 
 	encrypter, _, cerr := getStackEncrypter(destinationStack, destinationProjectStack)
 	if cerr != nil {
-		return cerr
+		return false, cerr
 	}
 
 	newProjectConfig, err := currentConfig.Copy(decrypter, encrypter)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	var requiresSaving bool
 	for key, val := range newProjectConfig {
 		err = destinationProjectStack.Config.Set(key, val, false)
 		if err != nil {
-			return err
+			return false, err
 		}
 		requiresSaving = true
 	}
 
-	// The use of `requiresSaving` here ensures that there was actually some config
-	// that needed saved, otherwise it's an unnecessary save call
-	if requiresSaving {
-		err := saveProjectStack(destinationStack, destinationProjectStack)
-		if err != nil {
-			return err
+	if currentEnvironments != nil && len(currentEnvironments.Imports()) > 0 {
+		if destinationProjectStack.Environment != nil {
+			imports := currentEnvironments.Imports()
+			for _, env := range imports {
+				destinationProjectStack.Environment.Append(env)
+			}
+		} else {
+			destinationProjectStack.Environment = currentEnvironments
 		}
+
+		requiresSaving = true
 	}
 
-	return nil
+	return requiresSaving, nil
 }
 
 func newConfigGetCmd(stack *string) *cobra.Command {

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -311,7 +311,8 @@ func TestCopyConfig(t *testing.T) {
 		err := yaml.Unmarshal([]byte("environment:\n  - test2"), &destinationProjectStack)
 		require.NoError(t, err)
 
-		requiresSaving, err := copyEntireConfigMap(sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
+		requiresSaving, err := copyEntireConfigMap(
+			sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
 		require.NoError(t, err)
 		assert.True(t, requiresSaving, "expected config file changes requiring saving")
 

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -311,8 +311,9 @@ func TestCopyConfig(t *testing.T) {
 		err := yaml.Unmarshal([]byte("environment:\n  - test2"), &destinationProjectStack)
 		require.NoError(t, err)
 
-		_, err = copyEntireConfigMap(sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
+		requiresSaving, err := copyEntireConfigMap(sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
 		require.NoError(t, err)
+		assert.True(t, requiresSaving, "expected config file changes requiring saving")
 
 		// Assert that only the source stack's environment
 		// remains in the destination stack.

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -314,12 +314,11 @@ func TestCopyConfig(t *testing.T) {
 		_, err = copyEntireConfigMap(sourceStack, &sourceProjectStack, destinationStack, &destinationProjectStack)
 		require.NoError(t, err)
 
-		// Assert that the "test" env from the source stack
-		// has been copied in addition to the "test2" env
-		// of the destination stack.
+		// Assert that only the source stack's environment
+		// remains in the destination stack.
 		envImports := destinationProjectStack.Environment.Imports()
 		assert.Contains(t, envImports, "test")
-		assert.Contains(t, envImports, "test2")
+		assert.NotContains(t, envImports, "test2")
 	})
 }
 

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -200,7 +200,19 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		// copy the config from the old to the new
-		return copyEntireConfigMap(copyStack, copyProjectStack, newStack, newProjectStack)
+		requiresSaving, err := copyEntireConfigMap(copyStack, copyProjectStack, newStack, newProjectStack)
+		if err != nil {
+			return err
+		}
+
+		// The use of `requiresSaving` here ensures that there was actually some config
+		// that needed saved, otherwise it's an unnecessary save call
+		if requiresSaving {
+			err := saveProjectStack(newStack, newProjectStack)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package secrets
 
 import (

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -1,0 +1,83 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+type MockSecretsManager struct {
+	TypeF      func() string
+	StateF     func() json.RawMessage
+	EncrypterF func() (config.Encrypter, error)
+	DecrypterF func() (config.Decrypter, error)
+}
+
+var _ Manager = &MockSecretsManager{}
+
+func (msm *MockSecretsManager) Type() string {
+	if msm.TypeF != nil {
+		return msm.TypeF()
+	}
+
+	panic("not implemented")
+}
+
+func (msm *MockSecretsManager) State() json.RawMessage {
+	if msm.StateF != nil {
+		return msm.StateF()
+	}
+
+	panic("not implemented")
+}
+
+func (msm *MockSecretsManager) Encrypter() (config.Encrypter, error) {
+	if msm.EncrypterF != nil {
+		return msm.EncrypterF()
+	}
+
+	panic("not implemented")
+}
+
+func (msm *MockSecretsManager) Decrypter() (config.Decrypter, error) {
+	if msm.DecrypterF != nil {
+		return msm.DecrypterF()
+	}
+
+	panic("not implemented")
+}
+
+type MockEncrypter struct {
+	EncryptValueF func() string
+}
+
+func (me *MockEncrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
+	if me.EncryptValueF != nil {
+		return me.EncryptValueF(), nil
+	}
+
+	return "", errors.New("mock value not provided")
+}
+
+type MockDecrypter struct {
+	DecryptValueF func() string
+	BulkDecryptF  func() map[string]string
+}
+
+func (md *MockDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	if md.DecryptValueF != nil {
+		return md.DecryptValueF(), nil
+	}
+
+	return "", errors.New("mock value not provided")
+}
+
+func (md *MockDecrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	if md.BulkDecryptF != nil {
+		return md.BulkDecryptF(), nil
+	}
+
+	return nil, errors.New("mock value not provided")
+}


### PR DESCRIPTION
# Description

This PR updates the copy config command to also copy the environments from the source stack to the destination stack. The list of environments in the destination stack's config will be overwritten.

Fixes #14564 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
