### PR TITLE
Refactor out Python virtualenv shim

### DIFF
--- a/changelog/pending/20240104--cli-new--adds-pulumi-template-tag-to-pulumi-new-created-projects.yaml
+++ b/changelog/pending/20240104--cli-new--adds-pulumi-template-tag-to-pulumi-new-created-projects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Adds pulumi:template tag to `pulumi new` created projects

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -99,6 +99,7 @@ func (be *MockBackend) URL() string {
 func (be *MockBackend) SetCurrentProject(project *workspace.Project) {
 	if be.SetCurrentProjectF != nil {
 		be.SetCurrentProjectF(project)
+		return
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -16,7 +16,6 @@ package backend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -195,22 +194,22 @@ func GetEnvironmentTagsForCurrentStack(root string,
 	}
 
 	// Grab any `pulumi:tag` config values and use those to update the stack's tags.
-	configTags, has, err := cfg.Get(config.MustMakeKey("pulumi", "tags"), false)
-	contract.AssertNoErrorf(err, "Config.Get(\"pulumi:tags\") failed unexpectedly")
+	configTags, has, err := cfg.Get(config.MustParseKey(apitype.PulumiTagsConfigKey), false)
+	contract.AssertNoErrorf(err, "Config.Get(\"%s\") failed unexpectedly", apitype.PulumiTagsConfigKey)
 	if has {
 		configTagInterface, err := configTags.ToObject()
 		if err != nil {
-			return nil, errors.New("pulumi:tags must be an object of strings")
+			return nil, fmt.Errorf("%s must be an object of strings", apitype.PulumiTagsConfigKey)
 		}
 		configTagObject, ok := configTagInterface.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("pulumi:tags must be an object of strings")
+			return nil, fmt.Errorf("%s must be an object of strings", apitype.PulumiTagsConfigKey)
 		}
 
 		for name, value := range configTagObject {
 			stringValue, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf("pulumi:tags[%s] must be a string", name)
+				return nil, fmt.Errorf("%s[%s] must be a string", apitype.PulumiTagsConfigKey, name)
 			}
 
 			tags[name] = stringValue

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -317,13 +317,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	proj.Name = tokens.PackageName(args.name)
 	proj.Description = &args.description
 	proj.Template = nil
-	// Workaround for python, most of our templates don't specify a venv but we want to use one
-	if proj.Runtime.Name() == "python" {
-		// If the template does give virtualenv use it, else default to "venv"
-		if _, has := proj.Runtime.Options()["virtualenv"]; !has {
-			proj.Runtime.SetOption("virtualenv", "venv")
-		}
-	}
+	proj.Runtime.FixupPythonDefaultVirtualenv()
 
 	proj.SetProjectTagsConfig(map[string]string{
 		apitype.ProjectTemplateTag: args.templateNameOrURL,

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -325,6 +325,10 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 	}
 
+	proj.SetProjectTagsConfig(map[string]string{
+		apitype.ProjectTemplateTag: args.templateNameOrURL,
+	})
+
 	if err = workspace.SaveProject(proj); err != nil {
 		return fmt.Errorf("saving project: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -168,14 +168,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	if err != nil {
 		return err
 	}
-
-	// Workaround for python, most of our templates don't specify a venv but we want to use one
-	if proj.Runtime.Name() == "python" {
-		// If the template does give virtualenv use it, else default to "venv"
-		if _, has := proj.Runtime.Options()["virtualenv"]; !has {
-			proj.Runtime.SetOption("virtualenv", "venv")
-		}
-	}
+	proj.Runtime.FixupPythonDefaultVirtualenv()
 
 	if err = proj.Save(projPath); err != nil {
 		return fmt.Errorf("saving project: %w", err)

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -390,6 +390,8 @@ const (
 	ProjectRuntimeTag StackTagName = "pulumi:runtime"
 	// ProjectDescriptionTag is a tag that represents the description of a project (Pulumi.yaml's `description`).
 	ProjectDescriptionTag StackTagName = "pulumi:description"
+	// ProjectTemplateTag is a tag that represents the template that was used to create a project.
+	ProjectTemplateTag StackTagName = "pulumi:template"
 	// GitHubOwnerNameTag is a tag that represents the name of the owner on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
 	// TODO [pulumi/pulumi-service#2306] Once the UI is updated, we would no longer need the GitHub specific keys.
@@ -409,6 +411,16 @@ const (
 	// VCSRepositoryRootTag is a tag that represents the root directory of the repository on the cloud VCS that
 	// this stack may be associated with (pulled from git by the CLI)
 	VCSRepositoryRootTag StackTagName = "vcs:root"
+)
+
+// ConfigKey is the key for a configuration value. This is just a string, but we use a type alias to provide a richer
+// description of how the string is used in our apitype definitions.
+type ConfigKey = string
+
+const (
+	// PulumiTagsConfigKey sets additional tags for a stack on a deployment. This is additive to any
+	// tags that are already set on the stack.
+	PulumiTagsConfigKey ConfigKey = "pulumi:tags"
 )
 
 // Stack describes a Stack running on a Pulumi Cloud.

--- a/sdk/go/common/resource/config/key.go
+++ b/sdk/go/common/resource/config/key.go
@@ -34,6 +34,14 @@ func MustMakeKey(namespace string, name string) Key {
 	return Key{namespace: namespace, name: name}
 }
 
+// MustParseKey creates a config.Key from a string. The string must be of the form
+// `<namespace>:<name>`.
+func MustParseKey(s string) Key {
+	key, err := ParseKey(s)
+	contract.AssertNoErrorf(err, "failed to parse key %s", s)
+	return key
+}
+
 func ParseKey(s string) (Key, error) {
 	// Keys can take on of two forms:
 	//

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
@@ -964,4 +965,33 @@ func save(path string, value interface{}, mkDirAll bool) error {
 
 	//nolint:gosec
 	return os.WriteFile(path, b, 0o644)
+}
+
+// To mitigate an import cycle, we define this here.
+const PulumiTagsConfigKey = "pulumi:tags"
+
+// SetProjectTagsConfig sets the project tags config to the given map of tags.
+func (proj *Project) SetProjectTagsConfig(tags map[string]string) {
+	if proj.Config == nil {
+		proj.Config = map[string]ProjectConfigType{}
+	}
+	configTags, has := proj.Config["pulumi:tags"]
+	if !has {
+		configTags = ProjectConfigType{
+			Value: map[string]string{},
+		}
+	}
+	if configTags.Value == nil {
+		configTags.Value = map[string]string{}
+	}
+
+	tagMap, ok := configTags.Value.(map[string]string)
+	if !ok {
+		logging.Warningf("overwriting non-object `%s` project config", "pulumi:tags")
+		tagMap = map[string]string{}
+	}
+	for k, v := range tags {
+		tagMap[k] = v
+	}
+	proj.Config["pulumi:tags"] = configTags
 }

--- a/sdk/go/common/workspace/project_runtime_shims.go
+++ b/sdk/go/common/workspace/project_runtime_shims.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+// FixupPythonDefaultVirtualenv sets the default virtualenv for Python projects.
+//
+// This is a workaround for Python projects, most of our templates don't specify a venv but we want
+// to use one by default.
+func (r *ProjectRuntimeInfo) FixupPythonDefaultVirtualenv() {
+	if r.Name() == "python" {
+		// If the template does give virtualenv use it, else default to "venv"
+		if _, has := r.Options()["virtualenv"]; !has {
+			r.SetOption("virtualenv", "venv")
+		}
+	}
+}


### PR DESCRIPTION
This code is duplicated here and in Pulumi Cloud, in template instantiation. Moving the shim to a
public function helps clean up this code duplication.
