### PR TITLE
Temporary changes to unblock v3.100.0 release

### DIFF
--- a/.github/workflows/on-release-manual-dispatch.yml
+++ b/.github/workflows/on-release-manual-dispatch.yml
@@ -1,0 +1,50 @@
+name: Release Dispatch
+
+permissions:
+  # To create the follow-up PR.
+  contents: write
+  pull-requests: write
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        description: "Git Tag"
+        type: string
+      release_notes:
+        required: true
+        description: "Release Notes"
+        type: string
+
+concurrency: release
+
+jobs:
+  info:
+    name: gather
+    runs-on: ubuntu-latest
+    outputs:
+      version: "${{ fromJSON(steps.version.outputs.version) }}"
+    steps:
+      - uses: actions/checkout@v3
+        # Uses release ref (tag)
+      - name: Info
+        id: version
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          PULUMI_VERSION="${TAG#v}" # remove prefix
+
+          ./.github/scripts/set-output version "${PULUMI_VERSION}"
+
+  release:
+    name: release
+    needs: [info]
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ inputs.tag_name }}
+      version: ${{ needs.info.outputs.version }}
+      release-notes: ${{ inputs.release_notes }}
+      queue-merge: true
+      run-dispatch-commands: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["nodejs", "python", "go"]
+        # language: ["nodejs", "python", "go"]
+        language: ["python"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -99,32 +100,32 @@ jobs:
         run: |
           make -C sdk/${{ matrix.language}} publish
 
-  s3-blobs:
-    name: s3 blobs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Download release artifacts
-        run: |
-          mkdir -p artifacts
-          gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'pulumi-*'
-          find artifacts
-      - name: Publish Blobs
-        run: |
-          aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
+  # s3-blobs:
+  #   name: s3 blobs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ inputs.ref }}
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-region: us-east-2
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         role-duration-seconds: 3600
+  #         role-external-id: upload-pulumi-release
+  #         role-session-name: pulumi@githubActions
+  #         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+  #     - name: Download release artifacts
+  #       run: |
+  #         mkdir -p artifacts
+  #         gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'pulumi-*'
+  #         find artifacts
+  #     - name: Publish Blobs
+  #       run: |
+  #         aws s3 sync artifacts s3://get.pulumi.com/releases/sdk --acl public-read
 
   pr:
     # Relies on the Go SDK being published to update pkg
@@ -179,14 +180,14 @@ jobs:
         run: ${{ matrix.job.run-command }}
 
 
-  update-homebrew-tap:
-    name: Update Homebrew Tap
-    if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
-    uses: ./.github/workflows/release-homebrew-tap.yml
-    permissions:
-      contents: read
-    with:
-      ref: ${{ inputs.ref }}
-      version: ${{ inputs.version }}
-      dry-run: false
-    secrets: inherit
+  # update-homebrew-tap:
+  #   name: Update Homebrew Tap
+  #   if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
+  #   uses: ./.github/workflows/release-homebrew-tap.yml
+  #   permissions:
+  #     contents: read
+  #   with:
+  #     ref: ${{ inputs.ref }}
+  #     version: ${{ inputs.version }}
+  #     dry-run: false
+  #   secrets: inherit


### PR DESCRIPTION
This commit contains two changes:

1. Temporarily comment out jobs that have already successfully run in the `release.yml` workflow. See https://github.com/pulumi/pulumi/actions/runs/7404894608

2. Add a way to manually dispatch a release via `on-release-manual-dispatch.yml` workflow. The new file is a copy of `on-release.yml`, but setup to allow manual trigger with input variables, rather than being triggered by a release.

This change will be reverted after v3.100.0 is fully released.

Part of #15043