### PR TITLE
Fix panic when looking up home

### DIFF
--- a/changelog/pending/20240117--cli--fix-a-panic-when-users-home-directory-could-not-be-looked-up.yaml
+++ b/changelog/pending/20240117--cli--fix-a-panic-when-users-home-directory-could-not-be-looked-up.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic when user's home directory could not be looked up.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -254,6 +254,10 @@ func GetPulumiHomeDir() (string, error) {
 		return "", fmt.Errorf("getting current user: %w", err)
 	}
 
+	if user == nil || user.HomeDir == "" {
+		return "", fmt.Errorf("could not find user home directory, set %s", PulumiHomeEnvVar)
+	}
+
 	return filepath.Join(user.HomeDir, BookkeepingDir), nil
 }
 


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15159.

`user.Current()` can potentially return nil in cases where the user lookup fails, further there's a chance that `HomeDir` might be empty even if a user is found. This makes both of these cases an error, preventing a panic in the former and preventing trying to use "/.pulumi/" in the later.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
