### PR TITLE
Fix a bug in pulumi config env ls json output

### DIFF
--- a/changelog/pending/20231220--cli-config--fix-pulumi-config-env-ls-json.yaml
+++ b/changelog/pending/20231220--cli-config--fix-pulumi-config-env-ls-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config
+  description: Fix a bug in `pulumi config env ls --json` where the json flag was not being correctly passed through.

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -119,9 +119,13 @@ func (cmd *configEnvCmd) listStackEnvironments(jsonOut bool) error {
 	imports := projectStack.Environment.Imports()
 
 	if jsonOut {
-		err := fprintJSON(cmd.stdout, imports)
-		if err != nil {
-			return err
+		if len(imports) == 0 {
+			fprintf(cmd.stdout, "[]\n")
+		} else {
+			err := fprintJSON(cmd.stdout, imports)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		rows := []cmdutil.TableRow{}

--- a/pkg/cmd/pulumi/config_env_ls.go
+++ b/pkg/cmd/pulumi/config_env_ls.go
@@ -22,7 +22,7 @@ import (
 func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
 	var jsonOut bool
 
-	impl := configEnvLsCmd{parent: parent, jsonOut: jsonOut}
+	impl := configEnvLsCmd{parent: parent, jsonOut: &jsonOut}
 
 	cmd := &cobra.Command{
 		Use:   "ls",
@@ -42,9 +42,9 @@ func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
 type configEnvLsCmd struct {
 	parent *configEnvCmd
 
-	jsonOut bool
+	jsonOut *bool
 }
 
 func (cmd *configEnvLsCmd) run(_ *cobra.Command, _ []string) error {
-	return cmd.parent.listStackEnvironments(cmd.jsonOut)
+	return cmd.parent.listStackEnvironments(*cmd.jsonOut)
 }

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func TestConfigEnvLsCmd(t *testing.T) {
 	t.Parallel()
 
@@ -47,7 +51,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: false}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
@@ -73,11 +77,11 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: true}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
-		const expectedOut = "null\n"
+		const expectedOut = "[]\n"
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
@@ -105,7 +109,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: false}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
@@ -141,7 +145,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: true}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
@@ -178,7 +182,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: false}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 
@@ -215,7 +219,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: true}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
 		err := ls.run(nil, nil)
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The `--json` flag for `pulumi config env ls` was not being correctly passed through, this fixes the issue. Also changed the default output of no envs from `null` to `[]` so automation api doesn't need to handle the null case in all languages.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
