### PR TITLE
[CI] Ignore python mypy typecheck on google.protobuf.pyext to re-enable CI builds

### DIFF
--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -126,7 +126,7 @@ except ImportError:
 
 # New versions of protobuf have moved the above import to api_implementation
 try:
-    from google.protobuf.pyext import (
+    from google.protobuf.pyext import (  # type: ignore
         cpp_message,
     )  # pylint: disable-msg=E0611
 


### PR DESCRIPTION
Fixes #15111 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
