### PR TITLE
[ci] `pkg/resource/deploy/(step(_generator|_executor)?|import).go` coverage

### DIFF
--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -1,0 +1,205 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImportDeployment(t *testing.T) {
+	t.Parallel()
+	t.Run("NewImportDeployment", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error in migrate providers", func(t *testing.T) {
+			t.Parallel()
+			var decrypterCalled bool
+			_, err := NewImportDeployment(&plugin.Context{}, &Target{
+				Snapshot: &Snapshot{
+					Resources: []*resource.State{
+						{
+							URN:    "urn:pulumi:stack::project::type::oldName",
+							Custom: true,
+						},
+					},
+				},
+				Name: tokens.MustParseStackName("target-name"),
+				Config: config.Map{
+					config.MustMakeKey("", "secret"): config.NewSecureValue("secret"),
+				},
+				Decrypter: &decrypterMock{
+					DecryptValueF: func(ctx context.Context, ciphertext string) (string, error) {
+						decrypterCalled = true
+						return "", fmt.Errorf("expected fail")
+					},
+				},
+			}, "projectName", nil, true)
+			assert.ErrorContains(t, err, "could not fetch configuration for default provider")
+			assert.True(t, decrypterCalled)
+		})
+	})
+}
+
+func TestImporter(t *testing.T) {
+	t.Parallel()
+	t.Run("registerProviders", func(t *testing.T) {
+		t.Parallel()
+		t.Run("incorrect package type specified", func(t *testing.T) {
+			t.Parallel()
+			i := &importer{
+				deployment: &Deployment{
+					imports: []Import{
+						{
+							Type: "::",
+						},
+					},
+					target: &Target{
+						Name: tokens.MustParseStackName("stack-name"),
+					},
+					source: &nullSource{
+						project: "project-name",
+					},
+				},
+			}
+			_, _, err := i.registerProviders(context.Background())
+			assert.ErrorContains(t, err, "incorrect package type specified")
+		})
+		t.Run("ensure provider is called correctly", func(t *testing.T) {
+			t.Parallel()
+			version := semver.MustParse("1.0.0")
+			expectedErr := errors.New("expected error")
+			i := &importer{
+				deployment: &Deployment{
+					goals:  &goalMap{},
+					ctx:    &plugin.Context{Diag: &deploytest.NoopSink{}},
+					target: &Target{},
+					source: &nullSource{},
+					providers: providers.NewRegistry(&mockHost{
+						ProviderF: func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+							assert.Equal(t, tokens.Package("foo"), pkg)
+							assert.Equal(t, "1.0.0", version.String())
+							return nil, expectedErr
+						},
+					}, true, nil),
+					imports: []Import{
+						{
+							Version:           &version,
+							PluginDownloadURL: "download-url",
+							PluginChecksums: map[string][]byte{
+								"a": {},
+								"b": {},
+								"c": {},
+							},
+							Type: "foo:bar:Bar",
+						},
+					},
+				},
+			}
+			_, _, err := i.registerProviders(context.Background())
+			assert.ErrorIs(t, err, expectedErr)
+		})
+	})
+	t.Run("importResources", func(t *testing.T) {
+		t.Parallel()
+		t.Run("registerExistingResources", func(t *testing.T) {
+			t.Parallel()
+			t.Run("ok", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						prev: &Snapshot{
+							Resources: []*resource.State{
+								{
+									URN: "some-urn",
+								},
+							},
+						},
+						goals:  &goalMap{},
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+		})
+		t.Run("getOrCreateStackResource", func(t *testing.T) {
+			t.Parallel()
+			t.Run("ok", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+			t.Run("ignore existing delete resources", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				i := &importer{
+					executor: &stepExecutor{
+						ctx: ctx,
+					},
+					deployment: &Deployment{
+						prev: &Snapshot{
+							Resources: []*resource.State{
+								{
+									Delete: true,
+								},
+							},
+						},
+						// goals is left nil as nothing should be added to it.
+						goals:  nil,
+						source: &nullSource{},
+						target: &Target{},
+						imports: []Import{
+							{},
+						},
+					},
+				}
+				assert.NoError(t, i.importResources(ctx))
+			})
+		})
+	})
+}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -163,6 +163,7 @@ type CreateStep struct {
 	detailedDiff  map[string]plugin.PropertyDiff // the structured property diff (only for replacements).
 	replacing     bool                           // true if this is a create due to a replacement.
 	pendingDelete bool                           // true if this replacement should create a pending delete.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 var _ Step = (*CreateStep)(nil)
@@ -239,7 +240,7 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	resourceStatus := resource.StatusOK
 	if s.new.Custom {
 		// Invoke the Create RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -291,6 +292,7 @@ type DeleteStep struct {
 	old            *resource.State       // the state of the existing resource.
 	replacing      bool                  // true if part of a replacement.
 	otherDeletions map[resource.URN]bool // other resources that are planned to delete
+	provider       plugin.Provider       // the optional provider to use.
 }
 
 var _ Step = (*DeleteStep)(nil)
@@ -410,7 +412,7 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		// Not preview and not external and not Drop and is custom, do the actual delete
 
 		// Invoke the Delete RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -463,6 +465,7 @@ type UpdateStep struct {
 	diffs         []resource.PropertyKey         // the keys causing a diff.
 	detailedDiff  map[string]plugin.PropertyDiff // the structured diff.
 	ignoreChanges []string                       // a list of property paths to ignore when updating.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 var _ Step = (*UpdateStep)(nil)
@@ -521,7 +524,7 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	resourceStatus := resource.StatusOK
 	if s.new.Custom {
 		// Invoke the Update RPC function for this provider:
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -633,6 +636,7 @@ type ReadStep struct {
 	old        *resource.State   // the old resource state, if one exists for this urn
 	new        *resource.State   // the new resource state, to be used to query the provider
 	replacing  bool              // whether or not the new resource is replacing the old resource
+	provider   plugin.Provider   // the optional provider to use.
 }
 
 // NewReadStep creates a new Read step.
@@ -708,7 +712,7 @@ func (s *ReadStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 	if id == plugin.UnknownStringValue {
 		s.new.Outputs = resource.PropertyMap{}
 	} else {
-		prov, err := getProvider(s)
+		prov, err := getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -778,6 +782,7 @@ type RefreshStep struct {
 	old        *resource.State // the old resource state, if one exists for this urn
 	new        *resource.State // the new resource state, to be used to query the provider
 	done       chan<- bool     // the channel to use to signal completion, if any
+	provider   plugin.Provider // the optional provider to use.
 }
 
 // NewRefreshStep creates a new Refresh step.
@@ -829,7 +834,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 	}
 
 	// For a custom resource, fetch the resource's provider and read the resource's current state.
-	prov, err := getProvider(s)
+	prov, err := getProvider(s, s.provider)
 	if err != nil {
 		return resource.StatusOK, nil, err
 	}
@@ -909,6 +914,7 @@ type ImportStep struct {
 	detailedDiff  map[string]plugin.PropertyDiff // the structured property diff.
 	ignoreChanges []string                       // a list of property paths to ignore when updating.
 	randomSeed    []byte                         // the random seed to use for Check.
+	provider      plugin.Provider                // the optional provider to use.
 }
 
 func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State,
@@ -1019,7 +1025,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
 		// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.
 		var err error
-		prov, err = getProvider(s)
+		prov, err = getProvider(s, s.provider)
 		if err != nil {
 			return resource.StatusOK, nil, err
 		}
@@ -1350,7 +1356,10 @@ func ConstrainedTo(op display.StepOp, constraint display.StepOp) bool {
 }
 
 // getProvider fetches the provider for the given step.
-func getProvider(s Step) (plugin.Provider, error) {
+func getProvider(s Step, override plugin.Provider) (plugin.Provider, error) {
+	if override != nil {
+		return override, nil
+	}
 	if providers.IsProviderType(s.Type()) {
 		return s.Deployment().providers, nil
 	}

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -15,10 +15,13 @@
 package deploy
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,3 +54,172 @@ func (e *mockRegisterResourceOutputsEvent) Outputs() resource.PropertyMap {
 }
 
 func (e *mockRegisterResourceOutputsEvent) Done() {}
+
+type mockEvents struct {
+	OnResourceStepPreF   func(step Step) (interface{}, error)
+	OnResourceStepPostF  func(ctx interface{}, step Step, status resource.Status, err error) error
+	OnResourceOutputsF   func(step Step) error
+	OnPolicyViolationF   func(resource.URN, plugin.AnalyzeDiagnostic)
+	OnPolicyRemediationF func(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap)
+}
+
+func (e *mockEvents) OnResourceStepPre(step Step) (interface{}, error) {
+	if e.OnResourceStepPreF != nil {
+		return e.OnResourceStepPreF(step)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnResourceStepPost(ctx interface{}, step Step, status resource.Status, err error) error {
+	if e.OnResourceStepPostF != nil {
+		return e.OnResourceStepPostF(ctx, step, status, err)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnResourceOutputs(step Step) error {
+	if e.OnResourceOutputsF != nil {
+		return e.OnResourceOutputsF(step)
+	}
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyViolation(resource.URN, plugin.AnalyzeDiagnostic) {
+	panic("unimplemented")
+}
+
+func (e *mockEvents) OnPolicyRemediation(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap) {
+	panic("unimplemented")
+}
+
+var _ Events = (*mockEvents)(nil)
+
+func TestStepExecutor(t *testing.T) {
+	t.Parallel()
+	t.Run("ExecuteRegisterResourceOutputs", func(t *testing.T) {
+		t.Parallel()
+		t.Run("no plan for resource", func(t *testing.T) {
+			t.Parallel()
+
+			se := &stepExecutor{
+				deployment: &Deployment{
+					plan: &Plan{},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorContains(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}), "no plan for resource")
+		})
+		t.Run("resource should already have a plan", func(t *testing.T) {
+			t.Parallel()
+
+			se := &stepExecutor{
+				opts: Options{
+					GeneratePlan: true,
+				},
+				deployment: &Deployment{
+					newPlans: &resourcePlans{},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorContains(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}), "resource should already have a plan")
+		})
+		t.Run("error in resource outputs", func(t *testing.T) {
+			t.Parallel()
+
+			var cancelCalled bool
+			se := &stepExecutor{
+				cancel: func() {
+					cancelCalled = true
+				},
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceOutputsF: func(step Step) error {
+							return errors.New("expected error")
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			// Does not error.
+			assert.NoError(t, se.ExecuteRegisterResourceOutputs(&registerResourceOutputsEvent{
+				urn: "not-in-plan",
+			}))
+			assert.True(t, cancelCalled)
+		})
+	})
+	t.Run("executeStep", func(t *testing.T) {
+		t.Run("error in onResourceStepPre", func(t *testing.T) {
+			t.Parallel()
+
+			expectedErr := errors.New("expected error")
+			se := &stepExecutor{
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceStepPreF: func(step Step) (interface{}, error) {
+							return nil, expectedErr
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+				},
+				pendingNews: sync.Map{},
+			}
+			se.pendingNews.Store(resource.URN("not-in-plan"), &CreateStep{new: &resource.State{}})
+			assert.ErrorIs(t, se.executeStep(0, &CreateStep{
+				new: &resource.State{URN: "some-urn"},
+			}), expectedErr)
+		})
+		t.Run("disallow mark id secret", func(t *testing.T) {
+			t.Parallel()
+
+			expectedErr := errors.New("expected error")
+			se := &stepExecutor{
+				opts: Options{
+					Events: &mockEvents{
+						OnResourceStepPreF: func(step Step) (interface{}, error) {
+							return nil, nil
+						},
+						OnResourceStepPostF: func(
+							ctx interface{}, step Step, status resource.Status, err error,
+						) error {
+							return expectedErr
+						},
+					},
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+					goals: &goalMap{},
+				},
+				pendingNews: sync.Map{},
+			}
+			step := &CreateStep{
+				new: &resource.State{
+					URN: "some-urn",
+					AdditionalSecretOutputs: []resource.PropertyKey{
+						"id",
+						"non-existent-property",
+					},
+				},
+				provider: &deploytest.Provider{},
+			}
+			assert.ErrorContains(t, se.executeStep(0, step), "post-step event returned an error")
+		})
+	})
+}

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -526,5 +527,200 @@ func TestDeleteProtectedErrorUsesCorrectQuotesOnOS(t *testing.T) {
 			return
 		}
 		assert.Contains(t, gotErrMsg, contains)
+	})
+}
+
+func TestStepGenerator(t *testing.T) {
+	t.Parallel()
+	t.Run("isTargetedForUpdate", func(t *testing.T) {
+		t.Parallel()
+		t.Run("has targeted dependencies", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				opts: Options{
+					TargetDependents: true,
+					Targets: UrnTargets{
+						literals: []resource.URN{"c"},
+					},
+				},
+				targetsActual: UrnTargets{
+					literals: []resource.URN{"b"},
+				},
+			}
+			assert.False(t, sg.isTargetedForUpdate(&resource.State{
+				Dependencies: []resource.URN{"a"},
+			}))
+			assert.True(t, sg.isTargetedForUpdate(&resource.State{
+				Dependencies: []resource.URN{
+					"a",
+					"b", // targeted
+				},
+			}))
+		})
+	})
+	t.Run("checkParent", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+			}
+			_, err := sg.checkParent("does-not-exist", "")
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+	})
+	t.Run("GenerateReadSteps", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+			}
+			_, err := sg.GenerateReadSteps(&readResourceEvent{
+				parent: "does-not-exist",
+			})
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+		t.Run("fail generateURN", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{
+					"urn:pulumi:::::::": true,
+				},
+				deployment: &Deployment{
+					target: &Target{},
+					source: &nullSource{},
+					ctx:    &plugin.Context{Diag: &deploytest.NoopSink{}},
+				},
+			}
+			_, err := sg.GenerateReadSteps(&readResourceEvent{})
+			assert.ErrorContains(t, err, "Duplicate resource URN")
+		})
+	})
+	t.Run("generateSteps", func(t *testing.T) {
+		t.Parallel()
+		t.Run("could not find parent resource", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					target: &Target{},
+					source: &nullSource{},
+				},
+			}
+			_, err := sg.generateSteps(&registerResourceEvent{
+				goal: &resource.Goal{
+					Parent: "does-not-exist",
+				},
+			})
+			assert.ErrorContains(t, err, "could not find parent resource")
+		})
+	})
+	t.Run("determineAllowedResourcesToDeleteFromTargets", func(t *testing.T) {
+		t.Parallel()
+		t.Run("handle non-existent target", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{
+						Resources: []*resource.State{
+							{
+								URN: "a",
+							},
+						},
+					},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			targets, err := sg.determineAllowedResourcesToDeleteFromTargets(UrnTargets{
+				literals: []resource.URN{"a"},
+			})
+			assert.NoError(t, err)
+			assert.Empty(t, targets)
+		})
+	})
+	t.Run("ScheduleDeletes", func(t *testing.T) {
+		t.Parallel()
+		t.Run("don't TrustDependencies", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				opts: Options{
+					TrustDependencies: false,
+				},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			antichains := sg.ScheduleDeletes([]Step{
+				&DeleteStep{},
+				&CreateStep{},
+				&UpdateStep{},
+			})
+			assert.Len(t, antichains, 3)
+		})
+	})
+	t.Run("providerChanged", func(t *testing.T) {
+		t.Parallel()
+		t.Run("invalid old ProviderReference", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "invalid-old-provider",
+				},
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+				},
+			)
+			assert.ErrorContains(t, err, "expected '::' in provider reference 'invalid-old-provider'")
+		})
+		t.Run("invalid new ProviderReference", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev: &Snapshot{},
+					olds: map[resource.URN]*resource.State{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+				},
+				&resource.State{
+					Provider: "invalid-new-provider",
+				},
+			)
+			assert.ErrorContains(t, err, "expected '::' in provider reference 'invalid-new-provider'")
+		})
+		t.Run("error getting new default provider", func(t *testing.T) {
+			t.Parallel()
+			sg := &stepGenerator{
+				urns: map[resource.URN]bool{},
+				deployment: &Deployment{
+					prev:      &Snapshot{},
+					olds:      map[resource.URN]*resource.State{},
+					providers: &providers.Registry{},
+				},
+			}
+			_, err := sg.providerChanged("",
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::default_name::uuid",
+				},
+				&resource.State{
+					Provider: "urn:pulumi:stack::project::pulumi:providers:provider::default_new::uuid",
+				},
+			)
+			assert.ErrorContains(t, err, "failed to resolve provider reference")
+		})
 	})
 }

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -15,9 +15,15 @@
 package deploy
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,4 +104,836 @@ func TestPastTense(t *testing.T) {
 			PastTense("not-a-real-operation")
 		})
 	})
