### PR TITLE
fix goproxy environment variable in makefile

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -122,7 +122,8 @@ GO_TEST_FAST_FLAGS = -short ${GO_TEST_FLAGS}
 GO_TEST      = $(PYTHON) $(ROOT_DIR)/../scripts/go-test.py $(GO_TEST_FLAGS)
 GO_TEST_FAST = $(PYTHON) $(ROOT_DIR)/../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
-GOPROXY = 'https://goproxy.io'
+GOPROXY = https://proxy.golang.org
+export GOPROXY
 
 .PHONY: default all only_build only_test lint install test_all core build
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -122,7 +122,7 @@ GO_TEST_FAST_FLAGS = -short ${GO_TEST_FLAGS}
 GO_TEST      = $(PYTHON) $(ROOT_DIR)/../scripts/go-test.py $(GO_TEST_FLAGS)
 GO_TEST_FAST = $(PYTHON) $(ROOT_DIR)/../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
-GOPROXY = 'https://proxy.golang.org'
+GOPROXY = 'https://goproxy.io'
 
 .PHONY: default all only_build only_test lint install test_all core build
 


### PR DESCRIPTION
# Description

~sourcegraph.com/sourcegraph/appdash-data disappeared from proxy.golang.org.  As a very temporary workaround we can use goproxy.io, which still has it in its cache.  However we should still try to get rid of the dependency as a high priority.~

While trying to fix the sourcegraph.com/sourcegraph/appdash-data dependency disappearing issue, one idea that came to mind was trying to use a different goproxy.  We already have a `GOPROXY` variable set in our Makefiles, so just changing that should have worked.  However that variable had two problems:
- It was quoted in single quotes, which because this is a Makefile and not shell were added to the environment, confusing Go.
- The variable was not exported, so it would never actually be used. 

Fix these two problems, in case we need to use this in the future.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
