### PR TITLE
Pin date in template for sdk/go/pulumix/applyn.go

### DIFF
--- a/sdk/go/internal/gen-pux-applyn/tmpl/applyn.go.tmpl
+++ b/sdk/go/internal/gen-pux-applyn/tmpl/applyn.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2016-{{ .Year }}, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/go/internal/gen-pux-applyn/tmpl/applyn_test.go.tmpl
+++ b/sdk/go/internal/gen-pux-applyn/tmpl/applyn_test.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2016-{{ .Year }}, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
`TestPulumixIsUpToDate` verifies the code in pulumix is up-to-date, but the generated code includes a copyright range including the current year, which now fails because of 2024. This commit pins the copyright date in the template to 2023.