### PR TITLE
Warn if checkpoints are slow

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1014,7 +1014,8 @@ func (b *localBackend) apply(
 		persister,
 		op.SecretsManager,
 		update.GetTarget().Snapshot,
-		op.StackConfiguration.Config)
+		op.StackConfiguration.Config,
+		&backend.MonotonicTimeMonitor{})
 	engineCtx := &engine.Context{
 		Cancel:          scope.Context(),
 		Events:          engineEvents,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1261,7 +1261,8 @@ func (b *cloudBackend) runEngineAction(
 		persister,
 		op.SecretsManager,
 		u.GetTarget().Snapshot,
-		op.StackConfiguration.Config)
+		op.StackConfiguration.Config,
+		&backend.MonotonicTimeMonitor{})
 
 	// Depending on the action, kick off the relevant engine activity.  Note that we don't immediately check and
 	// return error conditions, because we will do so below after waiting for the display channels to close.

--- a/pkg/util/testutil/testdiagsink.go
+++ b/pkg/util/testutil/testdiagsink.go
@@ -41,6 +41,7 @@ func NewTestDiagSink(pwd string) *TestDiagSink {
 
 func (d *TestDiagSink) DebugMsgs() []string   { return d.messages[diag.Debug] }
 func (d *TestDiagSink) InfoMsgs() []string    { return d.messages[diag.Info] }
+func (d *TestDiagSink) InfoerrMsgs() []string { return d.messages[diag.Infoerr] }
 func (d *TestDiagSink) ErrorMsgs() []string   { return d.messages[diag.Error] }
 func (d *TestDiagSink) WarningMsgs() []string { return d.messages[diag.Warning] }
 
@@ -54,6 +55,10 @@ func (d *TestDiagSink) Debugf(dia *diag.Diag, args ...interface{}) {
 
 func (d *TestDiagSink) Infof(dia *diag.Diag, args ...interface{}) {
 	d.messages[diag.Info] = append(d.messages[diag.Info], d.combine(diag.Info, dia, args...))
+}
+
+func (d *TestDiagSink) Infoerrf(dia *diag.Diag, args ...interface{}) {
+	d.messages[diag.Infoerr] = append(d.messages[diag.Infoerr], d.combine(diag.Info, dia, args...))
 }
 
 func (d *TestDiagSink) Errorf(dia *diag.Diag, args ...interface{}) {

--- a/sdk/go/common/util/cmdutil/diag.go
+++ b/sdk/go/common/util/cmdutil/diag.go
@@ -96,3 +96,11 @@ func InitDiag(opts diag.FormatOptions) {
 	contract.Assertf(snk == nil, "Cannot initialize diagnostics sink more than once")
 	snk = diag.DefaultSink(os.Stdout, os.Stderr, opts)
 }
+
+func ReplaceDiag(replacement diag.Sink) diag.Sink {
+	snkMutex.Lock()
+	defer snkMutex.Unlock()
+	prev := snk
+	snk = replacement
+	return prev
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This prints a warning if the cummulative time spent saving checkpoints is more than 50%

This is a WIP &mdash; the actual threshold is t.b.d.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
