### PR TITLE
Switch to API Token for PyPi uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  PYPI_USERNAME: __token__
+  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
 jobs:
   sdks:

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -99,7 +99,7 @@ publish::
 		mv -vT "$${file}" "../../artifacts/$${basename##sdk-python-}"; \
 	done
 	twine upload \
-	-u pulumi -p "${PYPI_PASSWORD}" \
+	-u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" \
 		../../artifacts/*.whl \
 		--skip-existing \
 		--verbose


### PR DESCRIPTION
Username/Password authentication is no longer supported. This PR migrates to using API Tokens per https://pypi.org/help/#apitoken. We use `__token__` for the username and the org-wide `PYPI_API_TOKEN` secret for the password.

Part of https://github.com/pulumi/pulumi/issues/15043

Reference:
- https://github.com/pulumi/ci-mgmt/issues/751
- https://github.com/pulumi/ci-mgmt/pull/767