### PR TITLE
Add work target to initialize a go workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ $ pulumi preview --logtostderr -v=5
 
 is a pretty standard starting point during debugging that will show a fairly comprehensive trace log of a compilation.
 
+### Go Language Server
+
+Since this repository contains multiple go modules, `gopls` requires a go workspace. Run `make work` to setup a suitable go workspace.
+
 ## Submitting a Pull Request
 
 For contributors we use the [standard fork based workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962): Fork this repository, create a topic branch, and when ready, open a pull request from your fork.

--- a/Makefile
+++ b/Makefile
@@ -205,3 +205,15 @@ get_schemas: \
 .PHONY: changelog
 changelog:
 	go run github.com/aaronfriel/go-change@v0.1.2 create
+
+.PHONY: work
+work:
+	rm -f go.work go.work.sum
+	go work init \
+		cmd/pulumi-test-language \
+		pkg \
+		sdk \
+		sdk/go/pulumi-language-go \
+		sdk/nodejs/cmd/pulumi-language-nodejs \
+		sdk/python/cmd/pulumi-language-python \
+		tests


### PR DESCRIPTION
# Description

Add a make target to setup a go workspace. This is needed to make `gopls`, the go language server, work seamlessly when opening the root of the repo.
