### PR TITLE
[auto/nodejs] don't mutate original stack settings when saving

### DIFF
--- a/changelog/pending/20231219--auto-nodejs--dont-mutate-original-stack-settings-when-saving.yaml
+++ b/changelog/pending/20231219--auto-nodejs--dont-mutate-original-stack-settings-when-saving.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Don't mutate original stack settings when saving

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -387,7 +387,7 @@ export class LocalWorkspace implements Workspace {
             }
         }
         const path = upath.joinSafe(this.workDir, `Pulumi.${stackSettingsName}${foundExt}`);
-        const serializeSettings = settings as any;
+        const serializeSettings = { ...settings } as any;
         let contents;
 
         // Transform the keys to the serialized representation that we expect.

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -50,6 +50,8 @@ describe("LocalWorkspace", () => {
             assert.strictEqual(settings.secretsProvider, "abc");
             assert.strictEqual(settings.config!["plain"], "plain");
             assert.strictEqual(settings.config!["secure"].secure, "secret");
+            await ws.saveStackSettings("dev", settings);
+            assert.strictEqual(settings.secretsProvider, "abc");
         }
     });
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

When writing out the stack settings, some keys get renamed (`secretsProvider` -> `secretsprovider`). We were mutating the stack settings object in place instead of working on a copy.

Fixes https://github.com/pulumi/pulumi/issues/14003

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
