### PR TITLE
ci-dev-release: remove extra quotes

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -37,7 +37,7 @@ jobs:
           version="${version#v}"
           ./.github/scripts/set-output dev-version "$version"
     outputs:
-      dev-version: "${{ steps.strip-prefix.outputs.dev-version }}"
+      dev-version: ${{ steps.strip-prefix.outputs.dev-version }}
       version: ${{ inputs.version }}
 
   matrix:


### PR DESCRIPTION
GitHub actions interprets these quotes literally, so the version we end up with includes the quotes, and will therefore end up in the form of `v"1.0.0-11-gdeadbeef" in the output.  Remove the extra quotes as they are not needed.

It's a bit awkward to test this, but I *think* this should do the trick.