+}
+
+func TestSameStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("bad provider state for resource", func(t *testing.T) {
+			t.Parallel()
+			s := &SameStep{
+				old: &resource.State{
+					URN: "urn:pulumi:stack::project::type::foo",
+				},
+				new: &resource.State{
+					URN:  "urn:pulumi:stack::project::type::foo",
+					Type: "pulumi:providers:some-provider",
+				},
+				deployment: &Deployment{},
+			}
+			_, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "bad provider state for resource")
+		})
+	})
+}
+
+func TestCreateStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("custom", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error getting provider", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+						// Use denydefaultprovider ID to ensure failure.
+						Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("error in create", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				var createCalled bool
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							createCalled = true
+							return "", nil, resource.StatusOK, expectedErr
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, createCalled)
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("handle InitError", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							return "", nil, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "intentional error")
+				assert.Len(t, s.new.InitErrors, 1)
+				assert.Equal(t, resource.StatusPartialFailure, status)
+			})
+			t.Run("error create no ID", func(t *testing.T) {
+				t.Parallel()
+				s := &CreateStep{
+					new: &resource.State{
+						Custom: true,
+					},
+					deployment: &Deployment{},
+					provider: &deploytest.Provider{
+						CreateF: func(
+							urn resource.URN, inputs resource.PropertyMap,
+							timeout float64, preview bool,
+						) (resource.ID, resource.PropertyMap, resource.Status, error) {
+							return "", nil, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(false /* preview */)
+				assert.ErrorContains(t, err, "provider did not return an ID from Create")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+	})
+}
+
+func TestDeleteStep(t *testing.T) {
+	t.Parallel()
+	t.Run("isDeletedWith", func(t *testing.T) {
+		t.Parallel()
+		otherDeletions := map[resource.URN]bool{
+			"false-key": false,
+			"true-key":  true,
+		}
+		assert.False(t, isDeletedWith("", otherDeletions))
+		assert.False(t, isDeletedWith("does-not-exist", otherDeletions))
+		assert.False(t, isDeletedWith("false-key", otherDeletions))
+		assert.True(t, isDeletedWith("true-key", otherDeletions))
+	})
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("custom", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error getting provider", func(t *testing.T) {
+				t.Parallel()
+				s := &DeleteStep{
+					old: &resource.State{
+						Custom: true,
+						// Use denydefaultprovider ID to ensure failure.
+						Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+					},
+				}
+				status, _, err := s.Apply(false)
+				assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+	})
+}
+
+func TestRemovePendingReplaceStep(t *testing.T) {
+	t.Parallel()
+	t.Run("NewRemovePendingReplaceStep", func(t *testing.T) {
+		t.Parallel()
+		t.Run("panics on old=nil", func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() {
+				NewRemovePendingReplaceStep(nil, nil)
+			})
+		})
+		t.Run("panics if not old.PendingReplacement", func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() {
+				NewRemovePendingReplaceStep(nil, &resource.State{
+					PendingReplacement: false,
+				})
+			})
+		})
+	})
+	t.Run("Op", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.Equal(t, OpRemovePendingReplace, s.Op())
+	})
+	t.Run("Deployment", func(t *testing.T) {
+		t.Parallel()
+		d := &Deployment{}
+		s := NewRemovePendingReplaceStep(d, &resource.State{
+			Type:               "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, d, s.Deployment())
+	})
+	t.Run("Type", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			Type:               "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, tokens.Type("expected-value"), s.Type())
+	})
+	t.Run("Provider", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			Provider:           "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, "expected-value", s.Provider())
+	})
+	t.Run("URN", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			URN:                "expected-value",
+			PendingReplacement: true,
+		})
+		assert.Equal(t, resource.URN("expected-value"), s.URN())
+	})
+	t.Run("Old", func(t *testing.T) {
+		t.Parallel()
+		old := &resource.State{
+			URN:                "expected-value",
+			PendingReplacement: true,
+		}
+		s := NewRemovePendingReplaceStep(nil, old)
+		assert.Equal(t, old, s.Old())
+	})
+	t.Run("New", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.Equal(t, (*resource.State)(nil), s.New())
+	})
+	t.Run("Res", func(t *testing.T) {
+		t.Parallel()
+		old := &resource.State{
+			PendingReplacement: true,
+		}
+		s := NewRemovePendingReplaceStep(nil, old)
+		assert.Equal(t, old, s.Res())
+	})
+	t.Run("Logical", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		assert.False(t, s.Logical())
+	})
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		s := NewRemovePendingReplaceStep(nil, &resource.State{
+			PendingReplacement: true,
+		})
+		status, _, err := s.Apply(true)
+		assert.NoError(t, err)
+		assert.Equal(t, resource.StatusOK, status)
+	})
+}
+
+func TestUpdateStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					UpdateF: func(
+						urn resource.URN, id resource.ID,
+						oldInputs, oldOutputs, newInputs resource.PropertyMap,
+						timeout float64, ignoreChanges []string, preview bool,
+					) (resource.PropertyMap, resource.Status, error) {
+						return nil, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &UpdateStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					UpdateF: func(
+						urn resource.URN, id resource.ID,
+						oldInputs, oldOutputs, newInputs resource.PropertyMap,
+						timeout float64, ignoreChanges []string, preview bool,
+					) (resource.PropertyMap, resource.Status, error) {
+						return resource.PropertyMap{
+								"key": resource.NewStringProperty("expected-value"),
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "intentional error")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, resource.PropertyMap{
+				"key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+		})
+	})
+}
+
+func TestReplaceStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Deployment", func(t *testing.T) {
+		t.Parallel()
+		d := &Deployment{}
+		s := ReplaceStep{deployment: d}
+		assert.Equal(t, d, s.Deployment())
+	})
+}
+
+func TestReadStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{}, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				old: &resource.State{},
+				new: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{
+								ID: "new-id",
+								Inputs: resource.PropertyMap{
+									"inputs-key": resource.NewStringProperty("expected-value"),
+								},
+								Outputs: resource.PropertyMap{
+									"outputs-key": resource.NewStringProperty("expected-value"),
+								},
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "intentional error")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, (resource.PropertyMap)(nil), s.new.Inputs)
+			assert.Equal(t, resource.PropertyMap{
+				"outputs-key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+			assert.Equal(t, resource.ID("new-id"), s.new.ID)
+		})
+		t.Run("unknown id", func(t *testing.T) {
+			t.Parallel()
+			s := &ReadStep{
+				new: &resource.State{
+					ID: plugin.UnknownStringValue,
+				},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						panic("should not be called")
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.NoError(t, err)
+			assert.Equal(t, resource.StatusOK, status)
+			// News should be updated.
+			assert.Equal(t, resource.PropertyMap{}, s.new.Outputs)
+		})
+	})
+}
+
+func TestRefreshStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("error getting provider", func(t *testing.T) {
+			t.Parallel()
+			s := &RefreshStep{
+				old: &resource.State{
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "Default provider for 'default_5_42_0' disabled.")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("failure in provider", func(t *testing.T) {
+			t.Parallel()
+			expectedErr := errors.New("expected error")
+			s := &RefreshStep{
+				old: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{}, resource.StatusOK, expectedErr
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorIs(t, err, expectedErr)
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("partial failure in provider", func(t *testing.T) {
+			t.Parallel()
+			s := &RefreshStep{
+				old: &resource.State{
+					URN:    "some-urn",
+					ID:     "some-id",
+					Type:   "some-type",
+					Custom: true,
+					// Use denydefaultprovider ID to ensure failure.
+					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
+				},
+				deployment: &Deployment{
+					ctx: &plugin.Context{Diag: &deploytest.NoopSink{}},
+				},
+				provider: &deploytest.Provider{
+					ReadF: func(
+						urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{
+								ID: "new-id",
+								Inputs: resource.PropertyMap{
+									"inputs-key": resource.NewStringProperty("expected-value"),
+								},
+								Outputs: resource.PropertyMap{
+									"outputs-key": resource.NewStringProperty("expected-value"),
+								},
+							}, resource.StatusPartialFailure, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+					},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.NoError(t, err, "InitError should be discarded")
+			assert.Equal(t, resource.StatusPartialFailure, status)
+
+			// News should be updated.
+			assert.Len(t, s.new.InitErrors, 1)
+			assert.Equal(t, resource.PropertyMap{
+				"outputs-key": resource.NewStringProperty("expected-value"),
+			}, s.new.Outputs)
+			assert.Equal(t, resource.ID("new-id"), s.new.ID)
+		})
+	})
+}
+
+func TestImportStep(t *testing.T) {
+	t.Parallel()
+	t.Run("Apply", func(t *testing.T) {
+		t.Parallel()
+		t.Run("missing parent", func(t *testing.T) {
+			t.Parallel()
+			s := &ImportStep{
+				planned: true,
+				new: &resource.State{
+					Parent: "urn:pulumi:stack::project::foo:bar:Bar::name",
+				},
+				deployment: &Deployment{
+					olds: map[resource.URN]*resource.State{},
+					news: &resourceMap{},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "unknown parent")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("getProvider error", func(t *testing.T) {
+			t.Parallel()
+			s := &ImportStep{
+				new: &resource.State{
+					URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+					ID:     "some-id",
+					Custom: true,
+				},
+				deployment: &Deployment{
+					olds: map[resource.URN]*resource.State{},
+					news: &resourceMap{},
+				},
+			}
+			status, _, err := s.Apply(true)
+			assert.ErrorContains(t, err, "bad provider reference")
+			assert.Equal(t, resource.StatusOK, status)
+		})
+		t.Run("provider read error", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, expectedErr
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("init error", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, &plugin.InitError{
+								Reasons: []string{
+									"intentional error",
+								},
+							}
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.Error(t, err)
+				assert.Equal(t, resource.StatusOK, status)
+				assert.Len(t, s.new.InitErrors, 1)
+			})
+			t.Run("resource does not exist", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{}, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "does not exist")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("provider does not support importing resources", func(t *testing.T) {
+				t.Parallel()
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+					},
+				}
+				status, _, err := s.Apply(true)
+				assert.ErrorContains(t, err, "provider does not support importing resources")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+		})
+		t.Run("provider check error", func(t *testing.T) {
+			t.Parallel()
+			t.Run("error", func(t *testing.T) {
+				t.Parallel()
+				expectedErr := errors.New("expected error")
+				var readCalled bool
+				var checkCalled bool
+				s := &ImportStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:     "some-id",
+						Type:   "foo:bar:Bar",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+					},
+					randomSeed: []byte{},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							readCalled = true
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+								Inputs:  resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+						CheckF: func(
+							urn resource.URN, olds, news resource.PropertyMap, randomSeed []byte,
+						) (resource.PropertyMap, []plugin.CheckFailure, error) {
+							checkCalled = true
+							return resource.PropertyMap{}, nil, expectedErr
+						},
+					},
+				}
+				_, _, err := s.Apply(true)
+				assert.ErrorIs(t, err, expectedErr)
+				assert.True(t, readCalled)
+				assert.True(t, checkCalled)
+			})
+			t.Run("failures", func(t *testing.T) {
+				t.Parallel()
+				var readCalled bool
+				var checkCalled bool
+				s := &ImportStep{
+					new: &resource.State{
+						URN:      "urn:pulumi:stack::project::foo:bar:Bar::name",
+						ID:       "some-id",
+						Type:     "foo:bar:Bar",
+						Custom:   true,
+						Parent:   "urn:pulumi:stack::project::pulumi:pulumi:Stack::name",
+						Provider: "urn:pulumi:stack::project::pulumi:providers:provider::name::uuid",
+					},
+					planned: true,
+					deployment: &Deployment{
+						olds: map[resource.URN]*resource.State{},
+						news: &resourceMap{},
+						ctx: &plugin.Context{
+							Diag: &deploytest.NoopSink{},
+						},
+					},
+					randomSeed: []byte{},
+					provider: &deploytest.Provider{
+						ReadF: func(
+							urn resource.URN, id resource.ID, inputs, state resource.PropertyMap,
+						) (plugin.ReadResult, resource.Status, error) {
+							readCalled = true
+							return plugin.ReadResult{
+								Outputs: resource.PropertyMap{},
+								Inputs:  resource.PropertyMap{},
+							}, resource.StatusOK, nil
+						},
+						CheckF: func(
+							urn resource.URN, olds, news resource.PropertyMap, randomSeed []byte,
+						) (resource.PropertyMap, []plugin.CheckFailure, error) {
+							checkCalled = true
+							return resource.PropertyMap{}, []plugin.CheckFailure{
+								{
+									Reason: "intentional failure",
+								},
+							}, nil
+						},
+					},
+				}
+				_, _, err := s.Apply(true)
+				assert.NoError(t, err)
+				assert.True(t, readCalled)
+				assert.True(t, checkCalled)
+			})
+		})
+	})
+}
+
+func TestGetProvider(t *testing.T) {
+	t.Parallel()
+	t.Run("ensure default is not selected", func(t *testing.T) {
+		t.Parallel()
+		s := &CreateStep{
+			new: &resource.State{
+				Provider: "invalid-provider",
+			},
+		}
+		prov, err := getProvider(s, s.provider)
+		assert.Nil(t, prov)
+		assert.ErrorContains(t, err, "bad provider reference")
+	})
+	t.Run("ensure default is not selected", func(t *testing.T) {
+		t.Parallel()
+		expectedProvider := &deploytest.Provider{}
+		s := &CreateStep{
+			provider: expectedProvider,
+			new: &resource.State{
+				Provider: "invalid-provider",
+			},
+		}
+		prov, err := getProvider(s, s.provider)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedProvider, prov)
+	})
+}
+
+func TestSuffix(t *testing.T) {
+	t.Parallel()
+	for op, expectation := range map[display.StepOp]string{
+		OpSame:                 "",
+		OpCreate:               "",
+		OpDelete:               "",
+		OpDeleteReplaced:       "",
+		OpRead:                 "",
+		OpReadDiscard:          "",
+		OpDiscardReplaced:      "",
+		OpRemovePendingReplace: "",
+		OpImport:               "",
+		"not-a-real-step-op":   "",
+
+		OpCreateReplacement: colors.Reset,
+		OpUpdate:            colors.Reset,
+		OpReplace:           colors.Reset,
+		OpReadReplacement:   colors.Reset,
+		OpRefresh:           colors.Reset,
+		OpImportReplacement: colors.Reset,
+	} {
+		assert.Equal(t, expectation, Suffix(op))
+	}
 }


### PR DESCRIPTION
covers
- step.go
- step_executor.go
- step_generator.go
- import.go

They all depend on an added field to steps that use providers in `Apply()`

# Includes changes to a non-test file: step.go

steps query the deployment for providers. There is not a straightforward way of mocking a provider for a step. I've added a field called `provider plugin.Provider` to steps that use providers to be used instead of querying the Deployment with getProvider(). 

This approach aims to minimize the cognitive complexity and potential for errors in comparison to the branching alternative due to the behavior of `:=` and assigning the value to an existing value while also defining a new variable err.

```diff
-               prov, err := getProvider(s, s.provider)
-               if err != nil {
-                       return resource.StatusOK, nil, err
+               prov := s.provider
+               if prov == nil {
+                       var err error
+                       prov, err = getProvider(s)
+                       if err != nil {
+                               return resource.StatusOK, nil, err
+                       }
                }
```