### PR TITLE
Clean up uses of .Error()

### DIFF
--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -12,5 +12,5 @@ type ConflictingUpdateError struct {
 
 func (c ConflictingUpdateError) Error() string {
 	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit "+
-		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err.Error())
+		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err)
 }

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -81,8 +81,7 @@ func TestAPIErrorResponses(t *testing.T) {
 		unauthorizedClient := newMockClient(unauthorizedServer)
 		_, _, unauthorizedErr := unauthorizedClient.GetCLIVersionInfo(context.Background())
 
-		assert.Error(t, unauthorizedErr)
-		assert.Equal(t, unauthorizedErr.Error(), "this command requires logging in; try running `pulumi login` first")
+		assert.EqualError(t, unauthorizedErr, "this command requires logging in; try running `pulumi login` first")
 	})
 	t.Run("TestRateLimitError", func(t *testing.T) {
 		t.Parallel()
@@ -94,8 +93,7 @@ func TestAPIErrorResponses(t *testing.T) {
 		rateLimitedClient := newMockClient(rateLimitedServer)
 		_, _, rateLimitErr := rateLimitedClient.GetCLIVersionInfo(context.Background())
 
-		assert.Error(t, rateLimitErr)
-		assert.Equal(t, rateLimitErr.Error(), "pulumi service: request rate-limit exceeded")
+		assert.EqualError(t, rateLimitErr, "pulumi service: request rate-limit exceeded")
 	})
 	t.Run("TestDefaultError", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -87,12 +87,12 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment)
 
 	delta, err := dds.computeEdits(childCtx, dds.lastSavedDeployment, deployment)
 	if err != nil {
-		return deploymentDiff{}, fmt.Errorf("Cannot marshal the edits: %v", err)
+		return deploymentDiff{}, fmt.Errorf("Cannot marshal the edits: %w", err)
 	}
 
 	checkpointHash, err := checkpointHashPromise.Result(ctx)
 	if err != nil {
-		return deploymentDiff{}, fmt.Errorf("Cannot compute the checkpoint hash: %v", err)
+		return deploymentDiff{}, fmt.Errorf("Cannot compute the checkpoint hash: %w", err)
 	}
 
 	tracingSpan.SetTag("before", len(before))

--- a/pkg/backend/httpstate/diffs_post_1.20.go
+++ b/pkg/backend/httpstate/diffs_post_1.20.go
@@ -169,7 +169,7 @@ func (*deploymentDiffState) computeEdits(ctx context.Context, before, after depl
 
 	delta, err := json.Marshal(edits)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot marshal the edits: %v", err)
+		return nil, fmt.Errorf("Cannot marshal the edits: %w", err)
 	}
 
 	return delta, nil

--- a/pkg/cmd/pulumi/errors.go
+++ b/pkg/cmd/pulumi/errors.go
@@ -38,7 +38,7 @@ func PrintEngineResult(res result.Result) result.Result {
 func printDecryptError(e engine.DecryptError) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	fprintf(writer, "failed to decrypt encrypted configuration value '%s': %s", e.Key, e.Err.Error())
+	fprintf(writer, "failed to decrypt encrypted configuration value '%s': %s", e.Key, e.Err)
 	fprintf(writer, ""+
 		"This can occur when a secret is copied from one stack to another. Encryption of secrets is done per-stack and "+
 		"it is not possible to share an encrypted configuration value across stacks.\n"+

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -172,7 +172,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	}
 	err = cmd.outputFormat.Render(&cmd.searchCmd, res)
 	if err != nil {
-		return fmt.Errorf("table rendering error: %s", err)
+		return fmt.Errorf("table rendering error: %w", err)
 	}
 	if cmd.openWeb {
 		err = browser.OpenURL(res.URL)

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -107,7 +107,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if cmd.openWeb {
 		err = browser.OpenURL(res.URL)
 		if err != nil {
-			return fmt.Errorf("failed to open URL: %s", err)
+			return fmt.Errorf("failed to open URL: %w", err)
 		}
 	}
 	return nil

--- a/pkg/cmd/pulumi/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/package_extract_mapping.go
@@ -60,7 +60,7 @@ func newExtractMappingCommand() *cobra.Command {
 
 			err = os.WriteFile(out, data, 0o600)
 			if err != nil {
-				return fmt.Errorf("write mapping data file: %s", err)
+				return fmt.Errorf("write mapping data file: %w", err)
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -161,7 +161,7 @@ func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
 			if new.Provider != "" {
 				ref, err := providers.ParseReference(new.Provider)
 				if err != nil {
-					return importFile{}, fmt.Errorf("could not parse provider reference: %v", err)
+					return importFile{}, fmt.Errorf("could not parse provider reference: %w", err)
 				}
 
 				// If we're trying to create this provider in the same deployment and it's not a default provider then
@@ -183,7 +183,7 @@ func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
 
 				v, err := providers.GetProviderVersion(inputs)
 				if err != nil {
-					return importFile{}, fmt.Errorf("could not get provider version for %s: %v", ref, err)
+					return importFile{}, fmt.Errorf("could not get provider version for %s: %w", ref, err)
 				}
 				if v != nil {
 					version = v.String()
@@ -191,7 +191,7 @@ func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
 
 				pluginDownloadURL, err = providers.GetProviderDownloadURL(inputs)
 				if err != nil {
-					return importFile{}, fmt.Errorf("could not get provider download url for %s: %v", ref, err)
+					return importFile{}, fmt.Errorf("could not get provider download url for %s: %w", ref, err)
 				}
 			}
 

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -572,7 +572,7 @@ func TestRegressTypeDuplicatesInChunking(t *testing.T) {
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader)
 	require.NoError(t, err)
-	t.Logf("%v", diags.Error())
+	t.Logf("%v", diags)
 	require.False(t, diags.HasErrors())
 
 	fs, err := GeneratePackage("tests", pkg)

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -352,7 +352,7 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 					typeExpr, diags := model.BindExpressionText(item.Labels[1], model.TypeScope, item.LabelRanges[1].Start)
 					diagnostics = append(diagnostics, diags...)
 					if typeExpr == nil {
-						return diagnostics, fmt.Errorf("cannot bind expression: %v", diagnostics.Error())
+						return diagnostics, fmt.Errorf("cannot bind expression: %v", diagnostics)
 					}
 					typ = typeExpr.Type()
 					switch configType := typ.(type) {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3153,7 +3153,7 @@ func ensureValidPulumiVersion(requires map[string]string) (map[string]string, er
 
 		lowerBound, err := pep440VersionToSemver(matches[1])
 		if err != nil {
-			return nil, fmt.Errorf("invalid version for lower bound: %v", err)
+			return nil, fmt.Errorf("invalid version for lower bound: %w", err)
 		}
 		if lowerBound.LT(oldestAllowedPulumi) {
 			return nil, fmt.Errorf("lower version bound must be at least %v", oldestAllowedPulumi)

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -36,5 +36,5 @@ type DecryptError struct {
 }
 
 func (d DecryptError) Error() string {
-	return fmt.Sprintf("failed to decrypt configuration key '%s': %s", d.Key, d.Err.Error())
+	return fmt.Sprintf("failed to decrypt configuration key '%s': %s", d.Key, d.Err)
 }

--- a/pkg/resource/analyzer/config_test.go
+++ b/pkg/resource/analyzer/config_test.go
@@ -324,10 +324,7 @@ func TestExtractEnforcementLevelFail(t *testing.T) {
 
 			result, err := extractEnforcementLevel(test.Properties)
 			assert.Equal(t, apitype.EnforcementLevel(""), result)
-			assert.Error(t, err)
-			if test.ExpectedError != "" {
-				assert.Equal(t, test.ExpectedError, err.Error())
-			}
+			assert.EqualError(t, err, test.ExpectedError)
 		})
 	}
 }

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -188,7 +188,7 @@ func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer,
 	)
 	if err != nil {
 		contract.IgnoreClose(wrapper)
-		return nil, nil, fmt.Errorf("could not connect to resource provider service: %v", err)
+		return nil, nil, fmt.Errorf("could not connect to resource provider service: %w", err)
 	}
 	wrapped := plugin.NewProviderWithClient(nil, provider.Pkg(), pulumirpc.NewResourceProviderClient(conn), false)
 	return wrapped, wrapper, nil
@@ -286,7 +286,7 @@ func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
-		panic(fmt.Errorf("could not start engine service: %v", err))
+		panic(fmt.Errorf("could not start engine service: %w", err))
 	}
 	engine.address = fmt.Sprintf("127.0.0.1:%v", handle.Port)
 

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -115,7 +115,7 @@ func GetProviderVersion(inputs resource.PropertyMap) (*semver.Version, error) {
 
 	sv, err := semver.ParseTolerant(version.StringValue())
 	if err != nil {
-		return nil, fmt.Errorf("could not parse provider version: %v", err)
+		return nil, fmt.Errorf("could not parse provider version: %w", err)
 	}
 	return &sv, nil
 }
@@ -430,16 +430,16 @@ func (r *Registry) Same(res *resource.State) error {
 		// Parse the provider version, then load, configure, and register the provider.
 		version, err := GetProviderVersion(res.Inputs)
 		if err != nil {
-			return fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+			return fmt.Errorf("parse version for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		downloadURL, err := GetProviderDownloadURL(res.Inputs)
 		if err != nil {
-			return fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
+			return fmt.Errorf("parse download URL for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		// TODO: We should thread checksums through here.
 		provider, err = loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
 		if err != nil {
-			return fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
+			return fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		if provider == nil {
 			return fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
@@ -450,7 +450,7 @@ func (r *Registry) Same(res *resource.State) error {
 	if err := provider.Configure(res.Inputs); err != nil {
 		closeErr := r.host.CloseProvider(provider)
 		contract.IgnoreError(closeErr)
-		return fmt.Errorf("configure provider '%v': %v", urn, err)
+		return fmt.Errorf("configure provider '%v': %w", urn, err)
 	}
 
 	logging.V(7).Infof("loaded provider %v", ref)
@@ -483,18 +483,18 @@ func (r *Registry) Create(urn resource.URN, news resource.PropertyMap, timeout f
 		version, err := GetProviderVersion(news)
 		if err != nil {
 			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("parse version for %v provider '%v': %v", providerPkg, urn, err)
+				fmt.Errorf("parse version for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		downloadURL, err := GetProviderDownloadURL(news)
 		if err != nil {
 			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("parse download URL for %v provider '%v': %v", providerPkg, urn, err)
+				fmt.Errorf("parse download URL for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		// TODO: We should thread checksums through here.
 		provider, err = loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
 		if err != nil {
 			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("load plugin for %v provider '%v': %v", providerPkg, urn, err)
+				fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, urn, err)
 		}
 		if provider == nil {
 			return "", nil, resource.StatusUnknown,

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -143,14 +143,14 @@ func (snap *Snapshot) VerifyIntegrity() error {
 			if providers.IsProviderType(state.Type) {
 				ref, err := providers.NewReference(urn, state.ID)
 				if err != nil {
-					return fmt.Errorf("provider %s is not referenceable: %v", urn, err)
+					return fmt.Errorf("provider %s is not referenceable: %w", urn, err)
 				}
 				provs[ref] = struct{}{}
 			}
 			if provider := state.Provider; provider != "" {
 				ref, err := providers.ParseReference(provider)
 				if err != nil {
-					return fmt.Errorf("failed to parse provider reference for resource %s: %v", urn, err)
+					return fmt.Errorf("failed to parse provider reference for resource %s: %w", urn, err)
 				}
 				if _, has := provs[ref]; !has {
 					return fmt.Errorf("resource %s refers to unknown provider %s", urn, ref)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -643,7 +643,7 @@ func getProviderReference(defaultProviders *defaultProviders, req providers.Prov
 	if rawProviderRef != "" {
 		ref, err := providers.ParseReference(rawProviderRef)
 		if err != nil {
-			return providers.Reference{}, fmt.Errorf("could not parse provider reference: %v", err)
+			return providers.Reference{}, fmt.Errorf("could not parse provider reference: %w", err)
 		}
 		return ref, nil
 	}
@@ -1636,7 +1636,7 @@ func (rm *resmon) RegisterResourceOutputs(ctx context.Context,
 	// Obtain and validate the message's inputs (a URN plus the output property map).
 	urn, err := resource.ParseURN(req.Urn)
 	if err != nil {
-		return nil, fmt.Errorf("invalid resource URN: %s", err)
+		return nil, fmt.Errorf("invalid resource URN: %w", err)
 	}
 
 	label := fmt.Sprintf("ResourceMonitor.RegisterResourceOutputs(%s)", urn)

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -163,16 +163,13 @@ func TestQueryResourceMonitor_UnsupportedOperations(t *testing.T) {
 	rm := &queryResmon{}
 
 	_, err := rm.ReadResource(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Equal(t, "Query mode does not support reading resources", err.Error())
+	assert.EqualError(t, err, "Query mode does not support reading resources")
 
 	_, err = rm.RegisterResource(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Equal(t, "Query mode does not support creating, updating, or deleting resources", err.Error())
+	assert.EqualError(t, err, "Query mode does not support creating, updating, or deleting resources")
 
 	_, err = rm.RegisterResourceOutputs(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Equal(t, "Query mode does not support registering resource operations", err.Error())
+	assert.EqualError(t, err, "Query mode does not support registering resource operations")
 }
 
 //

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -139,7 +139,7 @@ func (s *SameStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 			err := s.Deployment().SameProvider(s.new)
 			if err != nil {
 				return resource.StatusOK, nil,
-					fmt.Errorf("bad provider state for resource %v: %v", s.URN(), err)
+					fmt.Errorf("bad provider state for resource %v: %w", s.URN(), err)
 			}
 		}
 	}
@@ -1356,7 +1356,7 @@ func getProvider(s Step) (plugin.Provider, error) {
 	}
 	ref, err := providers.ParseReference(s.Provider())
 	if err != nil {
-		return nil, fmt.Errorf("bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
+		return nil, fmt.Errorf("bad provider reference '%v' for resource %v: %w", s.Provider(), s.URN(), err)
 	}
 	if providers.IsDenyDefaultsProvider(ref) {
 		pkg := providers.GetDeniedDefaultProviderPkg(ref)

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -220,7 +220,7 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 	// If there is an event subscription for finishing the resource, execute them.
 	if e := se.opts.Events; e != nil {
 		if eventerr := e.OnResourceOutputs(reg); eventerr != nil {
-			se.log(synchronousWorkerID, "register resource outputs failed: %s", eventerr.Error())
+			se.log(synchronousWorkerID, "register resource outputs failed: %s", eventerr)
 
 			// This is a bit of a kludge, but ExecuteRegisterResourceOutputs is an odd duck
 			// in that it doesn't execute on worker goroutines. Arguably, it should, but today it's

--- a/pkg/resource/provider/main.go
+++ b/pkg/resource/provider/main.go
@@ -53,7 +53,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 		var err error
 		host, err = NewHostClient(args[0])
 		if err != nil {
-			return fmt.Errorf("fatal: could not connect to host RPC: %v", err)
+			return fmt.Errorf("fatal: could not connect to host RPC: %w", err)
 		}
 
 		// If we have a host cancel our cancellation context if it fails the healthcheck
@@ -86,7 +86,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
-		return fmt.Errorf("fatal: %v", err)
+		return fmt.Errorf("fatal: %w", err)
 	}
 
 	// The resource provider protocol requires that we now write out the port we have chosen to listen on.
@@ -94,7 +94,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 
 	// Finally, wait for the server to stop serving.
 	if err := <-handle.Done; err != nil {
-		return fmt.Errorf("fatal: %v", err)
+		return fmt.Errorf("fatal: %w", err)
 	}
 
 	return nil

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -622,7 +622,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					} else {
 						unencryptedText, err := dec.DecryptValue(ctx, ciphertext)
 						if err != nil {
-							return resource.PropertyValue{}, fmt.Errorf("error decrypting secret value: %s", err.Error())
+							return resource.PropertyValue{}, fmt.Errorf("error decrypting secret value: %w", err)
 						}
 						plaintext = unencryptedText
 					}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -459,8 +459,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 		},
 	}, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
-	assert.Error(t, err)
-	assert.Equal(t, "resource missing required 'urn' field", err.Error())
+	assert.EqualError(t, err, "resource missing required 'urn' field")
 
 	urn := "urn:pulumi:prod::acme::acme:erp:Backend$aws:ebs/volume:Volume::PlatformBackendDb"
 
@@ -472,8 +471,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 		},
 	}, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Sprintf("resource '%s' missing required 'type' field", urn), err.Error())
+	assert.EqualError(t, err, fmt.Sprintf("resource '%s' missing required 'type' field", urn))
 
 	deployment, err = DeserializeDeploymentV3(ctx, apitype.DeploymentV3{
 		Resources: []apitype.ResourceV3{
@@ -486,8 +484,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 		},
 	}, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Sprintf("resource '%s' has 'custom' false but non-empty ID", urn), err.Error())
+	assert.EqualError(t, err, fmt.Sprintf("resource '%s' has 'custom' false but non-empty ID", urn))
 }
 
 func TestSerializePropertyValue(t *testing.T) {

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -3,7 +3,6 @@ package passphrase
 import (
 	"encoding/json"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,8 +81,8 @@ func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
 	_, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
-	assert.Error(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
-		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
+	assert.ErrorContains(t, err, "passphrase must be set with "+
+		"PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment variables")
 }
 
 //nolint:paralleltest // mutates environment variables
@@ -127,6 +126,6 @@ func TestPassphraseManagerEmptyPassfileReturnsError(t *testing.T) {
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 
 	_, err := NewPromptingPassphraseSecretsManagerFromState([]byte(state))
-	assert.Error(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
-		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
+	assert.ErrorContains(t, err, "passphrase must be set with "+
+		"PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment variables")
 }

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1555,7 +1555,7 @@ func (pt *ProgramTester) exportImport(dir string) error {
 	if f := pt.opts.ExportStateValidator; f != nil {
 		bytes, err := os.ReadFile(filepath.Join(dir, "stack.json"))
 		if err != nil {
-			pt.t.Logf("Failed to read stack.json: %s", err.Error())
+			pt.t.Logf("Failed to read stack.json: %s", err)
 			return err
 		}
 		pt.t.Logf("Calling ExportStateValidator")

--- a/pkg/util/rpcdebug/interceptors.go
+++ b/pkg/util/rpcdebug/interceptors.go
@@ -164,12 +164,12 @@ func (i *DebugInterceptor) record(log debugInterceptorLogEntry) error {
 
 	f, err := os.OpenFile(i.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
-		return fmt.Errorf("Failed to append GRPC debug logs to file %s: %v", i.logFile, err)
+		return fmt.Errorf("Failed to append GRPC debug logs to file %s: %w", i.logFile, err)
 	}
 	defer f.Close()
 
 	if err := json.NewEncoder(f).Encode(log); err != nil {
-		return fmt.Errorf("Failed to encode GRPC debug logs: %v", err)
+		return fmt.Errorf("Failed to encode GRPC debug logs: %w", err)
 	}
 	return nil
 }

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -58,9 +58,8 @@ func TestValidateStackTag(t *testing.T) {
 				}
 
 				err := ValidateStackTags(tags)
-				assert.Error(t, err)
 				msg := "stack tag names may only contain alphanumerics, hyphens, underscores, periods, or colons"
-				assert.Equal(t, err.Error(), msg)
+				assert.EqualError(t, err, msg)
 			})
 		}
 	})
@@ -73,9 +72,8 @@ func TestValidateStackTag(t *testing.T) {
 		}
 
 		err := ValidateStackTags(tags)
-		assert.Error(t, err)
 		msg := fmt.Sprintf("stack tag %q is too long (max length %d characters)", strings.Repeat("v", 41), 40)
-		assert.Equal(t, err.Error(), msg)
+		assert.EqualError(t, err, msg)
 	})
 
 	t.Run("too long tag value", func(t *testing.T) {
@@ -86,8 +84,7 @@ func TestValidateStackTag(t *testing.T) {
 		}
 
 		err := ValidateStackTags(tags)
-		assert.Error(t, err)
 		msg := fmt.Sprintf("stack tag %q value is too long (max length %d characters)", "tag-name", 256)
-		assert.Equal(t, err.Error(), msg)
+		assert.EqualError(t, err, msg)
 	})
 }

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -106,7 +106,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.ExpectedError, tt.Err.Error())
+			assert.EqualError(t, &tt.Err, tt.ExpectedError)
 		})
 	}
 }

--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -37,7 +37,7 @@ func newAutoError(err error, stdout, stderr string, code int) autoError {
 }
 
 func (ae autoError) Error() string {
-	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err.Error(), ae.code, ae.stdout, ae.stderr)
+	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err, ae.code, ae.stdout, ae.stderr)
 }
 
 // IsConcurrentUpdateError returns true if the error was a result of a conflicting update locking the stack.

--- a/sdk/go/common/util/result/result_test.go
+++ b/sdk/go/common/util/result/result_test.go
@@ -27,14 +27,14 @@ func TestBail(t *testing.T) {
 	t.Parallel()
 
 	err := BailError(errors.New("big boom"))
-	assert.Equal(t, "BAIL: big boom", err.Error())
+	assert.EqualError(t, err, "BAIL: big boom")
 }
 
 func TestBailf(t *testing.T) {
 	t.Parallel()
 
 	err := BailErrorf("%d booms", 5)
-	assert.Equal(t, "BAIL: 5 booms", err.Error())
+	assert.EqualError(t, err, "BAIL: 5 booms")
 }
 
 func TestFprintBailf(t *testing.T) {
@@ -42,7 +42,7 @@ func TestFprintBailf(t *testing.T) {
 
 	var buff bytes.Buffer
 	err := FprintBailf(&buff, "%d booms", 5)
-	assert.Equal(t, "BAIL: 5 booms", err.Error())
+	assert.EqualError(t, err, "BAIL: 5 booms")
 	assert.Equal(t, "5 booms\n", buff.String())
 }
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1387,7 +1387,7 @@ func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginCon
 	if err := cleanupTempDirs(finalDir); err != nil {
 		// We don't want to fail the installation if there was an error cleaning up these old temp dirs.
 		// Instead, log the error and continue on.
-		logging.V(5).Infof("Install: Error cleaning up temp dirs: %s", err.Error())
+		logging.V(5).Infof("Install: Error cleaning up temp dirs: %s", err)
 	}
 
 	// Get the partial file path (e.g. <pluginsdir>/<kind>-<name>-<version>.partial).

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -726,7 +726,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		require.NoError(t, err)
 		version, err := source.GetLatestVersion(getHTTPResponse)
 		assert.Nil(t, version)
-		assert.Equal(t, "GetLatestVersion is not supported for plugins from http sources", err.Error())
+		assert.EqualError(t, err, "GetLatestVersion is not supported for plugins from http sources")
 	})
 	t.Run("Custom https URL", func(t *testing.T) {
 		spec := PluginSpec{
@@ -738,7 +738,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		require.NoError(t, err)
 		version, err := source.GetLatestVersion(getHTTPResponse)
 		assert.Nil(t, version)
-		assert.Equal(t, "GetLatestVersion is not supported for plugins from http sources", err.Error())
+		assert.EqualError(t, err, "GetLatestVersion is not supported for plugins from http sources")
 	})
 	t.Run("Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
@@ -1162,7 +1162,7 @@ func TestMissingErrorText(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			err := NewMissingError(tt.Plugin.Kind, tt.Plugin.Name, tt.Plugin.Version, tt.IncludeAmbient)
-			assert.Equal(t, tt.ExpectedError, err.Error())
+			assert.EqualError(t, err, tt.ExpectedError)
 		})
 	}
 }

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -79,8 +79,7 @@ func TestProjectValidationFailsForIncorrectDefaultValueType(t *testing.T) {
 
 	project.Config = invalidConfig
 	err := project.Validate()
-	assert.Contains(t,
-		err.Error(),
+	assert.ErrorContains(t, err,
 		"The default value specified for configuration key 'instanceSize' is not of the expected type 'integer'")
 
 	invalidValues := make([]interface{}, 0)
@@ -102,9 +101,7 @@ func TestProjectValidationFailsForIncorrectDefaultValueType(t *testing.T) {
 	}
 	project.Config = invalidConfigWithArray
 	err = project.Validate()
-	assert.Error(t, err, "There is a validation error")
-	assert.Contains(t,
-		err.Error(),
+	assert.ErrorContains(t, err,
 		"The default value specified for configuration key 'values' is not of the expected type 'array<array<string>>'")
 }
 
@@ -798,9 +795,7 @@ config:
 		invalidStackConfig.Config,
 		config.NewPanicCrypter(),
 		config.NewPanicCrypter())
-	assert.NotNil(t, configError, "there should be a config type error")
-	assert.Contains(t,
-		configError.Error(),
+	assert.ErrorContains(t, configError,
 		"Stack 'dev' with configuration key 'importantNumber' must be of type 'integer'")
 }
 
@@ -965,9 +960,7 @@ config:
 		invalidStackConfig.Config,
 		crypter,
 		crypter)
-	assert.NotNil(t, configError, "there should be a config type error")
-	assert.Contains(t,
-		configError.Error(),
+	assert.ErrorContains(t, configError,
 		"Stack 'dev' with configuration key 'importantNumber' must be encrypted as it's secret")
 }
 

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -129,7 +129,7 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				logging.V(2).Infof(
 					"Failed to load template %s: %s",
-					name, err.Error(),
+					name, err,
 				)
 				result = append(result, Template{Name: name, Error: err})
 			} else if err == nil {
@@ -183,7 +183,7 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				logging.V(2).Infof(
 					"Failed to load template %s: %s",
-					name, err.Error(),
+					name, err,
 				)
 				result = append(result, PolicyPackTemplate{Name: name, Error: err})
 			} else if err == nil {

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -689,7 +689,7 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 				"GetRequiredPlugins: Ignoring dependency: %s, version: %s, error: %s",
 				m.Path,
 				m.Version,
-				err.Error(),
+				err,
 			)
 			continue
 		}

--- a/sdk/go/pulumi/config/require.go
+++ b/sdk/go/pulumi/config/require.go
@@ -53,7 +53,7 @@ func Require(ctx *pulumi.Context, key string) string {
 func requireObject(ctx *pulumi.Context, key string, secret bool, output interface{}, use, insteadOf string) {
 	v := require(ctx, key, secret, use, insteadOf)
 	if err := json.Unmarshal([]byte(v), output); err != nil {
-		failf("unable to unmarshall required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to unmarshall required configuration variable '%s'; %s", key, err)
 	}
 }
 
@@ -67,7 +67,7 @@ func requireBool(ctx *pulumi.Context, key string, secret bool, use, insteadOf st
 	v := require(ctx, key, secret, use, insteadOf)
 	o, err := cast.ToBoolE(v)
 	if err != nil {
-		failf("unable to parse required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to parse required configuration variable '%s'; %s", key, err)
 	}
 	return o
 }
@@ -81,7 +81,7 @@ func requireFloat64(ctx *pulumi.Context, key string, secret bool, use, insteadOf
 	v := require(ctx, key, secret, use, insteadOf)
 	o, err := cast.ToFloat64E(v)
 	if err != nil {
-		failf("unable to parse required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to parse required configuration variable '%s'; %s", key, err)
 	}
 	return o
 }
@@ -95,7 +95,7 @@ func requireInt(ctx *pulumi.Context, key string, secret bool, use, insteadOf str
 	v := require(ctx, key, secret, use, insteadOf)
 	o, err := cast.ToIntE(v)
 	if err != nil {
-		failf("unable to parse required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to parse required configuration variable '%s'; %s", key, err)
 	}
 	return o
 }

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -762,7 +762,7 @@ func (ctx *Context) getResource(urn string) (*pulumirpc.RegisterResourceResponse
 		AcceptResources: !disableResourceReferences,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("invoke(%s, ...): error: %v", tok, err)
+		return nil, fmt.Errorf("invoke(%s, ...): error: %w", tok, err)
 	}
 
 	// If there were any failures from the provider, return them.

--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -337,7 +337,7 @@ func main() {
 
 		pwd, err := os.Getwd()
 		if err != nil {
-			log.Fatalf("code generation failed: %v", err.Error())
+			log.Fatalf("code generation failed: %v", err)
 		}
 
 		fullname := filepath.Join(pwd, templateFilePath(t.Name()))

--- a/sdk/go/pulumi/generate/templates/config-require.go.template
+++ b/sdk/go/pulumi/generate/templates/config-require.go.template
@@ -53,7 +53,7 @@ func Require(ctx *pulumi.Context, key string) string {
 func requireObject(ctx *pulumi.Context, key string, secret bool, output interface{}, use, insteadOf string) {
 	v := require(ctx, key, secret, use, insteadOf)
 	if err := json.Unmarshal([]byte(v), output); err != nil {
-		failf("unable to unmarshall required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to unmarshall required configuration variable '%s'; %s", key, err)
 	}
 }
 
@@ -69,7 +69,7 @@ func require{{.Name}}(ctx *pulumi.Context, key string, secret bool, use, instead
 	v := require(ctx, key, secret, use, insteadOf)
 	o, err := cast.To{{.Name}}E(v)
 	if err != nil {
-		failf("unable to parse required configuration variable '%s'; %s", key, err.Error())
+		failf("unable to parse required configuration variable '%s'; %s", key, err)
 	}
 	return o
 }

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -1114,7 +1114,7 @@ func TestJSONMarshalNested(t *testing.T) {
 	}()
 	json := JSONMarshal(out)
 	v, known, secret, deps, err := await(json)
-	assert.Equal(t, "json: error calling MarshalJSON for type pulumi.AnyOutput: outputs can not be marshaled to JSON", err.Error())
+	assert.EqualError(t, err, "json: error calling MarshalJSON for type pulumi.AnyOutput: outputs can not be marshaled to JSON")
 	assert.True(t, known)
 	assert.False(t, secret)
 	assert.Nil(t, deps)

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -72,7 +72,7 @@ func (node *npmManager) Pack(ctx context.Context, dir string, stderr io.Writer) 
 
 	packTarball, err := os.ReadFile(packfile)
 	if err != nil {
-		newErr := fmt.Errorf("'npm pack' completed successfully but the package .tgz file was not generated: %v", err)
+		newErr := fmt.Errorf("'npm pack' completed successfully but the package .tgz file was not generated: %w", err)
 		return nil, newErr
 	}
 

--- a/sdk/nodejs/npm/yarn.go
+++ b/sdk/nodejs/npm/yarn.go
@@ -103,7 +103,7 @@ func (yarn *yarnClassic) Pack(ctx context.Context, dir string, stderr io.Writer)
 	// Read the tarball in as a byte slice.
 	tarball, err := os.ReadFile(packfile)
 	if err != nil {
-		return nil, fmt.Errorf("'yarn pack' completed successfully but the packed .tgz file was not generated: %v", err)
+		return nil, fmt.Errorf("'yarn pack' completed successfully but the packed .tgz file was not generated: %w", err)
 	}
 
 	return tarball, nil

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -486,7 +486,7 @@ func determinePluginDependency(
 		if err != nil {
 			logging.V(5).Infof(
 				"GetRequiredPlugins: Could not determine plugin version for package %s with version %s: %s",
-				pkg.Name, pkg.Version, err.Error())
+				pkg.Name, pkg.Version, err)
 			return nil, nil
 		}
 	}
@@ -836,7 +836,7 @@ func validateVersion(ctx context.Context, virtualEnvPath string) {
 	}
 	var out []byte
 	if out, err = versionCmd.Output(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to resolve python version command: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to resolve python version command: %s\n", err)
 		return
 	}
 	version := strings.TrimSpace(strings.TrimPrefix(string(out), "Python "))

--- a/tests/integration/stack_reference/go/main.go
+++ b/tests/integration/stack_reference/go/main.go
@@ -15,7 +15,7 @@ func main() {
 		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		_, err := pulumi.NewStackReference(ctx, slug, nil)
 		if err != nil {
-			return fmt.Errorf("error reading stack reference: %v", err)
+			return fmt.Errorf("error reading stack reference: %w", err)
 		}
 		ctx.Export("val",
 			pulumi.StringArray([]pulumi.StringInput{pulumi.String("a"), pulumi.String("b")}))

--- a/tests/integration/stack_reference/go/step1/main.go
+++ b/tests/integration/stack_reference/go/step1/main.go
@@ -15,7 +15,7 @@ func main() {
 		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 		if err != nil {
-			return fmt.Errorf("error reading stack reference: %v", err)
+			return fmt.Errorf("error reading stack reference: %w", err)
 		}
 
 		val := pulumi.StringArrayOutput(stackRef.GetOutput(pulumi.String("val")))

--- a/tests/integration/stack_reference/go/step2/main.go
+++ b/tests/integration/stack_reference/go/step2/main.go
@@ -16,7 +16,7 @@ func main() {
 		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 		if err != nil {
-			return fmt.Errorf("error reading stack reference: %v", err)
+			return fmt.Errorf("error reading stack reference: %w", err)
 		}
 
 		val := pulumi.StringArrayOutput(stackRef.GetOutput(pulumi.String("val2")))


### PR DESCRIPTION
Combination of a few cleanups.

1. Don't call .Error() on errors that are being passed to "%s" format functions. Format will call `Error()` itself.
2. Don't call assert.Error then assert.Equal/Contains, just use assert.ErrorEqual/ErrorContains instead.
3. Use "%w" if appropriate, instead of "%v"/"%s".