### PR TITLE
Move nodejs feature checks to startup

### DIFF
--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -90,7 +90,7 @@ export function error(msg: string, resource?: resourceTypes.Resource, streamId?:
 }
 
 function log(
-    engine: engrpc.EngineClient,
+    engine: engrpc.IEngineClient,
     sev: engproto.LogSeverity,
     msg: string,
     resource: resourceTypes.Resource | undefined,

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -308,7 +308,7 @@ class Server implements grpc.UntypedServiceImplementation {
                 return;
             }
 
-            configureRuntime(req, this.engineAddr);
+            await configureRuntime(req, this.engineAddr);
 
             const inputs = await deserializeInputs(req.getInputs(), req.getInputdependenciesMap());
 
@@ -399,7 +399,7 @@ class Server implements grpc.UntypedServiceImplementation {
                 return;
             }
 
-            configureRuntime(req, this.engineAddr);
+            await configureRuntime(req, this.engineAddr);
 
             const args = await deserializeInputs(req.getArgs(), req.getArgdependenciesMap());
 
@@ -489,7 +489,7 @@ class Server implements grpc.UntypedServiceImplementation {
     }
 }
 
-function configureRuntime(req: any, engineAddr: string | undefined) {
+async function configureRuntime(req: any, engineAddr: string | undefined) {
     // NOTE: these are globals! We should ensure that all settings are identical between calls, and eventually
     // refactor so we can avoid the global state.
     if (engineAddr === undefined) {
@@ -505,6 +505,9 @@ function configureRuntime(req: any, engineAddr: string | undefined) {
         req.getDryrun(),
         req.getOrganization(),
     );
+
+    // resetOptions doesn't reset the saved features
+    await settings.awaitFeatureSupport();
 
     const pulumiConfig: { [key: string]: string } = {};
     const rpcConfig = req.getConfigMap();

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -14,6 +14,7 @@
 
 import { deserializeProperties, serializeProperties } from "./rpc";
 import { getProject, getStack, setMockOptions } from "./settings";
+import { getStore } from "./state";
 
 import * as structproto from "google-protobuf/google/protobuf/struct_pb";
 import * as provproto from "../proto/provider_pb";
@@ -244,6 +245,20 @@ export class MockMonitor {
  * @param preview: If provided, indicates whether or not the program is running a preview. Defaults to false.
  * @param organization: If provided, the name of the Pulumi organization. Defaults to nothing.
  */
-export function setMocks(mocks: Mocks, project?: string, stack?: string, preview?: boolean, organization?: string) {
+export async function setMocks(
+    mocks: Mocks,
+    project?: string,
+    stack?: string,
+    preview?: boolean,
+    organization?: string,
+) {
     setMockOptions(new MockMonitor(mocks), project, stack, preview, organization);
+
+    // Mocks enable all features except outputValues.
+    const store = getStore();
+    store.supportsSecrets = true;
+    store.supportsResourceReferences = true;
+    store.supportsOutputValues = false;
+    store.supportsDeletedWith = true;
+    store.supportsAliasSpecs = true;
 }

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -36,7 +36,7 @@ import {
 } from "../resource";
 import { debuggablePromise, debugPromiseLeaks } from "./debuggable";
 import { invoke } from "./invoke";
-import { monitorSupportsDeletedWith } from "./settings";
+import { getStore } from "./state";
 
 import { isGrpcError } from "../errors";
 import {
@@ -56,7 +56,6 @@ import {
     getStack,
     isDryRun,
     isLegacyApplyEnabled,
-    monitorSupportsAliasSpecs,
     rpcKeepAlive,
     serialize,
     terminateRpcs,
@@ -482,7 +481,7 @@ export function registerResource(
             req.setAliasspecs(true);
             req.setSourceposition(marshalSourcePosition(sourcePosition));
 
-            if (resop.deletedWithURN && !(await monitorSupportsDeletedWith())) {
+            if (resop.deletedWithURN && !getStore().supportsDeletedWith) {
                 throw new Error(
                     "The Pulumi CLI does not support the DeletedWith option. Please update the Pulumi CLI.",
                 );
@@ -811,7 +810,7 @@ export async function prepareResource(
             propertyToDirectDependencyURNs.set(propertyName, urns);
         }
 
-        const monitorSupportsStructuredAliases = await monitorSupportsAliasSpecs();
+        const monitorSupportsStructuredAliases = getStore().supportsAliasSpecs;
         let computedAliases;
         if (!monitorSupportsStructuredAliases && parent) {
             computedAliases = allAliases(opts.aliases || [], name!, type!, parent, parent.__name!);

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -64,15 +64,50 @@ export interface WriteableOptions {
 export interface Store {
     settings: {
         options: WriteableOptions;
-        monitor?: resrpc.ResourceMonitorClient;
-        engine?: engrpc.EngineClient;
+        monitor?: resrpc.IResourceMonitorClient;
+        engine?: engrpc.IEngineClient;
         rpcDone: Promise<any>;
+        // Needed for legacy @pulumi/pulumi packages doing async feature checks.
         featureSupport: Record<string, boolean>;
     };
     config: Record<string, string>;
     stackResource?: Stack;
     leakCandidates: Set<Promise<any>>;
     logErrorCount: number;
+
+    /**
+     * monitorSupportsSecrets returns a promise that when resolved tells you if the resource monitor we are connected
+     * to is able to support secrets across its RPC interface. When it does, we marshal outputs marked with the secret
+     * bit in a special way.
+     */
+    supportsSecrets: boolean;
+
+    /**
+     * monitorSupportsResourceReferences returns a promise that when resolved tells you if the resource monitor we are
+     * connected to is able to support resource references across its RPC interface. When it does, we marshal resources
+     * in a special way.
+     */
+    supportsResourceReferences: boolean;
+
+    /**
+     * monitorSupportsOutputValues returns a promise that when resolved tells you if the resource monitor we are
+     * connected to is able to support output values across its RPC interface. When it does, we marshal outputs
+     * in a special way.
+     */
+    supportsOutputValues: boolean;
+
+    /**
+     * monitorSupportsDeletedWith returns a promise that when resolved tells you if the resource monitor we are
+     * connected to is able to support the deletedWith resource option across its RPC interface.
+     */
+    supportsDeletedWith: boolean;
+
+    /**
+     * monitorSupportsAliasSpecs returns a promise that when resolved tells you if the resource monitor we are
+     * connected to is able to support alias specs across its RPC interface. When it does, we marshal aliases
+     * in a special way.
+     */
+    supportsAliasSpecs: boolean;
 }
 
 /** @internal */
@@ -106,6 +141,12 @@ export class LocalStore implements Store {
     leakCandidates = new Set<Promise<any>>();
 
     logErrorCount = 0;
+
+    supportsSecrets = false;
+    supportsResourceReferences = false;
+    supportsOutputValues = false;
+    supportsDeletedWith = false;
+    supportsAliasSpecs = false;
 }
 
 /** Get the root stack resource for the current stack deployment

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -24,6 +24,7 @@ import {
     runtime,
     secret,
 } from "../../index";
+import * as state from "../../runtime/state";
 
 import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 
@@ -206,7 +207,7 @@ describe("runtime", () => {
 
             for (const test of generateTests()) {
                 it(`marshals ${test.name} correctly`, async () => {
-                    runtime._setFeatureSupport("outputValues", true);
+                    state.getStore().supportsOutputValues = true;
 
                     const inputs = { value: test.input };
                     const expected = { value: test.expected };
@@ -255,7 +256,7 @@ describe("runtime", () => {
             };
 
             // Serialize and then deserialize all the properties, checking that they round-trip as expected.
-            runtime._setFeatureSupport("secrets", true);
+            state.getStore().supportsSecrets = true;
             let transfer = gstruct.Struct.fromJavaScript(await runtime.serializeProperties("test", inputs));
             let result = runtime.deserializeProperties(transfer);
             assert.ok(runtime.isRpcSecret(result.secret1));
@@ -264,7 +265,7 @@ describe("runtime", () => {
             assert.strictEqual(runtime.unwrapRpcSecret(result.secret2), null);
 
             // Serialize and then deserialize all the properties, checking that they round-trip as expected.
-            runtime._setFeatureSupport("secrets", false);
+            state.getStore().supportsSecrets = false;
             transfer = gstruct.Struct.fromJavaScript(await runtime.serializeProperties("test", inputs));
             result = runtime.deserializeProperties(transfer);
             assert.ok(!runtime.isRpcSecret(result.secret1));
@@ -288,7 +289,7 @@ describe("runtime", () => {
                 custom: custom,
             };
 
-            runtime._setFeatureSupport("resourceReferences", true);
+            state.getStore().supportsResourceReferences = true;
 
             let serialized = await runtime.serializeProperties("test", inputs);
             assert.deepEqual(serialized, {
@@ -303,7 +304,7 @@ describe("runtime", () => {
                 },
             });
 
-            runtime._setFeatureSupport("resourceReferences", false);
+            state.getStore().supportsResourceReferences = false;
             serialized = await runtime.serializeProperties("test", inputs);
             assert.deepEqual(serialized, {
                 component: componentURN,
@@ -326,7 +327,7 @@ describe("runtime", () => {
                 custom: custom,
             };
 
-            runtime._setFeatureSupport("resourceReferences", true);
+            state.getStore().supportsResourceReferences = true;
 
             let serialized = await runtime.serializeProperties("test", inputs);
             assert.deepEqual(serialized, {
@@ -341,7 +342,7 @@ describe("runtime", () => {
                 },
             });
 
-            runtime._setFeatureSupport("resourceReferences", false);
+            state.getStore().supportsResourceReferences = false;
             serialized = await runtime.serializeProperties("test", inputs);
             assert.deepEqual(serialized, {
                 component: componentURN,
@@ -416,7 +417,7 @@ describe("runtime", () => {
         });
         it("deserializes resource references properly during preview", async () => {
             runtime.setMocks(new TestMocks());
-            runtime._setFeatureSupport("resourceReferences", true);
+            state.getStore().supportsResourceReferences = true;
             runtime.registerResourceModule("test", "index", new TestResourceModule());
 
             const component = new TestComponentResource("test");


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We need to synchronously check for transform support in `registerStackTransformation` and resource constructors when adding remote transform support to node (c.f. https://github.com/pulumi/pulumi/pull/14303). This change changes all the feature checks to be done at startup and then accessed via just a field lookup. Adding the "transform" feature to this set is clearly simple.

Sadly there's no single entry point to make these changes in. So we need to update entry point of construct/call, the entry point of programs, and test setup. Miss any one of these and current tests start failing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
