### PR TITLE
Add pulumi config env ls command

### DIFF
--- a/changelog/pending/20231214--cli-config--adds-pulumi-config-env-ls-command.yaml
+++ b/changelog/pending/20231214--cli-config--adds-pulumi-config-env-ls-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Adds `pulumi config env ls` command to list the environment imports declared in a stack configuration.

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -135,7 +135,8 @@ func (cmd *configEnvCmd) listStackEnvironments(jsonOut bool) error {
 				Rows:    rows,
 			}, nil)
 		} else {
-			fprintf(cmd.stdout, "This stack configuration has no environments listed. Try adding one with `pulumi config env add [envName]`.\n")
+			fprintf(cmd.stdout, "This stack configuration has no environments listed. "+
+				"Try adding one with `pulumi config env add [envName]`.\n")
 		}
 
 	}

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -55,6 +55,7 @@ func newConfigEnvCmd(stackRef *string) *cobra.Command {
 	cmd.AddCommand(newConfigEnvInitCmd(&impl))
 	cmd.AddCommand(newConfigEnvAddCmd(&impl))
 	cmd.AddCommand(newConfigEnvRmCmd(&impl))
+	cmd.AddCommand(newConfigEnvLsCmd(&impl))
 
 	return cmd
 }
@@ -84,6 +85,64 @@ type configEnvCmd struct {
 	stackRef *string
 }
 
+func (cmd *configEnvCmd) loadEnvPreamble() (*workspace.ProjectStack, *workspace.Project, *backend.Stack, error) {
+	opts := display.Options{Color: cmd.color}
+
+	project, _, err := cmd.readProject()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stack, err := cmd.requireStack(cmd.ctx, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	_, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+
+	projectStack, err := cmd.loadProjectStack(project, stack)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return projectStack, project, &stack, nil
+}
+
+func (cmd *configEnvCmd) listStackEnvironments(jsonOut bool) error {
+	projectStack, _, _, err := cmd.loadEnvPreamble()
+	if err != nil {
+		return err
+	}
+	imports := projectStack.Environment.Imports()
+
+	if jsonOut {
+		err := fprintJSON(cmd.stdout, imports)
+		if err != nil {
+			return err
+		}
+	} else {
+		rows := []cmdutil.TableRow{}
+		for _, imp := range imports {
+			rows = append(rows, cmdutil.TableRow{Columns: []string{imp}})
+		}
+
+		if len(imports) > 0 {
+			fprintTable(cmd.stdout, cmdutil.Table{
+				Headers: []string{"ENVIRONMENTS"},
+				Rows:    rows,
+			}, nil)
+		} else {
+			fprintf(cmd.stdout, "This stack configuration has no environments listed. Try adding one with `pulumi config env add [envName]`.\n")
+		}
+
+	}
+
+	return nil
+}
+
 func (cmd *configEnvCmd) editStackEnvironment(
 	showSecrets bool,
 	yes bool,
@@ -93,24 +152,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		return errors.New("--yes must be passed in to proceed when running in non-interactive mode")
 	}
 
-	opts := display.Options{Color: cmd.color}
-
-	project, _, err := cmd.readProject()
-	if err != nil {
-		return err
-	}
-
-	stack, err := cmd.requireStack(cmd.ctx, *cmd.stackRef, stackOfferNew|stackSetCurrent, opts)
-	if err != nil {
-		return err
-	}
-
-	_, ok := stack.Backend().(backend.EnvironmentsBackend)
-	if !ok {
-		return fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
-	}
-
-	projectStack, err := cmd.loadProjectStack(project, stack)
+	projectStack, project, stack, err := cmd.loadEnvPreamble()
 	if err != nil {
 		return err
 	}
@@ -119,7 +161,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		return err
 	}
 
-	if err := listConfig(cmd.ctx, cmd.stdout, project, stack, projectStack, showSecrets, false); err != nil {
+	if err := listConfig(cmd.ctx, cmd.stdout, project, *stack, projectStack, showSecrets, false); err != nil {
 		return err
 	}
 
@@ -138,7 +180,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		}
 	}
 
