### PR TITLE
Adds a flag to graph command to insert fragment

### DIFF
--- a/changelog/pending/20231214--cli--adds-a-flag-to-insert-fragment-in-graph.yaml
+++ b/changelog/pending/20231214--cli--adds-a-flag-to-insert-fragment-in-graph.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds a flag that allows inserting a fragment into the dot file when generating a graph. This can be used for styling the graph elements, setting properties etc.

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -29,27 +29,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Whether or not we should ignore parent edges when building up our graph.
-var ignoreParentEdges bool
+type graphCommandOptions struct {
+	stackName string
 
-// Whether or not we should ignore dependency edges when building up our graph.
-var ignoreDependencyEdges bool
+	// Whether or not we should ignore parent edges when building up our graph.
+	ignoreParentEdges bool
 
-// The color of dependency edges in the graph. Defaults to #246C60, a blush-green.
-var dependencyEdgeColor string
+	// Whether or not we should ignore dependency edges when building up our graph.
+	ignoreDependencyEdges bool
 
-// The color of parent edges in the graph. Defaults to #AA6639, an orange.
-var parentEdgeColor string
+	// The color of dependency edges in the graph. Defaults to #246C60, a blush-green.
+	dependencyEdgeColor string
 
-// Whether or not to return resource name as the node label for each node of the graph.
-var shortNodeName bool
+	// The color of parent edges in the graph. Defaults to #AA6639, an orange.
+	parentEdgeColor string
 
-// A DOT fragment that will be inserted at the top of the digraph element. This
-// can be used for styling the graph elements, setting graph properties etc.")
-var dotFragment string
+	// Whether or not to return resource name as the node label for each node of the graph.
+	shortNodeName bool
+
+	// A DOT fragment that will be inserted at the top of the digraph element. This
+	// can be used for styling the graph elements, setting graph properties etc.")
+	dotFragment string
+}
 
 func newStackGraphCmd() *cobra.Command {
-	var stackName string
+	var cmdOpts graphCommandOptions
 
 	cmd := &cobra.Command{
 		Use:   "graph [filename]",
@@ -66,7 +70,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
+			s, err := requireStack(ctx, cmdOpts.stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -77,18 +81,17 @@ func newStackGraphCmd() *cobra.Command {
 
 			// This will prevent a panic when trying to assemble a dependencyGraph when no snapshot is found
 			if snap == nil {
-				return fmt.Errorf("unable to find snapshot for stack %q", stackName)
+				return fmt.Errorf("unable to find snapshot for stack %q", cmdOpts.stackName)
 			}
 
-			dg := makeDependencyGraph(snap)
-			dg.setDotFragment(dotFragment)
+			dg := makeDependencyGraph(snap, &cmdOpts)
 
 			file, err := os.Create(args[0])
 			if err != nil {
 				return err
 			}
 
-			if err := dotconv.Print(dg, file); err != nil {
+			if err := dotconv.Print(dg, file, cmdOpts.dotFragment); err != nil {
 				_ = file.Close()
 				return err
 			}
@@ -99,18 +102,18 @@ func newStackGraphCmd() *cobra.Command {
 		}),
 	}
 	cmd.PersistentFlags().StringVarP(
-		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
-	cmd.PersistentFlags().BoolVar(&ignoreParentEdges, "ignore-parent-edges", false,
+		&cmdOpts.stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	cmd.PersistentFlags().BoolVar(&cmdOpts.ignoreParentEdges, "ignore-parent-edges", false,
 		"Ignores edges introduced by parent/child resource relationships")
-	cmd.PersistentFlags().BoolVar(&ignoreDependencyEdges, "ignore-dependency-edges", false,
+	cmd.PersistentFlags().BoolVar(&cmdOpts.ignoreDependencyEdges, "ignore-dependency-edges", false,
 		"Ignores edges introduced by dependency resource relationships")
-	cmd.PersistentFlags().StringVar(&dependencyEdgeColor, "dependency-edge-color", "#246C60",
+	cmd.PersistentFlags().StringVar(&cmdOpts.dependencyEdgeColor, "dependency-edge-color", "#246C60",
 		"Sets the color of dependency edges in the graph")
-	cmd.PersistentFlags().StringVar(&parentEdgeColor, "parent-edge-color", "#AA6639",
+	cmd.PersistentFlags().StringVar(&cmdOpts.parentEdgeColor, "parent-edge-color", "#AA6639",
 		"Sets the color of parent edges in the graph")
-	cmd.PersistentFlags().BoolVar(&shortNodeName, "short-node-name", false,
+	cmd.PersistentFlags().BoolVar(&cmdOpts.shortNodeName, "short-node-name", false,
 		"Sets the resource name as the node label for each node of the graph")
-	cmd.PersistentFlags().StringVar(&dotFragment, "dot-fragment", "",
+	cmd.PersistentFlags().StringVar(&cmdOpts.dotFragment, "dot-fragment", "",
 		"An optional DOT fragment that will be inserted at the top of the digraph element. "+
 			"This can be used for styling the graph elements, setting graph properties etc.")
 	return cmd
@@ -126,6 +129,7 @@ type dependencyEdge struct {
 	to     *dependencyVertex
 	from   *dependencyVertex
 	labels []string
+	color  string
 }
 
 // In this simple case, edges have no data.
@@ -146,15 +150,16 @@ func (edge *dependencyEdge) From() graph.Vertex {
 }
 
 func (edge *dependencyEdge) Color() string {
-	return dependencyEdgeColor
+	return edge.color
 }
 
 // parentEdges represent edges in the parent-child graph, which
 // exists alongside the dependency graph. An edge exists from node
 // A to node B if node B is considered to be a parent of node A.
 type parentEdge struct {
-	to   *dependencyVertex
-	from *dependencyVertex
+	to    *dependencyVertex
+	from  *dependencyVertex
+	color string
 }
 
 func (edge *parentEdge) Data() interface{} {
@@ -175,7 +180,7 @@ func (edge *parentEdge) From() graph.Vertex {
 }
 
 func (edge *parentEdge) Color() string {
-	return parentEdgeColor
+	return edge.color
 }
 
 // A dependencyVertex contains a reference to the graph to which it belongs
@@ -186,6 +191,7 @@ type dependencyVertex struct {
 	resource      *resource.State
 	incomingEdges []graph.Edge
 	outgoingEdges []graph.Edge
+	useShortName  bool
 }
 
 func (vertex *dependencyVertex) Data() interface{} {
@@ -193,7 +199,7 @@ func (vertex *dependencyVertex) Data() interface{} {
 }
 
 func (vertex *dependencyVertex) Label() string {
-	if shortNodeName {
+	if vertex.useShortName {
 		return vertex.resource.URN.Name()
 	}
 	return string(vertex.resource.URN)
@@ -213,8 +219,7 @@ func (vertex *dependencyVertex) Outs() []graph.Edge {
 // A dependencyGraph is a thin wrapper around a map of URNs to vertices in
 // the graph. It is constructed directly from a snapshot.
 type dependencyGraph struct {
-	vertices    map[resource.URN]*dependencyVertex
-	dotFragment string
+	vertices map[resource.URN]*dependencyVertex
 }
 
 // Roots are edges that point to the root set of our graph. In our case,
@@ -233,33 +238,25 @@ func (dg *dependencyGraph) Roots() []graph.Edge {
 	return rootEdges
 }
 
-func (dg *dependencyGraph) DotFragment() string {
-	return dg.dotFragment
-}
-
-func (dg *dependencyGraph) setDotFragment(dotFragment string) {
-	dg.dotFragment = dotFragment
-}
-
 // Makes a dependency graph from a deployment snapshot, allocating a vertex
 // for every resource in the graph.
-func makeDependencyGraph(snapshot *deploy.Snapshot) *dependencyGraph {
+func makeDependencyGraph(snapshot *deploy.Snapshot, opts *graphCommandOptions) *dependencyGraph {
 	dg := &dependencyGraph{
-		vertices:    make(map[resource.URN]*dependencyVertex),
-		dotFragment: "",
+		vertices: make(map[resource.URN]*dependencyVertex),
 	}
 
 	for _, resource := range snapshot.Resources {
 		vertex := &dependencyVertex{
-			graph:    dg,
-			resource: resource,
+			graph:        dg,
+			resource:     resource,
+			useShortName: opts.shortNodeName,
 		}
 
 		dg.vertices[resource.URN] = vertex
 	}
 
 	for _, vertex := range dg.vertices {
-		if !ignoreDependencyEdges {
+		if !opts.ignoreDependencyEdges {
 			// If we have per-property dependency information, annotate the dependency edges
 			// we generate with the names of the properties associated with each dependency.
 			depBlame := make(map[resource.URN][]string)
@@ -273,7 +270,7 @@ func makeDependencyGraph(snapshot *deploy.Snapshot) *dependencyGraph {
 			// resources on which this vertex immediately depends upon.
 			for _, dep := range vertex.resource.Dependencies {
 				vertexWeDependOn := vertex.graph.vertices[dep]
-				edge := &dependencyEdge{to: vertex, from: vertexWeDependOn, labels: depBlame[dep]}
+				edge := &dependencyEdge{to: vertex, from: vertexWeDependOn, labels: depBlame[dep], color: opts.dependencyEdgeColor}
 				vertex.incomingEdges = append(vertex.incomingEdges, edge)
 				vertexWeDependOn.outgoingEdges = append(vertexWeDependOn.outgoingEdges, edge)
 			}
@@ -282,12 +279,13 @@ func makeDependencyGraph(snapshot *deploy.Snapshot) *dependencyGraph {
 		// alongside the dependency graph sits the resource parentage graph, which
 		// is also displayed as part of this graph, although with different colored
 		// edges.
-		if !ignoreParentEdges {
+		if !opts.ignoreParentEdges {
 			if parent := vertex.resource.Parent; parent != resource.URN("") {
 				parentVertex := dg.vertices[parent]
 				vertex.outgoingEdges = append(vertex.outgoingEdges, &parentEdge{
-					to:   parentVertex,
-					from: vertex,
+					to:    parentVertex,
+					from:  vertex,
+					color: opts.parentEdgeColor,
 				})
 			}
 		}

--- a/pkg/cmd/pulumi/stack_graph_test.go
+++ b/pkg/cmd/pulumi/stack_graph_test.go
@@ -28,6 +28,7 @@ import (
 // Tests the output of 'pulumi stack graph'
 // under different conditions.
 func TestStackGraphCmd_smokeTest(t *testing.T) {
+	t.Parallel()
 	snap := deploy.Snapshot{
 		Resources: []*resource.State{
 			{
@@ -36,11 +37,11 @@ func TestStackGraphCmd_smokeTest(t *testing.T) {
 		},
 	}
 
-	shortNodeName = false
-	dg := makeDependencyGraph(&snap)
+	opts := graphCommandOptions{}
+	dg := makeDependencyGraph(&snap, &opts)
 
 	var outputBuf bytes.Buffer
-	require.NoError(t, dotconv.Print(dg, &outputBuf))
+	require.NoError(t, dotconv.Print(dg, &outputBuf, opts.dotFragment))
 
 	dotOutput := outputBuf.String()
 
@@ -51,6 +52,7 @@ func TestStackGraphCmd_smokeTest(t *testing.T) {
 }
 
 func TestStackGraphCmd_dotFragmentIsInserted(t *testing.T) {
+	t.Parallel()
 	snap := deploy.Snapshot{
 		Resources: []*resource.State{
 			{
@@ -59,12 +61,13 @@ func TestStackGraphCmd_dotFragmentIsInserted(t *testing.T) {
 		},
 	}
 
-	shortNodeName = false
-	dg := makeDependencyGraph(&snap)
-	dg.setDotFragment("[node shape=rect]\n[edge penwidth=2]")
+	opts := graphCommandOptions{
+		dotFragment: "[node shape=rect]\n[edge penwidth=2]",
+	}
+	dg := makeDependencyGraph(&snap, &opts)
 
 	var outputBuf bytes.Buffer
-	require.NoError(t, dotconv.Print(dg, &outputBuf))
+	require.NoError(t, dotconv.Print(dg, &outputBuf, opts.dotFragment))
 
 	dotOutput := outputBuf.String()
 
@@ -77,6 +80,7 @@ func TestStackGraphCmd_dotFragmentIsInserted(t *testing.T) {
 }
 
 func TestStackGraphCmd_parentAndChild(t *testing.T) {
+	t.Parallel()
 	expectedMaxNode := 2
 	provider := resource.URN("urn:pulumi:dev::pets::random::provider")
 	parent := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet::parent")
@@ -103,11 +107,11 @@ func TestStackGraphCmd_parentAndChild(t *testing.T) {
 		},
 	}
 
-	shortNodeName = false
-	dg := makeDependencyGraph(&snap)
+	opts := graphCommandOptions{}
+	dg := makeDependencyGraph(&snap, &opts)
 
 	var outputBuf bytes.Buffer
-	require.NoError(t, dotconv.Print(dg, &outputBuf))
+	require.NoError(t, dotconv.Print(dg, &outputBuf, opts.dotFragment))
 
 	dotOutput := outputBuf.String()
 
@@ -122,6 +126,7 @@ func TestStackGraphCmd_parentAndChild(t *testing.T) {
 }
 
 func TestStackGraphCmd_shortNodeName(t *testing.T) {
+	t.Parallel()
 	expectedLabels := []string{
 		"provider", "parent", "child",
 	}
@@ -151,12 +156,13 @@ func TestStackGraphCmd_shortNodeName(t *testing.T) {
 		},
 	}
 
-	shortNodeName = true
-
-	dg := makeDependencyGraph(&snap)
+	opts := graphCommandOptions{
+		shortNodeName: true,
+	}
+	dg := makeDependencyGraph(&snap, &opts)
 
 	var outputBuf bytes.Buffer
-	require.NoError(t, dotconv.Print(dg, &outputBuf))
+	require.NoError(t, dotconv.Print(dg, &outputBuf, opts.dotFragment))
 
 	dotOutput := outputBuf.String()
 

--- a/pkg/cmd/pulumi/stack_graph_test.go
+++ b/pkg/cmd/pulumi/stack_graph_test.go
@@ -1,0 +1,166 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests the output of 'pulumi stack graph'
+// under different conditions.
+func TestStackGraphCmd_smokeTest(t *testing.T) {
+	snap := deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				Type: resource.RootStackType,
+			},
+		},
+	}
+
+	shortNodeName = false
+	dg := makeDependencyGraph(&snap)
+
+	var outputBuf bytes.Buffer
+	require.NoError(t, dotconv.Print(dg, &outputBuf))
+
+	dotOutput := outputBuf.String()
+
+	require.Equal(t, `strict digraph {
+    Resource0;
+}
+`, dotOutput)
+}
+
+func TestStackGraphCmd_dotFragmentIsInserted(t *testing.T) {
+	snap := deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				Type: resource.RootStackType,
+			},
+		},
+	}
+
+	shortNodeName = false
+	dg := makeDependencyGraph(&snap)
+	dg.setDotFragment("[node shape=rect]\n[edge penwidth=2]")
+
+	var outputBuf bytes.Buffer
+	require.NoError(t, dotconv.Print(dg, &outputBuf))
+
+	dotOutput := outputBuf.String()
+
+	require.Equal(t, `strict digraph {
+[node shape=rect]
+[edge penwidth=2]
+    Resource0;
+}
+`, dotOutput)
+}
+
+func TestStackGraphCmd_parentAndChild(t *testing.T) {
+	expectedMaxNode := 2
+	provider := resource.URN("urn:pulumi:dev::pets::random::provider")
+	parent := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet::parent")
+	child := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet$random:index/randomPet:RandomPet::child")
+
+	snap := deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				URN:  provider,
+				ID:   "provider-id",
+				Type: "pulumi:provider:random",
+			},
+			{
+				URN:  parent,
+				ID:   "parent-id",
+				Type: "random:index/randomPet:RandomPet",
+			},
+			{
+				URN:    child,
+				ID:     "child-id",
+				Type:   "random:index/randomPet:RandomPet",
+				Parent: parent,
+			},
+		},
+	}
+
+	shortNodeName = false
+	dg := makeDependencyGraph(&snap)
+
+	var outputBuf bytes.Buffer
+	require.NoError(t, dotconv.Print(dg, &outputBuf))
+
+	dotOutput := outputBuf.String()
+
+	for i := 0; i <= expectedMaxNode; i++ {
+		require.Contains(t, dotOutput, fmt.Sprintf("Resource%d [label=", i))
+	}
+	for i := 1; i <= 4; i++ {
+		require.NotContains(t, dotOutput, fmt.Sprintf("Resource%d", expectedMaxNode+i))
+	}
+
+	require.Contains(t, dotOutput, " -> ")
+}
+
+func TestStackGraphCmd_shortNodeName(t *testing.T) {
+	expectedLabels := []string{
+		"provider", "parent", "child",
+	}
+
+	provider := resource.URN("urn:pulumi:dev::pets::random::provider")
+	parent := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet::parent")
+	child := resource.URN("urn:pulumi:dev::pets::random:index/randomPet:RandomPet$random:index/randomPet:RandomPet::child")
+
+	snap := deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				URN:  provider,
+				ID:   "provider-id",
+				Type: "pulumi:provider:random",
+			},
+			{
+				URN:  parent,
+				ID:   "parent-id",
+				Type: "random:index/randomPet:RandomPet",
+			},
+			{
+				URN:    child,
+				ID:     "child-id",
+				Type:   "random:index/randomPet:RandomPet",
+				Parent: parent,
+			},
+		},
+	}
+
+	shortNodeName = true
+
+	dg := makeDependencyGraph(&snap)
+
+	var outputBuf bytes.Buffer
+	require.NoError(t, dotconv.Print(dg, &outputBuf))
+
+	dotOutput := outputBuf.String()
+
+	for _, label := range expectedLabels {
+		require.Contains(t, dotOutput, fmt.Sprintf("[label=\"%s\"]", label))
+	}
+}

--- a/pkg/graph/dotconv/print.go
+++ b/pkg/graph/dotconv/print.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Print prints a resource graph.
-func Print(g graph.Graph, w io.Writer) error {
+func Print(g graph.Graph, w io.Writer, dotFragment string) error {
 	// Allocate a new writer.  In general, we will ignore write errors throughout this function, for simplicity, opting
 	// instead to return the result of flushing the buffer at the end, which is generally latching.
 	b := bufio.NewWriter(w)
@@ -41,7 +41,6 @@ func Print(g graph.Graph, w io.Writer) error {
 	}
 
 	// If the caller provided a fragment then insert it here.
-	dotFragment := g.DotFragment()
 	if dotFragment != "" {
 		if _, err := b.WriteString(dotFragment); err != nil {
 			return err

--- a/pkg/graph/dotconv/print.go
+++ b/pkg/graph/dotconv/print.go
@@ -40,6 +40,20 @@ func Print(g graph.Graph, w io.Writer) error {
 		return err
 	}
 
+	// If the caller provided a fragment then insert it here.
+	dotFragment := g.DotFragment()
+	if dotFragment != "" {
+		if _, err := b.WriteString(dotFragment); err != nil {
+			return err
+		}
+
+		// Ensure that the fragment is followed by newline, this reduces
+		// problems if the fragment doesn't end with a semicolon
+		if _, err := b.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+
 	// Initialize the frontier with unvisited graph vertices.
 	queued := make(map[graph.Vertex]bool)
 	frontier := slice.Prealloc[graph.Vertex](len(g.Roots()))

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -27,8 +27,7 @@ package graph
 // Graph is an instance of a resource digraph.  Each is associated with a single program input, along
 // with a set of optional arguments used to evaluate it, along with the output DAG with node types and properties.
 type Graph interface {
-	Roots() []Edge       // the root edges.
-	DotFragment() string // a fragment to be inserted at the top of the digraph context
+	Roots() []Edge // the root edges.
 }
 
 // Vertex is a single vertex within an overall resource graph.

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -27,7 +27,8 @@ package graph
 // Graph is an instance of a resource digraph.  Each is associated with a single program input, along
 // with a set of optional arguments used to evaluate it, along with the output DAG with node types and properties.
 type Graph interface {
-	Roots() []Edge // the root edges.
+	Roots() []Edge       // the root edges.
+	DotFragment() string // a fragment to be inserted at the top of the digraph context
 }
 
 // Vertex is a single vertex within an overall resource graph.


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This enables you to insert arbitrary dot inside the `digraph` element. This can be used to style the dot file. For example:

with the file `fragment.dot` having the contents:

```
rankdir=LR
ranksep=0.01
dpi=300
node [shape=rect style=filled fillcolor="#8a3391" fontcolor="white" fontname="Arial"]
edge [fontname="Arial" fontcolor="#83a3391" penwidth=2]
```

You could then call

`pulumu stack graph --dot-fragment "$(<fragment.dot)" stack.dot`

Which could be in a command pipeline like

`pulumu stack graph --dot-fragment "$(<fragment.dot)" stack.dot && dot -Tpng -O stack.dot && open stack.dot.png`

To generate and display a styled view of the graph without needing to hand edit the dot file in the process.

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
