### PR TITLE
[schema] Emit a warning when using id or urn as resource properties

### DIFF
--- a/changelog/pending/20240105--sdkgen--emit-a-warning-when-using-id-or-urn-as-resource-outputs.yaml
+++ b/changelog/pending/20240105--sdkgen--emit-a-warning-when-using-id-or-urn-as-resource-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdkgen
+  description: Emit a warning when using id or urn as resource outputs

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -80,6 +80,16 @@ func errorf(path, message string, args ...interface{}) *hcl.Diagnostic {
 	}
 }
 
+func warningf(path, message string, args ...interface{}) *hcl.Diagnostic {
+	contract.Requiref(path != "", "path", "must not be empty")
+
+	summary := path + ": " + fmt.Sprintf(message, args...)
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  summary,
+	}
+}
+
 func validateSpec(spec PackageSpec) (hcl.Diagnostics, error) {
 	bytes, err := json.Marshal(spec)
 	if err != nil {
@@ -1357,6 +1367,19 @@ func (t *types) bindResourceDetails(path, token string, spec ResourceSpec, decl 
 	diags = diags.Extend(propertyDiags)
 	if err != nil {
 		return diags, fmt.Errorf("failed to bind properties for %v: %w", token, err)
+	}
+
+	// urn is a reserved property name for all resources
+	// id is a reserved property name for resources which are not components
+	// emit a warning if either of these are used
+	for _, property := range properties {
+		if property.Name == "urn" {
+			diags = diags.Append(warningf(path+"/properties/urn", "urn is a reserved property name"))
+		}
+
+		if !spec.IsComponent && property.Name == "id" {
+			diags = diags.Append(warningf(path+"/properties/id", "id is a reserved property name for resources"))
+		}
 	}
 
 	inputProperties, _, inputDiags, err := t.bindProperties(path+"/inputProperties", spec.InputProperties,


### PR DESCRIPTION
# Description

Emits a warning when binding properties of resources if we encounter a property with name `urn` or when we encounter a property with name `id` (only for resources which are not components / MLCs). This is a follow up PR for #15025 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
