### PR TITLE
`--import-file` now omits empty resource lists.

### DIFF
--- a/changelog/pending/20240110--cli-import--import-file-now-omits-empty-resource-lists.yaml
+++ b/changelog/pending/20240110--cli-import--import-file-now-omits-empty-resource-lists.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: --import-file now omits empty resource lists.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -161,7 +161,7 @@ type importSpec struct {
 
 type importFile struct {
 	NameTable map[string]resource.URN `json:"nameTable,omitempty"`
-	Resources []importSpec            `json:"resources"`
+	Resources []importSpec            `json:"resources,omitempty"`
 }
 
 func readImportFile(p string) (importFile, error) {

--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -404,33 +404,36 @@ func TestParseImportFileAutoURN(t *testing.T) {
 func TestImportFileMarshal(t *testing.T) {
 	t.Parallel()
 
-	importFile := importFile{
-		NameTable: map[string]resource.URN{
-			"foo": "urn:pulumi:stack::proj::foo:bar:a::arb",
-		},
-		Resources: []importSpec{
-			{
-				Name: "bar",
-				Type: "foo:bar:b",
-				ID:   "123",
-			},
-			{
-				Name:      "comp",
-				Type:      "some/comp",
-				Component: true,
-			},
-			{
-				Name:              "thirdParty",
-				Type:              "some:third:party",
-				ID:                "abc123",
-				Parent:            "bar",
-				Version:           "1.2.3",
-				PluginDownloadURL: "https://example.com",
-			},
-		},
-	}
+	t.Run("initial", func(t *testing.T) {
+		t.Parallel()
 
-	expected := `{
+		importFile := importFile{
+			NameTable: map[string]resource.URN{
+				"foo": "urn:pulumi:stack::proj::foo:bar:a::arb",
+			},
+			Resources: []importSpec{
+				{
+					Name: "bar",
+					Type: "foo:bar:b",
+					ID:   "123",
+				},
+				{
+					Name:      "comp",
+					Type:      "some/comp",
+					Component: true,
+				},
+				{
+					Name:              "thirdParty",
+					Type:              "some:third:party",
+					ID:                "abc123",
+					Parent:            "bar",
+					Version:           "1.2.3",
+					PluginDownloadURL: "https://example.com",
+				},
+			},
+		}
+
+		expected := `{
   "nameTable": {
     "foo": "urn:pulumi:stack::proj::foo:bar:a::arb"
   },
@@ -456,10 +459,23 @@ func TestImportFileMarshal(t *testing.T) {
   ]
 }
 `
-	var buffer bytes.Buffer
-	enc := json.NewEncoder(&buffer)
-	enc.SetIndent("", "  ")
-	err := enc.Encode(importFile)
-	require.NoError(t, err)
-	assert.Equal(t, expected, buffer.String())
+		var buffer bytes.Buffer
+		enc := json.NewEncoder(&buffer)
+		enc.SetIndent("", "  ")
+		err := enc.Encode(importFile)
+		require.NoError(t, err)
+		assert.Equal(t, expected, buffer.String())
+	})
+
+	t.Run("omit empty resources list", func(t *testing.T) {
+		t.Parallel()
+
+		importFile := importFile{}
+
+		var buffer bytes.Buffer
+		enc := json.NewEncoder(&buffer)
+		err := enc.Encode(importFile)
+		require.NoError(t, err)
+		assert.NotContains(t, buffer.String(), "resources")
+	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #15041

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
