### PR TITLE
[sdk/python] Escape trailing underscore in docstring

### DIFF
--- a/changelog/pending/20231215--sdk-python--fix-python-sdk-docs-by-escaping-the-trailing-underscore-in-a-docstring.yaml
+++ b/changelog/pending/20231215--sdk-python--fix-python-sdk-docs-by-escaping-the-trailing-underscore-in-a-docstring.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix Python SDK docs by escaping the trailing underscore in a docstring

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -424,7 +424,7 @@ class ResourceOptions:
         :param Optional[List[str]] additional_secret_outputs: If provided, a list of output property names that should
                also be treated as secret.
         :param Optional[Input[str]] id: If provided, an existing resource ID to read, rather than create.
-        :param Optional[str] import_: When provided with a resource ID, import indicates that this resource's provider should
+        :param Optional[str] import\\_: When provided with a resource ID, import indicates that this resource's provider should
                import its state from the cloud resource with the given ID. The inputs to the resource's constructor must align
                with the resource's current state. Once a resource has been imported, the import property must be removed from
                the resource's options.


### PR DESCRIPTION
The trailing underscore in this docstring [needs to be escaped](https://github.com/sphinx-doc/sphinx/issues/519) for it to render properly with Sphinx.

[Currently](https://www.pulumi.com/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions), it's rendered as `import` without the trailing underscore:

<img width="560" alt="Screen Shot 2023-12-17 at 6 47 43 PM" src="https://github.com/pulumi/pulumi/assets/710598/3c520aef-5677-4ae5-bc37-a1d0607a94e8">

It should be rendered as `import_`:

<img width="555" alt="Screen Shot 2023-12-17 at 6 48 13 PM" src="https://github.com/pulumi/pulumi/assets/710598/f9cd0ed1-6dd3-49b7-9de9-4b9ff8ae7864">

This change should fix that.

This is a follow-up from https://github.com/pulumi/pulumi-hugo/issues/434