### PR TITLE
Fix data rate in backend/display/tree_test.go

### DIFF
--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -57,7 +57,7 @@ func TestTreeFrameSize(t *testing.T) {
 			treeRenderer.treeTableRows = treeRenderer.systemMessages
 
 			// Required to get the frame to render.
-			treeRenderer.dirty = true
+			treeRenderer.markDirty()
 
 			// This should not panic.
 			treeRenderer.frame(false /* locked */, false /* done */)


### PR DESCRIPTION
Fixes #15004

The `dirty` member of the interactive renderer is used in a separate goroutines and requires use of a lock to be set correctly.