### PR TITLE
Support passing an optional project name to pulumi convert

### DIFF
--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -35,7 +35,7 @@ func TestYamlConvert(t *testing.T) {
 
 	result := runConvert(
 		env.Global(), []string{}, "convert_testdata", []string{},
-		"yaml", "go", "convert_testdata/go", true, true)
+		"yaml", "go", "convert_testdata/go", true, true, "")
 	require.Nil(t, result, "convert failed: %v", result)
 }
 
@@ -47,7 +47,7 @@ func TestPclConvert(t *testing.T) {
 
 	result := runConvert(
 		env.Global(), []string{}, "pcl_convert_testdata",
-		[]string{}, "pcl", "pcl", tmp, true, true)
+		[]string{}, "pcl", "pcl", tmp, true, true, "")
 	assert.Nil(t, result)
 
 	// Check that we made one file


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Support passing an optional project name to pulumi convert

Fixes #[14655](https://github.com/pulumi/pulumi/issues/14645)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
