### PR TITLE
[program-gen/pcl] Avoid pretty printing large object graphs when encountering bind error in resource properties

### DIFF
--- a/changelog/pending/20231216--programgen--avoid-pretty-printing-large-object-graphs-when-a-resource-property-doesnt-type-check-when-binding-pcl-programs.yaml
+++ b/changelog/pending/20231216--programgen--avoid-pretty-printing-large-object-graphs-when-a-resource-property-doesnt-type-check-when-binding-pcl-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Avoid pretty printing large object graphs when a resource property doesn't type-check when binding PCL programs

--- a/pkg/codegen/hcl2/model/print_test.go
+++ b/pkg/codegen/hcl2/model/print_test.go
@@ -45,3 +45,15 @@ func TestPrintNoTokens(t *testing.T) {
 }`
 	assert.Equal(t, expected, fmt.Sprintf("%v", b))
 }
+
+func TestPrettyPrintingNoneType(t *testing.T) {
+	t.Parallel()
+	pretty := NoneType.Pretty().String()
+	assert.Equal(t, "none", pretty)
+}
+
+func TestPrettyPrintingDynamicType(t *testing.T) {
+	t.Parallel()
+	pretty := DynamicType.Pretty().String()
+	assert.Equal(t, "dynamic", pretty)
+}


### PR DESCRIPTION
# Description

When we bind PCL program and a resource property doesn't type-check, we pretty print the type of the resource property in its _entirety_ in the error message and that includes nested objects, nested maps, nested lists, unions etc. instead of using type references: we pretty print the `model.Type` derived from `schema.Type` and this resolves the entire graph. 

This PR changes it such that we print the `schema.Type` in string form in the error message when we encounter a bind error 
 in resource properties instead of fully resolving and printing the full `model.Type`. 

Fixes #14317

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
