### PR TITLE
Fix docs generator parent module computation 

### DIFF
--- a/changelog/pending/20240104--docs--fixes-docs-generator-parent-module-computation.yaml
+++ b/changelog/pending/20240104--docs--fixes-docs-generator-parent-module-computation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Fixes docs generator parent module computation

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -15,9 +15,11 @@
 package docs
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
@@ -67,4 +69,174 @@ func TestGeneratePackageTree(t *testing.T) {
 		assert.Equal(t, entryTypeResource, children[0].Type)
 		assert.Equal(t, entryTypeFunction, children[1].Type)
 	})
+}
+
+// Original issues: pulumi/pulumi#14821, pulumi/pulumi#14820.
+func TestGeneratePackageTreeNested(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name   string
+		spec   schema.PackageSpec
+		expect string
+	}
+
+	testCases := []testCase{
+		{
+			"14820",
+			schema.PackageSpec{
+				Name:    "fortios",
+				Version: "0.0.1",
+				Meta: &schema.MetadataSpec{
+					ModuleFormat: "(.*)(?:/[^/]*)",
+				},
+				Resources: map[string]schema.ResourceSpec{
+					"fortios:router/bgp:Bgp":             {},
+					"fortios:router/bgp/network:Network": {},
+				},
+			},
+			`
+			[
+			  {
+			    "name": "router",
+			    "type": "module",
+			    "link": "router/",
+			    "children": [
+			      {
+				"name": "bgp",
+				"type": "module",
+				"link": "bgp/",
+				"children": [
+				  {
+				    "name": "Network",
+				    "type": "resource",
+				    "link": "network"
+				  }
+				]
+			      },
+			      {
+				"name": "Bgp",
+				"type": "resource",
+				"link": "bgp"
+			      }
+			    ]
+			  },
+			  {
+			    "name": "Provider",
+			    "type": "resource",
+			    "link": "provider"
+			  }
+			]`,
+		},
+		{
+			"14821",
+			schema.PackageSpec{
+				Name:    "fortios",
+				Version: "0.0.1",
+				Meta: &schema.MetadataSpec{
+					ModuleFormat: "(.*)(?:/[^/]*)",
+				},
+				Resources: map[string]schema.ResourceSpec{
+					"fortios:log/syslogd/v2/filter:Filter":                   {},
+					"fortios:log/syslogd/v2/overridefilter:Overridefilter":   {},
+					"fortios:log/syslogd/v2/overridesetting:Overridesetting": {},
+					"fortios:log/syslogd/v2/setting:Setting":                 {},
+				},
+			},
+			`
+			[
+			  {
+			    "name": "log",
+			    "type": "module",
+			    "link": "log/",
+			    "children": [
+			      {
+				"name": "syslogd",
+				"type": "module",
+				"link": "syslogd/",
+				"children": [
+				  {
+				    "name": "v2",
+				    "type": "module",
+				    "link": "v2/",
+				    "children": [
+				      {
+					"name": "Filter",
+					"type": "resource",
+					"link": "filter"
+				      },
+				      {
+					"name": "Overridefilter",
+					"type": "resource",
+					"link": "overridefilter"
+				      },
+				      {
+					"name": "Overridesetting",
+					"type": "resource",
+					"link": "overridesetting"
+				      },
+				      {
+					"name": "Setting",
+					"type": "resource",
+					"link": "setting"
+				      }
+				    ]
+				  }
+				]
+			      }
+			    ]
+			  },
+			  {
+			    "name": "Provider",
+			    "type": "resource",
+			    "link": "provider"
+			  }
+			]`,
+		},
+	}
+
+	prep := func(t *testing.T, tc testCase) (*docGenContext, *schema.Package) {
+		t.Helper()
+
+		schemaPkg, err := schema.ImportSpec(tc.spec, nil)
+		assert.NoError(t, err, "importing spec")
+
+		c := newDocGenContext()
+		c.initialize("test", schemaPkg)
+
+		return c, schemaPkg
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := prep(t, tc)
+
+			items, err := c.generatePackageTree()
+			require.NoError(t, err)
+
+			data, err := json.MarshalIndent(items, "", "  ")
+			require.NoError(t, err)
+
+			t.Logf("%s", string(data))
+
+			require.JSONEq(t, tc.expect, string(data))
+		})
+
+		t.Run(tc.name+"/generatePackage", func(t *testing.T) {
+			t.Parallel()
+
+			c, schemaPkg := prep(t, tc)
+
+			files, err := c.generatePackage("test", schemaPkg)
+			require.NoError(t, err)
+
+			for f := range files {
+				t.Logf("+ %v", f)
+			}
+		})
+	}
 }

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -82,6 +82,58 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 	}
 
 	testCases := []testCase{
+
+		{
+			"index top module",
+			schema.PackageSpec{
+				Name:    "testindex",
+				Version: "0.0.1",
+				Resources: map[string]schema.ResourceSpec{
+					"testindex:index:Resource": {},
+				},
+			},
+			`[
+			 {
+			   "name": "Provider",
+			   "type": "resource",
+			   "link": "provider"
+			 },
+			 {
+			   "name": "Resource",
+			   "type": "resource",
+			   "link": "resource"
+			 }
+		       ]`,
+		},
+		{
+			"random",
+			schema.PackageSpec{
+				Name:    "random",
+				Version: "0.0.1",
+				Resources: map[string]schema.ResourceSpec{
+					"random:index/randomId:RandomId":             {},
+					"random:index/randomPassword:RandomPassword": {},
+				},
+			},
+			`
+			 [
+			  {
+			    "name": "Provider",
+			    "type": "resource",
+			    "link": "provider"
+			  },
+			  {
+			    "name": "RandomId",
+			    "type": "resource",
+			    "link": "randomid"
+			  },
+			  {
+			    "name": "RandomPassword",
+			    "type": "resource",
+			    "link": "randompassword"
+			  }
+			]`,
+		},
 		{
 			"14820",
 			schema.PackageSpec{

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -82,7 +82,6 @@ func TestGeneratePackageTreeNested(t *testing.T) {
 	}
 
 	testCases := []testCase{
-
 		{
 			"index top module",
 			schema.PackageSpec{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #14820
Fixes #14821

Fixes a bug in docs generator parent module computation that used to lead to duplicate files panics and undesirable documentation URL layout for affected providers such as [pulumi/fortios](https://github.com/pulumiverse/pulumi-fortios/issues).

Joint work with @tmeckel .

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