-	if err = cmd.saveProjectStack(stack, projectStack); err != nil {
+	if err = cmd.saveProjectStack(*stack, projectStack); err != nil {
 		return fmt.Errorf("saving stack config: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/config_env_ls.go
+++ b/pkg/cmd/pulumi/config_env_ls.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
+	var jsonOut bool
+
+	impl := configEnvLsCmd{parent: parent, jsonOut: jsonOut}
+
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "Lists imported environments.",
+		Long:  "Lists the environments imported into a stack's configuration.",
+		Args:  cmdutil.NoArgs,
+		Run:   cmdutil.RunFunc(impl.run),
+	}
+
+	cmd.Flags().BoolVarP(
+		&jsonOut, "json", "j", false,
+		"Emit output as JSON")
+
+	return cmd
+}
+
+type configEnvLsCmd struct {
+	parent *configEnvCmd
+
+	jsonOut bool
+}
+
+func (cmd *configEnvLsCmd) run(_ *cobra.Command, _ []string) error {
+	return cmd.parent.listStackEnvironments(cmd.jsonOut)
+}

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -51,7 +51,8 @@ runtime: yaml`
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "This stack configuration has no environments listed. Try adding one with `pulumi config env add [envName]`.\n"
+		const expectedOut = "This stack configuration has no environments listed. " +
+			"Try adding one with `pulumi config env add [envName]`.\n"
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -1,0 +1,156 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/esc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigEnvLsCmd(t *testing.T) {
+	t.Parallel()
+
+	projectYAML := `name: test
+runtime: yaml`
+
+	t.Run("no imports", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		env := &esc.Environment{
+			Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{
+					"aws:region": esc.NewValue("us-west-2"),
+				}),
+			},
+		}
+
+		stdin := strings.NewReader("")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
+		ls := &configEnvLsCmd{parent: parent, jsonOut: false}
+		err := ls.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "This stack configuration has no environments listed. Try adding one with `pulumi config env add [envName]`.\n"
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+	})
+
+	t.Run("no imports, json", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		env := &esc.Environment{
+			Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{
+					"aws:region": esc.NewValue("us-west-2"),
+				}),
+			},
+		}
+
+		stdin := strings.NewReader("")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
+		ls := &configEnvLsCmd{parent: parent, jsonOut: true}
+		err := ls.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = "null\n"
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+	})
+
+	t.Run("with imports", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		env := &esc.Environment{
+			Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{
+					"aws:region":   esc.NewValue("us-west-2"),
+					"app:password": esc.NewSecret("hunter2"),
+				}),
+			},
+		}
+
+		const stackYAML = `environment:
+    - env
+    - otherEnv
+    - thirdEnv
+`
+
+		stdin := strings.NewReader("")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		ls := &configEnvLsCmd{parent: parent, jsonOut: false}
+		err := ls.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = `ENVIRONMENTS
+env
+otherEnv
+thirdEnv
+`
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+	})
+
+	t.Run("with imports, json", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		env := &esc.Environment{
+			Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{
+					"aws:region":   esc.NewValue("us-west-2"),
+					"app:password": esc.NewSecret("hunter2"),
+				}),
+			},
+		}
+
+		const stackYAML = `environment:
+    - env
+    - otherEnv
+    - thirdEnv
+`
+
+		stdin := strings.NewReader("")
+		var stdout bytes.Buffer
+		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		ls := &configEnvLsCmd{parent: parent, jsonOut: true}
+		err := ls.run(nil, nil)
+		require.NoError(t, err)
+
+		const expectedOut = `[
+  "env",
+  "otherEnv",
+  "thirdEnv"
+]
+`
+
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+	})
+}

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -19,14 +19,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/pulumi/esc/ast"
-	"github.com/pulumi/esc/eval"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/pulumi/esc/ast"
+	"github.com/pulumi/esc/eval"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pgavlin/fx"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a `pulumi config env ls` command to list the environments imported into the stack configuration.

Fixes #14774 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
