### PR TITLE
do update-dev-version before ci-ok

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -90,6 +90,8 @@ jobs:
         id: ghd
         uses: proudust/gh-describe@v1
       - name: Dispatch event to docs repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
           pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version=${{ steps.ghd.outputs.describe }}
 

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -108,5 +108,8 @@ jobs:
       - name: Dev release failed
         if: ${{ needs.dev-release.result != 'success' }}
         run: exit 1
+      - name: Update dev version failed
+        if: ${{ needs.update-dev-version.result != 'success' }}
+        run: exit 1
       - name: CI succeeded
         run: exit 0

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -70,27 +70,9 @@ jobs:
       version: ${{ needs.info.outputs.version }}
     secrets: inherit
 
-  ci-ok:
-    name: ci-ok
-    needs: [ci, prepare-release, dev-release]
-    if: always() # always report a status
-    runs-on: ubuntu-latest
-    steps:
-      - name: CI failed
-        if: ${{ needs.ci.result != 'success' }}
-        run: exit 1
-      - name: Release failed
-        if: ${{ needs.prepare-release.result != 'success' }}
-        run: exit 1
-      - name: Dev release failed
-        if: ${{ needs.dev-release.result != 'success' }}
-        run: exit 1
-      - name: CI succeeded
-        run: exit 0
-
   update-dev-version:
     name: update-dev-version
-    needs: [ci-ok]
+    needs: [dev-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -110,3 +92,21 @@ jobs:
       - name: Dispatch event to docs repo
         run: |
           pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version=${{ steps.ghd.outputs.describe }}
+
+  ci-ok:
+    name: ci-ok
+    needs: [ci, prepare-release, dev-release, update-dev-version]
+    if: always() # always report a status
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI failed
+        if: ${{ needs.ci.result != 'success' }}
+        run: exit 1
+      - name: Release failed
+        if: ${{ needs.prepare-release.result != 'success' }}
+        run: exit 1
+      - name: Dev release failed
+        if: ${{ needs.dev-release.result != 'success' }}
+        run: exit 1
+      - name: CI succeeded
+        run: exit 0


### PR DESCRIPTION
The reason for this is twofold:
- Once ci-ok is run, GitHub deletes the merge queue branch, and thus the checkout in the update-dev-version step fails.
- If we do the update-dev-version after ci-ok, we might still merge the changes even though we haven't updated the dev version properly. This isn't a big deal, but can be confusing nonetheless.


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
