### PR TITLE
[program-gen/csharp,python] Allow object keys to be template expressions

### DIFF
--- a/changelog/pending/20231223--programgen-dotnet-python--allow-object-keys-to-be-template-expressions-such-as-static-quoted-strings.yaml
+++ b/changelog/pending/20231223--programgen-dotnet-python--allow-object-keys-to-be-template-expressions-such-as-static-quoted-strings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet,python
+  description: Allow object keys to be template expressions such as static quoted strings 

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -499,6 +499,22 @@ func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 	g.genObjectConsExpression(w, expr, expr.Type())
 }
 
+func objectKey(item model.ObjectConsItem) string {
+	switch key := item.Key.(type) {
+	case *model.LiteralValueExpression:
+		return key.Value.AsString()
+	case *model.TemplateExpression:
+		// assume a template expression has one constant part that is a LiteralValueExpression
+		if len(key.Parts) == 1 {
+			if literal, ok := key.Parts[0].(*model.LiteralValueExpression); ok {
+				return literal.Value.AsString()
+			}
+		}
+	}
+
+	return ""
+}
+
 func (g *generator) genObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression, destType model.Type) {
 	typeName := g.argumentTypeName(expr, destType) // Example: aws.s3.BucketLoggingArgs
 	if typeName != "" {
@@ -510,8 +526,8 @@ func (g *generator) genObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 			g.Indented(func() {
 				for _, item := range expr.Items {
 					g.Fgenf(w, "%s", g.Indent)
-					lit := item.Key.(*model.LiteralValueExpression)
-					g.Fprint(w, PyName(lit.Value.AsString()))
+					propertyKey := objectKey(item)
+					g.Fprint(w, PyName(propertyKey))
 					g.Fgenf(w, "=%.v,\n", item.Value)
 				}
 			})

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
@@ -12,6 +12,12 @@ return await Deployment.RunAsync(() =>
         {
             Namespace = "foo",
             Name = "bar",
+            Labels = 
+            {
+                { "app.kubernetes.io/name", "cilium-agent" },
+                { "app.kubernetes.io/part-of", "cilium" },
+                { "k8s-app", "cilium" },
+            },
         },
         Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
         {

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -13,6 +13,11 @@ func main() {
 			Metadata: &metav1.ObjectMetaArgs{
 				Namespace: pulumi.String("foo"),
 				Name:      pulumi.String("bar"),
+				Labels: pulumi.StringMap{
+					"app.kubernetes.io/name":    pulumi.String("cilium-agent"),
+					"app.kubernetes.io/part-of": pulumi.String("cilium"),
+					"k8s-app":                   pulumi.String("cilium"),
+				},
 			},
 			Spec: &corev1.PodSpecArgs{
 				Containers: []corev1.ContainerArgs{

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
@@ -3,6 +3,11 @@ resource bar "kubernetes:core/v1:Pod" {
     metadata = {
         namespace = "foo"
         name = "bar"
+        "labels" = {
+            "app.kubernetes.io/name" = "cilium-agent"
+            "app.kubernetes.io/part-of" = "cilium"
+            "k8s-app" = "cilium"
+        }
     }
     spec = {
         containers = [

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
@@ -6,6 +6,11 @@ const bar = new kubernetes.core.v1.Pod("bar", {
     metadata: {
         namespace: "foo",
         name: "bar",
+        labels: {
+            "app.kubernetes.io/name": "cilium-agent",
+            "app.kubernetes.io/part-of": "cilium",
+            "k8s-app": "cilium",
+        },
     },
     spec: {
         containers: [

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
@@ -6,6 +6,11 @@ bar = kubernetes.core.v1.Pod("bar",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
         namespace="foo",
         name="bar",
+        labels={
+            "app.kubernetes.io/name": "cilium-agent",
+            "app.kubernetes.io/part-of": "cilium",
+            "k8s-app": "cilium",
+        },
     ),
     spec=kubernetes.core.v1.PodSpecArgs(
         containers=[


### PR DESCRIPTION
# Description

I've noticed while working with PCL generated from Kubernetes manifests that when an object property key is quoted for example `{ "key" = value }` instead of `{ key = value }` then program-gen for csharp and python _panic_ because they assume the object keys to be strictly a literal value expression and this type assertion fails:
```go
lit := item.Key.(*model.LiteralValueExpression)
```
This PR fixes this panic and allows program-gen to handle cases where the object keys are `TemplateExpression` assuming that it has one part which is a literal value expression (handling cases like `{ "key" = value }`) 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
