### PR TITLE
state delete: fix panic when there are no snapshots

### DIFF
--- a/changelog/pending/20240104--cli-state--fix-a-panic-in-pulumi-state-when-no-snapshots-are-available.yaml
+++ b/changelog/pending/20240104--cli-state--fix-a-panic-in-pulumi-state-when-no-snapshots-are-available.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix a panic in pulumi state when no snapshots are available

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -226,6 +226,9 @@ func getURNFromState(
 		if err != nil {
 			return "", err
 		}
+		if *snap == nil {
+			return "", errors.New("no snapshot found")
+		}
 	}
 	urnList := make([]string, len((*snap).Resources))
 	for i, r := range (*snap).Resources {

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -64,7 +64,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				urn, err = getURNFromState(ctx, stack, nil,
 					"Select the resource to delete")
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to select resource: %w", err)
 				}
 			} else {
 				urn = resource.URN(args[0])

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -181,6 +181,9 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				err := surveyStack(
 					func() (err error) {
 						urn, err = getURNFromState(ctx, stack, &snap, "Select a resource to rename:")
+						if err != nil {
+							err = fmt.Errorf("failed to select resource: %w", err)
+						}
 						return
 					},
 					func() (err error) {

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -62,7 +62,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				var err error
 				urn, err = getURNFromState(ctx, stack, nil, "Select a resource to unprotect:")
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to select resource: %w", err)
 				}
 			} else {
 				urn = resource.URN(args[0])


### PR DESCRIPTION
Currently when there are no snapshots, and a user calls `pulumi state delete` without specifying a URN, and no snapshot available, it panics.  Fix this panic, and give the user better error message in this case.

Fixes #15033 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
