### PR TITLE
go-wrapper: fix script if PULUMI_TEST_COVERAGE_PATH is set

### DIFF
--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -30,7 +30,7 @@ case "$1" in
         if [ -z "$MODE" ]; then
             # If a build mode was not specified,
             # guess based on whether a coverage path was supplied.
-            MODE=normal
+            MODE=coverage
             if [ -z "$PULUMI_TEST_COVERAGE_PATH" ]; then
                 MODE=normal
             fi


### PR DESCRIPTION
The intention if this environment variable is set, is that we want to run in coverage mode.  However in
6af5f0b39dbf8291c8a6461659bffa7f96f22647 that accidentally got lost. Fix it.

I noticed this while looking at https://github.com/pulumi/pulumi/pull/15120 and got confused what the script is trying to do.
