### PR TITLE
correct version check when we have a dev version installed

### DIFF
--- a/changelog/pending/20231219--cli-display--warn-correctly-about-new-versions-being-availablen-when-using-the-cli-dev-channel.yaml
+++ b/changelog/pending/20231219--cli-display--warn-correctly-about-new-versions-being-availablen-when-using-the-cli-dev-channel.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Warn correctly about new versions being availablen when using the CLI dev channel

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -286,6 +286,13 @@ func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver
 		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
+	// If there is no dev version, return the latest and oldest
+	// versions.  This can happen if the server does not include
+	// https://github.com/pulumi/pulumi-service/pull/17429 yet
+	if versionInfo.LatestDevVersion == "" {
+		return latestSem, oldestSem, semver.Version{}, nil
+	}
+
 	devSem, err := semver.ParseTolerant(versionInfo.LatestDevVersion)
 	if err != nil {
 		return semver.Version{}, semver.Version{}, semver.Version{}, err

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -257,8 +257,8 @@ func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 }
 
 // GetCLIVersionInfo asks the service for information about versions of the CLI (the newest version as well as the
-// oldest version before the CLI should warn about an upgrade).
-func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, error) {
+// oldest version before the CLI should warn about an upgrade, and the current dev version).
+func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, semver.Version, error) {
 	var versionInfo apitype.CLIVersionResponse
 
 	err := pc.restCallWithOptions(
@@ -273,20 +273,25 @@ func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver
 		},
 	)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	latestSem, err := semver.ParseTolerant(versionInfo.LatestVersion)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	oldestSem, err := semver.ParseTolerant(versionInfo.OldestWithoutWarning)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
