### PR TITLE
enable race detection in dev channel releases

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -40,6 +40,11 @@ on:
         default: false
         required: false
         type: boolean
+      enable-race-detection:
+        description: "Build binaries with race detection"
+        default: false
+        required: false
+        type: boolean
 
 defaults:
   run:
@@ -117,6 +122,7 @@ jobs:
           GORELEASER_CURRENT_TAG: v${{ inputs.version }}
           PULUMI_VERSION: ${{ inputs.dev-version || inputs.version }}
           PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && 'coverage' || 'normal' }}
+          PULUMI_ENABLE_RACE_DETECTION: ${{ inputs.enable-race-detection && 'true' || 'false' }}
         run: |
           set -euxo pipefail
           # Spurious, this command requires piping via stdin

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -85,6 +85,7 @@ jobs:
       build-platform: ${{ matrix.build-platform }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: false
+      enable-race-detection: true
     secrets: inherit
 
   sign:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
   main: ./cmd/pulumi
   gobinary: ../scripts/go-wrapper.sh
   env:
-  - CGO_ENABLED=0
   - GO111MODULE=on
   goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -37,9 +37,12 @@ case "$1" in
         fi
 
         RACE=
+        CGO_ENABLED=0
         if [ "$PULUMI_ENABLE_RACE_DETECTION" = "true" ]; then
             RACE='-race'
+            CGO_ENABLED=1
         fi
+        export CGO_ENABLED
 
         case "$MODE" in
             normal)

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -36,13 +36,19 @@ case "$1" in
             fi
         fi
 
+        RACE=
+        if [ "$PULUMI_ENABLE_RACE_DETECTION" = "true" ]; then
+            RACE='-race'
+        fi
+
         case "$MODE" in
             normal)
-                go "$@"
+                shift
+                go build ${RACE} "$@"
                 ;;
             coverage)
                 shift
-                go build -cover -coverpkg "$COVERPKG" "$@"
+                go build ${RACE} -cover -coverpkg "$COVERPKG" "$@"
                 ;;
             *)
                 echo "unknown build mode: $MODE"


### PR DESCRIPTION
We use dev channel releases to catch bugs early.  To increase the chance bugs are found, also enable race detection in these releases. This does mean these releases will be a little slower, and it might introduce more errors, but that seems like a good thing in exchange for potentially better quality of actual releases.

Fixes https://github.com/pulumi/pulumi/issues/15117

/cc @Frassle 