### PR TITLE
Add in support in stack config for plugin secrets

### DIFF
--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -122,8 +121,8 @@ func (s *localStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
-func (s *localStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
-	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)
+func (s *localStack) DefaultSecretManager() (secrets.Manager, error) {
+	return passphrase.NewPromptingPassphraseSecretsManager(nil, false /* rotatePassphraseSecretsProvider */)
 }
 
 type localStackSummary struct {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -209,8 +209,8 @@ func (s *cloudStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
-func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
-	return service.NewServiceSecretsManager(s.b.Client(), s.StackIdentifier(), info)
+func (s *cloudStack) DefaultSecretManager() (secrets.Manager, error) {
+	return service.NewServiceSecretsManager(s.b.Client(), s.StackIdentifier())
 }
 
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -459,7 +459,7 @@ type MockStack struct {
 		query operations.LogQuery) ([]operations.LogEntry, error)
 	ExportDeploymentF     func(ctx context.Context) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF     func(ctx context.Context, deployment *apitype.UntypedDeployment) error
-	DefaultSecretManagerF func(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManagerF func() (secrets.Manager, error)
 }
 
 var _ Stack = (*MockStack)(nil)
@@ -597,9 +597,9 @@ func (ms *MockStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 	panic("not implemented")
 }
 
-func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
+func (ms *MockStack) DefaultSecretManager() (secrets.Manager, error) {
 	if ms.DefaultSecretManagerF != nil {
-		return ms.DefaultSecretManagerF(info)
+		return ms.DefaultSecretManagerF()
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -71,7 +71,7 @@ type Stack interface {
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 
 	// Return the default secrets manager to use for this stack.
-	DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManager() (secrets.Manager, error)
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -36,8 +36,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
-	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -487,21 +485,12 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 				return fmt.Errorf("unmarshaling deployment: %w", err)
 			}
 			if deployment.SecretsProviders != nil {
-				// TODO: It would be really nice if the format of secrets state in the config file matched
-				// what we kept in the statefile. That would go well with the pluginification of secret
-				// providers as well, but for now just switch on the secret provider type and ask it to fill in
-				// the config file for us.
-				if deployment.SecretsProviders.Type == passphrase.Type {
-					err = passphrase.EditProjectStack(ps, deployment.SecretsProviders.State)
-				} else if deployment.SecretsProviders.Type == cloud.Type {
-					err = cloud.EditProjectStack(ps, deployment.SecretsProviders.State)
-				} else {
-					// Anything else assume we can just clear all the secret bits
-					ps.EncryptionSalt = ""
-					ps.SecretsProvider = ""
-					ps.EncryptedKey = ""
+				secrets := workspace.SecretsProvider{
+					Name:  deployment.SecretsProviders.Type,
+					State: deployment.SecretsProviders.State,
 				}
 
+				err := ps.SetSecrets(secrets)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config_env_init_test.go
@@ -85,7 +85,9 @@ runtime: yaml`
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
-		const expectedYAML = `environment:
+		const expectedYAML = `secrets:
+  name: b64
+environment:
   - test-stack
 `
 
@@ -163,7 +165,9 @@ runtime: yaml`
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
-		const expectedYAML = `environment:
+		const expectedYAML = `secrets:
+  name: b64
+environment:
   - test-stack
 `
 		assert.Equal(t, expectedYAML, newStackYAML)
@@ -239,7 +243,9 @@ runtime: yaml`
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
-		const expectedYAML = `environment:
+		const expectedYAML = `secrets:
+  name: b64
+environment:
   - test-stack
 `
 		assert.Equal(t, expectedYAML, newStackYAML)
@@ -320,7 +326,9 @@ runtime: yaml`
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
-		const expectedYAML = `environment:
+		const expectedYAML = `secrets:
+  name: b64
+environment:
   - env
   - test-stack
 `

--- a/pkg/cmd/pulumi/config_env_rm_test.go
+++ b/pkg/cmd/pulumi/config_env_rm_test.go
@@ -108,7 +108,9 @@ Save? Yes
 
 		ctx := context.Background()
 
-		const stackYAML = `environment:
+		const stackYAML = `secrets:
+  name: b64
+environment:
   - env
   - env2
 `
@@ -145,7 +147,9 @@ Save? Yes
 			},
 		}
 
-		const stackYAML = `environment:
+		const stackYAML = `secrets:
+  name: b64
+environment:
  - env
  - env2
 `
@@ -167,50 +171,9 @@ Save? Yes
 
 		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
-		const expectedYAML = `environment:
-  - env
-`
-
-		assert.Equal(t, expectedYAML, newStackYAML)
-	})
-
-	t.Run("two imports, secrets", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := context.Background()
-
-		env := &esc.Environment{
-			Properties: map[string]esc.Value{
-				"pulumiConfig": esc.NewValue(map[string]esc.Value{
-					"aws:region":   esc.NewValue("us-west-2"),
-					"app:password": esc.NewSecret("hunter2"),
-				}),
-			},
-		}
-
-		const stackYAML = `environment:
- - env
- - env2
-`
-
-		var newStackYAML string
-		stdin := strings.NewReader("y")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
-		rm := &configEnvRmCmd{parent: parent, showSecrets: true}
-		err := rm.run(nil, []string{"env2"})
-		require.NoError(t, err)
-
-		const expectedOut = `KEY           VALUE
-app:password  hunter2
-aws:region    us-west-2
-
-Save? Yes
-`
-
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
-
-		const expectedYAML = `environment:
+		const expectedYAML = `secrets:
+  name: b64
+environment:
   - env
 `
 

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -123,7 +123,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 						CheckYAMLEnvironmentF: checkYAMLEnvironment,
 					}
 				},
-				DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+				DefaultSecretManagerF: func() (secrets.Manager, error) {
 					return b64.NewBase64SecretsManager(), nil
 				},
 			}, nil

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -99,8 +100,11 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 					FullyQualifiedNameV: tokens.QName("org/project/name"),
 				}
 			},
-			DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
-				return nil, nil
+			DefaultSecretManagerF: func() (secrets.Manager, error) {
+				return &secrets.MockSecretsManager{
+					TypeF:  func() string { return "mock" },
+					StateF: func() json.RawMessage { return nil },
+				}, nil
 			},
 			BackendF: func() backend.Backend {
 				return &backend.MockBackend{
@@ -261,6 +265,8 @@ func TestCopyConfig(t *testing.T) {
 	}
 
 	mockSecretsManager := &secrets.MockSecretsManager{
+		TypeF:  func() string { return "mock" },
+		StateF: func() json.RawMessage { return nil },
 		EncrypterF: func() (config.Encrypter, error) {
 			encrypter := &secrets.MockEncrypter{EncryptValueF: func() string { return "ciphertext" }}
 			return encrypter, nil
@@ -291,7 +297,7 @@ func TestCopyConfig(t *testing.T) {
 				FullyQualifiedNameV: tokens.QName("org/project/" + name),
 			}
 		}
-		stack.DefaultSecretManagerF = func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		stack.DefaultSecretManagerF = func() (secrets.Manager, error) {
 			return mockSecretsManager, nil
 		}
 

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -217,7 +217,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			snapshot = snap
 			return nil
 		},
-		DefaultSecretManagerF: func(_ *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func() (secrets.Manager, error) {
 			return secretsManager, nil
 		},
 	}
@@ -245,6 +245,9 @@ runtime: mock
 	require.NoError(t, err)
 	cfgKey := config.MustMakeKey("testStack", "secret")
 	cfg := workspace.ProjectStack{
+		Secrets: &workspace.SecretsProvider{
+			Name: "b64",
+		},
 		Config: config.Map{
 			cfgKey: config.NewSecureValue(secretBar),
 		},

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -16,11 +16,11 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,8 +78,7 @@ func TestAzureKeyVaultExistingKey(t *testing.T) {
 
 	//nolint:lll // this is a base64 encoded key
 	encryptedKeyBase64 := "Ti1qQklqTnlPTWh4RFUtNmd2WmhxcTBHeUFDa0hlS1lmNERwb3dpRHhIRlFMekxyVEdvRTZ6aFV3Q2N1Q1NISmFOeXFqajd6QzY5VmNxQzF1Z0hxRExUQUtJQUhpbE00T0ZFeXU2aUdfeS1YVE9adjlPS0M5aHlYSXdJUGwyZk01Z2FRWmJhckZfQ1kyd3lWRHlXS3JQUDcwWGFQcFBZSWJnQWJuTm5KVF9ua3gyR3I0QnBTZDVabnVrd0ViM0w1NEpjOGFqc29paVZPNVZ6OURmQ0x3MXUzVDZxTHBGLXZpV1VMTlJoQnZTMjRHdzhRWGtmczRfTzZ1NTZWdmxJRWh5TUREOF9tb2YzYlpQY0V5NW1nZDVzVjJWWHhVQWdQQlYwVDFGT2p4cGxvN1VvTUdEWUd1Q1FMcmJBS0JxbEdNZmFtSFRZcDZlYXVTQ3pUd3ptYW93"
-	stackConfig := &workspace.ProjectStack{}
-	stackConfig.EncryptedKey = encryptedKeyBase64
+	stackConfig := []byte(fmt.Sprintf(`{"url": "%s", "encryptedkey": "%s"}`, url, encryptedKeyBase64))
 	manager, err := NewCloudSecretsManager(stackConfig, url, false)
 	require.NoError(t, err)
 

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/authhelpers"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // Type is the type of secrets managed by this secrets provider
@@ -125,20 +124,6 @@ func (m *Manager) State() json.RawMessage               { return m.state }
 func (m *Manager) Encrypter() (config.Encrypter, error) { return m.crypter, nil }
 func (m *Manager) Decrypter() (config.Decrypter, error) { return m.crypter, nil }
 
-func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {
-	info.EncryptionSalt = ""
-
-	var s cloudSecretsManagerState
-	err := json.Unmarshal(state, &s)
-	if err != nil {
-		return fmt.Errorf("unmarshalling cloud state: %w", err)
-	}
-
-	info.SecretsProvider = s.URL
-	info.EncryptedKey = base64.StdEncoding.EncodeToString(s.EncryptedKey)
-	return nil
-}
-
 // NewCloudSecretsManagerFromState deserialize configuration from state and returns a secrets
 // manager that uses the target cloud key management service to encrypt/decrypt a data key used for
 // envelope encryption of secrets values.
@@ -151,13 +136,15 @@ func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, er
 	return newCloudSecretsManager(s.URL, s.EncryptedKey)
 }
 
-func NewCloudSecretsManager(info *workspace.ProjectStack,
+func NewCloudSecretsManager(state json.RawMessage,
 	secretsProvider string, rotateSecretsProvider bool,
 ) (secrets.Manager, error) {
-	// Only a passphrase provider has an encryption salt. So changing a secrets provider
-	// from passphrase to a cloud secrets provider should ensure that we remove the enryptionsalt
-	// as it's a legacy artifact and needs to be removed
-	info.EncryptionSalt = ""
+	var s cloudSecretsManagerState
+	if len(state) != 0 {
+		if err := json.Unmarshal(state, &s); err != nil {
+			return nil, fmt.Errorf("unmarshalling state: %w", err)
+		}
+	}
 
 	var secretsManager *Manager
 
@@ -170,12 +157,12 @@ func NewCloudSecretsManager(info *workspace.ProjectStack,
 
 	// If we're rotating then just clear the key so we create a fresh one below
 	if rotateSecretsProvider {
-		info.EncryptedKey = ""
+		s.EncryptedKey = nil
 	}
 
 	// if there is no key OR the secrets provider is changing
 	// then we need to generate the new key based on the new secrets provider
-	if info.EncryptedKey == "" || info.SecretsProvider != secretsProvider {
+	if s.EncryptedKey == nil || s.URL != secretsProvider {
 		dataKey, err := generateNewDataKey(secretsProvider)
 		if err != nil {
 			return nil, err
@@ -187,27 +174,25 @@ func NewCloudSecretsManager(info *workspace.ProjectStack,
 		if strings.HasPrefix(secretsProvider, "azurekeyvault://") {
 			dataKey = []byte(base64.RawURLEncoding.EncodeToString(dataKey))
 		}
-		info.EncryptedKey = base64.StdEncoding.EncodeToString(dataKey)
+		s.EncryptedKey = dataKey
 	}
-	info.SecretsProvider = secretsProvider
+	s.URL = secretsProvider
 
 	// We're emulating gocloud.dev's old behaviour here.  Pre
 	// v0.28.0 it used to have an inner wrapping, which we keep
 	// for compatibility (see above).  However the newer version
 	// expects this to be unwrapped, before it's used, so let's do
 	// that here.
-	dataKey, err := base64.StdEncoding.DecodeString(info.EncryptedKey)
-	if err != nil {
-		return nil, err
-	}
+	dataKey := s.EncryptedKey
 	if strings.HasPrefix(secretsProvider, "azurekeyvault://") {
+		var err error
 		dataKey, err = base64.RawURLEncoding.DecodeString(string(dataKey))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	secretsManager, err = newCloudSecretsManager(secretsProvider, dataKey)
+	secretsManager, err := newCloudSecretsManager(secretsProvider, dataKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/secrets"
@@ -32,10 +31,7 @@ import (
 // the main testing function, takes a kms url and tries to make a new secret manager out of it and encrypt and
 // decrypt data, this is used by the aws_test and azure_test files.
 func testURL(ctx context.Context, t *testing.T, url string) {
-	info := &workspace.ProjectStack{}
-	info.SecretsProvider = url
-
-	manager, err := NewCloudSecretsManager(info, url, false)
+	manager, err := NewCloudSecretsManager(nil, url, false)
 	require.NoError(t, err)
 
 	enc, err := manager.Encrypter()
@@ -71,18 +67,16 @@ func TestSecretsProviderOverride(t *testing.T) {
 	// PULUMI_CLOUD_SECRET_OVERRIDE env var and it may interfere with other
 	// tests.
 
-	stackConfig := &workspace.ProjectStack{}
-
 	opener := &mockSecretsKeeperOpener{}
 	secrets.DefaultURLMux().RegisterKeeper("test", opener)
 
 	//nolint:paralleltest
 	t.Run("without override", func(t *testing.T) {
 		opener.wantURL = "test://foo"
-		_, createSecretsManagerError := NewCloudSecretsManager(stackConfig, "test://foo", false)
+		_, createSecretsManagerError := NewCloudSecretsManager(nil, "test://foo", false)
 		assert.Nil(t, createSecretsManagerError, "Creating the cloud secret manager should succeed")
 
-		_, createSecretsManagerError = NewCloudSecretsManager(stackConfig, "test://bar", false)
+		_, createSecretsManagerError = NewCloudSecretsManager(nil, "test://bar", false)
 		msg := "NewCloudSecretsManager with unexpected secretsProvider URL succeeded, expected an error"
 		assert.NotNil(t, createSecretsManagerError, msg)
 	})
@@ -95,9 +89,9 @@ func TestSecretsProviderOverride(t *testing.T) {
 		// Last argument here shouldn't matter anymore, since it gets overridden
 		// by the env var. Both calls should succeed.
 		msg := "creating the secrets manager should succeed regardless of secrets provider"
-		_, createSecretsManagerError := NewCloudSecretsManager(stackConfig, "test://foo", false)
+		_, createSecretsManagerError := NewCloudSecretsManager(nil, "test://foo", false)
 		assert.Nil(t, createSecretsManagerError, msg)
-		_, createSecretsManagerError = NewCloudSecretsManager(stackConfig, "test://bar", false)
+		_, createSecretsManagerError = NewCloudSecretsManager(nil, "test://bar", false)
 		assert.Nil(t, createSecretsManagerError, msg)
 	})
 }

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 const Type = "passphrase"
@@ -113,19 +112,6 @@ func (sm *localSecretsManager) Decrypter() (config.Decrypter, error) {
 func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
 	contract.Assertf(sm.crypter != nil, "encrypter not initialized")
 	return sm.crypter, nil
-}
-
-func EditProjectStack(info *workspace.ProjectStack, state json.RawMessage) error {
-	info.EncryptedKey = ""
-	info.SecretsProvider = ""
-
-	var s localSecretsManagerState
-	err := json.Unmarshal(state, &s)
-	if err != nil {
-		return fmt.Errorf("unmarshalling passphrase state: %w", err)
-	}
-	info.EncryptionSalt = s.Salt
-	return nil
 }
 
 var (
@@ -266,38 +252,37 @@ func NewPromptingPassphraseSecretsManagerFromState(state json.RawMessage) (secre
 	}
 }
 
-func NewPromptingPassphraseSecretsManager(info *workspace.ProjectStack,
+func NewPromptingPassphraseSecretsManager(state json.RawMessage,
 	rotateSecretsProvider bool,
 ) (secrets.Manager, error) {
-	if rotateSecretsProvider {
-		info.EncryptionSalt = ""
+	var s localSecretsManagerState
+	if len(state) != 0 {
+		if err := json.Unmarshal(state, &s); err != nil {
+			return nil, fmt.Errorf("unmarshalling state: %w", err)
+		}
 	}
 
-	// If there are any other secrets providers set in the config, remove them, as the passphrase
-	// provider deals only with EncryptionSalt, not EncryptedKey or SecretsProvider.
-	info.EncryptedKey = ""
-	info.SecretsProvider = ""
+	if rotateSecretsProvider {
+		s.Salt = ""
+	}
 
 	// If we have a salt, we can just use it.
-	if info.EncryptionSalt != "" {
-		return newPromptingPassphraseSecretsManagerFromState(info.EncryptionSalt)
+	if s.Salt != "" {
+		return newPromptingPassphraseSecretsManagerFromState(s.Salt)
 	}
 
 	// Otherwise, prompt the user for a new passphrase.
-	state, sm, err := promptForNewPassphrase(rotateSecretsProvider)
+	sm, err := promptForNewPassphrase(rotateSecretsProvider)
 	if err != nil {
 		return nil, err
 	}
-
-	// Store the salt and save it.
-	info.EncryptionSalt = state
 
 	// Return the passphrase secrets manager.
 	return sm, nil
 }
 
 // promptForNewPassphrase prompts for a new passphrase, and returns the state and the secrets manager.
-func promptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
+func promptForNewPassphrase(rotate bool) (secrets.Manager, error) {
 	var phrase string
 
 	// Get a the passphrase from the user, ensuring that they match.
@@ -316,7 +301,7 @@ func promptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 		// Here, the stack does not have an EncryptionSalt, so we will get a passphrase and create one
 		first, _, err := readPassphrase(firstMessage, !rotate)
 		if err != nil {
-			return "", nil, err
+			return nil, err
 		}
 		secondMessage := "Re-enter your passphrase to confirm"
 		if rotate {
@@ -324,7 +309,7 @@ func promptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 		}
 		second, _, err := readPassphrase(secondMessage, !rotate)
 		if err != nil {
-			return "", nil, err
+			return nil, err
 		}
 
 		if first == second {
@@ -337,10 +322,10 @@ func promptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 
 	state, sm, err := NewPassphraseSecretsManager(phrase)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	setCachedSecretsManager(state, sm)
-	return state, sm, err
+	return sm, err
 }
 
 func readPassphrase(prompt string, useEnv bool) (phrase string, interactive bool, err error) {

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -123,24 +123,8 @@ func (sm *serviceSecretsManager) Encrypter() (config.Encrypter, error) {
 }
 
 func NewServiceSecretsManager(
-	client *client.Client, id client.StackIdentifier, info *workspace.ProjectStack,
+	client *client.Client, id client.StackIdentifier,
 ) (secrets.Manager, error) {
-	// To change the secrets provider to a serviceSecretsManager we would need to ensure that there are no
-	// remnants of the old secret manager To remove those remnants, we would set those values to be empty in
-	// the project stack.
-	// A passphrase secrets provider has an encryption salt, therefore, changing
-	// from passphrase to serviceSecretsManager requires the encryption salt
-	// to be removed.
-	// A cloud secrets manager has an encryption key and a secrets provider,
-	// therefore, changing from cloud to serviceSecretsManager requires the
-	// encryption key and secrets provider to be removed.
-	// Regardless of what the current secrets provider is, all of these values
-	// need to be empty otherwise `getStackSecretsManager` in crypto.go can
-	// potentially return the incorrect secret type for the stack.
-	info.EncryptionSalt = ""
-	info.SecretsProvider = ""
-	info.EncryptedKey = ""
-
 	state, err := json.Marshal(serviceSecretsManagerState{
 		URL:      client.URL(),
 		Owner:    id.Owner,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
