### PR TITLE
[program-gen/go] Fix required config variables of type bool and number

### DIFF
--- a/changelog/pending/20231219--programgen-go--fix-required-config-variables-of-type-bool-and-number.yaml
+++ b/changelog/pending/20231219--programgen-go--fix-required-config-variables-of-type-bool-and-number.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix required config variables of type bool and number

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -264,12 +264,8 @@ func (pkg *pkgContext) tokenToEnum(tok string) string {
 
 	components := strings.Split(tok, ":")
 	contract.Assertf(len(components) == 3, "Token must have 3 components, got %d", len(components))
-	if pkg == nil {
-		panic(fmt.Errorf("pkg is nil. token %s", tok))
-	}
-	if pkg.pkg == nil {
-		panic(fmt.Errorf("pkg.pkg is nil. token %s", tok))
-	}
+	contract.Assertf(pkg != nil, "pkg is nil. token %s", tok)
+	contract.Assertf(pkg.pkg != nil, "pkg.pkg is nil. token %s", tok)
 
 	mod, name := pkg.tokenToPackage(tok), components[2]
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -1443,11 +1443,11 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	switch v.Type() {
 	case model.StringType: // Already default
 	case model.NumberType:
-		getType = "Float"
+		getType = "Float64"
 	case model.IntType:
 		getType = "Int"
 	case model.BoolType:
-		getType = "Boolean"
+		getType = "Bool"
 	case model.DynamicType:
 		getType = "Object"
 	}
@@ -1498,7 +1498,7 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 		case model.BoolType:
 			g.Fgenf(w, "if param := cfg.GetBool(\"%s\"); param {\n", v.LogicalName())
 		default:
-			g.Fgenf(w, "if param := cfg.GetBool(\"%s\"); param != nil {\n", v.LogicalName())
+			g.Fgenf(w, "if param := cfg.GetObject(\"%s\"); param != nil {\n", v.LogicalName())
 		}
 		g.Fgenf(w, "%s = param\n", name)
 		g.Fgen(w, "}\n")

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -231,21 +231,6 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 	case pcl.IntrinsicApply:
 		g.genApply(w, expr)
-	case "element":
-		g.genNYI(w, "element")
-	case "entries":
-		g.genNYI(w, "call %v", expr.Name)
-		// switch model.ResolveOutputs(expr.Args[0].Type()).(type) {
-		// case *model.ListType, *model.TupleType:
-		// 	if call, ok := expr.Args[0].(*model.FunctionCallExpression); ok && call.Name == "range" {
-		// 		g.genRange(w, call, true)
-		// 		return
-		// 	}
-		// 	g.Fgenf(w, "%.20v.Select((v, k)", expr.Args[0])
-		// case *model.MapType, *model.ObjectType:
-		// 	g.genNYI(w, "MapOrObjectEntries")
-		// }
-		// g.Fgenf(w, " => new { Key = k, Value = v })")
 	case "fileArchive":
 		g.Fgenf(w, "pulumi.NewFileArchive(%.v)", expr.Args[0])
 	case "remoteArchive":
@@ -317,16 +302,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "strings.Join(%v, %v)", expr.Args[1], expr.Args[0])
 	case "length":
 		g.Fgenf(w, "len(%.20v)", expr.Args[0])
-	case "lookup":
-		g.genNYI(w, "Lookup")
-	case keywordRange:
-		g.genNYI(w, "call %v", expr.Name)
-		// g.genRange(w, expr, false)
 	case "readFile":
 		// Assuming the existence of the following helper method located earlier in the preamble
 		g.Fgenf(w, "readFileOrPanic(%v)", expr.Args[0])
