### PR TITLE
Automation API support for listing environments

### DIFF
--- a/changelog/pending/20231221--auto-go-nodejs-python--adds-listenvironments-support.yaml
+++ b/changelog/pending/20231221--auto-go-nodejs-python--adds-listenvironments-support.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Adds ListEnvironments support to Go, Nodejs and Python Automation API.

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1727,6 +1727,12 @@ func TestEnvFunctions(t *testing.T) {
 	require.NoError(t, s.AddEnvironments(ctx, "automation-api-test-env", "automation-api-test-env-2"),
 		"adding environments failed, err: %v", err)
 
+	envs, err := s.ListEnvironments(ctx)
+	require.NoError(t, err, "listing environments failed, err: %v", err)
+	assert.Equal(t, 2, len(envs))
+	assert.Equal(t, "automation-api-test-env", envs[0])
+	assert.Equal(t, "automation-api-test-env-2", envs[1])
+
 	// Check that we can access config from the envs
 	cfg, err := s.GetAllConfig(ctx)
 	require.NoError(t, err, "getting config failed, err: %v", err)
@@ -1734,6 +1740,11 @@ func TestEnvFunctions(t *testing.T) {
 	assert.Equal(t, "business", cfg["testproj:also"].Value)
 
 	err = s.RemoveEnvironment(ctx, "automation-api-test-env")
+	envs, err = s.ListEnvironments(ctx)
+	require.NoError(t, err, "listing environments failed, err: %v", err)
+	assert.Equal(t, 1, len(envs))
+	assert.Equal(t, "automation-api-test-env-2", envs[0])
+
 	require.NoError(t, err, "removing environment failed, err: %v", err)
 	_, err = s.GetConfig(ctx, "new_key")
 	assert.Error(t, err)
@@ -1741,6 +1752,9 @@ func TestEnvFunctions(t *testing.T) {
 	assert.Equal(t, "business", v.Value)
 
 	err = s.RemoveEnvironment(ctx, "automation-api-test-env-2")
+	envs, err = s.ListEnvironments(ctx)
+	require.NoError(t, err, "listing environments failed, err: %v", err)
+	assert.Equal(t, 0, len(envs))
 	require.NoError(t, err, "removing environment failed, err: %v", err)
 	_, err = s.GetConfig(ctx, "also")
 	assert.Error(t, err)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1729,9 +1729,7 @@ func TestEnvFunctions(t *testing.T) {
 
 	envs, err := s.ListEnvironments(ctx)
 	require.NoError(t, err, "listing environments failed, err: %v", err)
-	assert.Equal(t, 2, len(envs))
-	assert.Equal(t, "automation-api-test-env", envs[0])
-	assert.Equal(t, "automation-api-test-env-2", envs[1])
+	assert.Equal(t, []string{"automation-api-test-env", "automation-api-test-env-2"}, envs)
 
 	// Check that we can access config from the envs
 	cfg, err := s.GetAllConfig(ctx)
@@ -1742,8 +1740,7 @@ func TestEnvFunctions(t *testing.T) {
 	err = s.RemoveEnvironment(ctx, "automation-api-test-env")
 	envs, err = s.ListEnvironments(ctx)
 	require.NoError(t, err, "listing environments failed, err: %v", err)
-	assert.Equal(t, 1, len(envs))
-	assert.Equal(t, "automation-api-test-env-2", envs[0])
+	assert.Equal(t, []string{"automation-api-test-env-2"}, envs)
 
 	require.NoError(t, err, "removing environment failed, err: %v", err)
 	_, err = s.GetConfig(ctx, "new_key")
@@ -1754,7 +1751,7 @@ func TestEnvFunctions(t *testing.T) {
 	err = s.RemoveEnvironment(ctx, "automation-api-test-env-2")
 	envs, err = s.ListEnvironments(ctx)
 	require.NoError(t, err, "listing environments failed, err: %v", err)
-	assert.Equal(t, 0, len(envs))
+	assert.Len(t, envs, 0)
 	require.NoError(t, err, "removing environment failed, err: %v", err)
 	_, err = s.GetConfig(ctx, "also")
 	assert.Error(t, err)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -682,6 +682,11 @@ func (s *Stack) AddEnvironments(ctx context.Context, envs ...string) error {
 	return s.Workspace().AddEnvironments(ctx, s.Name(), envs...)
 }
 
+// ListEnvironments returns the list of environments from the stack's configuration.
+func (s *Stack) ListEnvironments(ctx context.Context) ([]string, error) {
+	return s.Workspace().ListEnvironments(ctx, s.Name())
+}
+
 // RemoveEnvironment removes an environment from a stack's configuration.
 func (s *Stack) RemoveEnvironment(ctx context.Context, env string) error {
 	return s.Workspace().RemoveEnvironment(ctx, s.Name(), env)

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -46,6 +46,8 @@ type Workspace interface {
 	PostCommandCallback(context.Context, string) error
 	// AddEnvironments adds the specified environments to the provided stack's configuration.
 	AddEnvironments(context.Context, string, ...string) error
+	// ListEnvironments returns the list of environments from the provided stack's configuration.
+	ListEnvironments(context.Context, string) ([]string, error)
 	// RemoveEnvironment removes the specified environment from the provided stack's configuration.
 	RemoveEnvironment(context.Context, string, string) error
 	// GetConfig returns the value associated with the specified stack name and key,

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -478,7 +478,7 @@ export class LocalWorkspace implements Workspace {
             ver = semver.parse("3.0.0")!;
         }
 
-        // 3.99 added this command (
+        // 3.99 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.99.0)
         if (ver.compare("3.99.0") < 0) {
             throw new Error(`listEnvironments requires Pulumi version >= 3.99.0`);
         }

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -467,6 +467,26 @@ export class LocalWorkspace implements Workspace {
         await this.runPulumiCmd(["config", "env", "add", ...environments, "--stack", stackName, "--yes"]);
     }
     /**
+     * Returns the list of environments associated with the specified stack name.
+     *
+     * @param stackName The stack to operate on
+     */
+    async listEnvironments(stackName: string): Promise<string[]> {
+        let ver = this._pulumiVersion;
+        if (ver === undefined) {
+            // Assume an old version. Doesn't really matter what this is as long as it's pre-3.99.
+            ver = semver.parse("3.0.0")!;
+        }
+
+        // 3.99 added this command (
+        if (ver.compare("3.99.0") < 0) {
+            throw new Error(`listEnvironments requires Pulumi version >= 3.99.0`);
+        }
+
+        const result = await this.runPulumiCmd(["config", "env", "ls", "--stack", stackName, "--json"]);
+        return JSON.parse(result.stdout);
+    }
+    /**
      * Removes an environment from a stack's import list.
      *
      * @param stackName The stack to operate on

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -547,6 +547,12 @@ Event: ${line}\n${e.toString()}`);
         await this.workspace.addEnvironments(this.name, ...environments);
     }
     /**
+     * Returns the list of environments currently in the stack's import list.
+     */
+    async listEnvironments(): Promise<string[]> {
+        return this.workspace.listEnvironments(this.name);
+    }
+    /**
      * Removes an environment from a stack's import list.
      *
      * @param environment The name of the environment to remove from the stack's configuration

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -101,6 +101,12 @@ export interface Workspace {
      */
     addEnvironments(stackName: string, ...environments: string[]): Promise<void>;
     /**
+     * Returns the list of environments associated with the specified stack name.
+     *
+     * @param stackName The stack to operate on
+     */
+    listEnvironments(stackName: string): Promise<string[]>;
+    /**
      * Removes an environment from a stack's import list.
      *
      * @param stackName The stack to operate on

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -166,9 +166,7 @@ describe("LocalWorkspace", () => {
         await stack.addEnvironments("automation-api-test-env", "automation-api-test-env-2");
 
         let envs = await stack.listEnvironments();
-        assert.strictEqual(envs.length, 2);
-        assert.strictEqual(envs[0], "automation-api-test-env");
-        assert.strictEqual(envs[1], "automation-api-test-env-2");
+        assert.deepStrictEqual(envs, ["automation-api-test-env", "automation-api-test-env-2"]);
 
         const config = await stack.getAllConfig();
         assert.strictEqual(config["node_env_test:new_key"].value, "test_value");
@@ -177,8 +175,7 @@ describe("LocalWorkspace", () => {
         // Removing existing env should succeed.
         await stack.removeEnvironment("automation-api-test-env");
         envs = await stack.listEnvironments();
-        assert.strictEqual(envs.length, 1);
-        assert.strictEqual(envs[0], "automation-api-test-env-2");
+        assert.deepStrictEqual(envs, ["automation-api-test-env-2"]);
 
         const alsoConfig = await stack.getConfig("also");
         assert.strictEqual(alsoConfig.value, "business");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -165,17 +165,28 @@ describe("LocalWorkspace", () => {
         // Adding existing envs should succeed.
         await stack.addEnvironments("automation-api-test-env", "automation-api-test-env-2");
 
+        let envs = await stack.listEnvironments();
+        assert.strictEqual(envs.length, 2);
+        assert.strictEqual(envs[0], "automation-api-test-env");
+        assert.strictEqual(envs[1], "automation-api-test-env-2");
+
         const config = await stack.getAllConfig();
         assert.strictEqual(config["node_env_test:new_key"].value, "test_value");
         assert.strictEqual(config["node_env_test:also"].value, "business");
 
         // Removing existing env should succeed.
         await stack.removeEnvironment("automation-api-test-env");
+        envs = await stack.listEnvironments();
+        assert.strictEqual(envs.length, 1);
+        assert.strictEqual(envs[0], "automation-api-test-env-2");
+
         const alsoConfig = await stack.getConfig("also");
         assert.strictEqual(alsoConfig.value, "business");
         await assert.rejects(stack.getConfig("new_key"), "stack.getConfig('new_key') did not reject");
 
         await stack.removeEnvironment("automation-api-test-env-2");
+        envs = await stack.listEnvironments();
+        assert.strictEqual(envs.length, 0);
         await assert.rejects(stack.getConfig("also"), "stack.getConfig('also') did not reject");
 
         await ws.removeStack(stackName);

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -234,6 +234,23 @@ class LocalWorkspace(Workspace):
                 "upgrade to at least version 3.95.0."
             )
 
+    def list_environments(self, stack_name: str) -> List[str]:
+        # Assume an old version. Doesn't really matter what this is as long as it's pre-3.99.
+        ver = VersionInfo(3)
+        if self.__pulumi_version is not None:
+            ver = VersionInfo.parse(self.__pulumi_version)
+
+        if ver >= VersionInfo(3, 99):
+            result = self._run_pulumi_cmd_sync(
+                ["config", "env", "ls", "--json", "--stack", stack_name]
+            )
+            return json.loads(result.stdout)
+        else:
+            raise InvalidVersionError(
+                "The installed version of the CLI does not support this operation. Please "
+                "upgrade to at least version 3.99.0."
+            )
+
     def remove_environment(self, stack_name: str, environment_name: str) -> None:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.95.
         ver = VersionInfo(3)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -240,6 +240,7 @@ class LocalWorkspace(Workspace):
         if self.__pulumi_version is not None:
             ver = VersionInfo.parse(self.__pulumi_version)
 
+        # 3.99 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.99.0)
         if ver >= VersionInfo(3, 99):
             result = self._run_pulumi_cmd_sync(
                 ["config", "env", "ls", "--json", "--stack", stack_name]

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -246,11 +246,11 @@ class LocalWorkspace(Workspace):
                 ["config", "env", "ls", "--json", "--stack", stack_name]
             )
             return json.loads(result.stdout)
-        else:
-            raise InvalidVersionError(
-                "The installed version of the CLI does not support this operation. Please "
-                "upgrade to at least version 3.99.0."
-            )
+
+        raise InvalidVersionError(
+            "The installed version of the CLI does not support this operation. Please "
+            "upgrade to at least version 3.99.0."
+        )
 
     def remove_environment(self, stack_name: str, environment_name: str) -> None:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.95.

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -590,6 +590,12 @@ class Stack:
         """
         return self.workspace.add_environments(self.name, *environment_names)
 
+    def list_environments(self) -> List[str]:
+        """
+        Returns the list of environments specified in a stack's configuration.
+        """
+        return self.workspace.list_environments(self.name)
+
     def remove_environment(self, environment_name: str) -> None:
         """
         Removes an environment from a stack's import list.

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -214,7 +214,17 @@ class Workspace(ABC):
         environment.
 
 
+        :param stack_name: The name of the stack.
         :param environment_names: The names of the environment to add.
+        """
+
+    @abstractmethod
+    def list_environments(self, stack_name: str) -> List[str]:
+        """
+        Returns the list of environments specified in a stack's configuration.
+
+        :param stack_name: The name of the stack.
+        :returns: List[str]
         """
 
     @abstractmethod

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -236,9 +236,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
         # Ensure envs can be listed
         envs = stack.list_environments()
-        self.assertEqual(len(envs), 2)
-        self.assertEqual(envs[0], "automation-api-test-env")
-        self.assertEqual(envs[1], "automation-api-test-env-2")
+        self.assertListEqual(envs, ["automation-api-test-env", "automation-api-test-env-2"])
 
         # Check that we can access config from each env.
         config = stack.get_all_config()
@@ -250,8 +248,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
         # Check that only one env remains
         envs = stack.list_environments()
-        self.assertEqual(len(envs), 1)
-        self.assertEqual(envs[0], "automation-api-test-env")
+        self.assertListEqual(envs, ["automation-api-test-env"])
 
         # Check that we can still access config from the remaining env,
         # and that the config from the removed env is no longer present.

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -231,12 +231,14 @@ class TestLocalWorkspace(unittest.TestCase):
         # Ensure an env that doesn't exist errors
         self.assertRaises(CommandError, stack.add_environments, "non-existent-env")
 
-        # Ideally here we would be able to check that the envs were added/removed, but the CLI doesn't
-        # currently support listing envs from a stack configuration. We can at least check that the
-        # commands don't error.
-
         # Ensure envs that do exist can be added
         stack.add_environments("automation-api-test-env", "automation-api-test-env-2")
+
+        # Ensure envs can be listed
+        envs = stack.list_environments()
+        self.assertEqual(len(envs), 2)
+        self.assertEqual(envs[0], "automation-api-test-env")
+        self.assertEqual(envs[1], "automation-api-test-env-2")
 
         # Check that we can access config from each env.
         config = stack.get_all_config()
@@ -246,6 +248,11 @@ class TestLocalWorkspace(unittest.TestCase):
         # Ensure envs can be removed
         stack.remove_environment("automation-api-test-env-2")
 
+        # Check that only one env remains
+        envs = stack.list_environments()
+        self.assertEqual(len(envs), 1)
+        self.assertEqual(envs[0], "automation-api-test-env")
+
         # Check that we can still access config from the remaining env,
         # and that the config from the removed env is no longer present.
         self.assertEqual(stack.get_config("new_key").value, "test_value")
@@ -253,6 +260,10 @@ class TestLocalWorkspace(unittest.TestCase):
 
         stack.remove_environment("automation-api-test-env")
         self.assertRaises(CommandError, stack.get_config, "new_key")
+
+        # Check that no envs remain
+        envs = stack.list_environments()
+        self.assertEqual(len(envs), 0)
 
         ws.remove_stack(stack_name)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Automation API support for `pulumi config env ls`

Fixes https://github.com/pulumi/pulumi/issues/14797

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
