### PR TITLE
Verify partial journals in engine tests

### DIFF
--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -126,6 +126,12 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 //  4. Dependents must precede their dependencies in the resource list
 //  5. For every URN in the snapshot, there must be at most one resource with that URN that is not pending deletion
 //  6. The magic manifest number should change every time the snapshot is mutated
+//
+// N.B. Constraints 2 does NOT apply for resources that are pending deletion. This is because they may have
+// had their provider replaced but not yet be replaced themselves yet (due to a partial update). Pending
+// replacement resources also can't just be wholly removed from the snapshot because they may have dependents
+// that are not being replaced and thus would fail validation if the pending replacement resource was removed
+// and not re-created (again due to partial updates).
 func (snap *Snapshot) VerifyIntegrity() error {
 	if snap != nil {
 		// Ensure the magic cookie checks out.
@@ -152,7 +158,7 @@ func (snap *Snapshot) VerifyIntegrity() error {
 				if err != nil {
 					return fmt.Errorf("failed to parse provider reference for resource %s: %w", urn, err)
 				}
-				if _, has := provs[ref]; !has {
+				if _, has := provs[ref]; !has && !state.PendingReplacement {
 					return fmt.Errorf("resource %s refers to unknown provider %s", urn, ref)
 				}
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This updates test_plan.go to verify that every partial snapshot is also a valid snapshot. This tests that the journal always writes out _valid_ snapshots even for scenarios where an update only partially ran.

While doing this it flagged up that the validation code was wrong for delete-before-create resources.

When we do a delete-before-create replacement we need to leave the "being replaced" resource in the snapshot. This is because while that resource is being replaced it might have dependents that are not being replaced, and so there is a period of time where _it_ is deleted but dependents are still referring to it. If we removed it from the snapshot at this point those dependent resources would not validate.

But in the case of two resources both being delete-before-create replaced you can have a scenario where both get deleted (but are still in the snapshot file) and the first then gets created thus removing it's old entry from the snapshot file and adding it's new state. If the first resource was a provider that will change it's ID, thus making the provider reference in the second resource now look invalid.