-	case "readDir":
-		contract.Failf("unlowered readDir function expression @ %v", expr.SyntaxNode().Range())
 	case "secret":
 		outputTypeName := "pulumi.Any"
 		if model.ResolveOutputs(expr.Type()) != model.DynamicType {
@@ -339,15 +317,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			outputTypeName = g.argumentTypeName(nil, expr.Type(), false)
 		}
 		g.Fgenf(w, "pulumi.Unsecret(%v).(%sOutput)", expr.Args[0], outputTypeName)
-	case "split":
-		g.genNYI(w, "call %v", expr.Name)
-		// g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
 	case "toBase64":
 		g.Fgenf(w, "base64.StdEncoding.EncodeToString([]byte(%v))", expr.Args[0])
 	case fromBase64Fn:
 		g.Fgenf(w, "base64.StdEncoding.DecodeString(%v)", expr.Args[0])
-	case "toJSON":
-		contract.Failf("unlowered toJSON function expression @ %v", expr.SyntaxNode().Range())
 	case "mimeType":
 		g.Fgenf(w, "mime.TypeByExtension(path.Ext(%.v))", expr.Args[0])
 	case "sha1":
@@ -367,6 +340,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "cwd":
 		g.Fgen(w, "func(cwd string, err error) string { if err != nil { panic(err) }; return cwd }(os.Getwd())")
 	default:
