### PR TITLE
Include internalness of events sent to the service

### DIFF
--- a/changelog/pending/20231220--backend-service--include-internal-property-on-events-sent-to-pulumi-cloud.yaml
+++ b/changelog/pending/20231220--backend-service--include-internal-property-on-events-sent-to-pulumi-cloud.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Include Internal property on events sent to Pulumi Cloud

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -145,6 +145,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		apiEvent.ResourcePreEvent = &apitype.ResourcePreEvent{
 			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Planning: p.Planning,
+			Internal: p.Internal,
 		}
 
 	case engine.ResourceOutputsEvent:
@@ -155,6 +156,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		apiEvent.ResOutputsEvent = &apitype.ResOutputsEvent{
 			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Planning: p.Planning,
+			Internal: p.Internal,
 		}
 
 	case engine.ResourceOperationFailed:

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -179,12 +179,14 @@ type StepEventStateMetadata struct {
 type ResourcePreEvent struct {
 	Metadata StepEventMetadata `json:"metadata"`
 	Planning bool              `json:"planning,omitempty"`
+	Internal bool              `json:"internal,omitempty"`
 }
 
 // ResOutputsEvent is emitted when a resource is finished being provisioned.
 type ResOutputsEvent struct {
 	Metadata StepEventMetadata `json:"metadata"`
 	Planning bool              `json:"planning,omitempty"`
+	Internal bool              `json:"internal,omitempty"`
 }
 
 // ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As of https://github.com/pulumi/pulumi/commit/54c956af6d64638983eca50875d1dae704a18240, we now send internal events to Pulumi Cloud. This has led to errors in the update display code in Pulumi Cloud, as it is not equipped to handle internal events.

Additionally, the internalness of the events is not included in the event payload, rendering the Cloud service unable to differentiate which events are not meant for display. 

This change includes the `Internal` property on the events sent to the Cloud so that it can filter these events before attempting to display them.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
