### PR TITLE
Don't update new state outputs for replace steps

### DIFF
--- a/changelog/pending/20240109--engine--fix-an-uncommon-datarace-with-replace-steps.yaml
+++ b/changelog/pending/20240109--engine--fix-an-uncommon-datarace-with-replace-steps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix an uncommon datarace with replace steps.

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -354,8 +354,11 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 	}
 
 	// Ensure that any secrets properties in the output are marked as such and that the resource is tracked in the set
-	// of registered resources.
-	if step.New() != nil {
+	// of registered resources. We skip this for replace steps because while they _do_ have a "new" side to them that
+	// state may have already been added to the snapshot manager (in the case of create before delete replacements
+	// because the Create step is run before the Replace step) and mutating the state again causes dataraces (see
+	// https://github.com/pulumi/pulumi/issues/14994).
+	if step.New() != nil && step.Op() != OpReplace {
 		newState := step.New()
 		for _, k := range newState.AdditionalSecretOutputs {
 			if k == "id" {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This fixes a data race between the snapshot system and the step executor for create before delete replacements.

When doing a create-before-delete replacement the step generator would issue two steps to the step executor. The first step being Create which would create the new resource instance and add that state to the snapshot system to be saved. The second being a replace step, which didn't interact with the snapshot system but is a step that executes. There's a bit of code in the executor that ran for every step to mutate the outputs to ensure secrets propagated correctly. This could run in parallel with the snapshot system trying to iterator over the outputs to serialise them out and causes a "concurrent map iteration and map write" error.

It is obviously very hard to write a test to show this but, work being done in https://github.com/pulumi/pulumi/pull/14079 should improve the likelihood of us detecting issues like this in pu/pu tests.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