-	return latestSem, oldestSem, nil
+	devSem, err := semver.ParseTolerant(versionInfo.LatestDevVersion)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
+	}
+
+	return latestSem, oldestSem, devSem, nil
 }
 
 // ListStacksFilter describes optional filters when listing stacks.

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -114,7 +114,6 @@ func TestAPIErrorResponses(t *testing.T) {
 func TestAPIVersionResponses(t *testing.T) {
 	t.Parallel()
 
-	// test handling non-standard error message
 	versionServer := newMockServer(
 		200,
 		`{"latestVersion": "1.0.0", "oldestWithoutWarning": "0.1.0", "latestDevVersion": "1.0.0-11-gdeadbeef"}`,

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -416,6 +416,12 @@ func haveNewerDevVersion(devVersion semver.Version, curVersion semver.Version) b
 	// the number of commits since the last tag.
 	devVersionParts := strings.Split(devVersion.String(), "-")
 	curVersionParts := strings.Split(curVersion.String(), "-")
+
+	// We're being leninent with parsing here.  If we can't parse
+	// a version number correctly for any reason, we default to
+	// pretending there is no newer version, and not warning the
+	// user.  As this is only a warning this is better than
+	// asserting or crashing in the error case.
 	if len(devVersionParts) != 3 || len(curVersionParts) != 3 {
 		return false
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -546,7 +546,7 @@ func getCachedVersionInfo(devVersion bool) (semver.Version, semver.Version, semv
 type cachedVersionInfo struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
-	LatestDevVersion     string `json:"latestDevVersion`
+	LatestDevVersion     string `json:"latestDevVersion"`
 }
 
 // getUpgradeMessage gets a message to display to a user instructing them they are out of date and how to move from

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -405,28 +405,33 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 		logging.V(3).Infof("error parsing current version: %s", err)
 	}
 
-	// We don't care about warning for you to update if you have installed a developer version
-	if isDevVersion(curVer) {
+	// We don't care about warning for you to update if you have installed a locally complied version
+	if isLocalVersion(curVer) {
 		return nil
 	}
 
+	isDevVersion := isDevVersion(curVer)
+
 	var skipUpdateCheck bool
-	latestVer, oldestAllowedVer, err := getCachedVersionInfo()
+	latestVer, oldestAllowedVer, devVer, err := getCachedVersionInfo(isDevVersion)
 	if err == nil {
 		// If we have a cached version, we already warned the user once
 		// in the last 24 hours--the cache is considered stale after that.
 		// So we don't need to warn again.
 		skipUpdateCheck = true
 	} else {
-		latestVer, oldestAllowedVer, err = getCLIVersionInfo(ctx)
+		latestVer, oldestAllowedVer, devVer, err = getCLIVersionInfo(ctx)
 		if err != nil {
 			logging.V(3).Infof("error fetching latest version information "+
 				"(set `%s=true` to skip update checks): %s", env.SkipUpdateCheck.Var().Name(), err)
 		}
 	}
 
-	if oldestAllowedVer.GT(curVer) {
-		msg := getUpgradeMessage(latestVer, curVer)
+	if (isDevVersion && !devVer.EQ(curVer)) || (!isDevVersion && oldestAllowedVer.GT(curVer)) {
+		if isDevVersion {
+			latestVer = devVer
+		}
+		msg := getUpgradeMessage(latestVer, curVer, isDevVersion)
 		if skipUpdateCheck {
 			// If we're skipping the check,
 			// still log this to the internal logging system
@@ -442,11 +447,11 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 
 // getCLIVersionInfo returns information about the latest version of the CLI and the oldest version that should be
 // allowed without warning. It caches data from the server for a day.
-func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, error) {
+func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, semver.Version, error) {
 	client := client.NewClient(httpstate.DefaultURL(), "", false, cmdutil.Diag())
-	latest, oldest, err := client.GetCLIVersionInfo(ctx)
+	latest, oldest, dev, err := client.GetCLIVersionInfo(ctx)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	brewLatest, isBrew, err := getLatestBrewFormulaVersion()
@@ -455,19 +460,19 @@ func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, err
 	}
 	if isBrew {
 		// When consulting Homebrew for version info, we just use the latest version as the oldest allowed.
-		latest, oldest = brewLatest, brewLatest
+		latest, oldest, dev = brewLatest, brewLatest, brewLatest
 	}
 
-	err = cacheVersionInfo(latest, oldest)
+	err = cacheVersionInfo(latest, oldest, dev)
 	if err != nil {
 		logging.V(3).Infof("failed to cache version info: %s", err)
 	}
 
-	return latest, oldest, err
+	return latest, oldest, dev, err
 }
 
 // cacheVersionInfo saves version information in a cache file to be looked up later.
-func cacheVersionInfo(latest semver.Version, oldest semver.Version) error {
+func cacheVersionInfo(latest semver.Version, oldest semver.Version, dev semver.Version) error {
 	updateCheckFile, err := workspace.GetCachedVersionFilePath()
 	if err != nil {
 		return err
@@ -482,60 +487,72 @@ func cacheVersionInfo(latest semver.Version, oldest semver.Version) error {
 	return json.NewEncoder(file).Encode(cachedVersionInfo{
 		LatestVersion:        latest.String(),
 		OldestWithoutWarning: oldest.String(),
+		LatestDevVersion:     dev.String(),
 	})
 }
 
-// getCachedVersionInfo reads cached information about the newest CLI version, returning the newest version avaliaible
-// as well as the oldest version that should be allowed without warning the user they should upgrade.
-func getCachedVersionInfo() (semver.Version, semver.Version, error) {
+// getCachedVersionInfo reads cached information about the newest CLI version, returning the newest version available,
+// the oldest version that should be allowed without warning the user they should upgrade, as well as the
+// latest dev version.
+func getCachedVersionInfo(devVersion bool) (semver.Version, semver.Version, semver.Version, error) {
 	updateCheckFile, err := workspace.GetCachedVersionFilePath()
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	ts, err := times.Stat(updateCheckFile)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
-	if time.Now().After(ts.ModTime().Add(24 * time.Hour)) {
-		return semver.Version{}, semver.Version{}, errors.New("cached expired")
+	cacheTime := 24 * time.Hour
+	if devVersion {
+		cacheTime = 1 * time.Hour
+	}
+	if time.Now().After(ts.ModTime().Add(cacheTime)) {
+		return semver.Version{}, semver.Version{}, semver.Version{}, errors.New("cached expired")
 	}
 
 	file, err := os.OpenFile(updateCheckFile, os.O_RDONLY, 0o600)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 	defer contract.IgnoreClose(file)
 
 	var cached cachedVersionInfo
 	if err = json.NewDecoder(file).Decode(&cached); err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	latest, err := semver.ParseTolerant(cached.LatestVersion)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
 	oldest, err := semver.ParseTolerant(cached.OldestWithoutWarning)
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
 	}
 
-	return latest, oldest, err
+	dev, err := semver.ParseTolerant(cached.LatestDevVersion)
+	if err != nil {
+		return semver.Version{}, semver.Version{}, semver.Version{}, err
+	}
+
+	return latest, oldest, dev, err
 }
 
 // cachedVersionInfo is the on disk format of the version information the CLI caches between runs.
 type cachedVersionInfo struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
+	LatestDevVersion     string `json:"latestDevVersion`
 }
 
 // getUpgradeMessage gets a message to display to a user instructing them they are out of date and how to move from
 // current to latest.
-func getUpgradeMessage(latest semver.Version, current semver.Version) string {
-	cmd := getUpgradeCommand()
+func getUpgradeMessage(latest semver.Version, current semver.Version, isDevVersion bool) string {
+	cmd := getUpgradeCommand(isDevVersion)
 
 	msg := fmt.Sprintf("A new version of Pulumi is available. To upgrade from version '%s' to '%s', ", current, latest)
 	if cmd != "" {
@@ -548,7 +565,7 @@ func getUpgradeMessage(latest semver.Version, current semver.Version) string {
 
 // getUpgradeCommand returns a command that will upgrade the CLI to the newest version. If we can not determine how
 // the CLI was installed, the empty string is returned.
-func getUpgradeCommand() string {
+func getUpgradeCommand(isDevVersion bool) string {
 	curUser, err := user.Current()
 	if err != nil {
 		return ""
@@ -572,7 +589,11 @@ func getUpgradeCommand() string {
 	}
 
 	if runtime.GOOS != "windows" {
-		return "$ curl -sSL https://get.pulumi.com | sh"
+		command := "$ curl -sSL https://get.pulumi.com | sh"
+		if isDevVersion {
+			command = command + " -s -- --version dev"
+		}
+		return command
 	}
 
 	powershellCmd := `"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"`
@@ -581,8 +602,12 @@ func getUpgradeCommand() string {
 		powershellCmd = "powershell"
 	}
 
-	return "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ` +
+	powershellCmd = "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ` +
 		`((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"`
+	if isDevVersion {
+		powershellCmd = powershellCmd + " -version dev"
+	}
+	return powershellCmd
 }
 
 // isBrewInstall returns true if the current running executable is running on macOS and was installed with brew.
@@ -671,13 +696,22 @@ func getLatestBrewFormulaVersion() (semver.Version, bool, error) {
 	return stable, true, nil
 }
 
-func isDevVersion(s semver.Version) bool {
+func isLocalVersion(s semver.Version) bool {
 	if len(s.Pre) == 0 {
 		return false
 	}
 
 	devStrings := regexp.MustCompile(`alpha|beta|dev|rc`)
 	return !s.Pre[0].IsNum && devStrings.MatchString(s.Pre[0].VersionStr)
+}
+
+func isDevVersion(s semver.Version) bool {
+	if len(s.Pre) == 0 {
+		return false
+	}
+
+	devRegex := regexp.MustCompile(`\d*-g[0-9a-f]*$`)
+	return !s.Pre[0].IsNum && devRegex.MatchString(s.Pre[0].VersionStr)
 }
 
 func confirmPrompt(prompt string, name string, opts display.Options) bool {

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -56,6 +56,22 @@ func TestIsDevVersion(t *testing.T) {
 	assert.True(t, isDevVersion(devVer))
 }
 
+func TestHaveNewerDevVersion(t *testing.T) {
+	t.Parallel()
+
+	devVer, _ := semver.ParseTolerant("v1.0.0-11-g4ff08363")
+	olderCurVer, _ := semver.ParseTolerant("v1.0.0-10-gdeadbeef")
+	newerCurVer, _ := semver.ParseTolerant("v1.0.0-12-gdeadbeef")
+	newerPatchCurVer, _ := semver.ParseTolerant("v1.0.1-11-gdeadbeef")
+	olderMajorCurVer, _ := semver.ParseTolerant("v0.9.9-11-gdeadbeef")
+
+	assert.True(t, haveNewerDevVersion(devVer, olderCurVer))
+	assert.True(t, haveNewerDevVersion(devVer, olderMajorCurVer))
+	assert.False(t, haveNewerDevVersion(devVer, devVer))
+	assert.False(t, haveNewerDevVersion(devVer, newerCurVer))
+	assert.False(t, haveNewerDevVersion(devVer, newerPatchCurVer))
+}
+
 //nolint:paralleltest // changes environment variables and globals
 func TestCheckForUpdate(t *testing.T) {
 	realVersion := version.Version

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsDevVersion(t *testing.T) {
+func TestIsLocalVersion(t *testing.T) {
 	t.Parallel()
 
 	// This function primarily focuses on the "Pre" section of the semver string,
@@ -39,11 +39,21 @@ func TestIsDevVersion(t *testing.T) {
 	betaVer, _ := semver.ParseTolerant("v1.0.0-beta.1590772212")
 	rcVer, _ := semver.ParseTolerant("v1.0.0-rc.1")
 
+	assert.False(t, isLocalVersion(stableVer))
+	assert.True(t, isLocalVersion(devVer))
+	assert.True(t, isLocalVersion(alphaVer))
+	assert.True(t, isLocalVersion(betaVer))
+	assert.True(t, isLocalVersion(rcVer))
+}
+
+func TestIsDevVersion(t *testing.T) {
+	t.Parallel()
+
+	stableVer, _ := semver.ParseTolerant("1.0.0")
+	devVer, _ := semver.ParseTolerant("v1.0.0-11-g4ff08363")
+
 	assert.False(t, isDevVersion(stableVer))
 	assert.True(t, isDevVersion(devVer))
-	assert.True(t, isDevVersion(alphaVer))
-	assert.True(t, isDevVersion(betaVer))
-	assert.True(t, isDevVersion(rcVer))
 }
 
 //nolint:paralleltest // changes environment variables and globals
@@ -147,4 +157,74 @@ func TestCheckForUpdate_allFail(t *testing.T) {
 
 	// We should not make more than one attempt to get this information.
 	assert.Equal(t, 1, requestCounter)
+}
+
+//nolint:paralleltest // changes environment variables and globals
+func TestCheckForUpdate_devVersion(t *testing.T) {
+	realVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = realVersion
+	})
+	version.Version = "v1.0.0-11-g4ff08363"
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	// Cached version information is stored in PULUMI_HOME.
+	var requestCounter int // number of requests
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/cli/version":
+			requestCounter++
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"latestVersion": "v1.2.3",
+				"oldestWithoutWarning": "v1.2.0",
+				"latestDevVersion": "v1.0.0-12-gdeadbeef"
+			}`))
+			if !assert.NoError(t, err) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("PULUMI_API", srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	msg := checkForUpdate(ctx)
+	require.NotNil(t, msg)
+	assert.Contains(t, msg.Message, "A new version of Pulumi is available")
+	assert.Contains(t, msg.Message, "upgrade from version '1.0.0-11-g4ff08363' to '1.0.0-12-gdeadbeef'")
+	assert.Equal(t, 1, requestCounter,
+		"expected exactly one request to the HTTP server")
+
+	t.Run("cached", func(t *testing.T) {
+		// Once we have cached version information,
+		// we will not warn the user again until the cache expires.
+		requestCounter = 0
+		require.Nil(t, checkForUpdate(ctx))
+		assert.Equal(t, 0, requestCounter,
+			"no requests are expected to the HTTP server")
+	})
+
+	t.Run("cache expired", func(t *testing.T) {
+		// Expire the cached version information
+		// and verify that we query the server again.
+
+		versionCachePath, err := workspace.GetCachedVersionFilePath()
+		require.NoError(t, err)
+
+		expiredTime := time.Now().Add(-2 * time.Hour)
+		require.NoError(t,
+			os.Chtimes(versionCachePath, expiredTime, expiredTime))
+
+		requestCounter = 0
+		require.NotNil(t, checkForUpdate(ctx))
+		assert.Equal(t, 1, requestCounter)
+	})
 }

--- a/sdk/go/common/apitype/cli.go
+++ b/sdk/go/common/apitype/cli.go
@@ -18,4 +18,5 @@ package apitype
 type CLIVersionResponse struct {
 	LatestVersion        string `json:"latestVersion"`
 	OldestWithoutWarning string `json:"oldestWithoutWarning"`
+	LatestDevVersion     string `json:"latestDevVersion"`
 }


### PR DESCRIPTION
When we have a dev version from the dev CLI channel installed, we want to warn whenever a new version is available, so the users can upgrade. Do that, and also reduce the amount of time the version information is cached, since we expect dev versions to be released much more frequently than regular releases.

This needs https://github.com/pulumi/pulumi-service/pull/17429 to be merged and deployed first.

Fixes #14641

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
