### PR TITLE
make sure to also upload zip files

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -121,9 +121,12 @@ jobs:
         run: |
           find artifacts.tmp
           mkdir -p ./artifacts
-          mv ./artifacts.tmp/artifacts-signatures/pulumi-*.sig ./artifacts
+          mv ./artifacts.tmp/artifacts-signatures/pulumi-*.tar.gz.sig ./artifacts
+          mv ./artifacts.tmp/artifacts-signatures/pulumi-*.zip.sig ./artifacts
+          mv ./artifacts.tmp/artifacts-signatures/pulumi-*.txt.sig ./artifacts
           mv ./artifacts.tmp/artifacts-signatures/pulumi-*.txt ./artifacts
           mv ./artifacts.tmp/artifacts-cli-*/pulumi-*.tar.gz ./artifacts
+          mv ./artifacts.tmp/artifacts-cli-*/pulumi-*.zip ./artifacts
 
       - name: Find artifacts
         run: |


### PR DESCRIPTION
For windows we generate zip files, not tar.gz, so make sure to also upload those.

Also upload the signature files a bit more explicitly.  Because we have two sign processes running (first for building the release artifacts and then the dev artifacts), we get .sig.sig files otherwise, but we don't need these, so be more selective here.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
