### PR TITLE
Temporary change to unblock v3.100.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,45 +61,44 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
 jobs:
-  sdks:
-    name: ${{ matrix.language }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # language: ["nodejs", "python", "go"]
-        language: ["python"]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Python ${{ fromJson(inputs.version-set).python }}
-        if: ${{ matrix.language == 'python' }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ fromJson(inputs.version-set).python }}
-          cache-dependency-path: sdk/python/requirements.txt
-      - name: Install Python deps
-        if: ${{ matrix.language == 'python' }}
-        run: |
-          python -m pip install --upgrade pip requests wheel urllib3 chardet twine
-      - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
-        if: ${{ matrix.language == 'nodejs' }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ fromJson(inputs.version-set).nodejs }}
-          registry-url: https://registry.npmjs.org
-          always-auth: true
-      - name: Download release artifacts
-        if: ${{ matrix.language != 'go' }}
-        run: |
-          mkdir -p artifacts
-          gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'sdk-${{ matrix.language }}-*'
-          find artifacts
-      - name: Publish Packages
-        run: |
-          make -C sdk/${{ matrix.language}} publish
+#   sdks:
+#     name: ${{ matrix.language }}
+#     runs-on: ubuntu-latest
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         language: ["nodejs", "python", "go"]
+#     steps:
+#       - name: Checkout Repo
+#         uses: actions/checkout@v3
+#         with:
+#           ref: ${{ inputs.ref }}
+#       - name: Set up Python ${{ fromJson(inputs.version-set).python }}
+#         if: ${{ matrix.language == 'python' }}
+#         uses: actions/setup-python@v3
+#         with:
+#           python-version: ${{ fromJson(inputs.version-set).python }}
+#           cache-dependency-path: sdk/python/requirements.txt
+#       - name: Install Python deps
+#         if: ${{ matrix.language == 'python' }}
+#         run: |
+#           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
+#       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
+#         if: ${{ matrix.language == 'nodejs' }}
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: ${{ fromJson(inputs.version-set).nodejs }}
+#           registry-url: https://registry.npmjs.org
+#           always-auth: true
+#       - name: Download release artifacts
+#         if: ${{ matrix.language != 'go' }}
+#         run: |
+#           mkdir -p artifacts
+#           gh release download "v${PULUMI_VERSION}" --dir ./artifacts --pattern 'sdk-${{ matrix.language }}-*'
+#           find artifacts
+#       - name: Publish Packages
+#         run: |
+#           make -C sdk/${{ matrix.language}} publish
 
   # s3-blobs:
   #   name: s3 blobs
@@ -131,7 +130,7 @@ jobs:
   pr:
     # Relies on the Go SDK being published to update pkg
     name: PR
-    needs: [sdks]
+    # needs: [sdks]
     uses: ./.github/workflows/release-pr.yml
     permissions:
       contents: write


### PR DESCRIPTION
Turns out, we can't easily change the credentials of the Python publish step because it will run the publish command as defined in `v3.100.0` which is using the old username/password, rather than from `master` which has been updated to use the API token.

Instead, the wheel artifact from https://github.com/pulumi/pulumi/releases/tag/v3.100.0 has been manually published.

This change temporarily updates the release workflow to no longer do any SDK publishing steps, as these are now all complete. Once this has merged, I'll dispatch the release, which will run all subsequent release steps.

Then we can revert the temporary workflow changes.

Part of #15043