### PR TITLE
Remove b64 from the default secrets provider

### DIFF
--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -114,7 +114,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			}, nil
 		},
 		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, stack.DefaultSecretsProvider)
+			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, b64.Base64SecretsProvider)
 			if err != nil {
 				return err
 			}
@@ -210,7 +210,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			}, nil
 		},
 		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, stack.DefaultSecretsProvider)
+			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, b64.Base64SecretsProvider)
 			if err != nil {
 				return err
 			}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
@@ -42,8 +41,6 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	var sm secrets.Manager
 	var err error
 	switch ty {
-	case b64.Type:
-		sm = b64.NewBase64SecretsManager()
 	case passphrase.Type:
 		sm, err = passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
 	case service.Type:

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -195,7 +196,7 @@ type mapTestSecretsProvider struct {
 }
 
 func (p *mapTestSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
-	m, err := DefaultSecretsProvider.OfType(ty, state)
+	m, err := b64.Base64SecretsProvider.OfType(ty, state)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This removes "b64" from the default secrets provider. Anywhere we're using "b64" secrets we'll also be using the "Base64SecretsProvider" (which only returns b64 secret managers).
