### PR TITLE
Exclude internal events from those sent to the service

### DIFF
--- a/changelog/pending/20231220--backend-service--exclude-internal-events-from-pulumi-cloud.yaml
+++ b/changelog/pending/20231220--backend-service--exclude-internal-events-from-pulumi-cloud.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: Exclude internal events from those sent to Pulumi Cloud.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Following up from https://github.com/pulumi/pulumi/commit/54c956af6d64638983eca50875d1dae704a18240 to also exclude the internal events from being sent to Pulumi Cloud.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
