### PR TITLE
show test command in test name

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Create GCP service account key file
         run: |
           echo '${{ secrets.GCP_SERVICE_ACCOUNT }}' > '${{ runner.temp }}/application_default_credentials.json'
-      - name: run tests
+      - name: run tests ${{ inputs.test-command }}
         id: test
         run: ${{ inputs.test-command }}
         env:

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Create GCP service account key file
         run: |
           echo '${{ secrets.GCP_SERVICE_ACCOUNT }}' > '${{ runner.temp }}/application_default_credentials.json'
-      - name: run tests ${{ inputs.test-command }}
+      - name: run tests "${{ inputs.test-command }}"
         id: test
         run: ${{ inputs.test-command }}
         env:


### PR DESCRIPTION
The windows tests keep failing, without a good indication of what is actually failing, and no logs in the "run tests".  Maybe adding the test command we're actually running will give us some additional information to help track the issue down.


Not sure if this will actually help with anything, but I also don't think it can hurt.

/xref https://github.com/pulumi/pulumi/issues/14992
