### PR TITLE
Clean up project usage

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -161,7 +161,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 					}
 				}
 
-				progInfo := plugin.ProgInfo{Proj: proj, Pwd: pwd, Program: program}
+				progInfo := plugin.ProgInfo{Pwd: pwd, Program: program}
 				deps, err := lang.GetProgramDependencies(progInfo, transitiveDependencies)
 				if err != nil {
 					addError(err, "Failed to get information about the Pulumi program's dependencies")
@@ -589,8 +589,7 @@ func getProjectPluginsSilently(
 	os.Stdout = w
 
 	return plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
-		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,
-	}, plugin.AllPlugins)
+	}, proj, plugin.AllPlugins)
 }

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -86,7 +86,6 @@ func newInstallCmd() *cobra.Command {
 
 			// Compute the set of plugins the current project needs.
 			installs, err := lang.GetRequiredPlugins(plugin.ProgInfo{
-				Proj:    proj,
 				Pwd:     pwd,
 				Program: main,
 			})

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -70,10 +70,9 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	plugins, err := plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
-		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,
-	}, plugin.AllPlugins)
+	}, proj, plugin.AllPlugins)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -119,10 +119,12 @@ func newPluginSet(plugins ...workspace.PluginSpec) pluginSet {
 
 // gatherPluginsFromProgram inspects the given program and returns the set of plugins that the program requires to
 // function. If the language host does not support this operation, the empty set is returned.
-func gatherPluginsFromProgram(plugctx *plugin.Context, prog plugin.ProgInfo) (pluginSet, error) {
+func gatherPluginsFromProgram(
+	plugctx *plugin.Context, prog plugin.ProgInfo, proj *workspace.Project,
+) (pluginSet, error) {
 	logging.V(preparePluginLog).Infof("gatherPluginsFromProgram(): gathering plugins from language host")
 	set := newPluginSet()
-	langhostPlugins, err := plugin.GetRequiredPlugins(plugctx.Host, plugctx.Root, prog, plugin.AllPlugins)
+	langhostPlugins, err := plugin.GetRequiredPlugins(plugctx.Host, plugctx.Root, prog, proj, plugin.AllPlugins)
 	if err != nil {
 		return set, err
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -239,10 +239,9 @@ func installPlugins(ctx context.Context,
 	// In order to get a complete view of the set of plugins that we need for an update or query, we must
 	// consult both sources and merge their results into a list of plugins.
 	languagePlugins, err := gatherPluginsFromProgram(plugctx, plugin.ProgInfo{
-		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,
-	})
+	}, proj)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -15,7 +15,7 @@
 3523370423 3027 proto/pulumi/converter.proto
 2889436496 3240 proto/pulumi/engine.proto
 3421371250 793 proto/pulumi/errors.proto
-3077561539 10134 proto/pulumi/language.proto
+829031483 10232 proto/pulumi/language.proto
 2893249402 1992 proto/pulumi/plugin.proto
 2539158637 24561 proto/pulumi/provider.proto
 1320626516 12214 proto/pulumi/resource.proto

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -83,7 +83,7 @@ message AboutResponse {
 }
 
 message GetProgramDependenciesRequest {
-    string project = 1 [deprecated = true]; // the project name.
+    string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
     string pwd = 2 [deprecated = true];     // the program's working directory.
     string program = 3 [deprecated = true]; // the path to the program.
     bool transitiveDependencies = 4; // if transitive dependencies should be included in the result.
@@ -100,7 +100,7 @@ message GetProgramDependenciesResponse {
 }
 
 message GetRequiredPluginsRequest {
-    string project = 1 [deprecated = true]; // the project name.
+    string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
     string pwd = 2 [deprecated = true];     // the program's working directory.
     string program = 3 [deprecated = true]; // the path to the program.
     ProgramInfo info = 4; // the program info to use to calculate plugins.

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -586,18 +586,19 @@ const (
 var AllPlugins = AnalyzerPlugins | LanguagePlugins | ResourcePlugins
 
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
-func GetRequiredPlugins(host Host, root string, info ProgInfo, kinds Flags) ([]workspace.PluginSpec, error) {
+func GetRequiredPlugins(host Host, root string, info ProgInfo, proj *workspace.Project, kinds Flags,
+) ([]workspace.PluginSpec, error) {
 	var plugins []workspace.PluginSpec
 
 	if kinds&LanguagePlugins != 0 {
 		// First make sure the language plugin is present.  We need this to load the required resource plugins.
 		// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-		lang, err := host.LanguageRuntime(root, info.Pwd, info.Proj.Runtime.Name(), info.Proj.Runtime.Options())
+		lang, err := host.LanguageRuntime(root, info.Pwd, proj.Runtime.Name(), proj.Runtime.Options())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load language plugin %s", info.Proj.Runtime.Name())
+			return nil, errors.Wrapf(err, "failed to load language plugin %s", proj.Runtime.Name())
 		}
 		plugins = append(plugins, workspace.PluginSpec{
-			Name: info.Proj.Runtime.Name(),
+			Name: proj.Runtime.Name(),
 			Kind: workspace.LanguagePlugin,
 		})
 

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -93,9 +93,8 @@ type RunPluginInfo struct {
 
 // ProgInfo contains minimal information about the program to be run.
 type ProgInfo struct {
-	Proj    *workspace.Project // the program project/package.
-	Pwd     string             // the program's working directory.
-	Program string             // the path to the program to execute.
+	Pwd     string // the program's working directory.
+	Program string // the path to the program to execute.
 }
 
 // RunInfo contains all of the information required to perform a plan or deployment operation.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -138,9 +138,8 @@ func NewLanguageRuntimeClient(ctx *Context, runtime string, client pulumirpc.Lan
 
 // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
 func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error) {
-	proj := string(info.Proj.Name)
-	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(proj=%s,pwd=%s,program=%s) executing",
-		h.runtime, proj, info.Pwd, info.Program)
+	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(pwd=%s,program=%s) executing",
+		h.runtime, info.Pwd, info.Program)
 
 	opts, err := structpb.NewStruct(h.options)
 	if err != nil {
@@ -148,7 +147,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 	}
 
 	resp, err := h.client.GetRequiredPlugins(h.ctx.Request(), &pulumirpc.GetRequiredPluginsRequest{
-		Project: proj,
+		Project: "deprecated",
 		Pwd:     info.Pwd,
 		Program: info.Program,
 		Info: &pulumirpc.ProgramInfo{
@@ -160,8 +159,8 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
-		logging.V(7).Infof("langhost[%v].GetRequiredPlugins(proj=%s,pwd=%s,program=%s) failed: err=%v",
-			h.runtime, proj, info.Pwd, info.Program, rpcError)
+		logging.V(7).Infof("langhost[%v].GetRequiredPlugins(pwd=%s,program=%s) failed: err=%v",
+			h.runtime, info.Pwd, info.Program, rpcError)
 
 		// It's possible this is just an older language host, prior to the emergence of the GetRequiredPlugins
 		// method.  In such cases, we will silently error (with the above log left behind).
@@ -194,8 +193,8 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 		})
 	}
 
-	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(proj=%s,pwd=%s,program=%s) success: #versions=%d",
-		h.runtime, proj, info.Pwd, info.Program, len(results))
+	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(pwd=%s,program=%s) success: #versions=%d",
+		h.runtime, info.Pwd, info.Program, len(results))
 	return results, nil
 }
 
@@ -378,9 +377,8 @@ func (h *langhost) About() (AboutInfo, error) {
 }
 
 func (h *langhost) GetProgramDependencies(info ProgInfo, transitiveDependencies bool) ([]DependencyInfo, error) {
-	proj := string(info.Proj.Name)
-	prefix := fmt.Sprintf("langhost[%v].GetProgramDependencies(proj=%s,pwd=%s,program=%s,transitiveDependencies=%t)",
-		h.runtime, proj, info.Pwd, info.Program, transitiveDependencies)
+	prefix := fmt.Sprintf("langhost[%v].GetProgramDependencies(pwd=%s,program=%s,transitiveDependencies=%t)",
+		h.runtime, info.Pwd, info.Program, transitiveDependencies)
 
 	opts, err := structpb.NewStruct(h.options)
 	if err != nil {
@@ -389,7 +387,7 @@ func (h *langhost) GetProgramDependencies(info ProgInfo, transitiveDependencies 
 
 	logging.V(7).Infof("%s executing", prefix)
 	resp, err := h.client.GetProgramDependencies(h.ctx.Request(), &pulumirpc.GetProgramDependenciesRequest{
-		Project:                proj,
+		Project:                "deprecated",
 		Pwd:                    info.Pwd,
 		Program:                info.Program,
 		TransitiveDependencies: transitiveDependencies,

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -409,7 +409,7 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 		defer cancel()
 
 		res, err := host.GetRequiredPlugins(ctx, &pulumirpc.GetRequiredPluginsRequest{
-			Project: "prog",
+			Project: "deprecated",
 			Pwd:     progDir,
 			Info: &pulumirpc.ProgramInfo{
 				RootDirectory:    progDir,
@@ -433,7 +433,7 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 		defer cancel()
 
 		res, err := host.GetProgramDependencies(ctx, &pulumirpc.GetProgramDependenciesRequest{
-			Project:                "prog",
+			Project:                "deprecated",
 			Pwd:                    progDir,
 			TransitiveDependencies: true,
 			Info: &pulumirpc.ProgramInfo{

--- a/sdk/proto/go/language.pb.go
+++ b/sdk/proto/go/language.pb.go
@@ -188,7 +188,7 @@ type GetProgramDependenciesRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Deprecated: Do not use.
-	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name.
+	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name, the engine always sets this to "deprecated" now.
 	// Deprecated: Do not use.
 	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory.
 	// Deprecated: Do not use.
@@ -375,7 +375,7 @@ type GetRequiredPluginsRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Deprecated: Do not use.
-	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name.
+	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"` // the project name, the engine always sets this to "deprecated" now.
 	// Deprecated: Do not use.
 	Pwd string `protobuf:"bytes,2,opt,name=pwd,proto3" json:"pwd,omitempty"` // the program's working directory.
 	// Deprecated: Do not use.

--- a/sdk/python/lib/pulumi/runtime/proto/language_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/language_pb2.pyi
@@ -125,7 +125,7 @@ class GetProgramDependenciesRequest(google.protobuf.message.Message):
     TRANSITIVEDEPENDENCIES_FIELD_NUMBER: builtins.int
     INFO_FIELD_NUMBER: builtins.int
     project: builtins.str
-    """the project name."""
+    """the project name, the engine always sets this to "deprecated" now."""
     pwd: builtins.str
     """the program's working directory."""
     program: builtins.str
@@ -195,7 +195,7 @@ class GetRequiredPluginsRequest(google.protobuf.message.Message):
     PROGRAM_FIELD_NUMBER: builtins.int
     INFO_FIELD_NUMBER: builtins.int
     project: builtins.str
-    """the project name."""
+    """the project name, the engine always sets this to "deprecated" now."""
     pwd: builtins.str
     """the program's working directory."""
     program: builtins.str


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


The project field on `GetProgramDependenciesRequest` and `GetRequiredPluginsRequest` was marked deprecated at the start of December. None of the language runtimes are using this, so this cleans up the engine side code so we don't need to thread a `*workspace.Project` down to the plugin layer to fill in these fields anymore.

I haven't fully removed them from the Protobuf structs yet, we probably could but just to give a little more time for people to get a clear usage error if still using it.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
