### PR TITLE
fix data race for mocked backendInstance

### DIFF
--- a/pkg/cmd/pulumi/new_ai_test.go
+++ b/pkg/cmd/pulumi/new_ai_test.go
@@ -26,9 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint:paralleltest // mocks backendInstance
 func TestErrorsOnNonHTTPBackend(t *testing.T) {
-	t.Parallel()
-
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
 	mockBackendInstance(t, &backend.MockBackend{
@@ -57,13 +56,12 @@ type mockReaderCloser struct {
 
 func (mockReaderCloser) Close() error { return nil }
 
+//nolint:paralleltest // mocks backendInstance
 func TestExpectEOFOnHTTPBackend(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// This test behaves differently on Windows, due to an interaction between survey & os.Stdin.
 		t.Skip()
 	}
-
-	t.Parallel()
 
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)


### PR DESCRIPTION
Tests with mocked backend instances can't be run in parallel, since the backendInstance is a global.  Make these tests not parallel to avoid the race.

Fixes #14993