### PR TITLE
strip the v prefix from the latest-dev-version file

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -93,7 +93,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
-          pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version=${{ steps.ghd.outputs.describe }}
+          version="${{ steps.ghd.outputs.describe }}"
+          # the git describe output includes a 'v' prefix, but we
+          # don't expect that in the latest-dev-version file.  Strip
+          # it here.
+          version="${version#v}"
+          pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version="$version"
 
   ci-ok:
     name: ci-ok


### PR DESCRIPTION
The latest-dev-version file is not supposed to include a 'v' prefix. However the `git describe` output includes it.  Strip that from the string before dispatching the CI job that updates the latest-dev-version file.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
