### PR TITLE
Add Base64SecretsProvider for testing

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	b64secrets "github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -833,7 +832,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		M:                  &backend.UpdateMetadata{},
 		StackConfiguration: cfg,
 		SecretsManager:     sm,
-		SecretsProvider:    stack.DefaultSecretsProvider,
+		SecretsProvider:    b64secrets.Base64SecretsProvider,
 		Scopes:             backend.CancellationScopes,
 	})
 
@@ -845,7 +844,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			return nil, fmt.Errorf("get stack: %w", err)
 		}
 
-		snap, err = s.Snapshot(ctx, stack.DefaultSecretsProvider)
+		snap, err = s.Snapshot(ctx, b64secrets.Base64SecretsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("snapshot: %w", err)
 		}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -1386,13 +1386,13 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	require.NoError(t, err)
 
 	backend.DisableIntegrityChecking = false
-	snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
+	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider)
 	require.ErrorContains(t, err,
 		"child resource urn:pulumi:stack::proj::type::name1's parent urn:pulumi:stack::proj::type::name2 comes after it")
 	assert.Nil(t, snap)
 
 	backend.DisableIntegrityChecking = true
-	snap, err = s.Snapshot(ctx, stack.DefaultSecretsProvider)
+	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider)
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 }

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -188,13 +188,13 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	require.NoError(t, err)
 
 	backend.DisableIntegrityChecking = false
-	snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
+	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider)
 	require.ErrorContains(t, err,
 		"child resource urn:pulumi:stack::proj::type::name1's parent urn:pulumi:stack::proj::type::name2 comes after it")
 	assert.Nil(t, snap)
 
 	backend.DisableIntegrityChecking = true
-	snap, err = s.Snapshot(ctx, stack.DefaultSecretsProvider)
+	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider)
 	require.NoError(t, err)
 	assert.NotNil(t, snap)
 }

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -33,7 +34,7 @@ func getPulumiResources(t *testing.T, path string) *Resource {
 	assert.NoError(t, err)
 	err = json.Unmarshal(byts, &checkpoint)
 	assert.NoError(t, err)
-	snapshot, err := stack.DeserializeCheckpoint(ctx, stack.DefaultSecretsProvider, &checkpoint)
+	snapshot, err := stack.DeserializeCheckpoint(ctx, b64.Base64SecretsProvider, &checkpoint)
 	assert.NoError(t, err)
 	resources := NewResourceTree(snapshot.Resources)
 	return resources

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -200,7 +200,7 @@ func TestLoadTooNewDeployment(t *testing.T) {
 		Version: apitype.DeploymentSchemaVersionCurrent + 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, DefaultSecretsProvider)
+	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, b64.Base64SecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooNew, err)
@@ -214,7 +214,7 @@ func TestLoadTooOldDeployment(t *testing.T) {
 		Version: DeploymentSchemaVersionOldestSupported - 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, DefaultSecretsProvider)
+	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, b64.Base64SecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooOld, err)
@@ -445,7 +445,7 @@ func TestDeserializeDeploymentSecretCache(t *testing.T) {
 				ID:     "vol-044ba5ad2bd959bc1",
 			},
 		},
-	}, DefaultSecretsProvider)
+	}, b64.Base64SecretsProvider)
 	assert.NoError(t, err)
 }
 
@@ -457,7 +457,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 		Resources: []apitype.ResourceV3{
 			{},
 		},
-	}, DefaultSecretsProvider)
+	}, b64.Base64SecretsProvider)
 	assert.Nil(t, deployment)
 	assert.EqualError(t, err, "resource missing required 'urn' field")
 
@@ -469,7 +469,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 				URN: resource.URN(urn),
 			},
 		},
-	}, DefaultSecretsProvider)
+	}, b64.Base64SecretsProvider)
 	assert.Nil(t, deployment)
 	assert.EqualError(t, err, fmt.Sprintf("resource '%s' missing required 'type' field", urn))
 
@@ -482,7 +482,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 				ID:     "vol-044ba5ad2bd959bc1",
 			},
 		},
-	}, DefaultSecretsProvider)
+	}, b64.Base64SecretsProvider)
 	assert.Nil(t, deployment)
 	assert.EqualError(t, err, fmt.Sprintf("resource '%s' has 'custom' false but non-empty ID", urn))
 }

--- a/pkg/secrets/b64/provider.go
+++ b/pkg/secrets/b64/provider.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b64 implements a base64 secrets manager for testing purposes.
+package b64
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+)
+
+// Bas64SecretsProvider is a SecretsProvider that only supports base64 secrets, it is intended to be used for tests
+// where actual encryption is not needed.
+var Base64SecretsProvider secrets.Provider = b64SecretsProvider{}
+
+type b64SecretsProvider struct{}
+
+func (b64SecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	if ty != Type {
+		return nil, fmt.Errorf("no known secrets provider for type %q", ty)
+	}
+	return NewBase64SecretsManager(), nil
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
To support plugin based secret providers like (e.g. AGE https://github.com/pulumi/pulumi/issues/11493) the default secrets provider will need to become more complicated, requiring access to a plugin host at least.

As such for tests it will be simpler to have a basic secrets provider that only supports base64 and can be created without any setup.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
