### PR TITLE
Fix AI prompt repetition on Windows

### DIFF
--- a/changelog/pending/20240103--cli-new--fixes-repeated-ai-prompt-on-windows.yaml
+++ b/changelog/pending/20240103--cli-new--fixes-repeated-ai-prompt-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fixes duplicate printing of the AI prompt & answer on Windows.

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1104,7 +1104,9 @@ func promptForValue(
 			value = defaultValue
 		} else {
 			var prompt string
-			if defaultValue == "" {
+			if valueType == "" && defaultValue == "" {
+				// No need to print anything, this is a full line / blank prompt.
+			} else if defaultValue == "" {
 				prompt = opts.Color.Colorize(
 					fmt.Sprintf("%s%s%s", colors.SpecPrompt, valueType, colors.Reset))
 			} else {
@@ -1147,7 +1149,12 @@ func promptForValue(
 			} else if validationError != nil {
 				// If validation failed, let the user know. If interactive, we will print the error and
 				// prompt the user again; otherwise, in the case of --yes, we fail and report an error.
-				err := fmt.Errorf("Sorry, '%s' is not a valid %s. %w", value, valueType, validationError)
+				var err error
+				if valueType == "" {
+					err = fmt.Errorf("Sorry, '%s' is not valid: %w", value, validationError)
+				} else {
+					err = fmt.Errorf("Sorry, '%s' is not a valid %s: %w", value, valueType, validationError)
+				}
 				if yes {
 					return "", err
 				}

--- a/pkg/cmd/pulumi/new_ai.go
+++ b/pkg/cmd/pulumi/new_ai.go
@@ -168,7 +168,7 @@ var errEmptyPrompt = errors.New("prompt cannot be empty")
 
 func isValidAiPrompt(prompt string) error {
 	if prompt == "" {
-		return errors.New("prompt cannot be empty")
+		return errEmptyPrompt
 	}
 	return nil
 }

--- a/pkg/cmd/pulumi/new_ai_test.go
+++ b/pkg/cmd/pulumi/new_ai_test.go
@@ -15,18 +15,14 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"net/http"
-	"runtime"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint:paralleltest // mocks backendInstance
+//nolint:paralleltest // changes directory
 func TestErrorsOnNonHTTPBackend(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	chdir(t, tempdir)
@@ -48,42 +44,4 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 			context.Background(), testNewArgs,
 		),
 		"please log in to Pulumi Cloud to use Pulumi AI")
-}
-
-type mockReaderCloser struct {
-	*bytes.Buffer
-}
-
-func (mockReaderCloser) Close() error { return nil }
-
-//nolint:paralleltest // mocks backendInstance
-func TestExpectEOFOnHTTPBackend(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// This test behaves differently on Windows, due to an interaction between survey & os.Stdin.
-		t.Skip()
-	}
-
-	tempdir := tempProjectDir(t)
-	chdir(t, tempdir)
-	mockBackendInstance(t, &httpstate.MockHTTPBackend{
-		FPromptAI: func(ctx context.Context, requestBody httpstate.AIPromptRequestBody) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Status:     "200 OK",
-				Body:       mockReaderCloser{bytes.NewBufferString("")},
-			}, nil
-		},
-	})
-
-	testNewArgs := newArgs{
-		aiPrompt:        "prompt",
-		aiLanguage:      "typescript",
-		interactive:     true,
-		secretsProvider: "default",
-	}
-
-	assert.ErrorContains(t,
-		runNew(
-			context.Background(), testNewArgs,
-		), "EOF")
 }


### PR DESCRIPTION
# Description

Switches the prompt to use the `promptForValue` function, which now accepts an empty type descriptor. This renders to the user as:

```console
$ pulumi new
 Would you like to create a project from a template or using a Pulumi AI prompt? ai
 Please select a language for your project: TypeScript
What cloud infrastructure would you like to build?
(try something like "a static website on AWS behind a CDN")
> an eks cluster
Sending prompt to Pulumi AI...
Pulumi AI response:
\`\`\`typescript
...
\`\`\`
View this conversation at:  https://www.pulumi.com/ai/conversations/13a802da-50b6-46e8-bc82-fd2f7ac6e364
 Use this program as a template? refine
Tell Pulumi AI how to refine the previous program:
> add an awsx vpc
...
```

We're still a little inconsistent between the survey asked questions and those using `promptForValue`. An overhaul here would be a much larger change that's currently out of scope.

Removes a test that only tested the mocks, was not working on Windows due to OS-specific behavior in Survey.

Fixes #14973

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