+		// toJSON and readDir are reduced away, shouldn't see them here
+		reducedFunctions := codegen.NewStringSet("toJSON", "readDir")
+		contract.Assertf(!reducedFunctions.Has(expr.Name), "unlowered function %s", expr.Name)
+		// TODO: implement "element", "entries", "lookup", "split" and "range"
 		g.genNYI(w, "call %v", expr.Name)
 	}
 }

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -503,6 +503,7 @@ func TestTitle(t *testing.T) {
 	assert.Equal("WaldoThudFred", Title("waldo-ThudFred"))
 	assert.Equal("WaldoThud_Fred", Title("waldo-Thud_Fred"))
 	assert.Equal("WaldoThud_Fred", Title("waldo-thud_Fred"))
+	assert.Equal("WaldoThud_Fred", Title("$waldo-thud_Fred"))
 }
 
 func TestRegressTypeDuplicatesInChunking(t *testing.T) {

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -272,6 +272,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Multiline string literals",
 	},
 	{
+		Directory:   "config-variables",
+		Description: "Basic program with a bunch of config variables",
+		// TODO[https://github.com/pulumi/pulumi/issues/14957] - object config variables are broken here
+		SkipCompile: codegen.NewStringSet("go", "dotnet"),
+	},
+	{
 		Directory:   "regress-11176",
 		Description: "Regression test for https://github.com/pulumi/pulumi/issues/11176",
 		Skip:        allProgLanguages.Except("go"),

--- a/pkg/codegen/testing/test/testdata/config-variables-pp/config-variables.pp
+++ b/pkg/codegen/testing/test/testdata/config-variables-pp/config-variables.pp
@@ -1,0 +1,11 @@
+config "requiredString" "string" { }
+config "requiredInt" "int" { }
+config "requiredFloat" "number" { }
+config "requiredBool" "bool" { }
+config "requiredAny" "any" { }
+
+config "optionalString" "string" { default = "defaultStringValue" }
+config "optionalInt" "int" { default = 42 }
+config "optionalFloat" "number" { default = 3.14 }
+config "optionalBool" "bool" { default = true }
+config "optionalAny" "any" { default = { "key" = "value" } }

--- a/pkg/codegen/testing/test/testdata/config-variables-pp/dotnet/config-variables.cs
+++ b/pkg/codegen/testing/test/testdata/config-variables-pp/dotnet/config-variables.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var config = new Config();
+    var requiredString = config.Require("requiredString");
+    var requiredInt = config.RequireInt32("requiredInt");
+    var requiredFloat = config.RequireDouble("requiredFloat");
+    var requiredBool = config.RequireBoolean("requiredBool");
+    var requiredAny = config.RequireObject<dynamic>("requiredAny");
+    var optionalString = config.Get("optionalString") ?? "defaultStringValue";
+    var optionalInt = config.GetInt32("optionalInt") ?? 42;
+    var optionalFloat = config.GetDouble("optionalFloat") ?? 3.14;
+    var optionalBool = config.GetBoolean("optionalBool") ?? true;
+    var optionalAny = config.GetObject<dynamic>("optionalAny") ?? 
+    {
+        { "key", "value" },
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/config-variables-pp/go/config-variables.go
+++ b/pkg/codegen/testing/test/testdata/config-variables-pp/go/config-variables.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		requiredString := cfg.Require("requiredString")
+		requiredInt := cfg.RequireInt("requiredInt")
+		requiredFloat := cfg.RequireFloat64("requiredFloat")
+		requiredBool := cfg.RequireBool("requiredBool")
+		requiredAny := cfg.RequireObject("requiredAny")
+		optionalString := "defaultStringValue"
+		if param := cfg.Get("optionalString"); param != "" {
+			optionalString = param
+		}
+		optionalInt := 42
+		if param := cfg.GetInt("optionalInt"); param != 0 {
+			optionalInt = param
+		}
+		optionalFloat := float64(3.14)
+		if param := cfg.GetFloat64("optionalFloat"); param != 0 {
+			optionalFloat = param
+		}
+		optionalBool := true
+		if param := cfg.GetBool("optionalBool"); param {
+			optionalBool = param
+		}
+		optionalAny := map[string]interface{}{
+			"key": "value",
+		}
+		if param := cfg.GetObject("optionalAny"); param != nil {
+			optionalAny = param
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/config-variables-pp/nodejs/config-variables.ts
+++ b/pkg/codegen/testing/test/testdata/config-variables-pp/nodejs/config-variables.ts
@@ -1,0 +1,15 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const requiredString = config.require("requiredString");
+const requiredInt = config.requireNumber("requiredInt");
+const requiredFloat = config.requireNumber("requiredFloat");
+const requiredBool = config.requireBoolean("requiredBool");
+const requiredAny = config.requireObject("requiredAny");
+const optionalString = config.get("optionalString") || "defaultStringValue";
+const optionalInt = config.getNumber("optionalInt") || 42;
+const optionalFloat = config.getNumber("optionalFloat") || 3.14;
+const optionalBool = config.getBoolean("optionalBool") || true;
+const optionalAny = config.getObject("optionalAny") || {
+    key: "value",
+};

--- a/pkg/codegen/testing/test/testdata/config-variables-pp/python/config-variables.py
+++ b/pkg/codegen/testing/test/testdata/config-variables-pp/python/config-variables.py
@@ -1,0 +1,25 @@
+import pulumi
+
+config = pulumi.Config()
+required_string = config.require("requiredString")
+required_int = config.require_int("requiredInt")
+required_float = config.require_float("requiredFloat")
+required_bool = config.require_bool("requiredBool")
+required_any = config.require_object("requiredAny")
+optional_string = config.get("optionalString")
+if optional_string is None:
+    optional_string = "defaultStringValue"
+optional_int = config.get_int("optionalInt")
+if optional_int is None:
+    optional_int = 42
+optional_float = config.get_float("optionalFloat")
+if optional_float is None:
+    optional_float = 3.14
+optional_bool = config.get_bool("optionalBool")
+if optional_bool is None:
+    optional_bool = True
+optional_any = config.get_object("optionalAny")
+if optional_any is None:
+    optional_any = {
+        "key": "value",
+    }


### PR DESCRIPTION
# Description

While covering more parts of go codegen, I've seen that config variables are broken 😓 specifically when requiring config variables using `RequireFloat` it should be `RequireFloat64` and `RequireBoolean` should be `RequireBool`. 
Moreover, it seems that `RequireObject` doesn't work at all since the function signature doesn't match the way it was generated (see #14957) 

C# has a similar issue with optional untyped objects as config variables. For now have skipped compilation for those.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
