### PR TITLE
[auto/nodejs] always run cleanup for refresh and destroy commands

### DIFF
--- a/changelog/pending/20231219--auto-nodejs--always-run-cleanup-for-refresh-and-destroy-commands.yaml
+++ b/changelog/pending/20231219--auto-nodejs--always-run-cleanup-for-refresh-and-destroy-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Always run cleanup for refresh and destroy commands

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -454,9 +454,12 @@ Event: ${line}\n${e.toString()}`);
         const kind = this.workspace.program ? execKind.inline : execKind.local;
         args.push("--exec-kind", kind);
 
-        const refPromise = this.runPulumiCmd(args, opts?.onOutput);
-        const [refResult, logResult] = await Promise.all([refPromise, logPromise]);
-        await cleanUp(logFile, logResult);
+        let refResult: CommandResult;
+        try {
+            refResult = await this.runPulumiCmd(args, opts?.onOutput);
+        } finally {
+            await cleanUp(logFile, await logPromise);
+        }
 
         // If it's a remote workspace, explicitly set showSecrets to false to prevent attempting to
         // load the project file.
@@ -517,9 +520,12 @@ Event: ${line}\n${e.toString()}`);
         const kind = this.workspace.program ? execKind.inline : execKind.local;
         args.push("--exec-kind", kind);
 
-        const desPromise = this.runPulumiCmd(args, opts?.onOutput);
-        const [desResult, logResult] = await Promise.all([desPromise, logPromise]);
-        await cleanUp(logFile, logResult);
+        let desResult: CommandResult;
+        try {
+            desResult = await this.runPulumiCmd(args, opts?.onOutput);
+        } finally {
+            await cleanUp(logFile, await logPromise);
+        }
 
         // If it's a remote workspace, explicitly set showSecrets to false to prevent attempting to
         // load the project file.


### PR DESCRIPTION
# Description

Ensure we always wait for the log promise and run cleanup for `refresh` and `destroy` to ensure log files get removed and any open pipes get closed.

Fixes https://github.com/pulumi/pulumi/issues/14879

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
