### PR TITLE
[sdk-gen] Don't JSON-encode provider config

### DIFF
--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -31,7 +31,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       strategy:
         matrix:
-          provider: ["aws", "gcp", "azure", "azuread", "random"]
+          provider: ["aws", "gcp", "azure", "azuread", "random", "keycloak"]
         fail-fast: false
       steps:
         - name: Trigger upgrade
@@ -42,6 +42,7 @@ jobs:
             event-type: upgrade-bridge
             client-payload: |-
               {
+                 "kind": "pulumi",
                  "target-pulumi-version": ${{ toJSON( github.event.pull_request.head.sha ) }},
                  "target-bridge-version": "",
                  "pr-reviewers": ${{ toJSON( github.triggering_actor || 'justinvp' ) }},

--- a/changelog/pending/20240103--pkg--fix-codegen-to-no-longer-json-encode-provider-config.yaml
+++ b/changelog/pending/20240103--pkg--fix-codegen-to-no-longer-json-encode-provider-config.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Fix codegen to no longer JSON-encode provider config

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -905,12 +905,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 
 		propertyType := mod.typeString(typ, "Outputs", false, false, false)
 
-		if r.IsProvider && !schema.IsPrimitiveType(prop.Type) {
-			if !prop.IsRequired() {
-				propertyType += "?"
-			}
-		}
-
 		if prop.Secret {
 			secretProps = append(secretProps, prop.Name)
 		}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -530,18 +530,6 @@ func (pt *plainType) genInputPropertyAttribute(w io.Writer, indent string, prop 
 	if prop.IsRequired() {
 		attributeArgs = ", required: true"
 	}
-	if pt.res != nil && pt.res.IsProvider {
-		json := true
-		typ := codegen.UnwrapType(prop.Type)
-		if typ == schema.StringType {
-			json = false
-		} else if t, ok := typ.(*schema.TokenType); ok && t.UnderlyingType == schema.StringType {
-			json = false
-		}
-		if json {
-			attributeArgs += ", json: true"
-		}
-	}
 	fmt.Fprintf(w, "%s[Input(\"%s\"%s)]\n", indent, wireName, attributeArgs)
 }
 
@@ -917,9 +905,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 
 		propertyType := mod.typeString(typ, "Outputs", false, false, false)
 
-		// Workaround the fact that provider inputs come back as strings.
 		if r.IsProvider && !schema.IsPrimitiveType(prop.Type) {
-			propertyType = "string"
 			if !prop.IsRequired() {
 				propertyType += "?"
 			}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -793,9 +793,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 				}
 			}
 
-			if r.IsProvider && !isStringType(prop.Type) {
-				arg = fmt.Sprintf("pulumi.output(%s)", arg)
-			}
 			fmt.Fprintf(w, "%sresourceInputs[\"%s\"] = %s;\n", prefix, prop.Name, arg)
 		}
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -791,11 +791,10 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 
 					arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
 				}
+			}
 
-				// provider properties must be marshaled as JSON strings.
-				if r.IsProvider && !isStringType(prop.Type) {
-					arg = fmt.Sprintf("pulumi.output(%s).apply(JSON.stringify)", arg)
-				}
+			if r.IsProvider && !isStringType(prop.Type) {
+				arg = fmt.Sprintf("pulumi.output(%s)", arg)
 			}
 			fmt.Fprintf(w, "%sresourceInputs[\"%s\"] = %s;\n", prefix, prop.Name, arg)
 		}

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1374,17 +1374,8 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 			}
 		}
 
-		handledSecret := false
-		if res.IsProvider && !isStringType(prop.Type) {
-			if prop.Secret {
-				arg = fmt.Sprintf("pulumi.Output.secret(%s) if %s is not None else None", arg, arg)
-				handledSecret = true
-			} else {
-				arg = fmt.Sprintf("pulumi.Output.from_input(%s) if %s is not None else None", arg, arg)
-			}
-		}
 		name := PyName(prop.Name)
-		if prop.Secret && !handledSecret {
+		if prop.Secret {
 			fmt.Fprintf(w, "            __props__.__dict__[%[1]q] = None if %[2]s is None else pulumi.Output.secret(%[2]s)\n", name, arg)
 		} else {
 			fmt.Fprintf(w, "            __props__.__dict__[%q] = %s\n", name, arg)

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2446,16 +2446,6 @@ func (mod *modContext) pyType(typ schema.Type) string {
 	}
 }
 
-func isStringType(t schema.Type) bool {
-	t = codegen.UnwrapType(t)
-
-	for tt, ok := t.(*schema.TokenType); ok; tt, ok = t.(*schema.TokenType) {
-		t = tt.UnderlyingType
-	}
-
-	return t == schema.StringType
-}
-
 // pyPack returns the suggested package name for the given string.
 func pyPack(s string) string {
 	return "pulumi_" + strings.ReplaceAll(s, "-", "_")

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1374,16 +1374,13 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 			}
 		}
 
