### PR TITLE
Temporarily disable large Windows runners

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -414,7 +414,9 @@ def get_matrix(
         test_suites += run_gotestsum_ci_matrix_single_package(item, pkg_tests, tags)
 
     if kind == JobKind.ACCEPTANCE_TEST:
-        platforms = list(map(lambda p: "windows-16core-2022" if p == "windows-latest" else p, platforms))
+        # Temporarily disable running acceptance tests on Windows.
+        # platforms = list(map(lambda p: "windows-16core-2022" if p == "windows-latest" else p, platforms))
+        platforms = list(filter(lambda p: p != "windows-latest", platforms))
 
     return {
         "test-suite": test_suites,


### PR DESCRIPTION
We're seeing a significant increase in costs with our use of large Windows runners. Temporarily disable Windows runners while we root cause.