### PR TITLE
Remove b64 from the default secrets provider

### DIFF
--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -70,8 +71,13 @@ func mockStdin(t *testing.T, input string) {
 //nolint:paralleltest // mutates global state
 func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 	var stdoutBuff bytes.Buffer
+	secretsProvider := b64.Base64SecretsProvider.Add("passphrase", func(state json.RawMessage) (secrets.Manager, error) {
+		return passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
+	})
+
 	cmd := stackChangeSecretsProviderCmd{
-		stdout: &stdoutBuff,
+		stdout:          &stdoutBuff,
+		secretsProvider: secretsProvider,
 
 		stack: "testStack",
 	}
@@ -114,7 +120,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			}, nil
 		},
 		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, stack.DefaultSecretsProvider)
+			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)
 			if err != nil {
 				return err
 			}
@@ -162,9 +168,14 @@ runtime: mock
 func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 	ctx := context.Background()
 
+	secretsProvider := b64.Base64SecretsProvider.Add("passphrase", func(state json.RawMessage) (secrets.Manager, error) {
+		return passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
+	})
+
 	var stdoutBuff bytes.Buffer
 	cmd := stackChangeSecretsProviderCmd{
-		stdout: &stdoutBuff,
+		stdout:          &stdoutBuff,
+		secretsProvider: secretsProvider,
 
 		stack: "testStack",
 	}
@@ -210,7 +221,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			}, nil
 		},
 		ImportDeploymentF: func(ctx context.Context, deployment *apitype.UntypedDeployment) error {
-			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, stack.DefaultSecretsProvider)
+			snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, secretsProvider)
 			if err != nil {
 				return err
 			}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
@@ -42,8 +41,6 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	var sm secrets.Manager
 	var err error
 	switch ty {
-	case b64.Type:
-		sm = b64.NewBase64SecretsManager()
 	case passphrase.Type:
 		sm, err = passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
 	case service.Type:

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -195,7 +196,7 @@ type mapTestSecretsProvider struct {
 }
 
 func (p *mapTestSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
-	m, err := DefaultSecretsProvider.OfType(ty, state)
+	m, err := b64.Base64SecretsProvider.OfType(ty, state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/b64/provider.go
+++ b/pkg/secrets/b64/provider.go
@@ -17,20 +17,12 @@ package b64
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 )
 
-// Bas64SecretsProvider is a SecretsProvider that only supports base64 secrets, it is intended to be used for tests
+// Base64SecretsProvider is a SecretsProvider that only supports base64 secrets, it is intended to be used for tests
 // where actual encryption is not needed.
-var Base64SecretsProvider secrets.Provider = b64SecretsProvider{}
-
-type b64SecretsProvider struct{}
-
-func (b64SecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
-	if ty != Type {
-		return nil, fmt.Errorf("no known secrets provider for type %q", ty)
-	}
-	return NewBase64SecretsManager(), nil
-}
+var Base64SecretsProvider *secrets.MockProvider = (&secrets.MockProvider{}).Add(
+	Type, func(_ json.RawMessage) (secrets.Manager, error) { mgr := NewBase64SecretsManager(); return mgr, nil },
+)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This prevents anyone from using the b64 secrets manager in a real deployment. It's now purely a manager we can opt-in to for tests.

Required a little support for a more versatile mock provider because of the ChangeSecretProvider tests which we're checking we could switch between "b64" and "passphrase". Technically I don't think even "passphrase" is needed there and if we add another testing manager (hex, b58?) we could just use that and it would test the same thing but "passphrase" works fine for this test (for now at any rate).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
