### PR TITLE
publish dev releases to releases/dev-sdk in addition to releases/sdk

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -149,3 +149,4 @@ jobs:
       - name: Publish Blobs
         run: |
           aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
+          aws s3 sync artifacts s3://get.pulumi.com/releases/dev-sdk --acl public-read


### PR DESCRIPTION
For transitioning to the new releases/dev-sdk prefix for dev channel releases, start double publishing to the old and the new prefix while we're transitioning, so current users aren't broken when using dev releases.

Fixes https://github.com/pulumi/pulumi/issues/15031

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
