### PR TITLE
avoid quotes in dev version number; take 2

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           version="${{ steps.ghd.outputs.describe }}"
           version="${version#v}"
-          ./.github/scripts/set-output dev-version "$version"
+          echo version="$version" >>"${GITHUB_OUTPUT}"
     outputs:
       dev-version: ${{ steps.strip-prefix.outputs.dev-version }}
       version: ${{ inputs.version }}


### PR DESCRIPTION
Unfortunately https://github.com/pulumi/pulumi/pull/14964 didn't quite do what we wanted it to, and the version number still contained the extra quotes.  Investigating a bit more, I now believe the "set-output" script is the culprit because it does some extra quoting. Since we don't need any extra escaping here, we can just write to the file containing the outputs directly instead, which will hopefully fix the issue.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