-		// If this resource is a provider then, regardless of the schema of the underlying provider
-		// type, we must project all properties as strings. For all properties that are not strings,
-		// we'll marshal them to JSON and use the JSON string as a string input.
 		handledSecret := false
 		if res.IsProvider && !isStringType(prop.Type) {
 			if prop.Secret {
-				arg = fmt.Sprintf("pulumi.Output.secret(%s).apply(pulumi.runtime.to_json) if %s is not None else None", arg, arg)
+				arg = fmt.Sprintf("pulumi.Output.secret(%s) if %s is not None else None", arg, arg)
 				handledSecret = true
 			} else {
-				arg = fmt.Sprintf("pulumi.Output.from_input(%s).apply(pulumi.runtime.to_json) if %s is not None else None", arg, arg)
+				arg = fmt.Sprintf("pulumi.Output.from_input(%s) if %s is not None else None", arg, arg)
 			}
 		}
 		name := PyName(prop.Name)

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Example
         /// <summary>
         /// BETA FEATURE - Options to configure the Helm Release resource.
         /// </summary>
-        [Input("helmReleaseSettings", json: true)]
+        [Input("helmReleaseSettings")]
         public Input<Inputs.HelmReleaseSettingsArgs>? HelmReleaseSettings { get; set; }
 
         public ProviderArgs()

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
@@ -36,7 +36,7 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined);
+            resourceInputs["helmReleaseSettings"] = args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
@@ -36,7 +36,7 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
+            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -84,7 +84,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings).apply(pulumi.runtime.to_json) if helm_release_settings is not None else None
+            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings) if helm_release_settings is not None else None
         super(Provider, __self__).__init__(
             'example',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -84,7 +84,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings) if helm_release_settings is not None else None
