### PR TITLE
[program-gen/pcl] Fixes type-annotating nested resource properties when these have quoted keys

### DIFF
--- a/changelog/pending/20231225--programgen--fixes-type-annotating-nested-resource-properties-when-these-have-quoted-keys.yaml
+++ b/changelog/pending/20231225--programgen--fixes-type-annotating-nested-resource-properties-when-these-have-quoted-keys.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fixes type-annotating nested resource properties when these have quoted keys

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -173,6 +173,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "K8s Template",
 	},
 	{
+		Directory:   "kubernetes-template-quoted",
+		Description: "K8s Template with quoted string property keys to ensure that resource binding works here",
+	},
+	{
 		Directory:   "random-pet",
 		Description: "Random Pet",
 	},

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/dotnet/kubernetes-template-quoted.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/dotnet/kubernetes-template-quoted.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Kubernetes = Pulumi.Kubernetes;
+
+return await Deployment.RunAsync(() => 
+{
+    var argocd_serverDeployment = new Kubernetes.Apps.V1.Deployment("argocd_serverDeployment", new()
+    {
+        ApiVersion = "apps/v1",
+        Kind = "Deployment",
+        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        {
+            Name = "argocd-server",
+        },
+        Spec = new Kubernetes.Types.Inputs.Apps.V1.DeploymentSpecArgs
+        {
+            Selector = new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
+            {
+                MatchLabels = 
+                {
+                    { "app", "server" },
+                },
+            },
+            Replicas = 1,
+            Template = new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
+            {
+                Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+                {
+                    Labels = 
+                    {
+                        { "app", "server" },
+                    },
+                },
+                Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
+                {
+                    Containers = new[]
+                    {
+                        new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
+                        {
+                            Name = "nginx",
+                            Image = "nginx",
+                            Ports = new[]
+                            {
+                                new Kubernetes.Types.Inputs.Core.V1.ContainerPortArgs
+                                {
+                                    ContainerPortValue = 80,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/go/kubernetes-template-quoted.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/go/kubernetes-template-quoted.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := appsv1.NewDeployment(ctx, "argocd_serverDeployment", &appsv1.DeploymentArgs{
+			ApiVersion: pulumi.String("apps/v1"),
+			Kind:       pulumi.String("Deployment"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("argocd-server"),
+			},
+			Spec: &appsv1.DeploymentSpecArgs{
+				Selector: &metav1.LabelSelectorArgs{
+					MatchLabels: pulumi.StringMap{
+						"app": pulumi.String("server"),
+					},
+				},
+				Replicas: pulumi.Int(1),
+				Template: &corev1.PodTemplateSpecArgs{
+					Metadata: &metav1.ObjectMetaArgs{
+						Labels: pulumi.StringMap{
+							"app": pulumi.String("server"),
+						},
+					},
+					Spec: &corev1.PodSpecArgs{
+						Containers: corev1.ContainerArray{
+							&corev1.ContainerArgs{
+								Name:  pulumi.String("nginx"),
+								Image: pulumi.String("nginx"),
+								Ports: corev1.ContainerPortArray{
+									&corev1.ContainerPortArgs{
+										ContainerPort: pulumi.Int(80),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/kubernetes-template-quoted.pp
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/kubernetes-template-quoted.pp
@@ -1,0 +1,35 @@
+resource argocd_serverDeployment "kubernetes:apps/v1:Deployment" {
+	apiVersion = "apps/v1"
+	kind = "Deployment"
+	metadata = {
+		"name" = "argocd-server"
+	}
+	spec = {
+		"selector" = {
+			"matchLabels" = {
+				"app" = "server"
+			}
+		}
+		"replicas" = 1
+		"template" = {
+			"metadata" = {
+				"labels" = {
+					"app" = "server"
+				}
+			}
+			"spec" = {
+				"containers" = [
+					{
+						"name" = "nginx"
+						"image" = "nginx"
+						"ports" = [
+                            {
+                                "containerPort" = 80
+                            }
+                        ]
+					}
+				]
+			}
+		}
+	}
+}

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/nodejs/kubernetes-template-quoted.ts
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/nodejs/kubernetes-template-quoted.ts
@@ -1,0 +1,34 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as kubernetes from "@pulumi/kubernetes";
+
+const argocd_serverDeployment = new kubernetes.apps.v1.Deployment("argocd_serverDeployment", {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: {
+        name: "argocd-server",
+    },
+    spec: {
+        selector: {
+            matchLabels: {
+                app: "server",
+            },
+        },
+        replicas: 1,
+        template: {
+            metadata: {
+                labels: {
+                    app: "server",
+                },
+            },
+            spec: {
+                containers: [{
+                    name: "nginx",
+                    image: "nginx",
+                    ports: [{
+                        containerPort: 80,
+                    }],
+                }],
+            },
+        },
+    },
+});

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/python/kubernetes-template-quoted.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-quoted-pp/python/kubernetes-template-quoted.py
@@ -1,0 +1,33 @@
+import pulumi
+import pulumi_kubernetes as kubernetes
+
+argocd_server_deployment = kubernetes.apps.v1.Deployment("argocd_serverDeployment",
+    api_version="apps/v1",
+    kind="Deployment",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="argocd-server",
+    ),
+    spec=kubernetes.apps.v1.DeploymentSpecArgs(
+        selector=kubernetes.meta.v1.LabelSelectorArgs(
+            match_labels={
+                "app": "server",
+            },
+        ),
+        replicas=1,
+        template=kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                labels={
+                    "app": "server",
+                },
+            ),
+            spec=kubernetes.core.v1.PodSpecArgs(
+                containers=[kubernetes.core.v1.ContainerArgs(
+                    name="nginx",
+                    image="nginx",
+                    ports=[kubernetes.core.v1.ContainerPortArgs(
+                        container_port=80,
+                    )],
+                )],
+            ),
+        ),
+    ))


### PR DESCRIPTION
# Description

When binding resource properties and annotating these with types from their schemas, we seem to skip this annotation process when resource properties and their nested objects use _quoted_ keys `{ "key" = <value> }` rather than using _literal_ keys `{ key = <value> }`. 

This results in issues such as https://github.com/pulumi/kube2pulumi/issues/60 where a csharp property name override was not correctly applied because 
  1) kube2pulumi generated properties for resources that are quoted (this should be fine)
  2) binding the resource properties skipped annotating the nested object with its corresponding schema type
  3) program-gen in dotnet didn't have access to the schema type of the nested object to correctly apply the property override

This PR fixes this issue by extending PCL resource binding to also check for properties which have quoted keys.

Fixes https://github.com/pulumi/kube2pulumi/issues/60 and potentially other issues that arise from converters generating PCL with quoted keys. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
