### PR TITLE
add the v prefix in the version in pulumi about back

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Git describe
         id: ghd
         uses: proudust/gh-describe@v1
+      - name: strip prefix
+        id: strip-prefix
+        run: |
+          version="${{ steps.ghd.outputs.describe }}"
+          version="${version#v}"
+          ./.github/scripts/set-output dev-version "$version"
     outputs:
-      describe: "${{ steps.ghd.outputs.describe }}"
+      dev-version: "${{ steps.strip-prefix.outputs.dev-version }}"
       version: ${{ inputs.version }}
 
   matrix:
@@ -73,7 +79,7 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
-      dev-version: ${{ needs.gather-info.outputs.describe }}
+      dev-version: ${{ needs.gather-info.outputs.dev-version }}
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       build-platform: ${{ matrix.build-platform }}
@@ -128,10 +134,7 @@ jobs:
           (
             cd artifacts
             version="${{ inputs.version }}"
-            # The describe output includes a 'v' in front of the version number, 'inputs.version'
-            # does not.  Trim the 'v' to have consistent version numbering.
-            dev_version="${{ needs.gather-info.outputs.describe }}"
-            dev_version="${dev_version:1}"
+            dev_version="${{ needs.gather-info.outputs.dev-version }}"
             for file in *; do
               mv "$file" "${file//$version/$dev_version}"
             done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Env.PULUMI_VERSION}}
+    - -X github.com/pulumi/pulumi/pkg/v3/version.Version=v{{.Env.PULUMI_VERSION}}
   mod_timestamp: '{{ .CommitTimestamp }}'
 - <<: *pulumibin
   id: pulumi-language-go


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/14640/files#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689 inadvertently got rid of the v prefix in the version in pulumi about. Add it back.  Also make sure we don't get a duplicate `v` prefix in the dev releases.

Fixes #14800

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
