### PR TITLE
[python/sdk] Allow remote components to use output property called id

### DIFF
--- a/changelog/pending/20240117--sdk-python--allow-remote-components-to-use-output-property-called-id.yaml
+++ b/changelog/pending/20240117--sdk-python--allow-remote-components-to-use-output-property-called-id.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Allow remote components to use output property called id

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -1062,7 +1062,8 @@ class ComponentResource(Resource):
         :param bool remote: True if this is a remote component resource.
         """
         Resource.__init__(self, t, name, False, props, opts, remote, False)
-        self.__dict__["id"] = None
+        if not remote:
+            self.__dict__["id"] = None
         self._remote = remote
 
     def register_outputs(self, outputs: "Inputs"):

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -526,7 +526,7 @@ def get_resource(
         (resolve_id, res.__dict__["id"]) = resource_output(res)
 
     # Like the other resource functions, "transfer" all input properties onto unresolved futures on res.
-    resolvers = rpc.transfer_properties(res, props)
+    resolvers = rpc.transfer_properties(res, props, custom)
 
     async def do_get():
         try:
@@ -590,6 +590,7 @@ def get_resource(
             resp["state"],
             {},
             resolvers,
+            custom,
             transform_using_type_metadata,
         )
 
@@ -711,7 +712,8 @@ def read_resource(
     (resolve_id, res.__dict__["id"]) = resource_output(res)
 
     # Like below, "transfer" all input properties onto unresolved futures on res.
-    resolvers = rpc.transfer_properties(res, props)
+    custom = True  # Reads are always for custom resources (non-components)
+    resolvers = rpc.transfer_properties(res, props, custom)
 
     # Get the source position.
     #
@@ -799,6 +801,7 @@ def read_resource(
             resp.properties,
             {},
             resolvers,
+            custom,
             transform_using_type_metadata,
         )
 
@@ -846,7 +849,7 @@ def register_resource(
     # Now "transfer" all input properties into unresolved futures on res.  This way,
     # this resource will look like it has all its output properties to anyone it is
     # passed to.  However, those futures won't actually resolve until the RPC returns
-    resolvers = rpc.transfer_properties(res, props)
+    resolvers = rpc.transfer_properties(res, props, custom)
 
     # Get the source position.
     #
@@ -1032,6 +1035,7 @@ def register_resource(
                 resp.object,
                 property_deps,
                 resolvers,
+                custom,
                 transform_using_type_metadata,
             )
             resolve_outputs_called = True

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,6 +10,7 @@ replace (
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/golang/protobuf v1.5.3
 	github.com/grapl-security/pulumi-hcp/sdk v0.1.14
 	github.com/hexops/autogold v1.3.0
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
@@ -89,7 +90,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/tests/integration/construct_component_id_output/python/.gitignore
+++ b/tests/integration/construct_component_id_output/python/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/construct_component_id_output/python/Pulumi.yaml
+++ b/tests/integration/construct_component_id_output/python/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: construct_component_py
+description: A program that constructs remote component resources.
+runtime: python

--- a/tests/integration/construct_component_id_output/python/__main__.py
+++ b/tests/integration/construct_component_id_output/python/__main__.py
@@ -1,0 +1,8 @@
+# Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+from component import Component
+
+component_a = Component("a", id="hello")
+
+pulumi.export("id", component_a.id)

--- a/tests/integration/construct_component_id_output/python/component.py
+++ b/tests/integration/construct_component_id_output/python/component.py
@@ -1,0 +1,16 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+from typing import Any, Optional
+
+import pulumi
+
+class Component(pulumi.ComponentResource):
+    def __init__(self, name: str, id: pulumi.Input[str], opts: Optional[pulumi.ResourceOptions] = None):
+        props = dict()
+        props["id"] = id
+        super().__init__("testcomponent:index:Component", name, props, opts, True)
+
+    @property
+    @pulumi.getter
+    def id(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "id")

--- a/tests/integration/construct_component_id_output/testcomponent-go/.gitignore
+++ b/tests/integration/construct_component_id_output/testcomponent-go/.gitignore
@@ -1,0 +1,2 @@
+pulumi-resource-testcomponent
+pulumi-resource-testcomponent.exe

--- a/tests/integration/construct_component_id_output/testcomponent-go/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_id_output/testcomponent-go/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: go

--- a/tests/integration/construct_component_id_output/testcomponent-go/main.go
+++ b/tests/integration/construct_component_id_output/testcomponent-go/main.go
@@ -1,0 +1,247 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+//go:build !all
+// +build !all
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	pbempty "github.com/golang/protobuf/ptypes/empty"
+)
+
+type Resource struct {
+	pulumi.CustomResourceState
+}
+
+type resourceArgs struct {
+	Echo interface{} `pulumi:"echo"`
+}
+
+type ResourceArgs struct {
+	Echo pulumi.Input
+}
+
+func (ResourceArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*resourceArgs)(nil)).Elem()
+}
+
+func NewResource(ctx *pulumi.Context, name string, echo pulumi.Input,
+	opts ...pulumi.ResourceOption,
+) (*Resource, error) {
+	args := &ResourceArgs{Echo: echo}
+	var resource Resource
+	err := ctx.RegisterResource(providerName+":index:Resource", name, args, &resource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type Component struct {
+	pulumi.ResourceState
+	Id pulumi.StringOutput `pulumi:"id"`
+}
+
+type ComponentArgs struct {
+	Id pulumi.StringInput `pulumi:"id"`
+}
+
+func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
+	opts ...pulumi.ResourceOption,
+) (*Component, error) {
+	component := &Component{}
+	err := ctx.RegisterComponentResource(providerName+":index:Component", name, component, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := NewResource(ctx, fmt.Sprintf("child-%s", name), args.Id, pulumi.Parent(component))
+	if err != nil {
+		return nil, err
+	}
+
+	component.Id = pulumi.All(res.ID(), args.Id).ApplyT(func(resolvedArgs []interface{}) (string, error) {
+		resourceId := resolvedArgs[0].(pulumi.ID)
+		argsId := resolvedArgs[1].(string)
+		return fmt.Sprintf("%s-%s", resourceId, argsId), nil
+	}).(pulumi.StringOutput)
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{
+		"id": component.Id,
+	}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
+}
+
+const (
+	providerName = "testcomponent"
+	version      = "0.0.1"
+)
+
+func main() {
+	err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
+		return makeProvider(host, providerName, version)
+	})
+	if err != nil {
+		cmdutil.ExitError(err.Error())
+	}
+}
+
+type Provider struct {
+	pulumirpc.UnimplementedResourceProviderServer
+
+	host    *provider.HostClient
+	name    string
+	version string
+}
+
+func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
+	return &Provider{
+		host:    host,
+		name:    name,
+		version: version,
+	}, nil
+}
+
+func (p *Provider) Create(ctx context.Context,
+	req *pulumirpc.CreateRequest,
+) (*pulumirpc.CreateResponse, error) {
+	urn := resource.URN(req.GetUrn())
+	typ := urn.Type()
+	if typ != providerName+":index:Resource" {
+		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
+	}
+
+	// the id of the resource created is always 42
+	return &pulumirpc.CreateResponse{
+		Id: "42",
+	}, nil
+}
+
+func (p *Provider) Construct(ctx context.Context,
+	req *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
+	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
+		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption,
+	) (*pulumiprovider.ConstructResult, error) {
+		if typ != providerName+":index:Component" {
+			return nil, fmt.Errorf("unknown resource type %s", typ)
+		}
+
+		args := &ComponentArgs{}
+		if err := inputs.CopyTo(args); err != nil {
+			return nil, fmt.Errorf("setting args: %w", err)
+		}
+		component, err := NewComponent(ctx, name, args, options)
+		if err != nil {
+			return nil, fmt.Errorf("creating component: %w", err)
+		}
+
+		return pulumiprovider.NewConstructResult(component)
+	})
+}
+
+func (p *Provider) CheckConfig(ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
+}
+
+func (p *Provider) DiffConfig(ctx context.Context,
+	req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	return &pulumirpc.DiffResponse{}, nil
+}
+
+func (p *Provider) Configure(ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	return &pulumirpc.ConfigureResponse{
+		AcceptSecrets:   true,
+		SupportsPreview: true,
+		AcceptResources: true,
+	}, nil
+}
+
+func (p *Provider) Invoke(ctx context.Context,
+	req *pulumirpc.InvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
+}
+
+func (p *Provider) StreamInvoke(req *pulumirpc.InvokeRequest,
+	server pulumirpc.ResourceProvider_StreamInvokeServer,
+) error {
+	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
+}
+
+func (p *Provider) Call(ctx context.Context,
+	req *pulumirpc.CallRequest,
+) (*pulumirpc.CallResponse, error) {
+	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
+}
+
+func (p *Provider) Check(ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
+}
+
+func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
+	return &pulumirpc.DiffResponse{}, nil
+}
+
+func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
+	return &pulumirpc.ReadResponse{
+		Id:         req.GetId(),
+		Properties: req.GetProperties(),
+	}, nil
+}
+
+func (p *Provider) Update(ctx context.Context,
+	req *pulumirpc.UpdateRequest,
+) (*pulumirpc.UpdateResponse, error) {
+	return &pulumirpc.UpdateResponse{
+		Properties: req.GetNews(),
+	}, nil
+}
+
+func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}
+
+func (p *Provider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
+	return &pulumirpc.PluginInfo{
+		Version: p.version,
+	}, nil
+}
+
+func (p *Provider) Attach(ctx context.Context, req *pulumirpc.PluginAttach) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}
+
+func (p *Provider) GetSchema(ctx context.Context,
+	req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	return &pulumirpc.GetSchemaResponse{}, nil
+}
+
+func (p *Provider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}
+
+func (p *Provider) GetMapping(context.Context, *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {
+	return &pulumirpc.GetMappingResponse{}, nil
+}


### PR DESCRIPTION
# Description

This PR updates the python SDK to allow remote components to have ID property. Adds an integration test which implements a component that had an output property `id` to ensure that we can have `id` as an output that doesn't get filtered out when serializing and deserializing property maps. 

Component instantiation looks like this in python
```python
import pulumi
from component import Component

component_a = Component("a", id="hello")

pulumi.export("id", component_a.id)
```
Where we expect `component_a.id` to equal `"{resource.ID}-{args.Id}" => "42-hello"` and the 42 is the (constant) ID of the resource created inside the component. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
