### PR TITLE
enable race detection for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
       build-platform: ${{ matrix.target.build-platform }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: ${{ inputs.enable-coverage }}
+      enable-race-detection: true
     secrets: inherit
 
   build-sdks:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -40,6 +40,7 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       enable-coverage: true
+      enable-race-detection: true
     secrets: inherit
 
   prepare-release:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -40,7 +40,6 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       enable-coverage: true
-      enable-race-detection: true
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
Enable race detection in the binary we're using for integration tests. This will allow us to catch more data races before they get into any release.  This does mean the binary we're using for integration tests is slightly different from the binary we're releasing, however that's already the case as we're running a binary with coverage enabled for them.  Later we rebuild the binary we're actually releasing.

This builds on top of https://github.com/pulumi/pulumi/pull/15120 as that order made it easier to implement this, however it could be rebased and merged independently. 