+            __props__.__dict__["helm_release_settings"] = helm_release_settings
         super(Provider, __self__).__init__(
             'example',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Example
         /// <summary>
         /// BETA FEATURE - Options to configure the Helm Release resource.
         /// </summary>
-        [Input("helmReleaseSettings", json: true)]
+        [Input("helmReleaseSettings")]
         public Input<Inputs.HelmReleaseSettingsArgs>? HelmReleaseSettings { get; set; }
 
         public ProviderArgs()

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
@@ -36,7 +36,7 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined);
+            resourceInputs["helmReleaseSettings"] = args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
@@ -36,7 +36,7 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
+            resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsArgsProvideDefaults) : undefined) : undefined);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -84,7 +84,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings).apply(pulumi.runtime.to_json) if helm_release_settings is not None else None
+            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings) if helm_release_settings is not None else None
         super(Provider, __self__).__init__(
             'example',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -84,7 +84,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["helm_release_settings"] = pulumi.Output.from_input(helm_release_settings) if helm_release_settings is not None else None
+            __props__.__dict__["helm_release_settings"] = helm_release_settings
         super(Provider, __self__).__init__(
             'example',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/Provider.cs
@@ -43,10 +43,10 @@ namespace Configstation.Pulumi.Configstation
         /// <summary>
         /// this is a relaxed string enum which can also be set via env var
         /// </summary>
-        [Input("favoriteColor", json: true)]
+        [Input("favoriteColor")]
         public InputUnion<string, Configstation.Pulumi.Configstation.Color>? FavoriteColor { get; set; }
 
-        [Input("secretSandwiches", json: true)]
+        [Input("secretSandwiches")]
         private InputList<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>? _secretSandwiches;
 
         /// <summary>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
@@ -35,7 +35,7 @@ export class Provider extends pulumi.ProviderResource {
         opts = opts || {};
         {
             resourceInputs["favoriteColor"] = (args ? args.favoriteColor : undefined) ?? <any>utilities.getEnv("FAVE_COLOR");
-            resourceInputs["secretSandwiches"] = pulumi.output(args?.secretSandwiches ? pulumi.secret(args.secretSandwiches) : undefined);
+            resourceInputs["secretSandwiches"] = args?.secretSandwiches ? pulumi.secret(args.secretSandwiches) : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
@@ -35,7 +35,7 @@ export class Provider extends pulumi.ProviderResource {
         opts = opts || {};
         {
             resourceInputs["favoriteColor"] = (args ? args.favoriteColor : undefined) ?? <any>utilities.getEnv("FAVE_COLOR");
-            resourceInputs["secretSandwiches"] = pulumi.output(args?.secretSandwiches ? pulumi.secret(args.secretSandwiches) : undefined).apply(JSON.stringify);
+            resourceInputs["secretSandwiches"] = pulumi.output(args?.secretSandwiches ? pulumi.secret(args.secretSandwiches) : undefined);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -106,8 +106,8 @@ class Provider(pulumi.ProviderResource):
 
             if favorite_color is None:
                 favorite_color = _utilities.get_env('FAVE_COLOR')
-            __props__.__dict__["favorite_color"] = pulumi.Output.from_input(favorite_color) if favorite_color is not None else None
-            __props__.__dict__["secret_sandwiches"] = pulumi.Output.secret(secret_sandwiches) if secret_sandwiches is not None else None
+            __props__.__dict__["favorite_color"] = favorite_color
+            __props__.__dict__["secret_sandwiches"] = None if secret_sandwiches is None else pulumi.Output.secret(secret_sandwiches)
         super(Provider, __self__).__init__(
             'configstation',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -106,8 +106,8 @@ class Provider(pulumi.ProviderResource):
 
             if favorite_color is None:
                 favorite_color = _utilities.get_env('FAVE_COLOR')
-            __props__.__dict__["favorite_color"] = pulumi.Output.from_input(favorite_color).apply(pulumi.runtime.to_json) if favorite_color is not None else None
-            __props__.__dict__["secret_sandwiches"] = pulumi.Output.secret(secret_sandwiches).apply(pulumi.runtime.to_json) if secret_sandwiches is not None else None
+            __props__.__dict__["favorite_color"] = pulumi.Output.from_input(favorite_color) if favorite_color is not None else None
+            __props__.__dict__["secret_sandwiches"] = pulumi.Output.secret(secret_sandwiches) if secret_sandwiches is not None else None
         super(Provider, __self__).__init__(
             'configstation',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
@@ -77,7 +77,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["certmanager"] = pulumi.Output.from_input(certmanager).apply(pulumi.runtime.to_json) if certmanager is not None else None
+            __props__.__dict__["certmanager"] = pulumi.Output.from_input(certmanager) if certmanager is not None else None
         super(Provider, __self__).__init__(
             'foo',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/provider.py
@@ -77,7 +77,7 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["certmanager"] = pulumi.Output.from_input(certmanager) if certmanager is not None else None
+            __props__.__dict__["certmanager"] = certmanager
         super(Provider, __self__).__init__(
             'foo',
             resource_name,

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.59.0" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.59.0" />
     <PackageReference Include="Pulumi.Aws" Version="4.26.0" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.59.0" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7.2" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.59.0" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 

--- a/sdk/nodejs/tests/sxs_ts_test/yarn.lock
+++ b/sdk/nodejs/tests/sxs_ts_test/yarn.lock
@@ -1209,6 +1209,11 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typescript@^4:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 typescript@~3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"


### PR DESCRIPTION
# Description

Most of our SDKs (node, python, dotnet, java) send JSON-encoded provider configuration for legacy reasons, but YAML doesn't do this ([example](https://github.com/pulumi/pulumi-go-provider/pull/172#issuecomment-1874600691)).

This behavior originated a long time ago when our providers only supported [string properties](https://github.com/pulumi/pulumi-terraform-bridge/commit/b4446913ae60dcce95c1bdd0b0d85d119f2c91c8), but of course this is no longer the case. Fortunately providers today accept both JSON or strongly typed configuration -- they attempt vanilla `plugin.UnmarshalProperties` but will [fall back](https://github.com/pulumi/pulumi-terraform-bridge/blob/bda33f369ae3e8f69cae5d7286e6ff35e0967964/pkg/tfbridge/config_encoding.go#L139-L156) to JSON deserialization if that fails. This explains why YAML is able to send rich configuration without issue, and why it's safe to remove the legacy JSON serialization from other SDKs.

The only exception is the newer go-provider, which doesn't handle non-primitive config from our SDKs (only from YAML https://github.com/pulumi/pulumi-go-provider/issues/171) because it doesn't do any JSON unmarshalling. We could either:
1. add this legacy JSON unmarshalling to go-provider, and support it indefinitely in the same way tfbridge will need to support it forever (because JSON config will be persisted in state files), or
2. stop JSON encoding config from SDKs, so go-provider only needs to concern itself with rich configuration.

This PR opts for (2) and removes JSON serialization from provider configs. https://github.com/pulumi/pulumi-java/pull/1308 makes a similar change for java.

Fixes https://github.com/pulumi/pulumi/issues/12773
Fixes https://github.com/pulumi/pulumi-go-provider/issues/171
Supersedes https://github.com/pulumi/pulumi-go-provider/pull/172
Related https://github.com/pulumi/pulumi-java/pull/1308
Related https://github.com/pulumi/pulumi-terraform-bridge/pull/1610
Refs https://github.com/pulumi/pulumi/issues/13435
Refs https://github.com/pulumi/pulumi/pull/7058
Refs https://github.com/pulumi/pulumi-yaml/issues/455
Refs https://github.com/pulumi/pulumi-docker/issues/456

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`





