### PR TITLE
[ci] add coverage to `pkg/resource/deploy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           ls -lhR test-results
           find test-results -mindepth 1 -name '*.json' -mtime +7 -delete
   test-collect-coverage:
-    needs: [unit-test, integration-test, acceptance-test]
+    needs: [unit-test, integration-test]
     if: ${{ inputs.enable-coverage }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -106,7 +106,7 @@ jobs:
           || ''
         }}
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
-      enable-coverage: false
+      enable-coverage: true
     secrets: inherit
 
   prepare-release:

--- a/pkg/resource/deploy/deploytest/provider_test.go
+++ b/pkg/resource/deploy/deploytest/provider_test.go
@@ -1,0 +1,434 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploytest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+	t.Run("SignalCancellation", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has CancelF", func(t *testing.T) {
+			t.Parallel()
+			var called bool
+			prov := &Provider{
+				CancelF: func() error {
+					called = true
+					return fmt.Errorf("expected error")
+				},
+			}
+			assert.Error(t, prov.SignalCancellation())
+			assert.True(t, called)
+		})
+		t.Run("no CancelF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			assert.NoError(t, prov.SignalCancellation())
+		})
+	})
+	t.Run("Close", func(t *testing.T) {
+		t.Parallel()
+		prov := &Provider{}
+		assert.NoError(t, prov.Close())
+		// Ensure idempotent.
+		assert.NoError(t, prov.Close())
+	})
+	t.Run("GetPluginInfo", func(t *testing.T) {
+		t.Parallel()
+		prov := &Provider{
+			Name:    "expected-name",
+			Version: semver.MustParse("1.0.0"),
+		}
+		info, err := prov.GetPluginInfo()
+		assert.NoError(t, err)
+		assert.Equal(t, "expected-name", info.Name)
+		// Ensure reference is passed correctly.
+		assert.Equal(t, &prov.Version, info.Version)
+	})
+	t.Run("GetSchema", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has GetSchemaF", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			var called bool
+			prov := &Provider{
+				GetSchemaF: func(version int) ([]byte, error) {
+					assert.Equal(t, 1, version)
+					called = true
+					return nil, expectedErr
+				},
+			}
+			_, err := prov.GetSchema(1)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.True(t, called)
+		})
+		t.Run("no GetSchemaF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			b, err := prov.GetSchema(0)
+			assert.NoError(t, err)
+			assert.Equal(t, []byte("{}"), b)
+		})
+	})
+	t.Run("CheckConfig", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has CheckConfigF", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			var called bool
+			prov := &Provider{
+				CheckConfigF: func(
+					urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					assert.Equal(t, resource.URN("expected-urn"), urn)
+					assert.Equal(t, resource.NewStringProperty("old-value"), olds["old"])
+					assert.Equal(t, resource.NewStringProperty("new-value"), news["new"])
+					called = true
+					return nil, nil, expectedErr
+				},
+			}
+			_, _, err := prov.CheckConfig(
+				resource.URN("expected-urn"),
+				resource.PropertyMap{
+					"old": resource.NewStringProperty("old-value"),
+				},
+				resource.PropertyMap{
+					"new": resource.NewStringProperty("new-value"),
+				},
+				true,
+			)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.True(t, called)
+		})
+		t.Run("no CheckConfigF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			news, failures, err := prov.CheckConfig(resource.URN(""), nil /* olds */, resource.PropertyMap{
+				"expected": resource.NewStringProperty("expected-value"),
+			}, true)
+			assert.NoError(t, err)
+			assert.Empty(t, failures)
+			// Should return the news.
+			assert.Equal(t, resource.NewStringProperty("expected-value"), news["expected"])
+		})
+	})
+	t.Run("Construct", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has ConstructF", func(t *testing.T) {
+			t.Run("inject error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := fmt.Errorf("expected error")
+				var dialCalled bool
+				var constructCalled bool
+				expectedResmon := &ResourceMonitor{}
+				prov := &Provider{
+					DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+						assert.Equal(t, "expected-endpoint", endpoint)
+						dialCalled = true
+						// Returns no error to avoid short-circuiting due to the monitor being provided
+						// an invalid resource monitor address.
+						return expectedResmon, nil
+					},
+					ConstructF: func(
+						monitor *ResourceMonitor,
+						typ, name string, parent resource.URN, inputs resource.PropertyMap,
+						info plugin.ConstructInfo, options plugin.ConstructOptions,
+					) (plugin.ConstructResult, error) {
+						assert.Equal(t, expectedResmon, monitor)
+						constructCalled = true
+						return plugin.ConstructResult{}, expectedErr
+					},
+				}
+				_, err := prov.Construct(
+					plugin.ConstructInfo{
+						MonitorAddress: "expected-endpoint",
+					},
+					tokens.Type("some-type"),
+					"name",
+					resource.URN("<parent-urn>"),
+					nil, /* inputs */
+					plugin.ConstructOptions{})
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, dialCalled)
+				assert.True(t, constructCalled)
+			})
+			t.Run("dial error", func(t *testing.T) {
+				t.Parallel()
+				t.Run("invalid address", func(t *testing.T) {
+					t.Parallel()
+					prov := &Provider{
+						ConstructF: func(
+							monitor *ResourceMonitor,
+							typ, name string, parent resource.URN, inputs resource.PropertyMap,
+							info plugin.ConstructInfo, options plugin.ConstructOptions,
+						) (plugin.ConstructResult, error) {
+							assert.Fail(t, "Construct should not be called")
+							return plugin.ConstructResult{}, nil
+						},
+					}
+					_, err := prov.Construct(
+						plugin.ConstructInfo{},
+						tokens.Type("some-type"),
+						"name",
+						resource.URN("<parent-urn>"),
+						nil, /* inputs */
+						plugin.ConstructOptions{})
+					assert.ErrorContains(t, err, "could not connect to resource monitor")
+				})
+				t.Run("injected error", func(t *testing.T) {
+					t.Parallel()
+					expectedErr := fmt.Errorf("expected error")
+					var dialCalled bool
+					prov := &Provider{
+						DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+							dialCalled = true
+							// Returns no error to avoid short-circuiting due to the monitor being provided
+							// an invalid resource monitor address.
+							return nil, expectedErr
+						},
+						ConstructF: func(
+							monitor *ResourceMonitor,
+							typ, name string, parent resource.URN, inputs resource.PropertyMap,
+							info plugin.ConstructInfo, options plugin.ConstructOptions,
+						) (plugin.ConstructResult, error) {
+							assert.Fail(t, "Construct should not be called")
+							return plugin.ConstructResult{}, nil
+						},
+					}
+					_, err := prov.Construct(
+						plugin.ConstructInfo{},
+						tokens.Type("some-type"),
+						"name",
+						resource.URN("<parent-urn>"),
+						nil, /* inputs */
+						plugin.ConstructOptions{})
+					assert.ErrorIs(t, err, expectedErr)
+					assert.True(t, dialCalled)
+				})
+			})
+		})
+		t.Run("no ConstructF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{
+				DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+					assert.Fail(t, "DialMonitor should not be called")
+					return nil, nil
+				},
+			}
+			_, err := prov.Construct(
+				plugin.ConstructInfo{},
+				tokens.Type("some-type"),
+				"name",
+				resource.URN("<parent-urn>"),
+				nil, /* inputs */
+				plugin.ConstructOptions{})
+			assert.NoError(t, err)
+		})
+	})
+	t.Run("Invoke", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has InvokeF", func(t *testing.T) {
+			t.Parallel()
+			expectedPropertyMap := resource.PropertyMap{
+				"key": resource.NewStringProperty("expected-value"),
+			}
+			var called bool
+			prov := &Provider{
+				InvokeF: func(tok tokens.ModuleMember, inputs resource.PropertyMap,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					assert.Equal(t, tokens.ModuleMember("expected-tok"), tok)
+					called = true
+					return expectedPropertyMap, nil, nil
+				},
+			}
+			res, _, err := prov.Invoke("expected-tok", nil)
+			assert.NoError(t, err)
+			assert.True(t, called)
+			assert.Equal(t, expectedPropertyMap, res)
+		})
+		t.Run("no InvokeF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			news, failures, err := prov.Invoke("", nil)
+			assert.NoError(t, err)
+			assert.Empty(t, failures)
+			assert.Equal(t, resource.PropertyMap{}, news)
+		})
+	})
+	t.Run("StreamInvoke", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has StreamInvokeF", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			prov := &Provider{
+				StreamInvokeF: func(
+					tok tokens.ModuleMember, args resource.PropertyMap,
+					onNext func(resource.PropertyMap) error,
+				) ([]plugin.CheckFailure, error) {
+					assert.Equal(t, tokens.ModuleMember("expected-tok"), tok)
+					return nil, expectedErr
+				},
+			}
+			_, err := prov.StreamInvoke("expected-tok", nil, nil)
+			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("no StreamInvokeF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			_, err := prov.StreamInvoke("", nil, nil)
+			assert.ErrorContains(t, err, "StreamInvoke unimplemented")
+		})
+	})
+	t.Run("Call", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has CallF", func(t *testing.T) {
+			t.Run("inject error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := fmt.Errorf("expected error")
+				var dialCalled bool
+				var callCalled bool
+				expectedResmon := &ResourceMonitor{}
+				prov := &Provider{
+					DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+						dialCalled = true
+						// Returns no error to avoid short-circuiting due to the monitor being provided
+						// an invalid resource monitor address.
+						return expectedResmon, nil
+					},
+					CallF: func(
+						monitor *ResourceMonitor, tok tokens.ModuleMember, args resource.PropertyMap,
+						info plugin.CallInfo, options plugin.CallOptions,
+					) (plugin.CallResult, error) {
+						assert.Equal(t, expectedResmon, monitor)
+						assert.Equal(t, tokens.ModuleMember("expected-tok"), tok)
+						callCalled = true
+						return plugin.CallResult{}, expectedErr
+					},
+				}
+				_, err := prov.Call("expected-tok", nil, plugin.CallInfo{}, plugin.CallOptions{})
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, dialCalled)
+				assert.True(t, callCalled)
+			})
+			t.Run("dial error", func(t *testing.T) {
+				t.Parallel()
+				t.Run("invalid address", func(t *testing.T) {
+					t.Parallel()
+					prov := &Provider{
+						CallF: func(
+							monitor *ResourceMonitor, tok tokens.ModuleMember, args resource.PropertyMap,
+							info plugin.CallInfo, options plugin.CallOptions,
+						) (plugin.CallResult, error) {
+							assert.Fail(t, "Call should not be called")
+							return plugin.CallResult{}, nil
+						},
+					}
+					_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+					assert.ErrorContains(t, err, "could not connect to resource monitor")
+				})
+				t.Run("injected error", func(t *testing.T) {
+					t.Parallel()
+					expectedErr := fmt.Errorf("expected error")
+					var dialCalled bool
+					prov := &Provider{
+						DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+							dialCalled = true
+							// Returns no error to avoid short-circuiting due to the monitor being provided
+							// an invalid resource monitor address.
+							return nil, expectedErr
+						},
+						CallF: func(
+							monitor *ResourceMonitor, tok tokens.ModuleMember, args resource.PropertyMap,
+							info plugin.CallInfo, options plugin.CallOptions,
+						) (plugin.CallResult, error) {
+							assert.Fail(t, "Call should not be called")
+							return plugin.CallResult{}, expectedErr
+						},
+					}
+					_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+					assert.ErrorIs(t, err, expectedErr)
+					assert.True(t, dialCalled)
+				})
+			})
+		})
+		t.Run("no CallF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{
+				DialMonitorF: func(ctx context.Context, endpoint string) (*ResourceMonitor, error) {
+					assert.Fail(t, "Dial should not be called")
+					return nil, nil
+				},
+			}
+			_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+			assert.NoError(t, err)
+		})
+	})
+	t.Run("GetMapping", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has GetMappingF", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			prov := &Provider{
+				GetMappingF: func(key, provider string) ([]byte, string, error) {
+					assert.Equal(t, "expected-key", key)
+					assert.Equal(t, "expected-provider", provider)
+					return nil, "", expectedErr
+				},
+			}
+			_, _, err := prov.GetMapping("expected-key", "expected-provider")
+			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("no GetMappingF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			mappingB, mappingStr, err := prov.GetMapping("", "")
+			assert.NoError(t, err)
+			assert.Equal(t, "", mappingStr)
+			assert.Nil(t, mappingB)
+		})
+	})
+	t.Run("GetMappings", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has GetMappingsF", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			prov := &Provider{
+				GetMappingsF: func(key string) ([]string, error) {
+					assert.Equal(t, "expected-key", key)
+					return nil, expectedErr
+				},
+			}
+			_, err := prov.GetMappings("expected-key")
+			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("no GetMappingsF", func(t *testing.T) {
+			t.Parallel()
+			prov := &Provider{}
+			mappingStrs, err := prov.GetMappings("")
+			assert.NoError(t, err)
+			assert.Empty(t, mappingStrs)
+		})
+	})
+}

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -1,0 +1,205 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImportDeployment(t *testing.T) {
+	t.Parallel()
+	t.Run("NewImportDeployment", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error in migrate providers", func(t *testing.T) {
+			t.Parallel()
+			var decrypterCalled bool
+			_, err := NewImportDeployment(&plugin.Context{}, &Target{
+				Snapshot: &Snapshot{
+					Resources: []*resource.State{
+						{
+							URN:    "urn:pulumi:stack::project::type::oldName",
+							Custom: true,
+						},
+					},
+				},
+				Name: tokens.MustParseStackName("target-name"),
+				Config: config.Map{
+					config.MustMakeKey("", "secret"): config.NewSecureValue("secret"),
+				},
+				Decrypter: &decrypterMock{
+					DecryptValueF: func(ctx context.Context, ciphertext string) (string, error) {
+						decrypterCalled = true
+						return "", fmt.Errorf("expected fail")
+					},
+				},
+			}, "projectName", nil, true)
+			assert.ErrorContains(t, err, "could not fetch configuration for default provider")
+			assert.True(t, decrypterCalled)
+		})
+	})
+}
+
+func TestImporter(t *testing.T) {
+	t.Parallel()
+	t.Run("registerProviders", func(t *testing.T) {
+		t.Parallel()
+		t.Run("incorrect package type specified", func(t *testing.T) {
+			t.Parallel()
+			i := &importer{
+				deployment: &Deployment{
+					imports: []Import{
+						{
+							Type: "::",
+						},
+					},
+					target: &Target{
+						Name: tokens.MustParseStackName("stack-name"),
+					},
+					source: &nullSource{
+						project: "project-name",
+					},
+				},
+			}
+			_, _, err := i.registerProviders(context.Background())
+			assert.ErrorContains(t, err, "incorrect package type specified")
+		})
+		t.Run("ensure provider is called correctly", func(t *testing.T) {
+			t.Parallel()
+			version := semver.MustParse("1.0.0")
+			expectedErr := errors.New("expected error")
+			i := &importer{
+				deployment: &Deployment{
+					goals:  &goalMap{},
+					ctx:    &plugin.Context{Diag: &deploytest.NoopSink{}},
+					target: &Target{},
+					source: &nullSource{},
+					providers: providers.NewRegistry(&mockHost{
+						ProviderF: func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+							assert.Equal(t, tokens.Package("foo"), pkg)
+							assert.Equal(t, "1.0.0", version.String())
+							return nil, expectedErr
+						},
+					}, true, nil),
+					imports: []Import{
+						{
+							Version:           &version,
+							PluginDownloadURL: "download-url",
+							PluginChecksums: map[string][]byte{
+								"a": {},
+								"b": {},
+								"c": {},
+							},
+							Type: "foo:bar:Bar",
+						},
+					},
+				},
+			}
+			_, _, err := i.registerProviders(context.Background())
+			assert.ErrorIs(t, err, expectedErr)
+		})
+	})
+	t.Run("importResources", func(t *testing.T) {
+		t.Parallel()
+		t.Run("registerExistingResources", func(t *testing.T) {
+			t.Parallel()
+			t.Run("ok", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						prev: &Snapshot{
+							Resources: []*resource.State{
+								{
+									URN: "some-urn",
+								},
+							},
+						},
+						goals:  &goalMap{},
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+		})
+		t.Run("getOrCreateStackResource", func(t *testing.T) {
+			t.Parallel()
+			t.Run("ok", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+			t.Run("ignore existing delete resources", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						prev: &Snapshot{
+							Resources: []*resource.State{
+								{
+									Delete: true,
+								},
+							},
+						},
+						// goals is left nil as nothing should be added to it.
+						goals:  nil,
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+		})
+	})
+}

--- a/pkg/resource/deploy/source_error_test.go
+++ b/pkg/resource/deploy/source_error_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorSource(t *testing.T) {
+	t.Parallel()
+	t.Run("Close is nil", func(t *testing.T) {
+		t.Parallel()
+		s := &errorSource{}
+		assert.NoError(t, s.Close())
+		// Ensure idempotent.
+		assert.NoError(t, s.Close())
+	})
+	t.Run("Info is nil", func(t *testing.T) {
+		t.Parallel()
+		s := &errorSource{}
+		assert.Nil(t, s.Info())
+	})
+	t.Run("Iterate panics", func(t *testing.T) {
+		t.Parallel()
+		s := &errorSource{}
+		assert.Panics(t, func() {
+			_, err := s.Iterate(context.Background(), Options{}, nil)
+			contract.Ignore(err)
+		})
+	})
+}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -1379,7 +1379,7 @@ func TestStreamInvoke(t *testing.T) {
 			evt.done <- &RegisterResult{
 				State: &resource.State{
 					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
-					URN: "urn:pulumi:dev::11103::pulumi:providers:aws::default_5_42_0",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
 				},
 			}
 			wg.Done()
@@ -1395,6 +1395,131 @@ func TestStreamInvoke(t *testing.T) {
 		wg.Wait()
 		assert.NoError(t, err)
 		assert.True(t, called)
+	})
+	t.Run("StreamInvoke provider error", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		var called bool
+		expectedErr := fmt.Errorf("expected error")
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				StreamInvokeF: func(
+					tok tokens.ModuleMember, args resource.PropertyMap, onNext func(resource.PropertyMap) error,
+				) ([]plugin.CheckFailure, error) {
+					called = true
+					require.NoError(t, onNext(resource.PropertyMap{}))
+					return nil, expectedErr
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		err = mon.StreamInvoke(&pulumirpc.ResourceInvokeRequest{
+			Tok: "pkgA:index:func",
+		}, &streamInvokeMock{
+			SendF:    func(res *pulumirpc.InvokeResponse) error { return nil },
+			RecvMsgF: func(m interface{}) error { return nil },
+		})
+		// Ensure the channel is read from.
+		wg.Wait()
+		assert.ErrorIs(t, err, expectedErr)
+		assert.True(t, called)
+	})
+	t.Run("StreamInvoke provider failures", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		var called bool
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				StreamInvokeF: func(
+					tok tokens.ModuleMember, args resource.PropertyMap, onNext func(resource.PropertyMap) error,
+				) ([]plugin.CheckFailure, error) {
+					called = true
+					require.NoError(t, onNext(resource.PropertyMap{}))
+					return []plugin.CheckFailure{
+						{
+							Property: "some-property",
+							Reason:   "expect failure",
+						},
+					}, nil
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		var hasFailures bool
+		err = mon.StreamInvoke(&pulumirpc.ResourceInvokeRequest{
+			Tok: "pkgA:index:func",
+		}, &streamInvokeMock{
+			SendF: func(res *pulumirpc.InvokeResponse) error {
+				if len(res.Failures) > 0 {
+					hasFailures = true
+				}
+				return nil
+			},
+			RecvMsgF: func(m interface{}) error { return nil },
+		})
+		// Ensure the channel is read from.
+		wg.Wait()
+		assert.NoError(t, err)
+		assert.True(t, called)
+		assert.True(t, hasFailures)
 	})
 	t.Run("unknown provider", func(t *testing.T) {
 		t.Parallel()
@@ -1429,7 +1554,7 @@ func TestStreamInvoke(t *testing.T) {
 			evt.done <- &RegisterResult{
 				State: &resource.State{
 					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
-					URN: "urn:pulumi:dev::11103::pulumi:providers:aws::default_5_42_0",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
 				},
 			}
 			wg.Done()
@@ -1644,6 +1769,38 @@ func TestEvalSource(t *testing.T) {
 			assert.ErrorContains(t, err, "failed to decrypt config")
 			assert.True(t, decrypterCalled)
 		})
+		t.Run("failed to convert config to map", func(t *testing.T) {
+			t.Parallel()
+
+			var called int
+			var decrypterCalled bool
+			src := &evalSource{
+				plugctx: &plugin.Context{
+					Diag: &deploytest.NoopSink{},
+				},
+				runinfo: &EvalRunInfo{
+					Target: &Target{
+						Config: config.Map{
+							config.MustMakeKey("test", "secret"): config.NewSecureValue("secret"),
+						},
+						Decrypter: &decrypterMock{
+							DecryptValueF: func(ctx context.Context, ciphertext string) (string, error) {
+								decrypterCalled = true
+								if called == 0 {
+									// Will cause the next invocation to fail.
+									called++
+									return "", nil
+								}
+								return "", fmt.Errorf("expected fail")
+							},
+						},
+					},
+				},
+			}
+			_, err := src.Iterate(context.Background(), Options{}, &providerSourceMock{})
+			assert.ErrorContains(t, err, "failed to convert config to map")
+			assert.True(t, decrypterCalled)
+		})
 	})
 }
 
@@ -1819,6 +1976,33 @@ func TestDefaultProviders(t *testing.T) {
 			_, _, err := d.newRegisterDefaultProviderEvent(providers.ProviderRequest{})
 			assert.ErrorIs(t, err, expectedErr)
 		})
+		t.Run("use defaultProvider checksums", func(t *testing.T) {
+			t.Parallel()
+			d := &defaultProviders{
+				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{
+					tokens.Package(""): {
+						Checksums: map[string][]byte{"key": []byte("expected-checksum-value")},
+					},
+				},
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return resource.PropertyMap{}, nil
+					},
+				},
+			}
+			evt, done, err := d.newRegisterDefaultProviderEvent(providers.ProviderRequest{})
+			assert.NoError(t, err)
+			assert.NotNil(t, done)
+			assert.Equal(t,
+				resource.PropertyValue{
+					V: resource.PropertyMap{
+						"key": resource.PropertyValue{
+							V: "65787065637465642d636865636b73756d2d76616c7565",
+						},
+					},
+				},
+				evt.goal.Properties["pluginChecksums"])
+		})
 	})
 	t.Run("handleRequest", func(t *testing.T) {
 		t.Parallel()
@@ -1834,6 +2018,61 @@ func TestDefaultProviders(t *testing.T) {
 			}
 			_, err := d.handleRequest(providers.ProviderRequest{})
 			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("error in newRegisterDefaultProviderEvent", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := fmt.Errorf("expected error")
+			d := &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						if pkg == "pulumi" {
+							// Enables shouldDenyRequest(req) to succeed as it always calls using
+							// "pulumi".
+							return nil, nil
+						}
+						return nil, expectedErr
+					},
+				},
+			}
+			_, err := d.handleRequest(providers.ProviderRequest{})
+			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("error due to cancel before registration", func(t *testing.T) {
+			t.Parallel()
+			cancel := make(chan bool, 1)
+			cancel <- true
+			d := &defaultProviders{
+				cancel: cancel,
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			}
+			_, err := d.handleRequest(providers.ProviderRequest{})
+			assert.ErrorIs(t, err, context.Canceled)
+		})
+		t.Run("error cancel after registration, but before registration result", func(t *testing.T) {
+			t.Parallel()
+			cancel := make(chan bool, 1)
+
+			providerRegChan := make(chan *registerResourceEvent, 1)
+			d := &defaultProviders{
+				cancel:          cancel,
+				providerRegChan: providerRegChan,
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			}
+			go func() {
+				// Cancel after reading the registration.
+				<-providerRegChan
+				cancel <- true
+			}()
+			_, err := d.handleRequest(providers.ProviderRequest{})
+			assert.ErrorIs(t, err, context.Canceled)
 		})
 	})
 	t.Run("shouldDenyRequest", func(t *testing.T) {
@@ -1919,7 +2158,7 @@ func TestDefaultProviders(t *testing.T) {
 	})
 	t.Run("Cancel", func(t *testing.T) {
 		t.Parallel()
-		t.Run("serve", func(t *testing.T) {
+		t.Run("serve respects cancel", func(t *testing.T) {
 			t.Parallel()
 			cancel := make(chan bool, 1)
 			cancel <- true
@@ -1928,7 +2167,7 @@ func TestDefaultProviders(t *testing.T) {
 			}
 			d.serve()
 		})
-		t.Run("getDefaultProviderRef", func(t *testing.T) {
+		t.Run("getDefaultProviderRef respects cancel", func(t *testing.T) {
 			t.Parallel()
 			cancel := make(chan bool, 1)
 			cancel <- true
@@ -1957,5 +2196,1082 @@ func TestGetProviderReference(t *testing.T) {
 			cancel: cancel,
 		}, providers.ProviderRequest{}, "")
 		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestGetProviderFromSource(t *testing.T) {
+	t.Parallel()
+	t.Run("bad reference", func(t *testing.T) {
+		t.Parallel()
+		_, err := getProviderFromSource(nil, nil, providers.ProviderRequest{}, "bad-reference", "")
+		assert.ErrorContains(t, err, "getProviderFromSource")
+	})
+}
+
+func TestParseProviderRequest(t *testing.T) {
+	t.Parallel()
+	t.Run("bad version", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseProviderRequest("", "bad-version", "", nil)
+		assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+	})
+}
+
+func TestInvoke(t *testing.T) {
+	t.Parallel()
+	t.Run("bad version", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{}
+		_, err := rm.Invoke(context.Background(), &pulumirpc.ResourceInvokeRequest{
+			Tok:     "pkgA:index:func",
+			Version: "bad-version",
+		})
+		assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+	})
+	t.Run("error in invoke", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		var called bool
+		expectedErr := fmt.Errorf("expected error")
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				InvokeF: func(
+					tok tokens.ModuleMember, inputs resource.PropertyMap,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					called = true
+					return nil, nil, expectedErr
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		_, err = mon.Invoke(context.Background(), &pulumirpc.ResourceInvokeRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+		})
+		assert.ErrorContains(t, err, "returned an error")
+		// Ensure the channel is read from.
+		wg.Wait()
+		assert.True(t, called)
+	})
+	t.Run("error in invoke", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		var called bool
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				InvokeF: func(
+					tok tokens.ModuleMember, inputs resource.PropertyMap,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					called = true
+					return nil, []plugin.CheckFailure{
+						{
+							Property: "some-property",
+							Reason:   "expect failure",
+						},
+					}, nil
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		res, err := mon.Invoke(context.Background(), &pulumirpc.ResourceInvokeRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "some-property", res.Failures[0].Property)
+		assert.Equal(t, "expect failure", res.Failures[0].Reason)
+		// Ensure the channel is read from.
+		wg.Wait()
+		assert.True(t, called)
+	})
+}
+
+func TestCall(t *testing.T) {
+	t.Parallel()
+	t.Run("bad version", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{}
+		_, err := rm.Call(context.Background(), &pulumirpc.CallRequest{
+			Tok:     "pkgA:index:func",
+			Version: "bad-version",
+		})
+		assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+	})
+	t.Run("error in call", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		var called bool
+		expectedErr := fmt.Errorf("expected error")
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				CallF: func(
+					monitor *deploytest.ResourceMonitor,
+					tok tokens.ModuleMember, args resource.PropertyMap,
+					info plugin.CallInfo, options plugin.CallOptions,
+				) (plugin.CallResult, error) {
+					called = true
+					return plugin.CallResult{}, expectedErr
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		_, err = mon.Call(context.Background(), &pulumirpc.CallRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+		})
+		assert.ErrorContains(t, err, "returned an error")
+		// Ensure the channel is read from.
+		wg.Wait()
+		assert.True(t, called)
+	})
+	t.Run("handles args and arg dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		wg := &sync.WaitGroup{}
+		defer wg.Wait()
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+		var called bool
+		expectedErr := fmt.Errorf("expected error")
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				CallF: func(
+					monitor *deploytest.ResourceMonitor,
+					tok tokens.ModuleMember, args resource.PropertyMap,
+					info plugin.CallInfo, options plugin.CallOptions,
+				) (plugin.CallResult, error) {
+					assert.Equal(t,
+						resource.PropertyMap{
+							"test": resource.NewStringProperty("test-value"),
+						},
+						args)
+					assert.Equal(t,
+						map[resource.PropertyKey][]resource.URN{
+							"test": {
+								"urn:pulumi:stack::project::type::dep1",
+								"urn:pulumi:stack::project::type::dep2",
+								"urn:pulumi:stack::project::type::dep3",
+							},
+						},
+						options.ArgDependencies)
+					called = true
+					return plugin.CallResult{}, expectedErr
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		args, err := plugin.MarshalProperties(resource.PropertyMap{
+			"test": resource.NewStringProperty("test-value"),
+		}, plugin.MarshalOptions{})
+		require.NoError(t, err)
+
+		_, err = mon.Call(context.Background(), &pulumirpc.CallRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+			Args:    args,
+			ArgDependencies: map[string]*pulumirpc.CallRequest_ArgumentDependencies{
+				"test": {
+					Urns: []string{
+						"urn:pulumi:stack::project::type::dep1",
+						"urn:pulumi:stack::project::type::dep2",
+						"urn:pulumi:stack::project::type::dep3",
+					},
+				},
+			},
+		})
+		assert.ErrorContains(t, err, "returned an error")
+		// Ensure the channel is read from.
+		assert.True(t, called)
+	})
+	t.Run("catch invalid arg dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		wg := &sync.WaitGroup{}
+		defer wg.Wait()
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				CallF: func(
+					monitor *deploytest.ResourceMonitor,
+					tok tokens.ModuleMember, args resource.PropertyMap,
+					info plugin.CallInfo, options plugin.CallOptions,
+				) (plugin.CallResult, error) {
+					assert.Fail(t, "Call should not be called")
+					return plugin.CallResult{}, nil
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		args, err := plugin.MarshalProperties(resource.PropertyMap{
+			"test": resource.NewStringProperty("test-value"),
+		}, plugin.MarshalOptions{})
+		require.NoError(t, err)
+
+		_, err = mon.Call(context.Background(), &pulumirpc.CallRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+			Args:    args,
+			ArgDependencies: map[string]*pulumirpc.CallRequest_ArgumentDependencies{
+				"test": {
+					Urns: []string{
+						"invalid urn",
+					},
+				},
+			},
+		})
+		assert.ErrorContains(t, err, "invalid dependency")
+	})
+	t.Run("catch invalid arg dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		plugctx, err := plugin.NewContext(
+			&deploytest.NoopSink{}, &deploytest.NoopSink{},
+			deploytest.NewPluginHostF(nil, nil, nil)(),
+			nil, "", nil, false, nil)
+		require.NoError(t, err)
+
+		providerRegChan := make(chan *registerResourceEvent, 1)
+		wg := &sync.WaitGroup{}
+		defer wg.Wait()
+		wg.Add(1)
+		// Needed so defaultProviders.handleRequest() doesn't hang.
+		go func() {
+			evt := <-providerRegChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{
+					ID:  "b2562429-e255-4b8f-904b-2bd239301ff2",
+					URN: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				},
+			}
+			wg.Done()
+		}()
+
+		mon, err := newResourceMonitor(&evalSource{
+			runinfo: &EvalRunInfo{
+				Proj:   &workspace.Project{Name: "proj"},
+				Target: &Target{},
+			},
+			plugctx: plugctx,
+		}, &providerSourceMock{
+			Provider: &deploytest.Provider{
+				CallF: func(
+					monitor *deploytest.ResourceMonitor,
+					tok tokens.ModuleMember, args resource.PropertyMap,
+					info plugin.CallInfo, options plugin.CallOptions,
+				) (plugin.CallResult, error) {
+					return plugin.CallResult{
+						Return: resource.PropertyMap{
+							"result": resource.NewNumberProperty(100),
+						},
+						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
+							"prop": {
+								"urn:pulumi:stack::project::type::dep1",
+								"urn:pulumi:stack::project::type::dep2",
+								"urn:pulumi:stack::project::type::dep3",
+							},
+						},
+						Failures: []plugin.CheckFailure{
+							{
+								Property: "some-prop",
+								Reason:   "expected failure",
+							},
+						},
+					}, nil
+				},
+			},
+		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		require.NoError(t, err)
+
+		args, err := plugin.MarshalProperties(resource.PropertyMap{
+			"test": resource.NewStringProperty("test-value"),
+		}, plugin.MarshalOptions{})
+		require.NoError(t, err)
+
+		res, err := mon.Call(context.Background(), &pulumirpc.CallRequest{
+			Tok:     "pkgA:index:func",
+			Version: "1.0.0",
+			Args:    args,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t,
+			map[string]interface{}{
+				"result": float64(100),
+			}, res.Return.AsMap())
+		assert.Equal(t,
+			[]string{
+				"urn:pulumi:stack::project::type::dep1",
+				"urn:pulumi:stack::project::type::dep2",
+				"urn:pulumi:stack::project::type::dep3",
+			}, res.ReturnDependencies["prop"].Urns)
+		assert.Equal(t, &pulumirpc.CheckFailure{
+			Property: "some-prop",
+			Reason:   "expected failure",
+		}, res.Failures[0])
+	})
+}
+
+func TestReadResource(t *testing.T) {
+	t.Parallel()
+	t.Run("bad parent", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{}
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:   "foo:bar:some-type",
+			Parent: "invalid-parent",
+		})
+		assert.ErrorContains(t, err, "invalid parent URN")
+	})
+	t.Run("handles error from parseProviderRequest", func(t *testing.T) {
+		t.Parallel()
+		cancel := make(chan bool, 1)
+		cancel <- true
+		rm := &resmon{
+			defaultProviders: &defaultProviders{
+				cancel: cancel,
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:    "foo:bar:some-type",
+			Version: "1.0.0",
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("handles invalid dependencies", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{
+			defaultProviders: &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:    "pulumi:providers:fake-provider",
+			Version: "1.0.0",
+			Dependencies: []string{
+				"urn:pulumi:stack::project::type::dep1",
+				"urn:pulumi:stack::project::type::dep2",
+				"invalidURN",
+			},
+		})
+		assert.ErrorContains(t, err, "invalid URN")
+	})
+	t.Run("handles invalid dependencies", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{
+			defaultProviders: &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:    "pulumi:providers:fake-provider",
+			Version: "1.0.0",
+			Dependencies: []string{
+				"urn:pulumi:stack::project::type::dep1",
+				"urn:pulumi:stack::project::type::dep2",
+				"invalidURN",
+			},
+		})
+		assert.ErrorContains(t, err, "invalid URN")
+	})
+	t.Run("handles additional secret outputs", func(t *testing.T) {
+		t.Parallel()
+		regReadChan := make(chan *readResourceEvent, 1)
+		rm := &resmon{
+			regReadChan: regReadChan,
+			defaultProviders: &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			evt := <-regReadChan
+			assert.Equal(t, []resource.PropertyKey{"foo"}, evt.additionalSecretOutputs)
+			evt.done <- &ReadResult{
+				State: &resource.State{},
+			}
+			wg.Done()
+		}()
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:                    "pulumi:providers:fake-provider",
+			Version:                 "1.0.0",
+			AdditionalSecretOutputs: []string{"foo"},
+		})
+		assert.NoError(t, err)
+		wg.Wait()
+	})
+	t.Run("resource monitor shut down while sending resource registration", func(t *testing.T) {
+		t.Parallel()
+		cancel := make(chan bool, 1)
+		rm := &resmon{
+			cancel: cancel,
+			defaultProviders: &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			cancel <- true
+			wg.Done()
+		}()
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:    "pulumi:providers:fake-provider",
+			Version: "1.0.0",
+		})
+		assert.ErrorContains(t, err, "resource monitor shut down while sending resource registration")
+		wg.Wait()
+	})
+	t.Run("resource monitor shut down while waiting on step's done channel", func(t *testing.T) {
+		t.Parallel()
+		// requests := make(chan
+		cancel := make(chan bool, 1)
+		regReadChan := make(chan *readResourceEvent, 1)
+		rm := &resmon{
+			regReadChan: regReadChan,
+			cancel:      cancel,
+			defaultProviders: &defaultProviders{
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+		}
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			<-regReadChan
+			cancel <- true
+			wg.Done()
+		}()
+		_, err := rm.ReadResource(context.Background(), &pulumirpc.ReadResourceRequest{
+			Type:    "pulumi:providers:fake-provider",
+			Version: "1.0.0",
+		})
+		assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		wg.Wait()
+	})
+}
+
+func TestRegisterResource(t *testing.T) {
+	t.Parallel()
+	t.Run("gracefully handle cancellation", func(t *testing.T) {
+		t.Parallel()
+		t.Run("resource monitor shut down while sending resource registration", func(t *testing.T) {
+			t.Parallel()
+			cancel := make(chan bool, 1)
+			cancel <- true
+			rm := &resmon{
+				cancel: cancel,
+			}
+			_, err := rm.RegisterResource(context.Background(), &pulumirpc.RegisterResourceRequest{})
+			assert.ErrorContains(t, err, "resource monitor shut down while sending resource registration")
+		})
+		t.Run("resource monitor shut down while waiting on step's done channel", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			cancel := make(chan bool, 1)
+			go func() {
+				<-regChan
+				cancel <- true
+			}()
+
+			rm := &resmon{
+				regChan: regChan,
+				cancel:  cancel,
+			}
+			_, err := rm.RegisterResource(context.Background(), &pulumirpc.RegisterResourceRequest{})
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		})
+		t.Run("resource monitor shut down while waiting on step's done channel", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			cancel := make(chan bool, 1)
+			go func() {
+				<-regChan
+				cancel <- true
+			}()
+
+			rm := &resmon{
+				regChan: regChan,
+				cancel:  cancel,
+			}
+			_, err := rm.RegisterResource(context.Background(), &pulumirpc.RegisterResourceRequest{})
+			assert.ErrorContains(t, err, "resource monitor shut down while waiting on step's done channel")
+		})
+	})
+	t.Run("parent is component provider", func(t *testing.T) {
+		t.Parallel()
+		t.Run("resource has no provider", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			go func() {
+				evt := <-regChan
+				evt.done <- &RegisterResult{
+					State: &resource.State{},
+				}
+			}()
+			rm := &resmon{
+				regChan: regChan,
+				componentProviders: map[resource.URN]map[string]string{
+					"urn:pulumi:stack::project::type::foo": {
+						"urn:pulumi:stack::project::type::prov1": "",
+						"urn:pulumi:stack::project::type::prov2": "",
+					},
+				},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Parent: "urn:pulumi:stack::project::type::foo",
+			}
+			require.Nil(t, req.Providers)
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.NoError(t, err)
+			// Check request Providers mutated.
+			assert.NotNil(t, req.Providers)
+		})
+		t.Run("resource has a provider", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			go func() {
+				evt := <-regChan
+				evt.done <- &RegisterResult{
+					State: &resource.State{},
+				}
+			}()
+			rm := &resmon{
+				regChan: regChan,
+				componentProviders: map[resource.URN]map[string]string{
+					"urn:pulumi:stack::project::type::foo": {
+						"urn:pulumi:stack::project::type::prov1": "",
+						"urn:pulumi:stack::project::type::prov2": "expected-value",
+					},
+				},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Provider: "urn:pulumi:stack::project::type::bar",
+				Parent:   "urn:pulumi:stack::project::type::foo",
+			}
+			require.Nil(t, req.Providers)
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.NoError(t, err)
+			// Check request Providers mutated.
+			assert.Equal(t,
+				map[string]string{
+					"urn:pulumi:stack::project::type::prov1": "",
+					"urn:pulumi:stack::project::type::prov2": "expected-value",
+				},
+				req.Providers)
+		})
+	})
+	t.Run("remote handles improper version", func(t *testing.T) {
+		t.Parallel()
+		regChan := make(chan *registerResourceEvent, 1)
+		go func() {
+			evt := <-regChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{},
+			}
+		}()
+		rm := &resmon{}
+		req := &pulumirpc.RegisterResourceRequest{
+			Type:    "foo:bar:some-type",
+			Version: "improper-version",
+			Remote:  true,
+		}
+		_, err := rm.RegisterResource(context.Background(), req)
+		assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+	})
+	t.Run("custom handles improper version", func(t *testing.T) {
+		t.Parallel()
+		regChan := make(chan *registerResourceEvent, 1)
+		go func() {
+			evt := <-regChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{},
+			}
+		}()
+		rm := &resmon{}
+		req := &pulumirpc.RegisterResourceRequest{
+			Type:    "foo:bar:some-type",
+			Version: "improper-version",
+			Custom:  true,
+		}
+		require.False(t, providers.IsProviderType(tokens.Type(req.GetType())))
+		_, err := rm.RegisterResource(context.Background(), req)
+		assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+	})
+	t.Run("custom provider handles improper version", func(t *testing.T) {
+		t.Parallel()
+		regChan := make(chan *registerResourceEvent, 1)
+		go func() {
+			evt := <-regChan
+			evt.done <- &RegisterResult{
+				State: &resource.State{},
+			}
+		}()
+		rm := &resmon{}
+		req := &pulumirpc.RegisterResourceRequest{
+			Type:    "pulumi:providers:some-type",
+			Version: "improper-version",
+			Custom:  true,
+		}
+		require.True(t, providers.IsProviderType(tokens.Type(req.GetType())))
+		_, err := rm.RegisterResource(context.Background(), req)
+		assert.ErrorContains(t, err, "passed invalid version")
+	})
+	t.Run("invalid alias URN", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{}
+		req := &pulumirpc.RegisterResourceRequest{
+			Type: "pulumi:providers:some-type",
+			AliasURNs: []string{
+				"invalid-urn",
+			},
+		}
+		_, err := rm.RegisterResource(context.Background(), req)
+		assert.ErrorContains(t, err, "invalid alias URN")
+	})
+	t.Run("invalid dependency on property", func(t *testing.T) {
+		t.Parallel()
+		rm := &resmon{
+			defaultProviders: &defaultProviders{
+				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{},
+			},
+		}
+		req := &pulumirpc.RegisterResourceRequest{
+			Type:    "pulumi:providers:some-type",
+			Version: "1.0.0",
+			PropertyDependencies: map[string]*pulumirpc.RegisterResourceRequest_PropertyDependencies{
+				"invalid-urn": {
+					Urns: []string{"bad-urn"},
+				},
+			},
+		}
+		_, err := rm.RegisterResource(context.Background(), req)
+		assert.ErrorContains(t, err, "invalid dependency on property")
+	})
+	t.Run("remote resource", func(t *testing.T) {
+		t.Parallel()
+		t.Run("invalid provider in providers", func(t *testing.T) {
+			t.Parallel()
+			requests := make(chan defaultProviderRequest, 1)
+			go func() {
+				evt := <-requests
+				ref, err := providers.NewReference(
+					"urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+					"b2562429-e255-4b8f-904b-2bd239301ff2")
+				require.NoError(t, err)
+				evt.response <- defaultProviderResponse{
+					ref: ref,
+				}
+			}()
+			rm := &resmon{
+				defaultProviders: &defaultProviders{
+					requests: requests,
+					config: &configSourceMock{
+						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+							return nil, nil
+						},
+					},
+				},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Version: "1.0.0",
+				Type:    "pulumi:providers:some-type",
+				Remote:  true,
+				Providers: map[string]string{
+					"name": "invalid-provider-reference",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.ErrorContains(t, err, "could not parse provider reference")
+		})
+		t.Run("catch denied default provider", func(t *testing.T) {
+			t.Parallel()
+			requests := make(chan defaultProviderRequest, 1)
+			go func() {
+				evt := <-requests
+				ref, err := providers.NewReference(
+					"urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+					"denydefaultprovider")
+				require.NoError(t, err)
+				evt.response <- defaultProviderResponse{
+					ref: ref,
+				}
+			}()
+			rm := &resmon{
+				defaultProviders: &defaultProviders{
+					requests: requests,
+					config: &configSourceMock{
+						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+							return nil, nil
+						},
+					},
+				},
+				providers: &providerSourceMock{
+					Provider: &deploytest.Provider{},
+				},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Version: "1.0.0",
+				Type:    "pulumi:providers:some-type",
+				Remote:  true,
+				Providers: map[string]string{
+					"missing": "urn:pulumi:stack::project::pulumi:providers:aws::prov-1::uuid",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.ErrorContains(t, err,
+				"Default provider for 'pulumi' disabled. 'pulumi:providers:some-type' must use an explicit provider.")
+		})
+		t.Run("unknown provider", func(t *testing.T) {
+			t.Parallel()
+			requests := make(chan defaultProviderRequest, 1)
+			go func() {
+				evt := <-requests
+				ref, err := providers.NewReference(
+					"urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+					"b2562429-e255-4b8f-904b-2bd239301ff2")
+				require.NoError(t, err)
+				evt.response <- defaultProviderResponse{
+					ref: ref,
+				}
+			}()
+			rm := &resmon{
+				defaultProviders: &defaultProviders{
+					requests: requests,
+					config: &configSourceMock{
+						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+							return nil, nil
+						},
+					},
+				},
+				providers: &providerSourceMock{},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Version: "1.0.0",
+				Type:    "pulumi:providers:some-type",
+				Remote:  true,
+				Providers: map[string]string{
+					"missing": "urn:pulumi:stack::project::pulumi:providers:aws::prov-1::uuid",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.ErrorContains(t, err, "unknown provider")
+		})
+	})
+	t.Run("output dependencies", func(t *testing.T) {
+		t.Parallel()
+		t.Skip("TODO depends on DialMonitorF being merged")
+		requests := make(chan defaultProviderRequest, 1)
+		go func() {
+			evt := <-requests
+			ref, err := providers.NewReference(
+				"urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0",
+				"b2562429-e255-4b8f-904b-2bd239301ff2")
+			require.NoError(t, err)
+			evt.response <- defaultProviderResponse{
+				ref: ref,
+			}
+		}()
+		rm := &resmon{
+			defaultProviders: &defaultProviders{
+				requests: requests,
+				config: &configSourceMock{
+					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+						return nil, nil
+					},
+				},
+			},
+			providers: &providerSourceMock{
+				Provider: &deploytest.Provider{
+					ConstructF: func(monitor *deploytest.ResourceMonitor,
+						typ, name string, parent resource.URN, inputs resource.PropertyMap,
+						info plugin.ConstructInfo, options plugin.ConstructOptions,
+					) (plugin.ConstructResult, error) {
+						return plugin.ConstructResult{
+							OutputDependencies: map[resource.PropertyKey][]resource.URN{
+								"expected-key-1": {
+									"untrusted-urn-1",
+								},
+								"expected-key-2": {
+									"untrusted-urn-1",
+									"untrusted-urn-2",
+								},
+							},
+						}, nil
+					},
+				},
+			},
+		}
+		req := &pulumirpc.RegisterResourceRequest{
+			Version: "1.0.0",
+			Type:    "pulumi:providers:some-type",
+			Remote:  true,
+		}
+		res, err := rm.RegisterResource(context.Background(), req)
+		assert.NoError(t, err)
+		assert.Equal(t, nil, res.PropertyDependencies)
+	})
+	t.Run("not remote resource", func(t *testing.T) {
+		t.Parallel()
+		t.Run("additional secret keys", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			go func() {
+				evt := <-regChan
+				evt.done <- &RegisterResult{
+					State: &resource.State{},
+				}
+			}()
+			rm := &resmon{
+				regChan: regChan,
+				componentProviders: map[resource.URN]map[string]string{
+					"urn:pulumi:stack::project::type::foo": {
+						"urn:pulumi:stack::project::type::prov1": "",
+						"urn:pulumi:stack::project::type::prov2": "expected-value",
+					},
+				},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				Provider: "urn:pulumi:stack::project::type::bar",
+				Parent:   "urn:pulumi:stack::project::type::foo",
+				AdditionalSecretOutputs: []string{
+					"a",
+					"b",
+					"c",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.NoError(t, err)
+			assert.Equal(t,
+				[]string{"a", "b", "c"},
+				req.AdditionalSecretOutputs)
+		})
+		t.Run("handle invalid custom timeouts", func(t *testing.T) {
+			t.Parallel()
+			t.Run("Create", func(t *testing.T) {
+				t.Parallel()
+				regChan := make(chan *registerResourceEvent, 1)
+				go func() {
+					evt := <-regChan
+					evt.done <- &RegisterResult{
+						State: &resource.State{},
+					}
+				}()
+				rm := &resmon{
+					regChan:            regChan,
+					componentProviders: map[resource.URN]map[string]string{},
+				}
+				req := &pulumirpc.RegisterResourceRequest{
+					CustomTimeouts: &pulumirpc.RegisterResourceRequest_CustomTimeouts{
+						Create: "invalid",
+					},
+				}
+				_, err := rm.RegisterResource(context.Background(), req)
+				assert.ErrorContains(t, err, "unable to parse customTimeout Value")
+			})
+		})
+		t.Run("Delete", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			go func() {
+				evt := <-regChan
+				evt.done <- &RegisterResult{
+					State: &resource.State{},
+				}
+			}()
+			rm := &resmon{
+				regChan:            regChan,
+				componentProviders: map[resource.URN]map[string]string{},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				CustomTimeouts: &pulumirpc.RegisterResourceRequest_CustomTimeouts{
+					Delete: "invalid",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.ErrorContains(t, err, "unable to parse customTimeout Value")
+		})
+		t.Run("Update", func(t *testing.T) {
+			t.Parallel()
+			regChan := make(chan *registerResourceEvent, 1)
+			go func() {
+				evt := <-regChan
+				evt.done <- &RegisterResult{
+					State: &resource.State{},
+				}
+			}()
+			rm := &resmon{
+				regChan:            regChan,
+				componentProviders: map[resource.URN]map[string]string{},
+			}
+			req := &pulumirpc.RegisterResourceRequest{
+				CustomTimeouts: &pulumirpc.RegisterResourceRequest_CustomTimeouts{
+					Update: "invalid",
+				},
+			}
+			_, err := rm.RegisterResource(context.Background(), req)
+			assert.ErrorContains(t, err, "unable to parse customTimeout Value")
+		})
 	})
 }

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -17,10 +17,22 @@ package deploy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"sync"
 	"testing"
 
+	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 )
@@ -163,17 +175,128 @@ func TestQueryResourceMonitor_UnsupportedOperations(t *testing.T) {
 	rm := &queryResmon{}
 
 	_, err := rm.ReadResource(context.Background(), nil)
-	assert.EqualError(t, err, "Query mode does not support reading resources")
+	assert.Error(t, err)
+	assert.Equal(t, "Query mode does not support reading resources", err.Error())
 
 	_, err = rm.RegisterResource(context.Background(), nil)
-	assert.EqualError(t, err, "Query mode does not support creating, updating, or deleting resources")
+	assert.Error(t, err)
+	assert.Equal(t, "Query mode does not support creating, updating, or deleting resources", err.Error())
 
 	_, err = rm.RegisterResourceOutputs(context.Background(), nil)
-	assert.EqualError(t, err, "Query mode does not support registering resource operations")
+	assert.Error(t, err)
+	assert.Equal(t, "Query mode does not support registering resource operations", err.Error())
+}
+
+func TestQueryResourceMonitor(t *testing.T) {
+	t.Parallel()
+	t.Run("newQueryResourceMonitor", func(t *testing.T) {
+		t.Parallel()
+		t.Run("bad decrypter", func(t *testing.T) {
+			t.Parallel()
+			providerRegErrChan := make(chan error, 1)
+			expectedErr := fmt.Errorf("expected error")
+			resmon, err := newQueryResourceMonitor(
+				nil, nil, nil, nil, nil, providerRegErrChan, nil, &EvalRunInfo{
+					Proj: &workspace.Project{
+						Name: "expected-project",
+					},
+					Target: &Target{
+						Config: config.Map{
+							config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
+							config.MustMakeKey("test", "regular"): config.NewValue("regular-value"),
+						},
+						Decrypter: &decrypterMock{
+							DecryptValueF: func(
+								ctx context.Context, ciphertext string,
+							) (string, error) {
+								return "", expectedErr
+							},
+						},
+					},
+				},
+			)
+			_ = resmon
+			assert.ErrorIs(t, err, expectedErr)
+		})
+		t.Run("ok", func(t *testing.T) {
+			t.Parallel()
+			providerRegErrChan := make(chan error, 1)
+			resmon, err := newQueryResourceMonitor(
+				nil, nil, nil, nil, nil, providerRegErrChan, nil, &EvalRunInfo{
+					Proj: &workspace.Project{
+						Name: "expected-project",
+					},
+					Target: &Target{
+						Name: tokens.MustParseStackName("expected-name"),
+					},
+				},
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, "expected-project", resmon.callInfo.Project)
+			assert.Equal(t, "expected-name", resmon.callInfo.Stack)
+		})
+	})
+	t.Run("Cancel", func(t *testing.T) {
+		t.Parallel()
+		expectedErr := fmt.Errorf("expected-error")
+		done := make(chan error, 1)
+		done <- expectedErr
+		rm := &queryResmon{
+			cancel: make(chan bool),
+			done:   done,
+		}
+		assert.ErrorIs(t, rm.Cancel(), expectedErr)
+	})
+	t.Run("Invoke", func(t *testing.T) {
+		t.Parallel()
+		t.Run("bad provider request", func(t *testing.T) {
+			t.Parallel()
+			t.Run("bad version", func(t *testing.T) {
+				t.Parallel()
+
+				rm := &queryResmon{}
+				_, err := rm.Invoke(context.Background(), &pulumirpc.ResourceInvokeRequest{
+					Tok:     "pkgA:index:func",
+					Version: "bad-version",
+				})
+				assert.ErrorContains(t, err, "No Major.Minor.Patch elements found")
+			})
+			t.Run("default provider error", func(t *testing.T) {
+				t.Parallel()
+
+				providerRegChan := make(chan *registerResourceEvent, 1)
+				requests := make(chan defaultProviderRequest, 1)
+				rm := &queryResmon{
+					reg: &providers.Registry{},
+					defaultProviders: &defaultProviders{
+						requests:        requests,
+						providerRegChan: providerRegChan,
+					},
+				}
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
+				expectedErr := fmt.Errorf("expected error")
+				// Needed so defaultProviders.handleRequest() doesn't hang.
+				go func() {
+					req := <-rm.defaultProviders.requests
+					req.response <- defaultProviderResponse{
+						err: expectedErr,
+					}
+					wg.Done()
+				}()
+				_, err := rm.Invoke(context.Background(), &pulumirpc.ResourceInvokeRequest{
+					Tok:     "pkgA:index:func",
+					Version: "1.0.0",
+				})
+				wg.Wait()
+				assert.ErrorIs(t, err, expectedErr)
+			})
+		})
+	})
 }
 
 //
-// Test querySoruce constructor.
+// Test querySource constructor.
 //
 
 func newTestQuerySource(mon SourceResourceMonitor,
@@ -273,4 +396,478 @@ func (rm *mockResmon) RegisterResourceOutputs(ctx context.Context,
 		return rm.RegisterResourceOutputsF(ctx, req)
 	}
 	panic("not implemented")
+}
+
+func TestQuerySource(t *testing.T) {
+	t.Parallel()
+	t.Run("Wait", func(t *testing.T) {
+		t.Parallel()
+
+		var called bool
+		providerRegErrChan := make(chan error, 1)
+		expectedErr := fmt.Errorf("expected error")
+		providerRegErrChan <- expectedErr
+		src := &querySource{
+			providerRegErrChan: providerRegErrChan,
+			// Required to not nil ptr dereference.
+			cancel: context.Background(),
+			mon: &mockResmon{
+				CancelF: func() error {
+					called = true
+					return nil
+				},
+			},
+		}
+		err := src.Wait()
+		assert.ErrorIs(t, err, expectedErr)
+		assert.True(t, called)
+	})
+}
+
+func TestRunLangPlugin(t *testing.T) {
+	t.Parallel()
+	t.Run("failed to launch language host", func(t *testing.T) {
+		t.Parallel()
+
+		assert.ErrorContains(t, runLangPlugin(&querySource{
+			plugctx: &plugin.Context{
+				Host: &mockHost{
+					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+						return nil, fmt.Errorf("expected error")
+					},
+				},
+			},
+			runinfo: &EvalRunInfo{
+				Proj: &workspace.Project{
+					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
+				},
+			},
+		}), "failed to launch language host")
+	})
+	t.Run("bad decrypter", func(t *testing.T) {
+		t.Parallel()
+		expectedErr := fmt.Errorf("expected error")
+		err := runLangPlugin(&querySource{
+			plugctx: &plugin.Context{
+				Host: &mockHost{
+					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+						return &mockLanguageRuntime{}, nil
+					},
+				},
+			},
+			runinfo: &EvalRunInfo{
+				Proj: &workspace.Project{
+					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
+				},
+				Target: &Target{
+					Config: config.Map{
+						config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
+						config.MustMakeKey("test", "regular"): config.NewValue("regular-value"),
+					},
+					Decrypter: &decrypterMock{
+						DecryptValueF: func(
+							ctx context.Context, ciphertext string,
+						) (string, error) {
+							return "", expectedErr
+						},
+					},
+				},
+			},
+		})
+		assert.ErrorIs(t, err, expectedErr)
+	})
+	t.Run("bail successfully", func(t *testing.T) {
+		t.Parallel()
+		err := runLangPlugin(&querySource{
+			plugctx: &plugin.Context{
+				Host: &mockHost{
+					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+						return &mockLanguageRuntime{
+							RunF: func(info plugin.RunInfo) (string, bool, error) {
+								return "bail should override progerr", true /* bail */, nil
+							},
+						}, nil
+					},
+				},
+			},
+			// Prevent nilptr dereference.
+			mon: &mockResmon{
+				AddressF: func() string { return "" },
+			},
+			runinfo: &EvalRunInfo{
+				Proj: &workspace.Project{
+					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
+				},
+			},
+		})
+		assert.ErrorContains(t, err, "run bailed")
+	})
+	t.Run("progerr", func(t *testing.T) {
+		t.Parallel()
+		err := runLangPlugin(&querySource{
+			plugctx: &plugin.Context{
+				Host: &mockHost{
+					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+						return &mockLanguageRuntime{
+							RunF: func(info plugin.RunInfo) (string, bool, error) {
+								return "expected progerr", false /* bail */, nil
+							},
+						}, nil
+					},
+				},
+			},
+			// Prevent nilptr dereference.
+			mon: &mockResmon{
+				AddressF: func() string { return "" },
+			},
+			runinfo: &EvalRunInfo{
+				Proj: &workspace.Project{
+					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
+				},
+			},
+		})
+		assert.ErrorContains(t, err, "expected progerr")
+	})
+	t.Run("langhost is run correctly", func(t *testing.T) {
+		t.Parallel()
+		var runCalled bool
+		err := runLangPlugin(&querySource{
+			plugctx: &plugin.Context{
+				Host: &mockHost{
+					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+						return &mockLanguageRuntime{
+							RunF: func(info plugin.RunInfo) (string, bool, error) {
+								runCalled = true
+								assert.Equal(t, "expected-address", info.MonitorAddress)
+								assert.Equal(t, "expected-stack", info.Stack)
+								assert.Equal(t, "expected-project", info.Project)
+								assert.Equal(t, "expected-pwd", info.Pwd)
+								assert.Equal(t, "expected-program", info.Program)
+								assert.Equal(t, []string{"expected", "args"}, info.Args)
+								assert.Equal(t, "secret-value", info.Config[config.MustMakeKey("test", "secret")])
+								assert.Equal(t, "regular-value", info.Config[config.MustMakeKey("test", "regular")])
+								assert.True(t, info.QueryMode)
+								assert.True(t, info.DryRun)
+								// Disregard Parallel argument.
+								assert.Equal(t, "expected-organization", info.Organization)
+								return "", false, nil
+							},
+						}, nil
+					},
+				},
+			},
+			// Prevent nilptr dereference.
+			mon: &mockResmon{
+				AddressF: func() string { return "expected-address" },
+			},
+			runinfo: &EvalRunInfo{
+				Proj: &workspace.Project{
+					Name:    "expected-project",
+					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
+				},
+				Pwd:     "expected-pwd",
+				Program: "expected-program",
+				Args:    []string{"expected", "args"},
+				Target: &Target{
+					Config: config.Map{
+						config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
+						config.MustMakeKey("test", "regular"): config.NewValue("regular-value"),
+					},
+					Name:         tokens.MustParseStackName("expected-stack"),
+					Organization: "expected-organization",
+					Decrypter: &decrypterMock{
+						DecryptValueF: func(
+							ctx context.Context, ciphertext string,
+						) (string, error) {
+							return ciphertext, nil
+						},
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.True(t, runCalled)
+	})
+}
+
+type mockHost struct {
+	ServerAddrF func() string
+
+	LogF func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
+
+	LogStatusF func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
+
+	AnalyzerF func(nm tokens.QName) (plugin.Analyzer, error)
+
+	PolicyAnalyzerF func(name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error)
+
+	ListAnalyzersF func() []plugin.Analyzer
+
+	ProviderF func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error)
+
+	CloseProviderF func(provider plugin.Provider) error
+
+	LanguageRuntimeF func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error)
+
+	EnsurePluginsF func(plugins []workspace.PluginSpec, kinds plugin.Flags) error
+
+	ResolvePluginF func(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
+
+	GetProjectPluginsF func() []workspace.ProjectPlugin
+
+	SignalCancellationF func() error
+
+	CloseF func() error
+}
+
+var _ plugin.Host = (*mockHost)(nil)
+
+func (h *mockHost) ServerAddr() string {
+	if h.ServerAddrF != nil {
+		return h.ServerAddrF()
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
+	if h.LogF != nil {
+		h.LogF(sev, urn, msg, streamID)
+		return
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
+	if h.LogStatusF != nil {
+		h.LogStatusF(sev, urn, msg, streamID)
+		return
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
+	if h.AnalyzerF != nil {
+		return h.Analyzer(nm)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) PolicyAnalyzer(
+	name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
+) (plugin.Analyzer, error) {
+	if h.PolicyAnalyzerF != nil {
+		return h.PolicyAnalyzerF(name, path, opts)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) ListAnalyzers() []plugin.Analyzer {
+	if h.ListAnalyzersF != nil {
+		return h.ListAnalyzersF()
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+	if h.ProviderF != nil {
+		return h.ProviderF(pkg, version)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) CloseProvider(provider plugin.Provider) error {
+	if h.CloseProviderF != nil {
+		return h.CloseProviderF(provider)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) LanguageRuntime(
+	root, pwd, runtime string, options map[string]interface{},
+) (plugin.LanguageRuntime, error) {
+	if h.LanguageRuntimeF != nil {
+		return h.LanguageRuntimeF(root, pwd, runtime, options)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+	if h.EnsurePluginsF != nil {
+		return h.EnsurePluginsF(plugins, kinds)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) ResolvePlugin(
+	kind workspace.PluginKind, name string, version *semver.Version,
+) (*workspace.PluginInfo, error) {
+	if h.ResolvePluginF != nil {
+		return h.ResolvePluginF(kind, name, version)
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) GetProjectPlugins() []workspace.ProjectPlugin {
+	if h.GetProjectPluginsF != nil {
+		return h.GetProjectPluginsF()
+	}
+	panic("unimplemented")
+}
+
+func (h *mockHost) SignalCancellation() error {
+	if h.SignalCancellationF != nil {
+		return h.SignalCancellationF()
+	}
+	panic("unimplemented")
+}
+
+// Close reclaims any resources associated with the host.
+func (h *mockHost) Close() error {
+	if h.CloseF != nil {
+		return h.CloseF()
+	}
+	panic("unimplemented")
+}
+
+type mockLanguageRuntime struct {
+	CloseF func() error
+
+	GetRequiredPluginsF func(info plugin.ProgInfo) ([]workspace.PluginSpec, error)
+
+	RunF func(info plugin.RunInfo) (string, bool, error)
+
+	GetPluginInfoF func() (workspace.PluginInfo, error)
+
+	InstallDependenciesF func(pwd, main string) error
+
+	AboutF func() (plugin.AboutInfo, error)
+
+	GetProgramDependenciesF func(
+		info plugin.ProgInfo, transitiveDependencies bool,
+	) ([]plugin.DependencyInfo, error)
+
+	RunPluginF func(
+		info plugin.RunPluginInfo,
+	) (io.Reader, io.Reader, context.CancelFunc, error)
+
+	GenerateProjectF func(
+		sourceDirectory, targetDirectory, project string,
+		strict bool, loaderTarget string, localDependencies map[string]string,
+	) (hcl.Diagnostics, error)
+
+	GeneratePackageF func(
+		directory string, schema string,
+		extraFiles map[string][]byte, loaderTarget string,
+	) (hcl.Diagnostics, error)
+
+	GenerateProgramF func(
+		program map[string]string,
+		loaderTarget string,
+	) (map[string][]byte, hcl.Diagnostics, error)
+
+	PackF func(
+		packageDirectory string,
+		version semver.Version,
+		destinationDirectory string,
+	) (string, error)
+}
+
+var _ plugin.LanguageRuntime = (*mockLanguageRuntime)(nil)
+
+func (rt *mockLanguageRuntime) Close() error {
+	if rt.CloseF != nil {
+		return rt.CloseF()
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
+	if rt.GetRequiredPluginsF != nil {
+		return rt.GetRequiredPluginsF(info)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
+	if rt.RunF != nil {
+		return rt.RunF(info)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
+	if rt.GetPluginInfoF != nil {
+		return rt.GetPluginInfoF()
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) InstallDependencies(pwd, main string) error {
+	if rt.InstallDependenciesF != nil {
+		return rt.InstallDependenciesF(pwd, main)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) About() (plugin.AboutInfo, error) {
+	if rt.AboutF != nil {
+		return rt.AboutF()
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GetProgramDependencies(
+	info plugin.ProgInfo, transitiveDependencies bool,
+) ([]plugin.DependencyInfo, error) {
+	if rt.GetProgramDependenciesF != nil {
+		return rt.GetProgramDependenciesF(info, transitiveDependencies)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) RunPlugin(
+	info plugin.RunPluginInfo,
+) (io.Reader, io.Reader, context.CancelFunc, error) {
+	if rt.RunPluginF != nil {
+		return rt.RunPluginF(info)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GenerateProject(
+	sourceDirectory, targetDirectory, project string,
+	strict bool, loaderTarget string, localDependencies map[string]string,
+) (hcl.Diagnostics, error) {
+	if rt.GenerateProjectF != nil {
+		return rt.GenerateProjectF(
+			sourceDirectory, targetDirectory, project, strict, loaderTarget, localDependencies)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GeneratePackage(
+	directory string, schema string, extraFiles map[string][]byte, loaderTarget string,
+) (hcl.Diagnostics, error) {
+	if rt.GeneratePackageF != nil {
+		return rt.GeneratePackageF(directory, schema, extraFiles, loaderTarget)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) GenerateProgram(
+	program map[string]string, loaderTarget string,
+) (map[string][]byte, hcl.Diagnostics, error) {
+	if rt.GenerateProgramF != nil {
+		return rt.GenerateProgramF(program, loaderTarget)
+	}
+	panic("unimplemented")
+}
+
+func (rt *mockLanguageRuntime) Pack(
+	packageDirectory string, version semver.Version, destinationDirectory string,
+) (string, error) {
+	if rt.PackF != nil {
+		return rt.PackF(packageDirectory, version, destinationDirectory)
+	}
+	panic("unimplemented")
 }

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -163,6 +163,7 @@ type CreateStep struct {
 	detailedDiff  map[string]plugin.PropertyDiff // the structured property diff (only for replacements).
 	replacing     bool                           // true if this is a create due to a replacement.
 	pendingDelete bool                           // true if this replacement should create a pending delete.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 var _ Step = (*CreateStep)(nil)
@@ -239,7 +240,7 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	resourceStatus := resource.StatusOK
 	if s.new.Custom {
 		// Invoke the Create RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -291,6 +292,7 @@ type DeleteStep struct {
 	old            *resource.State       // the state of the existing resource.
 	replacing      bool                  // true if part of a replacement.
 	otherDeletions map[resource.URN]bool // other resources that are planned to delete
+	provider       plugin.Provider       // the optional provider to use.
 }
 
 var _ Step = (*DeleteStep)(nil)
@@ -410,7 +412,7 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		// Not preview and not external and not Drop and is custom, do the actual delete
 
 		// Invoke the Delete RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -463,6 +465,7 @@ type UpdateStep struct {
 	diffs         []resource.PropertyKey         // the keys causing a diff.
 	detailedDiff  map[string]plugin.PropertyDiff // the structured diff.
 	ignoreChanges []string                       // a list of property paths to ignore when updating.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 var _ Step = (*UpdateStep)(nil)
@@ -521,7 +524,7 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	resourceStatus := resource.StatusOK
 	if s.new.Custom {
 		// Invoke the Update RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -633,6 +636,7 @@ type ReadStep struct {
 	old        *resource.State   // the old resource state, if one exists for this urn
 	new        *resource.State   // the new resource state, to be used to query the provider
 	replacing  bool              // whether or not the new resource is replacing the old resource
+	provider   plugin.Provider   // the optional provider to use.
 }
 
 // NewReadStep creates a new Read step.
@@ -708,7 +712,7 @@ func (s *ReadStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 	if id == plugin.UnknownStringValue {
 		s.new.Outputs = resource.PropertyMap{}
 	} else {
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -778,6 +782,7 @@ type RefreshStep struct {
 	old        *resource.State // the old resource state, if one exists for this urn
 	new        *resource.State // the new resource state, to be used to query the provider
 	done       chan<- bool     // the channel to use to signal completion, if any
+	provider   plugin.Provider // the optional provider to use.
 }
 
 // NewRefreshStep creates a new Refresh step.
@@ -829,7 +834,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 	}
 
 	// For a custom resource, fetch the resource's provider and read the resource's current state.
-	prov, err := getProvider(s)
+	prov, err := getProvider(s, s.provider)
 	if err != nil {
 		return resource.StatusOK, nil, err
 	}
@@ -909,6 +914,7 @@ type ImportStep struct {
 	detailedDiff  map[string]plugin.PropertyDiff // the structured property diff.
 	ignoreChanges []string                       // a list of property paths to ignore when updating.
 	randomSeed    []byte                         // the random seed to use for Check.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State,
@@ -1019,7 +1025,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
 		// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.
 		var err error
-		prov, err = getProvider(s)
+		prov, err = getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -1350,7 +1356,10 @@ func ConstrainedTo(op display.StepOp, constraint display.StepOp) bool {
 }
 
 // getProvider fetches the provider for the given step.
-func getProvider(s Step) (plugin.Provider, error) {
+func getProvider(s Step, override plugin.Provider) (plugin.Provider, error) {
+	if override != nil {
+		return override, nil
+	}
 	if providers.IsProviderType(s.Type()) {
 		return s.Deployment().providers, nil
 	}

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -15,10 +15,13 @@
 package deploy
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,3 +54,172 @@ func (e *mockRegisterResourceOutputsEvent) Outputs() resource.PropertyMap {
 }
 
 func (e *mockRegisterResourceOutputsEvent) Done() {}
+
+type mockEvents struct {
+	OnResourceStepPreF   func(step Step) (interface{}, error)
+	OnResourceStepPostF  func(ctx interface{}, step Step, status resource.Status, err error) error
+	OnResourceOutputsF   func(step Step) error
+	OnPolicyViolationF   func(resource.URN, plugin.AnalyzeDiagnostic)
+	OnPolicyRemediationF func(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap)
+}
+
+func (e *mockEvents) OnResourceStepPre(step Step) (interface{}, error) {
+	if e.OnResourceStepPreF != nil {
+		return e.OnResourceStepPreF(step)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnResourceStepPost(ctx interface{}, step Step, status resource.Status, err error) error {
+	if e.OnResourceStepPostF != nil {
+		return e.OnResourceStepPostF(ctx, step, status, err)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnResourceOutputs(step Step) error {
+	if e.OnResourceOutputsF != nil {
+		return e.OnResourceOutputsF(step)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyViolation(resource.URN, plugin.AnalyzeDiagnostic) {
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyRemediation(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap) {
+	panic("unimplemented")
+}
+
+var _ Events = (*mockEvents)(nil)
+
+func TestStepExecutor(t *testing.T) {
+	t.Parallel()
+	t.Run("ExecuteRegisterResourceOutputs", func(t *testing.T) {
+		t.Parallel()
+		t.Run("no plan for resource", func(t *testing.T) {
+			t.Parallel()
+
+			se := &stepExecutor{
+				deployment: &Deployment{
+					plan: &Plan{},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorContains(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}), "no plan for resource")
+		})
+		t.Run("resource should already have a plan", func(t *testing.T) {
+			t.Parallel()
+
+			se := &stepExecutor{
+				opts: Options{
+					GeneratePlan: true,
+				},
+				deployment: &Deployment{
+					newPlans: &resourcePlans{},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorContains(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}), "resource should already have a plan")
+		})
+		t.Run("error in resource outputs", func(t *testing.T) {
+			t.Parallel()
+
+			var cancelCalled bool
+			se := &stepExecutor{
+				cancel: func() {
+					cancelCalled = true
+				},
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceOutputsF: func(step Step) error {
+							return errors.New("expected error")
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			// Does not error.
+			assert.NoError(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}))
+			assert.True(t, cancelCalled)
+		})
+	})
+	t.Run("executeStep", func(t *testing.T) {
+		t.Run("error in onResourceStepPre", func(t *testing.T) {
+			t.Parallel()
+
+			expectedErr := errors.New("expected error")
+			se := &stepExecutor{
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceStepPreF: func(step Step) (interface{}, error) {
+							return nil, expectedErr
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorIs(t, se.executeStep(0, &CreateStep{
+				new: &resource.State{URN: "some-urn"},
+			}), expectedErr)
+		})
+		t.Run("disallow mark id secret", func(t *testing.T) {
+			t.Parallel()
+
+			expectedErr := errors.New("expected error")
+			se := &stepExecutor{
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceStepPreF: func(step Step) (interface{}, error) {
+							return nil, nil
+						},
+						OnResourceStepPostF: func(
+							ctx interface{}, step Step, status resource.Status, err error,
+						) error {
+							return expectedErr
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+					goals: &goalMap{},
+				},
+				pendingNews: sync.Map{},
+			}
+			step := &CreateStep{
+				new: &resource.State{
+					URN: "some-urn",
+					AdditionalSecretOutputs: []resource.PropertyKey{
+						"id",
+						"non-existent-property",
+					},
+				},
+				provider: &deploytest.Provider{},
+			}
+			assert.ErrorContains(t, se.executeStep(0, step), "post-step event returned an error")
+		})
+	})
+}

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -526,5 +527,200 @@ func TestDeleteProtectedErrorUsesCorrectQuotesOnOS(t *testing.T) {
 			return
 		}
 		assert.Contains(t, gotErrMsg, contains)
+	})
+}
+
+func TestStepGenerator(t *testing.T) {
+	t.Parallel()
+	t.Run("isTargetedForUpdate", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has targeted dependencies", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				opts: Options{
+					TargetDependents: true,
+					Targets: UrnTargets{
+						literals: []resource.URN{"c"},
+					},
+				},
+				targetsActual: UrnTargets{
+					literals: []resource.URN{"b"},
+				},
+			}
+			assert.False(t, sg.isTargetedForUpdate(&resource.State{
+				Dependencies: []resource.URN{"a"},
+			}))
+			assert.True(t, sg.isTargetedForUpdate(&resource.State{
+				Dependencies: []resource.URN{
+					"a",
+					"b", // targeted
+				},
+			}))
+		})
+	})
+	t.Run("checkParent", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+			}
+			_, err := sg.checkParent("does-not-exist", "")
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+	})
+	t.Run("GenerateReadSteps", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+			}
+			_, err := sg.GenerateReadSteps(&readResourceEvent{
+				parent: "does-not-exist",
+			})
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+		t.Run("fail generateURN", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{
+					"urn:pulumi:::::::": true,
+				},
+				deployment: &Deployment{
+					target: &Target{},
+					source: &nullSource{},
+					ctx:    &plugin.Context{Diag: &deploytest.NoopSink{}},
+				},
+			}
+			_, err := sg.GenerateReadSteps(&readResourceEvent{})
+			assert.ErrorContains(t, err, "Duplicate resource URN")
+		})
+	})
+	t.Run("generateSteps", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					target: &Target{},
+					source: &nullSource{},
+				},
+			}
+			_, err := sg.generateSteps(&registerResourceEvent{
+				goal: &resource.Goal{
+					Parent: "does-not-exist",
+				},
+			})
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+	})
+	t.Run("determineAllowedResourcesToDeleteFromTargets", func(t *testing.T) {
+		t.Parallel()
+		t.Run("handle non-existent target", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{
+						Resources: []*resource.State{
+							{
+								URN: "a",
+							},
+						},
+					},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			targets, err := sg.determineAllowedResourcesToDeleteFromTargets(UrnTargets{
+				literals: []resource.URN{"a"},
+			})
+			assert.NoError(t, err)
+			assert.Empty(t, targets)
+		})
+	})
+	t.Run("ScheduleDeletes", func(t *testing.T) {
+		t.Parallel()
+		t.Run("don't TrustDependencies", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				opts: Options{
+					TrustDependencies: false,
+				},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			antichains := sg.ScheduleDeletes([]Step{
+				&DeleteStep{},
+				&CreateStep{},
+				&UpdateStep{},
+			})
+			assert.Len(t, antichains, 3)
+		})
+	})
+	t.Run("providerChanged", func(t *testing.T) {
+		t.Parallel()
+		t.Run("invalid old ProviderReference", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "invalid-old-provider",
+				},
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+				},
+			)
+			assert.ErrorContains(t, err, "expected '::' in provider reference 'invalid-old-provider'")
+		})
+		t.Run("invalid new ProviderReference", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+				},
+				&resource.State{
+					Provider: "invalid-new-provider",
+				},
+			)
+			assert.ErrorContains(t, err, "expected '::' in provider reference 'invalid-new-provider'")
+		})
+		t.Run("error getting new default provider", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev:      &Snapshot{},
+					olds:      map[resource.URN]*resource.State{},
+					providers: &providers.Registry{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::default_name::uuid",
+				},
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::default_new::uuid",
+				},
+			)
+			assert.ErrorContains(t, err, "failed to resolve provider reference")
+		})
 	})
 }

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -15,9 +15,15 @@
 package deploy
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,4 +104,836 @@ func TestPastTense(t *testing.T) {
 			PastTense("not-a-real-operation")
 		})
 	})
+}
+
+func TestSameStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("bad provider state for resource", func(t *testing.T) {
+			t.Parallel()
+			s := &SameStep{
+				old: &resource.State{
+					URN: "urn:pulumi:stack::project::type::foo",
+				},
+				new: &resource.State{
+					URN:  "urn:pulumi:stack::project::type::foo",
+					Type: "pulumi:providers:some-provider",
+				},
+				deployment: &Deployment{},
+			}
+			_, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "bad provider state for resource")
+		})
+	})
+}
+
+func TestCreateStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("custom", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error getting provider", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+						// Use denydefaultprovider ID to ensure failure.
+						Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("error in create", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				var createCalled bool
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							createCalled = true
+							return "", nil, resource.StatusOK, expectedErr
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, createCalled)
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("handle InitError", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							return "", nil, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "intentional error")
+				assert.Len(t, s.new.InitErrors, 1)
+				assert.Equal(t, resource.StatusPartialFailure, status)
+			})
+			t.Run("error create no ID", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							return "", nil, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(false /* preview */)
+				assert.ErrorContains(t, err, "provider did not return an ID from Create")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+	})
+}
+
+func TestDeleteStep(t *testing.T) {
+	t.Parallel()
+	t.Run("isDeletedWith", func(t *testing.T) {
+		t.Parallel()
+		otherDeletions := map[resource.URN]bool{
+			"false-key": false,
+			"true-key":  true,
+		}
+		assert.False(t, isDeletedWith("", otherDeletions))
+		assert.False(t, isDeletedWith("does-not-exist", otherDeletions))
+		assert.False(t, isDeletedWith("false-key", otherDeletions))
+		assert.True(t, isDeletedWith("true-key", otherDeletions))
+	})
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("custom", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error getting provider", func(t *testing.T) {
+				t.Parallel()
+				s := &DeleteStep{
+					old: &resource.State{
+						Custom: true,
+						// Use denydefaultprovider ID to ensure failure.
+						Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+					},
+				}
+				status, _, err := s.Apply(false)
+				assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+	})
+}
+
+func TestRemovePendingReplaceStep(t *testing.T) {
+	t.Parallel()
+	t.Run("NewRemovePendingReplaceStep", func(t *testing.T) {
+		t.Parallel()
+		t.Run("panics on old=nil", func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() {
+				NewRemovePendingReplaceStep(nil, nil)
+			})
+		})
+		t.Run("panics if not old.PendingReplacement", func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() {
+				NewRemovePendingReplaceStep(nil, &resource.State{
+					PendingReplacement: false,
+				})
+			})
+		})
+	})
+	t.Run("Op", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.Equal(t, OpRemovePendingReplace, s.Op())
+	})
+	t.Run("Deployment", func(t *testing.T) {
+		t.Parallel()
+		d := &Deployment{}
+		s := NewRemovePendingReplaceStep(d, &resource.State{
+			Type:               "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, d, s.Deployment())
+	})
+	t.Run("Type", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			Type:               "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, tokens.Type("expected-value"), s.Type())
+	})
+	t.Run("Provider", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			Provider:           "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, "expected-value", s.Provider())
+	})
+	t.Run("URN", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			URN:                "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, resource.URN("expected-value"), s.URN())
+	})
+	t.Run("Old", func(t *testing.T) {
+		t.Parallel()
+		old := &resource.State{
+			URN:                "expected-value",
+			PendingReplacement: true,
+		}
+		s := NewRemovePendingReplaceStep(nil, old)
+		assert.Equal(t, old, s.Old())
+	})
+	t.Run("New", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.Equal(t, (*resource.State)(nil), s.New())
+	})
+	t.Run("Res", func(t *testing.T) {
+		t.Parallel()
+		old := &resource.State{
+			PendingReplacement: true,
+		}
+		s := NewRemovePendingReplaceStep(nil, old)
+		assert.Equal(t, old, s.Res())
+	})
+	t.Run("Logical", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.False(t, s.Logical())
+	})
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		status, _, err := s.Apply(true)
+		assert.NoError(t, err)
+		assert.Equal(t, resource.StatusOK, status)
+	})
+}
+
+func TestUpdateStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					UpdateF: func(
+						urn resource.URN, id resource.ID,
+						oldInputs, oldOutputs, newInputs resource.PropertyMap,
+						timeout float64, ignoreChanges []string, preview bool,
+					) (resource.PropertyMap, resource.Status, error) {
+						return nil, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					UpdateF: func(
+						urn resource.URN, id resource.ID,
+						oldInputs, oldOutputs, newInputs resource.PropertyMap,
+						timeout float64, ignoreChanges []string, preview bool,
+					) (resource.PropertyMap, resource.Status, error) {
+						return resource.PropertyMap{
+								"key": resource.NewStringProperty("expected-value"),
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "intentional error")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, resource.PropertyMap{
+				"key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+		})
+	})
+}
+
+func TestReplaceStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Deployment", func(t *testing.T) {
+		t.Parallel()
+		d := &Deployment{}
+		s := ReplaceStep{deployment: d}
+		assert.Equal(t, d, s.Deployment())
+	})
+}
+
+func TestReadStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{}, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{
+								ID: "new-id",
+								Inputs: resource.PropertyMap{
+									"inputs-key": resource.NewStringProperty("expected-value"),
+								},
+								Outputs: resource.PropertyMap{
+									"outputs-key": resource.NewStringProperty("expected-value"),
+								},
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "intentional error")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, (resource.PropertyMap)(nil), s.new.Inputs)
+			assert.Equal(t, resource.PropertyMap{
+				"outputs-key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+			assert.Equal(t, resource.ID("new-id"), s.new.ID)
+		})
+		t.Run("unknown id", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				new: &resource.State{
+					ID: plugin.UnknownStringValue,
+				},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						panic("should not be called")
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.NoError(t, err)
+			assert.Equal(t, resource.StatusOK, status)
+			// News should be updated.
+			assert.Equal(t, resource.PropertyMap{}, s.new.Outputs)
+		})
+	})
+}
+
+func TestRefreshStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &RefreshStep{
+				old: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &RefreshStep{
+				old: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{}, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &RefreshStep{
+				old: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Type:   "some-type",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{Diag: &deploytest.NoopSink{}},
+				},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{
+								ID: "new-id",
+								Inputs: resource.PropertyMap{
+									"inputs-key": resource.NewStringProperty("expected-value"),
+								},
+								Outputs: resource.PropertyMap{
+									"outputs-key": resource.NewStringProperty("expected-value"),
+								},
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.NoError(t, err, "InitError should be discarded")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, resource.PropertyMap{
+				"outputs-key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+			assert.Equal(t, resource.ID("new-id"), s.new.ID)
+		})
+	})
+}
+
+func TestImportStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("missing parent", func(t *testing.T) {
+			t.Parallel()
+			s := &ImportStep{
+				planned: true,
+				new: &resource.State{
+					Parent: "urn:pulumi:stack::project::foo:bar:Bar::name",
+				},
+				deployment: &Deployment{
+					olds: map[resource.URN]*resource.State{},
+					news: &resourceMap{},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "unknown parent")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("getProvider error", func(t *testing.T) {
+			t.Parallel()
+			s := &ImportStep{
+				new: &resource.State{
+					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ID:     "some-id",
+					Custom: true,
+				},
+				deployment: &Deployment{
+					olds: map[resource.URN]*resource.State{},
+					news: &resourceMap{},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "bad provider reference")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("provider read error", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, expectedErr
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("init error", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.Error(t, err)
+				assert.Equal(t, resource.StatusOK, status)
+				assert.Len(t, s.new.InitErrors, 1)
+			})
+			t.Run("resource does not exist", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "does not exist")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("provider does not support importing resources", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "provider does not support importing resources")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+		t.Run("provider check error", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				var readCalled bool
+				var checkCalled bool
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Type:   "foo:bar:Bar",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					randomSeed: []byte{},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							readCalled = true
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+								Inputs:  resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+						CheckF: func(
+							urn resource.URN, olds, news resource.PropertyMap, randomSeed []byte,
+						) (resource.PropertyMap, []plugin.CheckFailure, error) {
+							checkCalled = true
+							return resource.PropertyMap{}, nil, expectedErr
+						},
+					},
+				}
+				_, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, readCalled)
+				assert.True(t, checkCalled)
+			})
+			t.Run("failures", func(t *testing.T) {
+				t.Parallel()
+				var readCalled bool
+				var checkCalled bool
+				s := &ImportStep{
+					new: &resource.State{
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:       "some-id",
+						Type:     "foo:bar:Bar",
+						Custom:   true,
+						Parent:   "urn:pulumi:stack::project::pulumi:pulumi:Stack::name",
+						Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+					},
+					planned: true,
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+						ctx: &plugin.Context{
+							Diag: &deploytest.NoopSink{},
+						},
+					},
+					randomSeed: []byte{},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							readCalled = true
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+								Inputs:  resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+						CheckF: func(
+							urn resource.URN, olds, news resource.PropertyMap, randomSeed []byte,
+						) (resource.PropertyMap, []plugin.CheckFailure, error) {
+							checkCalled = true
+							return resource.PropertyMap{}, []plugin.CheckFailure{
+								{
+									Reason: "intentional failure",
+								},
+							}, nil
+						},
+					},
+				}
+				_, _, err := s.Apply(true)
+				assert.NoError(t, err)
+				assert.True(t, readCalled)
+				assert.True(t, checkCalled)
+			})
+		})
+	})
+}
+
+func TestGetProvider(t *testing.T) {
+	t.Parallel()
+	t.Run("ensure default is not selected", func(t *testing.T) {
+		t.Parallel()
+		s := &CreateStep{
+			new: &resource.State{
+				Provider: "invalid-provider",
+			},
+		}
+		prov, err := getProvider(s, s.provider)
+		assert.Nil(t, prov)
+		assert.ErrorContains(t, err, "bad provider reference")
+	})
+	t.Run("ensure default is not selected", func(t *testing.T) {
+		t.Parallel()
+		expectedProvider := &deploytest.Provider{}
+		s := &CreateStep{
+			provider: expectedProvider,
+			new: &resource.State{
+				Provider: "invalid-provider",
+			},
+		}
+		prov, err := getProvider(s, s.provider)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedProvider, prov)
+	})
+}
+
+func TestSuffix(t *testing.T) {
+	t.Parallel()
+	for op, expectation := range map[display.StepOp]string{
+		OpSame:                 "",
+		OpCreate:               "",
+		OpDelete:               "",
+		OpDeleteReplaced:       "",
+		OpRead:                 "",
+		OpReadDiscard:          "",
+		OpDiscardReplaced:      "",
+		OpRemovePendingReplace: "",
+		OpImport:               "",
+		"not-a-real-step-op":   "",
+
+		OpCreateReplacement: colors.Reset,
+		OpUpdate:            colors.Reset,
+		OpReplace:           colors.Reset,
+		OpReadReplacement:   colors.Reset,
+		OpRefresh:           colors.Reset,
+		OpImportReplacement: colors.Reset,
+	} {
+		assert.Equal(t, expectation, Suffix(op))
+	}
 }

--- a/pkg/resource/deploy/target_test.go
+++ b/pkg/resource/deploy/target_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTarget(t *testing.T) {
+	t.Parallel()
+	t.Run("GetPackageConfig", func(t *testing.T) {
+		t.Parallel()
+		t.Run("bad crypter", func(t *testing.T) {
+			t.Parallel()
+			t.Run("secret in namespace", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := fmt.Errorf("expected error")
+				target := &Target{
+					Config: config.Map{
+						config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
+						config.MustMakeKey("test", "regular"): config.NewValue("secret-value"),
+					},
+					Decrypter: &decrypterMock{
+						DecryptValueF: func(
+							ctx context.Context, ciphertext string,
+						) (string, error) {
+							return "", expectedErr
+						},
+					},
+				}
+				_, err := target.GetPackageConfig("test")
+				assert.ErrorIs(t, err, expectedErr)
+			})
+			t.Run("different namespace", func(t *testing.T) {
+				target := &Target{
+					Config: config.Map{
+						config.MustMakeKey("a", "val"): config.NewSecureValue("secret-value"),
+						config.MustMakeKey("b", "val"): config.NewValue("plain-value"),
+					},
+					Decrypter: &decrypterMock{},
+				}
+				_, err := target.GetPackageConfig("something-else")
+				assert.NoError(t, err)
+			})
+		})
+		t.Run("ok", func(t *testing.T) {
+			expectedErr := fmt.Errorf("expected error")
+			target := &Target{
+				Config: config.Map{
+					config.MustMakeKey("a", "val"):        config.NewValue("a-value"),
+					config.MustMakeKey("b", "val"):        config.NewValue("b-value"),
+					config.MustMakeKey("c", "val"):        config.NewValue("c-value"),
+					config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
+					config.MustMakeKey("test", "regular"): config.NewValue("regular-value"),
+				},
+				Decrypter: &decrypterMock{
+					DecryptValueF: func(
+						ctx context.Context, ciphertext string,
+					) (string, error) {
+						return ciphertext, nil
+					},
+				},
+			}
+			res, err := target.GetPackageConfig("test")
+			assert.NoError(t, err, expectedErr)
+
+			cfg := res.Mappable()
+			assert.Equal(t, "regular-value", cfg["regular"])
+			secret, ok := cfg["secret"].(*resource.Secret)
+			assert.True(t, ok)
+			assert.Equal(t, "secret-value", secret.Element.V)
+
+			_, ok = cfg["a"].(*resource.Secret)
+			assert.False(t, ok)
+		})
+	})
+}

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args


### PR DESCRIPTION
Adds coverage to `pkg/resource/deploy` 83%->90%

**Not intended for merging or review**. This PR exists to simplify tracking progress on coverage goals, reduce the load on CI.

Tracking PRs:

- https://github.com/pulumi/pulumi/pull/14970
  - [ ] deploytest/provider.go
  - [ ] deploytest/provider_test.go
- https://github.com/pulumi/pulumi/pull/14979
  - [ ] source_eval_test.go
- https://github.com/pulumi/pulumi/pull/14955
  - [ ] source_query_test.go
- https://github.com/pulumi/pulumi/pull/14997
  - [ ] import_test.go
  - [ ] step.go
  - [ ] step_executor_test.go
  - [ ] step_generator_test.go
  - [ ] step_test.go
- https://github.com/pulumi/pulumi/pull/14981
  - [ ] target_test.go
- https://github.com/pulumi/pulumi/pull/14982
  - [ ] source_error_test.go