### PR TITLE
First pass at using config to control snapshots

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1010,7 +1010,11 @@ func (b *localBackend) apply(
 
 	// Create the management machinery.
 	persister := b.newSnapshotPersister(ctx, localStackRef)
-	manager := backend.NewSnapshotManager(persister, op.SecretsManager, update.GetTarget().Snapshot)
+	manager := backend.NewSnapshotManager(
+		persister,
+		op.SecretsManager,
+		update.GetTarget().Snapshot,
+		op.StackConfiguration.Config)
 	engineCtx := &engine.Context{
 		Cancel:          scope.Context(),
 		Events:          engineEvents,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1257,7 +1257,11 @@ func (b *cloudBackend) runEngineAction(
 	}()
 
 	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource)
-	snapshotManager := backend.NewSnapshotManager(persister, op.SecretsManager, u.GetTarget().Snapshot)
+	snapshotManager := backend.NewSnapshotManager(
+		persister,
+		op.SecretsManager,
+		u.GetTarget().Snapshot,
+		op.StackConfiguration.Config)
 
 	// Depending on the action, kick off the relevant engine activity.  Note that we don't immediately check and
 	// return error conditions, because we will do so below after waiting for the display channels to close.

--- a/tests/integration/unsafe_snapshot_tests/use_config/Pulumi.yaml
+++ b/tests/integration/unsafe_snapshot_tests/use_config/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: use_config
+runtime: nodejs
+config:
+  pulumi:disable-checkpoints: true

--- a/tests/integration/unsafe_snapshot_tests/use_config/index.ts
+++ b/tests/integration/unsafe_snapshot_tests/use_config/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2016-2022, Pulumi Corporation.  All rights reserved.
+import * as process from "process";
+import { Resource } from "./resource";
+// Base depends on nothing.
+const a = new Resource("base", { uniqueKey: 1, state: 99 });
+
+for(let i = 0; i < 1000; i++) {
+    new Resource(`base-${i}`, { uniqueKey: 100+i, state: 99 });
+}
+
+// Dependent depends on Base with state 99.
+new Resource("dependent", { uniqueKey: a.state.apply(() => {
+    if (process.env["PULUMI_NODEJS_DRY_RUN"] != "true") {
+        throw Error("`base` should be created and `dependent` should not");
+    }
+    return 1;
+}), state: a.state });

--- a/tests/integration/unsafe_snapshot_tests/use_config/package.json
+++ b/tests/integration/unsafe_snapshot_tests/use_config/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "stack_project_name",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "@types/node": "^18.7.17"
+    }
+}

--- a/tests/integration/unsafe_snapshot_tests/use_config/resource.ts
+++ b/tests/integration/unsafe_snapshot_tests/use_config/resource.ts
@@ -1,0 +1,67 @@
+// Copyright 2016-2022, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+export class Provider implements dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    private id: number = 0;
+
+    public async check(olds: any, news: any): Promise<dynamic.CheckResult> {
+        // When the engine re-creates a resource after it was deleted, it should
+        // not pass the old (deleted) inputs to Check when re-creating.
+        //
+        // This Check implementation fails the test if this happens.
+        if (olds.state === 99 && news.state === 22) {
+            return {
+                inputs: news,
+                failures: [
+                    {
+                        property: "state",
+                        reason: "engine did invalid comparison of old and new check inputs for recreated resource",
+                    },
+                ],
+            };
+        }
+
+        return {
+            inputs: news,
+        };
+    }
+
+    public async diff(id: pulumi.ID, olds: any, news: any): Promise<dynamic.DiffResult> {
+        if (olds.state !== news.state) {
+            return {
+                changes: true,
+                replaces: ["state"],
+                deleteBeforeReplace: true,
+            };
+        }
+
+        return {
+            changes: false,
+        };
+    }
+
+    public async create(inputs: any): Promise<dynamic.CreateResult> {
+        return {
+            id: (this.id++).toString(),
+            outs: inputs,
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public uniqueKey?: pulumi.Output<number>;
+    public state: pulumi.Output<number>;
+
+    constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}
+
+export interface ResourceProps {
+    readonly uniqueKey?: pulumi.Input<number>;
+    readonly state: pulumi.Input<number>;
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Currently (as of #10750) there is an environment variable `PULUMI_SKIP_CHECKPOINTS` that allows a user to disable checkpoints.

This PR adds a config entry `pulumi:disable-checkpoints` that allows this to be set as either a project or stack level config

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
