### PR TITLE
Move assets and archives to their own package

### DIFF
--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype/migrate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -590,15 +592,15 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 			objmap := obj.Mappable()
 			if sig, hasSig := objmap[resource.SigKey]; hasSig {
 				switch sig {
-				case resource.AssetSig:
-					asset, isasset, err := resource.DeserializeAsset(objmap)
+				case asset.AssetSig:
+					asset, isasset, err := asset.Deserialize(objmap)
 					if err != nil {
 						return resource.PropertyValue{}, err
 					}
 					contract.Assertf(isasset, "resource with asset signature is not an asset")
 					return resource.NewAssetProperty(asset), nil
-				case resource.ArchiveSig:
-					archive, isarchive, err := resource.DeserializeArchive(objmap)
+				case archive.ArchiveSig:
+					archive, isarchive, err := archive.Deserialize(objmap)
 					if err != nil {
 						return resource.PropertyValue{}, err
 					}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	resource_testing "github.com/pulumi/pulumi/sdk/v3/go/common/resource/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -282,7 +283,7 @@ func TestDeserializeResourceReferencePropertyValueID(t *testing.T) {
 func TestCustomSerialization(t *testing.T) {
 	t.Parallel()
 
-	textAsset, err := resource.NewTextAsset("alpha beta gamma")
+	textAsset, err := rasset.FromText("alpha beta gamma")
 	assert.NoError(t, err)
 
 	strProp := resource.NewStringProperty("strProp")

--- a/sdk/go/common/resource/archive/archive_test.go
+++ b/sdk/go/common/resource/archive/archive_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileExtentionSniffing(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, Format(ZIPArchive), detectArchiveFormat("./some/path/my.zip"))
+	assert.Equal(t, Format(TarArchive), detectArchiveFormat("./some/path/my.tar"))
+	assert.Equal(t, Format(TarGZIPArchive), detectArchiveFormat("./some/path/my.tar.gz"))
+	assert.Equal(t, Format(TarGZIPArchive), detectArchiveFormat("./some/path/my.tgz"))
+	assert.Equal(t, Format(JARArchive), detectArchiveFormat("./some/path/my.jar"))
+	assert.Equal(t, Format(NotArchive), detectArchiveFormat("./some/path/who.knows"))
+
+	// In #2589 we had cases where a file would look like it had an longer extension, because the suffix would include
+	// some stuff after a dot. i.e. we failed to treat "my.file.zip" as a ZIPArchive.
+	assert.Equal(t, Format(ZIPArchive), detectArchiveFormat("./some/path/my.file.zip"))
+	assert.Equal(t, Format(TarArchive), detectArchiveFormat("./some/path/my.file.tar"))
+	assert.Equal(t, Format(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tar.gz"))
+	assert.Equal(t, Format(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tgz"))
+	assert.Equal(t, Format(JARArchive), detectArchiveFormat("./some/path/my.file.jar"))
+	assert.Equal(t, Format(NotArchive), detectArchiveFormat("./some/path/who.even.knows"))
+}

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -1,0 +1,109 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+// The contents of this file have been moved. The logic behind assets and archives now
+// lives in "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset" and
+// "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive", respectively. This file
+// exists to fulfill backwards-compatibility requirements. No new declarations should be
+// added here.
+
+import (
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+)
+
+const (
+	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
+	// Copied from workspace.BookkeepingDir to break import cycle.
+	BookkeepingDir = ".pulumi"
+)
+
+type (
+	Asset         = asset.Asset
+	Blob          = asset.Blob
+	Archive       = archive.Archive
+	ArchiveFormat = archive.Format
+	Reader        = archive.Reader
+)
+
+const (
+	AssetSig          = asset.AssetSig
+	AssetHashProperty = asset.AssetHashProperty
+	AssetTextProperty = asset.AssetTextProperty
+	AssetPathProperty = asset.AssetPathProperty
+	AssetURIProperty  = asset.AssetURIProperty
+
+	ArchiveSig            = archive.ArchiveSig
+	ArchiveHashProperty   = archive.ArchiveHashProperty   // the dynamic property for an archive's hash.
+	ArchiveAssetsProperty = archive.ArchiveAssetsProperty // the dynamic property for an archive's assets.
+	ArchivePathProperty   = archive.ArchivePathProperty   // the dynamic property for an archive's path.
+	ArchiveURIProperty    = archive.ArchiveURIProperty    // the dynamic property for an archive's URI.
+)
+
+// NewTextAsset produces a new asset and its corresponding SHA256 hash from the given text.
+func NewTextAsset(text string) (*Asset, error) { return asset.FromText(text) }
+
+// NewPathAsset produces a new asset and its corresponding SHA256 hash from the given filesystem path.
+func NewPathAsset(path string) (*Asset, error) { return asset.FromPath(path) }
+
+// NewURIAsset produces a new asset and its corresponding SHA256 hash from the given network URI.
+func NewURIAsset(uri string) (*Asset, error) { return asset.FromURI(uri) }
+
+// DeserializeAsset checks to see if the map contains an asset, using its signature, and if so deserializes it.
+func DeserializeAsset(obj map[string]interface{}) (*Asset, bool, error) {
+	return asset.Deserialize(obj)
+}
+
+// NewByteBlob creates a new byte blob.
+func NewByteBlob(data []byte) *Blob { return asset.NewByteBlob(data) }
+
+// NewFileBlob creates a new asset blob whose size is known thanks to stat.
+func NewFileBlob(f *os.File) (*Blob, error) { return asset.NewFileBlob(f) }
+
+// NewReadCloserBlob turn any old ReadCloser into an Blob, usually by making a copy.
+func NewReadCloserBlob(r io.ReadCloser) (*Blob, error) { return asset.NewReadCloserBlob(r) }
+
+func NewAssetArchive(assets map[string]interface{}) (*Archive, error) {
+	return archive.FromAssets(assets)
+}
+
+func NewPathArchive(path string) (*Archive, error) {
+	return archive.FromPath(path)
+}
+
+func NewURIArchive(uri string) (*Archive, error) {
+	return archive.FromURI(uri)
+}
+
+// DeserializeArchive checks to see if the map contains an archive, using its signature, and if so deserializes it.
+func DeserializeArchive(obj map[string]interface{}) (*Archive, bool, error) {
+	return archive.Deserialize(obj)
+}
+
+const (
+	NotArchive = archive.NotArchive // not an archive.
+	TarArchive = archive.TarArchive // a POSIX tar archive.
+	// a POSIX tar archive that has been subsequently compressed using GZip.
+	TarGZIPArchive = archive.TarGZIPArchive
+	ZIPArchive     = archive.ZIPArchive // a multi-file ZIP archive.
+	JARArchive     = archive.JARArchive // a Java JAR file
+)
+
+// ArchiveExts maps from a file extension and its associated archive and/or compression format.
+var ArchiveExts = archive.ArchiveExts

--- a/sdk/go/common/resource/asset/asset.go
+++ b/sdk/go/common/resource/asset/asset.go
@@ -67,8 +67,8 @@ func FromPath(path string) (*Asset, error) {
 	return a, err
 }
 
-// FromURIL produces a new asset and its corresponding SHA256 hash from the given network URI.
-func FromURIL(uri string) (*Asset, error) {
+// FromURI produces a new asset and its corresponding SHA256 hash from the given network URI.
+func FromURI(uri string) (*Asset, error) {
 	a := &Asset{Sig: AssetSig, URI: uri}
 	err := a.EnsureHash()
 	return a, err

--- a/sdk/go/common/resource/asset/asset.go
+++ b/sdk/go/common/resource/asset/asset.go
@@ -1,0 +1,363 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asset
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
+)
+
+// Asset is a serialized asset reference.  It is a union: thus, only one of its fields will be non-nil.  Several helper
+// routines exist as members in order to easily interact with the assets referenced by an instance of this type.
+type Asset struct {
+	// Sig is the unique asset type signature (see properties.go).
+	Sig string `json:"4dabf18193072939515e22adb298388d" yaml:"4dabf18193072939515e22adb298388d"`
+	// Hash is the SHA256 hash of the asset's contents.
+	Hash string `json:"hash,omitempty" yaml:"hash,omitempty"`
+	// Text is set to a non-empty value for textual assets.
+	Text string `json:"text,omitempty" yaml:"text,omitempty"`
+	// Path will contain a non-empty path to the file on the current filesystem for file assets.
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	// URI will contain a non-empty URI (file://, http://, https://, or custom) for URI-backed assets.
+	URI string `json:"uri,omitempty" yaml:"uri,omitempty"`
+}
+
+const (
+	AssetSig          = sig.AssetSig
+	AssetHashProperty = "hash" // the dynamic property for an asset's hash.
+	AssetTextProperty = "text" // the dynamic property for an asset's text.
+	AssetPathProperty = "path" // the dynamic property for an asset's path.
+	AssetURIProperty  = "uri"  // the dynamic property for an asset's URI.
+)
+
+// FromText produces a new asset and its corresponding SHA256 hash from the given text.
+func FromText(text string) (*Asset, error) {
+	a := &Asset{Sig: AssetSig, Text: text}
+	err := a.EnsureHash()
+	return a, err
+}
+
+// FromPath produces a new asset and its corresponding SHA256 hash from the given filesystem path.
+func FromPath(path string) (*Asset, error) {
+	a := &Asset{Sig: AssetSig, Path: path}
+	err := a.EnsureHash()
+	return a, err
+}
+
+// FromURIL produces a new asset and its corresponding SHA256 hash from the given network URI.
+func FromURIL(uri string) (*Asset, error) {
+	a := &Asset{Sig: AssetSig, URI: uri}
+	err := a.EnsureHash()
+	return a, err
+}
+
+func (a *Asset) IsText() bool { return !a.IsPath() && !a.IsURI() }
+func (a *Asset) IsPath() bool { return a.Path != "" }
+func (a *Asset) IsURI() bool  { return a.URI != "" }
+
+func (a *Asset) GetText() (string, bool) {
+	if a.IsText() {
+		return a.Text, true
+	}
+	return "", false
+}
+
+func (a *Asset) GetPath() (string, bool) {
+	if a.IsPath() {
+		return a.Path, true
+	}
+	return "", false
+}
+
+func (a *Asset) GetURI() (string, bool) {
+	if a.IsURI() {
+		return a.URI, true
+	}
+	return "", false
+}
+
+// GetURIURL returns the underlying URI as a parsed URL, provided it is one.  If there was an error parsing the URI, it
+// will be returned as a non-nil error object.
+func (a *Asset) GetURIURL() (*url.URL, bool, error) {
+	if uri, isuri := a.GetURI(); isuri {
+		url, err := url.Parse(uri)
+		if err != nil {
+			return nil, true, err
+		}
+		return url, true, nil
+	}
+	return nil, false, nil
+}
+
+// Equals returns true if a is value-equal to other. In this case, value equality is determined only by the hash: even
+// if the contents of two assets come from different sources, they are treated as equal if their hashes match.
+// Similarly, if the contents of two assets come from the same source but the assets have different hashes, the assets
+// are not equal.
+func (a *Asset) Equals(other *Asset) bool {
+	if a == nil {
+		return other == nil
+	} else if other == nil {
+		return false
+	}
+
+	// If we can't get a hash for both assets, treat them as differing.
+	if err := a.EnsureHash(); err != nil {
+		return false
+	}
+	if err := other.EnsureHash(); err != nil {
+		return false
+	}
+	return a.Hash == other.Hash
+}
+
+// Serialize returns a weakly typed map that contains the right signature for serialization purposes.
+func (a *Asset) Serialize() map[string]interface{} {
+	result := map[string]interface{}{
+		sig.Key: AssetSig,
+	}
+	if a.Hash != "" {
+		result[AssetHashProperty] = a.Hash
+	}
+	if a.Text != "" {
+		result[AssetTextProperty] = a.Text
+	}
+	if a.Path != "" {
+		result[AssetPathProperty] = a.Path
+	}
+	if a.URI != "" {
+		result[AssetURIProperty] = a.URI
+	}
+	return result
+}
+
+// DeserializeAsset checks to see if the map contains an asset, using its signature, and if so deserializes it.
+func Deserialize(obj map[string]interface{}) (*Asset, bool, error) {
+	// If not an asset, return false immediately.
+	if obj[sig.Key] != AssetSig {
+		return &Asset{}, false, nil
+	}
+
+	// Else, deserialize the possible fields.
+	var hash string
+	if v, has := obj[AssetHashProperty]; has {
+		h, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, fmt.Errorf("unexpected asset hash of type %T", v)
+		}
+		hash = h
+	}
+	var text string
+	if v, has := obj[AssetTextProperty]; has {
+		t, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, fmt.Errorf("unexpected asset text of type %T", v)
+		}
+		text = t
+	}
+	var path string
+	if v, has := obj[AssetPathProperty]; has {
+		p, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, fmt.Errorf("unexpected asset path of type %T", v)
+		}
+		path = p
+	}
+	var uri string
+	if v, has := obj[AssetURIProperty]; has {
+		u, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, fmt.Errorf("unexpected asset URI of type %T", v)
+		}
+		uri = u
+	}
+
+	return &Asset{Hash: hash, Text: text, Path: path, URI: uri}, true, nil
+}
+
+// HasContents indicates whether or not an asset's contents can be read.
+func (a *Asset) HasContents() bool {
+	return a.IsText() || a.IsPath() || a.IsURI()
+}
+
+// Bytes returns the contents of the asset as a byte slice.
+func (a *Asset) Bytes() ([]byte, error) {
+	// If this is a text asset, just return its bytes directly.
+	if text, istext := a.GetText(); istext {
+		return []byte(text), nil
+	}
+
+	blob, err := a.Read()
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(blob)
+}
+
+// Read begins reading an asset.
+func (a *Asset) Read() (*Blob, error) {
+	if a.IsText() {
+		return a.readText()
+	} else if a.IsPath() {
+		return a.readPath()
+	} else if a.IsURI() {
+		return a.readURI()
+	}
+	return nil, errors.New("unrecognized asset type")
+}
+
+func (a *Asset) readText() (*Blob, error) {
+	text, istext := a.GetText()
+	contract.Assertf(istext, "Expected a text-based asset")
+	return NewByteBlob([]byte(text)), nil
+}
+
+func (a *Asset) readPath() (*Blob, error) {
+	path, ispath := a.GetPath()
+	contract.Assertf(ispath, "Expected a path-based asset")
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open asset file '%v': %w", path, err)
+	}
+
+	// Do a quick check to make sure it's a file, so we can fail gracefully if someone passes a directory.
+	info, err := file.Stat()
+	if err != nil {
+		contract.IgnoreClose(file)
+		return nil, fmt.Errorf("failed to stat asset file '%v': %w", path, err)
+	}
+	if info.IsDir() {
+		contract.IgnoreClose(file)
+		return nil, fmt.Errorf("asset path '%v' is a directory; try using an archive", path)
+	}
+
+	blob := &Blob{
+		rd: file,
+		sz: info.Size(),
+	}
+	return blob, nil
+}
+
+func (a *Asset) readURI() (*Blob, error) {
+	url, isURL, err := a.GetURIURL()
+	if err != nil {
+		return nil, err
+	}
+	contract.Assertf(isURL, "Expected a URI-based asset")
+	switch s := url.Scheme; s {
+	case "http", "https":
+		resp, err := httputil.GetWithRetry(url.String(), http.DefaultClient)
+		if err != nil {
+			return nil, err
+		}
+		return NewReadCloserBlob(resp.Body)
+	case "file":
+		contract.Assertf(url.User == nil, "file:// URIs cannot have a user: %v", url)
+		contract.Assertf(url.RawQuery == "", "file:// URIs cannot have a query string: %v", url)
+		contract.Assertf(url.Fragment == "", "file:// URIs cannot have a fragment: %v", url)
+		if url.Host != "" && url.Host != "localhost" {
+			return nil, fmt.Errorf("file:// host '%v' not supported (only localhost)", url.Host)
+		}
+		f, err := os.Open(url.Path)
+		if err != nil {
+			return nil, err
+		}
+		return NewFileBlob(f)
+	default:
+		return nil, fmt.Errorf("Unrecognized or unsupported URI scheme: %v", s)
+	}
+}
+
+// EnsureHash computes the SHA256 hash of the asset's contents and stores it on the object.
+func (a *Asset) EnsureHash() error {
+	if a.Hash == "" {
+		blob, err := a.Read()
+		if err != nil {
+			return err
+		}
+		defer contract.IgnoreClose(blob)
+
+		hash := sha256.New()
+		n, err := io.Copy(hash, blob)
+		if err != nil {
+			return err
+		}
+		if n != blob.Size() {
+			return fmt.Errorf("incorrect blob size: expected %v, got %v", blob.Size(), n)
+		}
+		a.Hash = hex.EncodeToString(hash.Sum(nil))
+	}
+	return nil
+}
+
+// Blob is a blob that implements ReadCloser and offers Len functionality.
+type Blob struct {
+	rd io.ReadCloser // an underlying reader.
+	sz int64         // the size of the blob.
+}
+
+func (blob *Blob) Close() error               { return blob.rd.Close() }
+func (blob *Blob) Read(p []byte) (int, error) { return blob.rd.Read(p) }
+func (blob *Blob) Size() int64                { return blob.sz }
+
+// NewByteBlob creates a new byte blob.
+func NewByteBlob(data []byte) *Blob {
+	return &Blob{
+		rd: io.NopCloser(bytes.NewReader(data)),
+		sz: int64(len(data)),
+	}
+}
+
+// NewFileBlob creates a new asset blob whose size is known thanks to stat.
+func NewFileBlob(f *os.File) (*Blob, error) {
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return &Blob{
+		rd: f,
+		sz: stat.Size(),
+	}, nil
+}
+
+// NewReadCloserBlob turn any old ReadCloser into an Blob, usually by making a copy.
+func NewReadCloserBlob(r io.ReadCloser) (*Blob, error) {
+	if f, isf := r.(*os.File); isf {
+		// If it's a file, we can "fast path" the asset creation without making a copy.
+		return NewFileBlob(f)
+	}
+	// Otherwise, read it all in, and create a blob out of that.
+	defer contract.IgnoreClose(r)
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return NewByteBlob(data), nil
+}
+
+func NewRawBlob(r io.ReadCloser, size int64) *Blob {
+	return &Blob{rd: r, sz: size}
+}

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -166,7 +166,7 @@ func TestAssetSerialize(t *testing.T) {
 
 		skipWindows(t)
 		url := "file:///dev/null"
-		asset, err := rasset.FromURIL(url)
+		asset, err := rasset.FromURI(url)
 		assert.NoError(t, err)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", asset.Hash)
 		assetSer := asset.Serialize()

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -27,10 +27,11 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
-
+	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -53,12 +54,12 @@ func TestAssetSerialize(t *testing.T) {
 		t.Parallel()
 
 		text := "a test asset"
-		asset, err := NewTextAsset(text)
+		asset, err := rasset.FromText(text)
 		assert.NoError(t, err)
 		assert.Equal(t, text, asset.Text)
 		assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset, err := DeserializeAsset(assetSer)
+		assetDes, isasset, err := rasset.Deserialize(assetSer)
 		assert.NoError(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsText())
@@ -67,25 +68,25 @@ func TestAssetSerialize(t *testing.T) {
 
 		// another text asset with the same contents, should hash the same way.
 		text2 := "a test asset"
-		asset2, err := NewTextAsset(text2)
+		asset2, err := rasset.FromText(text2)
 		assert.NoError(t, err)
 		assert.Equal(t, text2, asset2.Text)
 		assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset2.Hash)
 
 		// another text asset, but with different contents, should be a different hash.
 		text3 := "a very different and special test asset"
-		asset3, err := NewTextAsset(text3)
+		asset3, err := rasset.FromText(text3)
 		assert.NoError(t, err)
 		assert.Equal(t, text3, asset3.Text)
 		assert.Equal(t, "9a6ed070e1ff834427105844ffd8a399a634753ce7a60ec5aae541524bbe7036", asset3.Hash)
 
 		// check that an empty asset also works correctly.
-		empty, err := NewTextAsset("")
+		empty, err := rasset.FromText("")
 		assert.NoError(t, err)
 		assert.Equal(t, "", empty.Text)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", empty.Hash)
 		emptySer := empty.Serialize()
-		emptyDes, isasset, err := DeserializeAsset(emptySer)
+		emptyDes, isasset, err := rasset.Deserialize(emptySer)
 		assert.NoError(t, err)
 		assert.True(t, isasset)
 		assert.True(t, emptyDes.IsText())
@@ -93,7 +94,7 @@ func TestAssetSerialize(t *testing.T) {
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", emptyDes.Hash)
 
 		// now a map of nested assets and/or archives.
-		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		arch, err := rarchive.FromAssets(map[string]interface{}{"foo": asset})
 		assert.NoError(t, err)
 		switch runtime.Version() {
 		case go19Version:
@@ -103,13 +104,13 @@ func TestAssetSerialize(t *testing.T) {
 			assert.Equal(t, "27ab4a14a617df10cff3e1cf4e30cf510302afe56bf4cc91f84041c9f7b62fd8", arch.Hash)
 		}
 		archSer := arch.Serialize()
-		archDes, isarch, err := DeserializeArchive(archSer)
+		archDes, isarch, err := rarchive.Deserialize(archSer)
 		assert.NoError(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].(*Asset).IsText())
-		assert.Equal(t, text, archDes.Assets["foo"].(*Asset).Text)
+		assert.True(t, archDes.Assets["foo"].(*rasset.Asset).IsText())
+		assert.Equal(t, text, archDes.Assets["foo"].(*rasset.Asset).Text)
 		switch runtime.Version() {
 		case go19Version:
 			assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", archDes.Hash)
@@ -124,18 +125,18 @@ func TestAssetSerialize(t *testing.T) {
 		f, err := os.CreateTemp("", "")
 		assert.NoError(t, err)
 		file := f.Name()
-		asset, err := NewPathAsset(file)
+		asset, err := rasset.FromPath(file)
 		assert.NoError(t, err)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset, err := DeserializeAsset(assetSer)
+		assetDes, isasset, err := rasset.Deserialize(assetSer)
 		assert.NoError(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsPath())
 		assert.Equal(t, file, assetDes.Path)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", assetDes.Hash)
 
-		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		arch, err := rarchive.FromAssets(map[string]interface{}{"foo": asset})
 		assert.NoError(t, err)
 		switch runtime.Version() {
 		case go19Version:
@@ -145,13 +146,13 @@ func TestAssetSerialize(t *testing.T) {
 			assert.Equal(t, "d2587a875f82cdf3d3e6cfe9f8c6e6032be5dde8c344466e664e628da15757b0", arch.Hash)
 		}
 		archSer := arch.Serialize()
-		archDes, isarch, err := DeserializeArchive(archSer)
+		archDes, isarch, err := rarchive.Deserialize(archSer)
 		assert.NoError(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].(*Asset).IsPath())
-		assert.Equal(t, file, archDes.Assets["foo"].(*Asset).Path)
+		assert.True(t, archDes.Assets["foo"].(*rasset.Asset).IsPath())
+		assert.Equal(t, file, archDes.Assets["foo"].(*rasset.Asset).Path)
 		switch runtime.Version() {
 		case go19Version:
 			assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", archDes.Hash)
@@ -165,18 +166,18 @@ func TestAssetSerialize(t *testing.T) {
 
 		skipWindows(t)
 		url := "file:///dev/null"
-		asset, err := NewURIAsset(url)
+		asset, err := rasset.FromURIL(url)
 		assert.NoError(t, err)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset, err := DeserializeAsset(assetSer)
+		assetDes, isasset, err := rasset.Deserialize(assetSer)
 		assert.NoError(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsURI())
 		assert.Equal(t, url, assetDes.URI)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", assetDes.Hash)
 
-		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		arch, err := rarchive.FromAssets(map[string]interface{}{"foo": asset})
 		assert.NoError(t, err)
 		switch runtime.Version() {
 		case go19Version:
@@ -186,13 +187,13 @@ func TestAssetSerialize(t *testing.T) {
 			assert.Equal(t, "d2587a875f82cdf3d3e6cfe9f8c6e6032be5dde8c344466e664e628da15757b0", arch.Hash)
 		}
 		archSer := arch.Serialize()
-		archDes, isarch, err := DeserializeArchive(archSer)
+		archDes, isarch, err := rarchive.Deserialize(archSer)
 		assert.NoError(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].(*Asset).IsURI())
-		assert.Equal(t, url, archDes.Assets["foo"].(*Asset).URI)
+		assert.True(t, archDes.Assets["foo"].(*rasset.Asset).IsURI())
+		assert.Equal(t, url, archDes.Assets["foo"].(*rasset.Asset).URI)
 		switch runtime.Version() {
 		case go19Version:
 			assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", archDes.Hash)
@@ -207,11 +208,11 @@ func TestAssetSerialize(t *testing.T) {
 		file, err := tempArchive("test", false)
 		assert.NoError(t, err)
 		defer func() { contract.IgnoreError(os.Remove(file)) }()
-		arch, err := NewPathArchive(file)
+		arch, err := rarchive.FromPath(file)
 		assert.NoError(t, err)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch, err := DeserializeArchive(archSer)
+		archDes, isarch, err := rarchive.Deserialize(archSer)
 		assert.NoError(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsPath())
@@ -226,11 +227,11 @@ func TestAssetSerialize(t *testing.T) {
 		assert.NoError(t, err)
 		defer func() { contract.IgnoreError(os.Remove(file)) }()
 		url := "file:///" + file
-		arch, err := NewURIArchive(url)
+		arch, err := rarchive.FromURI(url)
 		assert.NoError(t, err)
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch, err := DeserializeArchive(archSer)
+		archDes, isarch, err := rarchive.Deserialize(archSer)
 		assert.NoError(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsURI())
@@ -247,13 +248,13 @@ func TestAssetSerialize(t *testing.T) {
 		file2, err := tempArchive("test2", false)
 		assert.NoError(t, err)
 		defer func() { contract.IgnoreError(os.Remove(file2)) }()
-		arch1, err := NewPathArchive(file1)
+		arch1, err := rarchive.FromPath(file1)
 		assert.NoError(t, err)
-		arch2, err := NewPathArchive(file2)
+		arch2, err := rarchive.FromPath(file2)
 		assert.NoError(t, err)
 		assert.True(t, arch1.Equals(arch2))
 		url := "file:///" + file1
-		arch3, err := NewURIArchive(url)
+		arch3, err := rarchive.FromURI(url)
 		assert.NoError(t, err)
 		assert.True(t, arch1.Equals(arch3))
 	})
@@ -264,20 +265,20 @@ func TestAssetSerialize(t *testing.T) {
 		file, err := tempArchive("test", true)
 		assert.NoError(t, err)
 		defer func() { contract.IgnoreError(os.Remove(file)) }()
-		arch1, err := NewPathArchive(file)
+		arch1, err := rarchive.FromPath(file)
 		assert.NoError(t, err)
 		assert.Nil(t, arch1.EnsureHash())
 		url := "file:///" + file
-		arch2, err := NewURIArchive(url)
+		arch2, err := rarchive.FromURI(url)
 		assert.NoError(t, err)
 		assert.Nil(t, arch2.EnsureHash())
 
 		assert.Nil(t, os.Truncate(file, 0))
-		arch3, err := NewPathArchive(file)
+		arch3, err := rarchive.FromPath(file)
 		assert.NoError(t, err)
 		assert.Nil(t, arch3.EnsureHash())
 		assert.False(t, arch1.Equals(arch3))
-		arch4, err := NewURIArchive(url)
+		arch4, err := rarchive.FromURI(url)
 		assert.NoError(t, err)
 		assert.Nil(t, arch4.EnsureHash())
 		assert.False(t, arch2.Equals(arch4))
@@ -315,8 +316,8 @@ func tempArchive(prefix string, fill bool) (string, error) {
 func TestDeserializeMissingHash(t *testing.T) {
 	t.Parallel()
 
-	assetSer := (&Asset{Text: "asset"}).Serialize()
-	assetDes, isasset, err := DeserializeAsset(assetSer)
+	assetSer := (&rasset.Asset{Text: "asset"}).Serialize()
+	assetDes, isasset, err := rasset.Deserialize(assetSer)
 	assert.NoError(t, err)
 	assert.True(t, isasset)
 	assert.Equal(t, "asset", assetDes.Text)
@@ -325,7 +326,7 @@ func TestDeserializeMissingHash(t *testing.T) {
 func TestAssetFile(t *testing.T) {
 	t.Parallel()
 
-	asset, err := NewPathAsset("../../../../pkg/resource/testdata/Fox.txt")
+	asset, err := rasset.FromPath("../../../../pkg/resource/testdata/Fox.txt")
 	assert.NoError(t, err)
 	assert.Equal(t, "85e5f2698ac92d10d50e2f2802ed0d51a13e7c81d0d0a5998a75349469e774c5", asset.Hash)
 	assertAssetTextEquals(t, asset,
@@ -339,7 +340,7 @@ asset jumps over the archive.
 func TestArchiveDir(t *testing.T) {
 	t.Parallel()
 
-	arch, err := NewPathArchive("../../../../pkg/resource/testdata/test_dir")
+	arch, err := rarchive.FromPath("../../../../pkg/resource/testdata/test_dir")
 	assert.NoError(t, err)
 	switch runtime.Version() {
 	case go19Version:
@@ -355,7 +356,7 @@ func TestArchiveTar(t *testing.T) {
 	t.Parallel()
 
 	// Note that test data was generated using the Go 1.9 headers
-	arch, err := NewPathArchive("../../../../pkg/resource/testdata/test_dir.tar")
+	arch, err := rarchive.FromPath("../../../../pkg/resource/testdata/test_dir.tar")
 	assert.NoError(t, err)
 	assert.Equal(t, "c618d74a40f87de3092ca6a6c4cca834aa5c6a3956c6ceb2054b40d04bb4cd76", arch.Hash)
 	validateTestDirArchive(t, arch, 3)
@@ -365,7 +366,7 @@ func TestArchiveTgz(t *testing.T) {
 	t.Parallel()
 
 	// Note that test data was generated using the Go 1.9 headers
-	arch, err := NewPathArchive("../../../../pkg/resource/testdata/test_dir.tgz")
+	arch, err := rarchive.FromPath("../../../../pkg/resource/testdata/test_dir.tgz")
 	assert.NoError(t, err)
 	assert.Equal(t, "f9b33523b6a3538138aff0769ff9e7d522038e33c5cfe28b258332b3f15790c8", arch.Hash)
 	validateTestDirArchive(t, arch, 3)
@@ -375,7 +376,7 @@ func TestArchiveZip(t *testing.T) {
 	t.Parallel()
 
 	// Note that test data was generated using the Go 1.9 headers
-	arch, err := NewPathArchive("../../../../pkg/resource/testdata/test_dir.zip")
+	arch, err := rarchive.FromPath("../../../../pkg/resource/testdata/test_dir.zip")
 	assert.NoError(t, err)
 	assert.Equal(t, "343da72cec1302441efd4a490d66f861d393fb270afb3ced27f92a0d96abc068", arch.Hash)
 	validateTestDirArchive(t, arch, 3)
@@ -384,7 +385,7 @@ func TestArchiveZip(t *testing.T) {
 func TestArchiveJar(t *testing.T) {
 	t.Parallel()
 
-	arch, err := NewPathArchive("../../../../pkg/resource/testdata/test_dir.jar")
+	arch, err := rarchive.FromPath("../../../../pkg/resource/testdata/test_dir.jar")
 	assert.NoError(t, err)
 	assert.Equal(t, "dfb9eb69f433564b07df524068621c5ac65c08868e6094b8fa4ee388a5ee66e7", arch.Hash)
 	validateTestDirArchive(t, arch, 4)
@@ -421,10 +422,10 @@ func TestArchiveTarFiles(t *testing.T) {
 	repoRoot, err := findRepositoryRoot()
 	assert.NoError(t, err)
 
-	arch, err := NewPathArchive(repoRoot)
+	arch, err := rarchive.FromPath(repoRoot)
 	assert.NoError(t, err)
 
-	err = arch.Archive(TarArchive, io.Discard)
+	err = arch.Archive(rarchive.TarArchive, io.Discard)
 	assert.NoError(t, err)
 }
 
@@ -435,10 +436,10 @@ func TestArchiveZipFiles(t *testing.T) {
 	repoRoot, err := findRepositoryRoot()
 	assert.NoError(t, err)
 
-	arch, err := NewPathArchive(repoRoot)
+	arch, err := rarchive.FromPath(repoRoot)
 	assert.NoError(t, err)
 
-	err = arch.Archive(ZIPArchive, io.Discard)
+	err = arch.Archive(rarchive.ZIPArchive, io.Discard)
 	assert.NoError(t, err)
 }
 
@@ -454,11 +455,11 @@ func TestNestedArchive(t *testing.T) {
 	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "c.txt"), []byte("c"), 0o777))
 
 	// Construct an AssetArchive with a nested PathArchive.
-	innerArch, err := NewPathArchive(filepath.Join(dirName, "./foo"))
+	innerArch, err := rarchive.FromPath(filepath.Join(dirName, "./foo"))
 	assert.NoError(t, err)
-	textAsset, err := NewTextAsset("hello world")
+	textAsset, err := rasset.FromText("hello world")
 	assert.NoError(t, err)
-	arch, err := NewAssetArchive(map[string]interface{}{
+	arch, err := rarchive.FromAssets(map[string]interface{}{
 		"./foo":    innerArch,
 		"fake.txt": textAsset,
 	})
@@ -468,7 +469,7 @@ func TestNestedArchive(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
-	err = arch.Archive(ZIPArchive, tmpFile)
+	err = arch.Archive(rarchive.ZIPArchive, tmpFile)
 	assert.NoError(t, err)
 	tmpFile.Close()
 
@@ -494,11 +495,11 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "foo", "bar", "b.txt"), []byte("b"), 0o777))
 
 	// Construct an AssetArchive with a nested PathArchive.
-	outerArch, err := NewPathArchive(filepath.Join(dirName, "./foo"))
+	outerArch, err := rarchive.FromPath(filepath.Join(dirName, "./foo"))
 	assert.NoError(t, err)
-	innerArch, err := NewPathArchive(filepath.Join(dirName, "./foo/bar"))
+	innerArch, err := rarchive.FromPath(filepath.Join(dirName, "./foo/bar"))
 	assert.NoError(t, err)
-	arch, err := NewAssetArchive(map[string]interface{}{
+	arch, err := rarchive.FromAssets(map[string]interface{}{
 		"./foo":     outerArch,
 		"./foo/bar": innerArch,
 	})
@@ -508,7 +509,7 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
-	err = arch.Archive(ZIPArchive, tmpFile)
+	err = arch.Archive(rarchive.ZIPArchive, tmpFile)
 	assert.NoError(t, err)
 	tmpFile.Close()
 
@@ -521,34 +522,14 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.Equal(t, "foo/bar/b.txt", filepath.ToSlash(files[0].Name))
 }
 
-func TestFileExtentionSniffing(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, ArchiveFormat(ZIPArchive), detectArchiveFormat("./some/path/my.zip"))
-	assert.Equal(t, ArchiveFormat(TarArchive), detectArchiveFormat("./some/path/my.tar"))
-	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.tar.gz"))
-	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.tgz"))
-	assert.Equal(t, ArchiveFormat(JARArchive), detectArchiveFormat("./some/path/my.jar"))
-	assert.Equal(t, ArchiveFormat(NotArchive), detectArchiveFormat("./some/path/who.knows"))
-
-	// In #2589 we had cases where a file would look like it had an longer extension, because the suffix would include
-	// some stuff after a dot. i.e. we failed to treat "my.file.zip" as a ZIPArchive.
-	assert.Equal(t, ArchiveFormat(ZIPArchive), detectArchiveFormat("./some/path/my.file.zip"))
-	assert.Equal(t, ArchiveFormat(TarArchive), detectArchiveFormat("./some/path/my.file.tar"))
-	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tar.gz"))
-	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tgz"))
-	assert.Equal(t, ArchiveFormat(JARArchive), detectArchiveFormat("./some/path/my.file.jar"))
-	assert.Equal(t, ArchiveFormat(NotArchive), detectArchiveFormat("./some/path/who.even.knows"))
-}
-
 func TestEmptyArchiveRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	emptyArchive, err := NewAssetArchive(nil)
+	emptyArchive, err := rarchive.FromAssets(nil)
 	require.NoError(t, err, "Creating an empty archive should work")
 	assert.True(t, emptyArchive.IsAssets(), "even empty archives should be have empty assets")
 	serialized := emptyArchive.Serialize()
-	deserialized, ok, err := DeserializeArchive(serialized)
+	deserialized, ok, err := rarchive.Deserialize(serialized)
 	assert.NoError(t, err, "Deserializing an empty archive should work")
 	assert.True(t, ok, "Deserializing an empty archive should return true")
 	assert.True(t, deserialized.IsAssets(), "Deserialized archive should be an AssetsArchive")
@@ -565,11 +546,11 @@ func TestInvalidPathArchive(t *testing.T) {
 	tmpFile.Close()
 
 	// Attempt to construct a PathArchive with the temp file.
-	_, err = NewPathArchive(fileName)
+	_, err = rarchive.FromPath(fileName)
 	assert.EqualError(t, err, fmt.Sprintf("'%s' is neither a recognized archive type nor a directory", fileName))
 }
 
-func validateTestDirArchive(t *testing.T, arch *Archive, expected int) {
+func validateTestDirArchive(t *testing.T, arch *rarchive.Archive, expected int) {
 	r, err := arch.Open()
 	assert.NoError(t, err)
 	defer func() {
@@ -640,14 +621,14 @@ perferendis doloribus asperiores repellat…
 `)
 }
 
-func assertAssetTextEquals(t *testing.T, asset *Asset, expect string) {
+func assertAssetTextEquals(t *testing.T, asset *rasset.Asset, expect string) {
 	blob, err := asset.Read()
 	assert.NoError(t, err)
 	assert.NotNil(t, blob)
 	assertAssetBlobEquals(t, blob, expect)
 }
 
-func assertAssetBlobEquals(t *testing.T, blob *Blob, expect string) {
+func assertAssetBlobEquals(t *testing.T, blob *rasset.Blob, expect string) {
 	var text bytes.Buffer
 	n, err := io.Copy(&text, blob)
 	assert.NoError(t, err)

--- a/sdk/go/common/resource/mapper_test.go
+++ b/sdk/go/common/resource/mapper_test.go
@@ -21,33 +21,34 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
 )
 
 type complexBag struct {
-	asset   resource.Asset
-	archive resource.Archive
+	asset   asset.Asset
+	archive archive.Archive
 
-	optionalAsset   *resource.Asset
-	optionalArchive *resource.Archive
+	optionalAsset   *asset.Asset
+	optionalArchive *archive.Archive
 }
 
 func TestAssetsAndArchives(t *testing.T) {
 	t.Parallel()
 
-	newAsset := func(s string) *resource.Asset {
-		a, err := resource.NewTextAsset(s)
+	newAsset := func(s string) *asset.Asset {
+		a, err := asset.FromText(s)
 		require.NoError(t, err, "creating asset %s", s)
 		return a
 	}
-	newArchive := func(m map[string]interface{}) *resource.Archive {
-		a, err := resource.NewAssetArchive(m)
+	newArchive := func(m map[string]interface{}) *archive.Archive {
+		a, err := archive.FromAssets(m)
 		require.NoError(t, err, "creating asset %#v", m)
 		return a
 	}
 
-	bigArchive := func() *resource.Archive {
+	bigArchive := func() *archive.Archive {
 		return newArchive(map[string]interface{}{
 			"asset1": newAsset("asset1"),
 			"archive1": newArchive(map[string]interface{}{

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -36,6 +36,8 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -599,16 +601,16 @@ func traverseMap(m resource.PropertyMap, f func(resource.PropertyValue)) {
 // Those inputs may echo back the input assets and the engine writes them out to the state. We need to make sure that
 // we don't write out empty assets to the state, so we restore the asset contents from the original inputs.
 func restoreElidedAssetContents(original resource.PropertyMap, transformed resource.PropertyMap) {
-	isEmptyAsset := func(v *resource.Asset) bool {
+	isEmptyAsset := func(v *asset.Asset) bool {
 		return v.Text == "" && v.Path == "" && v.URI == ""
 	}
 
-	isEmptyArchive := func(v *resource.Archive) bool {
+	isEmptyArchive := func(v *archive.Archive) bool {
 		return v.Path == "" && v.URI == "" && v.Assets == nil
 	}
 
-	originalAssets := map[string]*resource.Asset{}
-	originalArchives := map[string]*resource.Archive{}
+	originalAssets := map[string]*asset.Asset{}
+	originalArchives := map[string]*archive.Archive{}
 
 	traverseMap(original, func(value resource.PropertyValue) {
 		if value.IsAsset() {

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
@@ -244,7 +245,7 @@ func TestNestedSecret(t *testing.T) {
 func TestRestoreElidedAssetContents(t *testing.T) {
 	t.Parallel()
 	textAsset := func(text string) resource.PropertyValue {
-		asset, err := resource.NewTextAsset(text)
+		asset, err := asset.FromText(text)
 		require.NoError(t, err)
 		return resource.NewAssetProperty(asset)
 	}

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -349,11 +351,11 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 		}
 
 		switch sig {
-		case resource.AssetSig:
+		case asset.AssetSig:
 			if opts.RejectAssets {
 				return nil, fmt.Errorf("unexpected Asset property value for %q", key)
 			}
-			asset, isasset, err := resource.DeserializeAsset(objmap)
+			asset, isasset, err := asset.Deserialize(objmap)
 			if err != nil {
 				return nil, err
 			}
@@ -367,11 +369,11 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 			}
 			m := resource.NewAssetProperty(asset)
 			return &m, nil
-		case resource.ArchiveSig:
+		case archive.ArchiveSig:
 			if opts.RejectAssets {
 				return nil, fmt.Errorf("unexpected Asset Archive property value for %q", key)
 			}
-			archive, isarchive, err := resource.DeserializeArchive(objmap)
+			archive, isarchive, err := archive.Deserialize(objmap)
 			if err != nil {
 				return nil, err
 			}
@@ -516,9 +518,9 @@ func unmarshalUnknownPropertyValue(s string, opts MarshalOptions) (resource.Prop
 	case UnknownArrayValue:
 		elem, unknown = resource.NewArrayProperty([]resource.PropertyValue{}), true
 	case UnknownAssetValue:
-		elem, unknown = resource.NewAssetProperty(&resource.Asset{}), true
+		elem, unknown = resource.NewAssetProperty(&asset.Asset{}), true
 	case UnknownArchiveValue:
-		elem, unknown = resource.NewArchiveProperty(&resource.Archive{}), true
+		elem, unknown = resource.NewArchiveProperty(&archive.Archive{}), true
 	case UnknownObjectValue:
 		elem, unknown = resource.NewObjectProperty(make(resource.PropertyMap)), true
 	}
@@ -566,11 +568,11 @@ func MarshalStruct(obj *structpb.Struct, opts MarshalOptions) *structpb.Value {
 }
 
 // MarshalAsset marshals an asset into its wire form for resource provider plugins.
-func MarshalAsset(v *resource.Asset, opts MarshalOptions) (*structpb.Value, error) {
+func MarshalAsset(v *asset.Asset, opts MarshalOptions) (*structpb.Value, error) {
 	// If we are not providing access to an asset's contents, we simply need to record the fact that this asset existed.
 	// Serialize the asset with only its hash (if present).
 	if opts.ElideAssetContents {
-		v = &resource.Asset{Hash: v.Hash}
+		v = &asset.Asset{Hash: v.Hash}
 	} else {
 		// Ensure a hash is present if needed.
 		if v.Hash == "" && opts.ComputeAssetHashes {
@@ -588,11 +590,11 @@ func MarshalAsset(v *resource.Asset, opts MarshalOptions) (*structpb.Value, erro
 }
 
 // MarshalArchive marshals an archive into its wire form for resource provider plugins.
-func MarshalArchive(v *resource.Archive, opts MarshalOptions) (*structpb.Value, error) {
+func MarshalArchive(v *archive.Archive, opts MarshalOptions) (*structpb.Value, error) {
 	// If we are not providing access to an asset's contents, we simply need to record the fact that this asset existed.
 	// Serialize the asset with only its hash (if present).
 	if opts.ElideAssetContents {
-		v = &resource.Archive{Hash: v.Hash}
+		v = &archive.Archive{Hash: v.Hash}
 	} else {
 		// Ensure a hash is present if needed.
 		if v.Hash == "" && opts.ComputeAssetHashes {

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -665,19 +665,3 @@ const OutputValueSig = sig.OutputValue
 func IsInternalPropertyKey(key PropertyKey) bool {
 	return strings.HasPrefix(string(key), "__")
 }
-
-const (
-	// Re-export asset sigs
-	AssetSig          = asset.AssetSig
-	AssetHashProperty = asset.AssetHashProperty
-	AssetTextProperty = asset.AssetTextProperty
-	AssetPathProperty = asset.AssetPathProperty
-	AssetURIProperty  = asset.AssetURIProperty
-
-	// Re-export archive sigs
-	ArchiveSig            = sig.ArchiveSig
-	ArchiveHashProperty   = archive.ArchiveHashProperty   // the dynamic property for an archive's hash.
-	ArchiveAssetsProperty = archive.ArchiveAssetsProperty // the dynamic property for an archive's assets.
-	ArchivePathProperty   = archive.ArchivePathProperty   // the dynamic property for an archive's path.
-	ArchiveURIProperty    = archive.ArchiveURIProperty    // the dynamic property for an archive's URI.
-)

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -20,6 +20,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -216,7 +219,7 @@ func (props PropertyMap) StableKeys() []PropertyKey {
 //
 //nolint:lll
 type PropertyValueType interface {
-	bool | float64 | string | *Asset | *Archive | Computed | Output | *Secret | ResourceReference | []PropertyValue | PropertyMap
+	bool | float64 | string | *asset.Asset | *archive.Archive | Computed | Output | *Secret | ResourceReference | []PropertyValue | PropertyMap
 }
 
 // NewProperty creates a new PropertyValue.
@@ -229,8 +232,8 @@ func NewBoolProperty(v bool) PropertyValue                           { return Pr
 func NewNumberProperty(v float64) PropertyValue                      { return PropertyValue{v} }
 func NewStringProperty(v string) PropertyValue                       { return PropertyValue{v} }
 func NewArrayProperty(v []PropertyValue) PropertyValue               { return PropertyValue{v} }
-func NewAssetProperty(v *Asset) PropertyValue                        { return PropertyValue{v} }
-func NewArchiveProperty(v *Archive) PropertyValue                    { return PropertyValue{v} }
+func NewAssetProperty(v *asset.Asset) PropertyValue                  { return PropertyValue{v} }
+func NewArchiveProperty(v *archive.Archive) PropertyValue            { return PropertyValue{v} }
 func NewObjectProperty(v PropertyMap) PropertyValue                  { return PropertyValue{v} }
 func NewComputedProperty(v Computed) PropertyValue                   { return PropertyValue{v} }
 func NewOutputProperty(v Output) PropertyValue                       { return PropertyValue{v} }
@@ -316,9 +319,9 @@ func NewPropertyValueRepl(v interface{},
 		return NewProperty(t)
 	case string:
 		return NewProperty(t)
-	case *Asset:
+	case *asset.Asset:
 		return NewProperty(t)
-	case *Archive:
+	case *archive.Archive:
 		return NewProperty(t)
 	case Computed:
 		return NewProperty(t)
@@ -439,10 +442,10 @@ func (v PropertyValue) StringValue() string { return v.V.(string) }
 func (v PropertyValue) ArrayValue() []PropertyValue { return v.V.([]PropertyValue) }
 
 // AssetValue fetches the underlying asset value (panicking if it isn't an asset).
-func (v PropertyValue) AssetValue() *Asset { return v.V.(*Asset) }
+func (v PropertyValue) AssetValue() *asset.Asset { return v.V.(*asset.Asset) }
 
 // ArchiveValue fetches the underlying archive value (panicking if it isn't an archive).
-func (v PropertyValue) ArchiveValue() *Archive { return v.V.(*Archive) }
+func (v PropertyValue) ArchiveValue() *archive.Archive { return v.V.(*archive.Archive) }
 
 // ObjectValue fetches the underlying object value (panicking if it isn't a object).
 func (v PropertyValue) ObjectValue() PropertyMap { return v.V.(PropertyMap) }
@@ -490,13 +493,13 @@ func (v PropertyValue) IsArray() bool {
 
 // IsAsset returns true if the underlying value is an object.
 func (v PropertyValue) IsAsset() bool {
-	_, is := v.V.(*Asset)
+	_, is := v.V.(*asset.Asset)
 	return is
 }
 
 // IsArchive returns true if the underlying value is an object.
 func (v PropertyValue) IsArchive() bool {
-	_, is := v.V.(*Archive)
+	_, is := v.V.(*archive.Archive)
 	return is
 }
 
@@ -638,7 +641,7 @@ type Property struct {
 
 // SigKey is sometimes used to encode type identity inside of a map.  This is required when flattening into ordinary
 // maps, like we do when performing serialization, to ensure recoverability of type identities later on.
-const SigKey = "4dabf18193072939515e22adb298388d"
+const SigKey = sig.Key
 
 // HasSig checks to see if the given property map contains the specific signature match.
 func HasSig(obj PropertyMap, match string) bool {
@@ -649,16 +652,32 @@ func HasSig(obj PropertyMap, match string) bool {
 }
 
 // SecretSig is the unique secret signature.
-const SecretSig = "1b47061264138c4ac30d75fd1eb44270"
+const SecretSig = sig.Secret
 
 // ResourceReferenceSig is the unique resource reference signature.
-const ResourceReferenceSig = "5cf8f73096256a8f31e491e813e4eb8e"
+const ResourceReferenceSig = sig.ResourceReference
 
 // OutputValueSig is the unique output value signature.
-const OutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4"
+const OutputValueSig = sig.OutputValue
 
 // IsInternalPropertyKey returns true if the given property key is an internal key that should not be displayed to
 // users.
 func IsInternalPropertyKey(key PropertyKey) bool {
 	return strings.HasPrefix(string(key), "__")
 }
+
+const (
+	// Re-export asset sigs
+	AssetSig          = asset.AssetSig
+	AssetHashProperty = asset.AssetHashProperty
+	AssetTextProperty = asset.AssetTextProperty
+	AssetPathProperty = asset.AssetPathProperty
+	AssetURIProperty  = asset.AssetURIProperty
+
+	// Re-export archive sigs
+	ArchiveSig            = sig.ArchiveSig
+	ArchiveHashProperty   = archive.ArchiveHashProperty   // the dynamic property for an archive's hash.
+	ArchiveAssetsProperty = archive.ArchiveAssetsProperty // the dynamic property for an archive's assets.
+	ArchivePathProperty   = archive.ArchivePathProperty   // the dynamic property for an archive's path.
+	ArchiveURIProperty    = archive.ArchiveURIProperty    // the dynamic property for an archive's URI.
+)

--- a/sdk/go/common/resource/properties_diff_test.go
+++ b/sdk/go/common/resource/properties_diff_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -302,11 +304,11 @@ func TestObjectPropertyValueDiffs(t *testing.T) {
 
 func TestAssetPropertyValueDiffs(t *testing.T) {
 	t.Parallel()
-	a1, err := NewTextAsset("test")
+	a1, err := asset.FromText("test")
 	assert.NoError(t, err)
 	d1 := NewProperty(a1).Diff(NewProperty(a1))
 	assert.Nil(t, d1)
-	a2, err := NewTextAsset("test2")
+	a2, err := asset.FromText("test2")
 	assert.NoError(t, err)
 	d2 := NewProperty(a1).Diff(NewProperty(a2))
 	assert.NotNil(t, d2)
@@ -330,14 +332,14 @@ func TestArchivePropertyValueDiffs(t *testing.T) {
 	path, err := tempArchive("test", false)
 	assert.NoError(t, err)
 	defer func() { contract.IgnoreError(os.Remove(path)) }()
-	a1, err := NewPathArchive(path)
+	a1, err := archive.FromPath(path)
 	assert.NoError(t, err)
 	d1 := NewProperty(a1).Diff(NewProperty(a1))
 	assert.Nil(t, d1)
 	path2, err := tempArchive("test2", true)
 	assert.NoError(t, err)
 	defer func() { contract.IgnoreError(os.Remove(path)) }()
-	a2, err := NewPathArchive(path2)
+	a2, err := archive.FromPath(path2)
 	assert.NoError(t, err)
 	d2 := NewProperty(a1).Diff(NewProperty(a2))
 	assert.NotNil(t, d2)

--- a/sdk/go/common/resource/sig/sig.go
+++ b/sdk/go/common/resource/sig/sig.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sig
+
+const (
+	// SigKey is sometimes used to encode type identity inside of a map.  This is
+	// required when flattening into ordinary maps, like we do when performing
+	// serialization, to ensure recoverability of type identities later on.
+	Key = "4dabf18193072939515e22adb298388d"
+
+	// SecretSig is the unique secret signature.
+	Secret = "1b47061264138c4ac30d75fd1eb44270"
+
+	// ResourceReferenceSig is the unique resource reference signature.
+	ResourceReference = "5cf8f73096256a8f31e491e813e4eb8e"
+
+	// OutputValueSig is the unique output value signature.
+	OutputValue = "d0e6a833031e9bbcd3f4e8bde6ca49a4"
+
+	// a randomly assigned type hash for assets.
+	AssetSig = "c44067f5952c0a294b673a41bacd8c17"
+
+	// a randomly assigned archive type signature.
+	ArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7"
+)

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -6,6 +6,8 @@ import (
 	"pgregory.net/rapid"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
@@ -187,17 +189,17 @@ func StringPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	})
 }
 
-// TextAssetGenerator generates textual *resource.Asset values.
-func TextAssetGenerator() *rapid.Generator[*resource.Asset] {
-	return rapid.Custom(func(t *rapid.T) *resource.Asset {
-		asset, err := resource.NewTextAsset(rapid.String().Draw(t, "text asset contents"))
+// TextAssetGenerator generates textual *asset.Asset values.
+func TextAssetGenerator() *rapid.Generator[*asset.Asset] {
+	return rapid.Custom(func(t *rapid.T) *asset.Asset {
+		asset, err := asset.FromText(rapid.String().Draw(t, "text asset contents"))
 		assert.NoError(t, err)
 		return asset
 	})
 }
 
-// AssetGenerator generates *resource.Asset values.
-func AssetGenerator() *rapid.Generator[*resource.Asset] {
+// AssetGenerator generates *asset.Asset values.
+func AssetGenerator() *rapid.Generator[*asset.Asset] {
 	return TextAssetGenerator()
 }
 
@@ -208,9 +210,9 @@ func AssetPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 	})
 }
 
-// LiteralArchiveGenerator generates *resource.Archive values with literal archive contents.
-func LiteralArchiveGenerator(maxDepth int) *rapid.Generator[*resource.Archive] {
-	return rapid.Custom(func(t *rapid.T) *resource.Archive {
+// LiteralArchiveGenerator generates *archive.Archive values with literal archive contents.
+func LiteralArchiveGenerator(maxDepth int) *rapid.Generator[*archive.Archive] {
+	return rapid.Custom(func(t *rapid.T) *archive.Archive {
 		var contentsGenerator *rapid.Generator[map[string]interface{}]
 		if maxDepth > 0 {
 			contentsGenerator = rapid.MapOfN(
@@ -222,14 +224,14 @@ func LiteralArchiveGenerator(maxDepth int) *rapid.Generator[*resource.Archive] {
 		} else {
 			contentsGenerator = rapid.Just(map[string]interface{}{})
 		}
-		archive, err := resource.NewAssetArchive(contentsGenerator.Draw(t, "literal archive contents"))
+		archive, err := archive.FromAssets(contentsGenerator.Draw(t, "literal archive contents"))
 		assert.NoError(t, err)
 		return archive
 	})
 }
 
-// ArchiveGenerator generates *resource.Archive values.
-func ArchiveGenerator(maxDepth int) *rapid.Generator[*resource.Archive] {
+// ArchiveGenerator generates *archive.Archive values.
+func ArchiveGenerator(maxDepth int) *rapid.Generator[*archive.Archive] {
 	return LiteralArchiveGenerator(maxDepth)
 }
 

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
@@ -1574,7 +1576,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetArgs
 		{
 			name:  "AssetArgs no deps",
-			input: resource.NewAssetProperty(&resource.Asset{Text: "hello"}),
+			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1584,7 +1586,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetInputArgs
 		{
 			name:  "AssetInputArgs no deps",
-			input: resource.NewAssetProperty(&resource.Asset{Text: "hello"}),
+			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1594,7 +1596,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// ArchiveArgs
 		{
 			name:  "ArchiveArgs no deps",
-			input: resource.NewArchiveProperty(&resource.Archive{Path: "path"}),
+			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewFileArchive("path"), actual)
@@ -1604,7 +1606,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// ArchiveInputArgs
 		{
 			name:  "ArchiveInputArgs no deps",
-			input: resource.NewArchiveProperty(&resource.Archive{Path: "path"}),
+			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewFileArchive("path"), actual)
@@ -1614,7 +1616,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetOrArchiveArgs
 		{
 			name:  "AssetOrArchiveArgs no deps",
-			input: resource.NewAssetProperty(&resource.Asset{Text: "hello"}),
+			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)
@@ -1624,7 +1626,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 		// AssetOrArchiveInputArgs
 		{
 			name:  "AssetOrArchiveInputArgs no deps",
-			input: resource.NewAssetProperty(&resource.Asset{Text: "hello"}),
+			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
 				assert.Equal(t, NewStringAsset("hello"), actual)

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -25,6 +25,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
@@ -307,7 +309,7 @@ func marshalInputImpl(v interface{},
 			if v.invalid {
 				return resource.PropertyValue{}, nil, errors.New("invalid asset")
 			}
-			return resource.NewAssetProperty(&resource.Asset{
+			return resource.NewAssetProperty(&rasset.Asset{
 				Path: v.Path(),
 				Text: v.Text(),
 				URI:  v.URI(),
@@ -328,7 +330,7 @@ func marshalInputImpl(v interface{},
 					assets[k] = aa.V
 				}
 			}
-			return resource.NewArchiveProperty(&resource.Archive{
+			return resource.NewArchiveProperty(&rarchive.Archive{
 				Assets: assets,
 				Path:   v.Path(),
 				URI:    v.URI(),

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
@@ -1387,7 +1389,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Source: NewFileAsset("foo.txt"),
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewAssetProperty(&resource.Asset{
+				"source": resource.NewAssetProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1398,7 +1400,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Source: NewFileArchive("bar.zip"),
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewArchiveProperty(&resource.Archive{
+				"source": resource.NewArchiveProperty(&rarchive.Archive{
 					Path: "bar.zip",
 				}),
 			}),
@@ -1409,7 +1411,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Source: fileAssetOutput,
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"source": resource.NewAssetProperty(&resource.Asset{
+				"source": resource.NewAssetProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1421,7 +1423,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
 				"source": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewAssetProperty(&resource.Asset{
+					Element: resource.NewAssetProperty(&rasset.Asset{
 						Path: "foo.txt",
 					}),
 					Known:  true,
@@ -1436,7 +1438,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
 				"source": resource.NewOutputProperty(resource.Output{
-					Element: resource.NewAssetProperty(&resource.Asset{
+					Element: resource.NewAssetProperty(&rasset.Asset{
 						Path: "foo.txt",
 					}),
 					Known:        true,
@@ -1462,7 +1464,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Nested: nestedOutput,
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&resource.Asset{
+				"nested": resource.NewAssetProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1473,7 +1475,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Nested: nestedPtrOutput,
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&resource.Asset{
+				"nested": resource.NewAssetProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),
@@ -1484,7 +1486,7 @@ func TestOutputValueMarshallingNested(t *testing.T) {
 				Nested: nestedNestedOutput,
 			},
 			expected: resource.NewObjectProperty(resource.PropertyMap{
-				"nested": resource.NewAssetProperty(&resource.Asset{
+				"nested": resource.NewAssetProperty(&rasset.Asset{
 					Path: "foo.txt",
 				}),
 			}),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR is motivated by https://github.com/pulumi/pulumi/pull/15145.

`resource.*` should be built on top of `property.Value`,[^1] which means that `resource`
needs to be able to import `property.Value`, and so `property` cannot import
`resource`. Since Assets and Archives are both types of properties, they must be moved out
of `resource`.

[^1]: For example: https://github.com/pulumi/pulumi/blob/a1d686227cd7e3c70c51bd772450cb0cd57c1479/sdk/go/common/resource/resource_state.go#L35-L36

## Open Question

This PR moves them to their own sub-folders in `resource`. Should `asset` and `archive`
live somewhere more high level, like `sdk/go/property/{asset,archive}`?

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
