### PR TITLE
fixes fulfillValue error when joining a nil output state

### DIFF
--- a/changelog/pending/20231219--sdk-go--fixes-fulfillvalue-error-when-joining-a-nil-output-state.yaml
+++ b/changelog/pending/20231219--sdk-go--fixes-fulfillvalue-error-when-joining-a-nil-output-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: fixes fulfillValue error when joining a nil output state

--- a/sdk/go/internal/types.go
+++ b/sdk/go/internal/types.go
@@ -196,7 +196,7 @@ func (o *OutputState) fulfillValue(value reflect.Value, known, secret bool, deps
 	if o.join != nil {
 		// If this output is being resolved to another output O' with a different wait group, ensure that we
 		// don't decrement the current output's wait group until O' completes.
-		if other, ok := getOutputState(value); ok && other.join != o.join {
+		if other, ok := getOutputState(value); ok && other != nil && other.join != o.join {
 			go func() {
 				//nolint:errcheck
 				other.await(context.Background())


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

fixes fulfillValue error when joining a nil output state

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Error can be reproduced using https://github.com/mheers/pulumi-azure-app-reg-helm-go-error

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
