### PR TITLE
Add gci and importas linter to ensure consistent imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ linters:
     - paralleltest
     - perfsprint
     - depguard
+    - gci
+    - importas
 
 linters-settings:
   nakedret:
@@ -56,6 +58,19 @@ linters-settings:
         deny:
           - pkg: "github.com/golang/protobuf"
             desc: Use google.golang.org/protobuf instead
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/pulumi)
+  importas:
+    alias:
+    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go
+      alias: pulumirpc
+    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go/testing
+      alias: testingrpc
+    - pkg: github.com/deckarep/golang-set/v2
+      alias: mapset
 
 issues:
   exclude-rules:

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -25,12 +25,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	mapset "github.com/deckarep/golang-set/v2"
-
 	"github.com/blang/semver"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+	"github.com/segmentio/encoding/json"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	backendDisplay "github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
@@ -49,9 +52,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
-	"github.com/segmentio/encoding/json"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 type LanguageTestServer interface {

--- a/cmd/pulumi-test-language/interface_test.go
+++ b/cmd/pulumi-test-language/interface_test.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 	"testing"
 
-	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 )
 
 // Make sure that TestingT never diverges from testing.T.

--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -19,12 +19,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 )
 
 // Check that an invalid schema triggers an error

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -22,17 +22,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 )
 
 type L1EmptyLanguageHost struct {

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -22,11 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +29,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 )
 
 type L2ResourceSimpleLanguageHost struct {

--- a/cmd/pulumi-test-language/testing.go
+++ b/cmd/pulumi-test-language/testing.go
@@ -22,13 +22,13 @@ import (
 	"sync"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // L holds the state for the current language test.

--- a/cmd/pulumi-test-language/tests.go
+++ b/cmd/pulumi-test-language/tests.go
@@ -17,14 +17,15 @@ package main
 import (
 	"embed"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type languageTest struct {

--- a/pkg/authhelpers/gcpauth.go
+++ b/pkg/authhelpers/gcpauth.go
@@ -7,13 +7,11 @@ import (
 	"os"
 
 	"cloud.google.com/go/storage"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/gcsblob"
+	"gocloud.dev/gcp"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-
-	"gocloud.dev/blob/gcsblob"
-
-	"gocloud.dev/blob"
-	"gocloud.dev/gcp"
 )
 
 type GoogleCredentials struct {

--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -17,12 +17,13 @@ package backend
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestComputeUpdateStats tests that the number of non-stack resources and the number of retained resources is correct.

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -25,14 +25,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func loadEvents(path string) (events []engine.Event, err error) {

--- a/pkg/backend/display/events_test.go
+++ b/pkg/backend/display/events_test.go
@@ -19,8 +19,9 @@ package display
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 )
 
 // This test checks that the ANSI control codes are removed from EngineEvents

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -26,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -34,8 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/sergi/go-diff/diffmatchpatch"
-	"gopkg.in/yaml.v3"
 )
 
 // getIndent computes a step's parent indentation.

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -18,10 +18,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func Test_decodeValue(t *testing.T) {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -26,6 +26,7 @@ import (
 	"unicode"
 
 	"github.com/dustin/go-humanize/english"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -23,6 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -32,8 +35,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func testProgressEvents(t *testing.T, path string, accept, interactive bool, width, height int, raw bool) {

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pkg/browser"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-
 	user "github.com/tweekmonster/luser"
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/azureblob" // driver for azblob://

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"gocloud.dev/blob"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // Bucket is a wrapper around an underlying gocloud blob.Bucket.  It ensures that we pass all paths

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"gocloud.dev/blob"
 )
 

--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"gocloud.dev/gcerrors"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"gocloud.dev/gcerrors"
-	"gopkg.in/yaml.v3"
 )
 
 // Path inside the bucket where we store the metadata file.

--- a/pkg/backend/filestate/meta_test.go
+++ b/pkg/backend/filestate/meta_test.go
@@ -19,12 +19,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob/fileblob"
 	"gocloud.dev/blob/memblob"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 )
 
 func TestEnsurePulumiMeta(t *testing.T) {

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -19,9 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -30,8 +27,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // localStack is a local stack descriptor.

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -24,23 +24,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
-
-	"github.com/pulumi/pulumi/pkg/v3/engine"
-
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -23,13 +23,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gocloud.dev/blob"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"gocloud.dev/blob"
 )
 
 // These should be constants

--- a/pkg/backend/filestate/store_test.go
+++ b/pkg/backend/filestate/store_test.go
@@ -19,11 +19,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob/memblob"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestLegacyReferenceStore_referencePaths(t *testing.T) {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -22,6 +22,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
@@ -29,8 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //nolint:paralleltest // mutates environment variables

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func newMockServer(statusCode int, message string) *httptest.Server {

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	opentracing "github.com/opentracing/opentracing-go"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 )
 

--- a/pkg/backend/httpstate/diffs_post_1.20.go
+++ b/pkg/backend/httpstate/diffs_post_1.20.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/span"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pgavlin/diff/lcs"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	segmentio_json "github.com/segmentio/encoding/json"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 type deployment struct {

--- a/pkg/backend/httpstate/diffs_pre_1.20.go
+++ b/pkg/backend/httpstate/diffs_pre_1.20.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+	opentracing "github.com/opentracing/opentracing-go"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 type deployment struct {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -20,12 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/channel"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -34,7 +28,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/channel"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -19,11 +19,12 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 type aiCmd struct {

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 type PulumiAILanguage string

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -22,12 +22,13 @@ import (
 	"os"
 
 	"github.com/erikgeiser/promptkit/confirmation"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newConfigEnvCmd(stackRef *string) *cobra.Command {

--- a/pkg/cmd/pulumi/config_env_add.go
+++ b/pkg/cmd/pulumi/config_env_add.go
@@ -15,9 +15,10 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newConfigEnvAddCmd(parent *configEnvCmd) *cobra.Command {

--- a/pkg/cmd/pulumi/config_env_add_test.go
+++ b/pkg/cmd/pulumi/config_env_add_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/esc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/esc"
 )
 
 func TestConfigEnvAddCmd(t *testing.T) {

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/erikgeiser/promptkit/confirmation"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/esc"
 	"github.com/pulumi/esc/eval"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -33,8 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {

--- a/pkg/cmd/pulumi/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config_env_init_test.go
@@ -20,11 +20,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type base64EvalCrypter struct{}

--- a/pkg/cmd/pulumi/config_env_ls.go
+++ b/pkg/cmd/pulumi/config_env_ls.go
@@ -15,8 +15,9 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/esc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/esc"
 )
 
 func boolPtr(v bool) *bool {

--- a/pkg/cmd/pulumi/config_env_rm.go
+++ b/pkg/cmd/pulumi/config_env_rm.go
@@ -15,9 +15,10 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {

--- a/pkg/cmd/pulumi/config_env_rm_test.go
+++ b/pkg/cmd/pulumi/config_env_rm_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/esc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/esc"
 )
 
 func TestConfigEnvRmCmd(t *testing.T) {

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/acarl005/stripansi"
+
 	"github.com/pulumi/esc"
 	"github.com/pulumi/esc/eval"
 	"github.com/pulumi/esc/syntax"

--- a/pkg/cmd/pulumi/convert-trace.go
+++ b/pkg/cmd/pulumi/convert-trace.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/google/pprof/profile"
-	"github.com/pulumi/appdash"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/appdash"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -34,7 +34,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/util"
+	aferoUtil "github.com/pulumi/pulumi/pkg/v3/util/afero"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -43,9 +45,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
-	aferoUtil "github.com/pulumi/pulumi/pkg/v3/util/afero"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
 type projectGeneratorFunc func(directory string, project workspace.Project, p *pcl.Program) error

--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 )
 
 // TestConvert is an entrypoint for debugging `pulumi convert“. To use this with an editor such as

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	mapset "github.com/deckarep/golang-set/v2"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -27,12 +27,14 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
-
 	"github.com/spf13/cobra"
 
+	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
+	yamlgen "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -50,10 +52,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
-	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
-	yamlgen "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 )
 
 func parseResourceSpec(spec string) (string, resource.URN, error) {

--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/importer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParseImportFile_errors(t *testing.T) {

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -21,15 +21,14 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-
 	mobytime "github.com/moby/moby/api/types/time"
+	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/operations"

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -45,8 +46,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
 const (

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 func chdir(t *testing.T, dir string) {

--- a/pkg/cmd/pulumi/new_ai_test.go
+++ b/pkg/cmd/pulumi/new_ai_test.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 )
 
 //nolint:paralleltest // changes directory

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -25,13 +25,14 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // mockBackendInstance sets the backendInstance for the test and cleans it up after.

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -25,6 +25,10 @@ import (
 	"strconv"
 
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+	auto_table "go.pennock.tech/tabular/auto"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
@@ -32,9 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
-	auto_table "go.pennock.tech/tabular/auto"
-	"gopkg.in/yaml.v3"
 )
 
 type Delimiter rune

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -21,12 +21,13 @@ import (
 	"os"
 
 	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 type searchAICmd struct {

--- a/pkg/cmd/pulumi/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org_search_ai_test.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSearchAI_cmd(t *testing.T) {

--- a/pkg/cmd/pulumi/org_search_test.go
+++ b/pkg/cmd/pulumi/org_search_test.go
@@ -20,13 +20,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSearch_cmd(t *testing.T) {

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -24,18 +24,18 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func newPackageCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/package_extract_mapping.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/spf13/cobra"
 )
 
 func newExtractMappingCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/package_extract_schema.go
+++ b/pkg/cmd/pulumi/package_extract_schema.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func newExtractSchemaCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
-
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"

--- a/pkg/cmd/pulumi/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/package_pack_sdk.go
@@ -20,9 +20,9 @@ import (
 	"os"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -23,12 +23,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 func newPackagePublishCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -34,7 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newPluginInstallCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin_install_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test for https://github.com/pulumi/pulumi/issues/11703, check we give an error when trying to install a

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 
 	"github.com/dustin/go-humanize"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -18,14 +18,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"

--- a/pkg/cmd/pulumi/policy.go
+++ b/pkg/cmd/pulumi/policy.go
@@ -15,8 +15,9 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func newPolicyCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -15,9 +15,10 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 type policyDisableArgs struct {

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -17,11 +17,12 @@ package main
 import (
 	"encoding/json"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 const latestKeyword = "latest"

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -25,6 +25,8 @@ import (
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/opentracing/opentracing-go"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -32,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 type newPolicyArgs struct {

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -21,13 +21,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newPolicyPublishCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/policy_publish_test.go
+++ b/pkg/cmd/pulumi/policy_publish_test.go
@@ -6,13 +6,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPolicyPublishCmd_default(t *testing.T) {

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
-	"github.com/spf13/cobra"
 )
 
 const allKeyword = "all"

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -18,9 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 func newPolicyValidateCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/preview_test.go
+++ b/pkg/cmd/pulumi/preview_test.go
@@ -18,14 +18,15 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func makeRootStackMetadata(op display.StepOp) engine.StepEventMetadata {

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -33,13 +33,11 @@ import (
 	"strings"
 	"time"
 
-	user "github.com/tweekmonster/luser"
-
 	"github.com/blang/semver"
 	"github.com/djherbis/times"
 	"github.com/moby/term"
-
 	"github.com/spf13/cobra"
+	user "github.com/tweekmonster/luser"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -22,10 +22,11 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/pkg/v3/version"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestIsLocalVersion(t *testing.T) {

--- a/pkg/cmd/pulumi/schema.go
+++ b/pkg/cmd/pulumi/schema.go
@@ -15,8 +15,9 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func newSchemaCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/schema_check.go
+++ b/pkg/cmd/pulumi/schema_check.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
-
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -29,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 type stackChangeSecretsProviderCmd struct {

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -21,6 +21,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -32,8 +35,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Test that we validate the secrets provider and return an error

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/graph"
 	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
@@ -26,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 type graphCommandOptions struct {

--- a/pkg/cmd/pulumi/stack_graph_test.go
+++ b/pkg/cmd/pulumi/stack_graph_test.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 // Tests the output of 'pulumi stack graph'

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-multierror"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"

--- a/pkg/cmd/pulumi/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack_init_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // When a backend doesn't support the --teams flag,

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Tests the output of 'pulumi stack output'

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"

--- a/pkg/cmd/pulumi/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack_unselect.go
@@ -17,9 +17,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 // Resets the currently selected stack from the current workspace such that

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -18,13 +18,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-
-	"github.com/spf13/cobra"
 )
 
 func newStateDeleteCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 
 	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -32,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
-	"github.com/spf13/cobra"
 )
 
 func newStateEditCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/state_edit_test.go
+++ b/pkg/cmd/pulumi/state_edit_test.go
@@ -17,10 +17,11 @@ package main
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestSnapshotFrontendRoundTrip(t *testing.T) {

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -26,8 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
-	"github.com/spf13/cobra"
 )
 
 func updateDependencies(dependencies []resource.URN, oldUrn resource.URN, newUrn resource.URN) []resource.URN {

--- a/pkg/cmd/pulumi/state_rename_test.go
+++ b/pkg/cmd/pulumi/state_rename_test.go
@@ -17,11 +17,12 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestRenameProvider tests that we can rename a provider and produce a valid snapshot.

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -19,14 +19,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
-	"github.com/spf13/cobra"
 )
 
 func newStateUnprotectCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -22,6 +22,8 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
@@ -30,8 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
-	"github.com/spf13/cobra"
 )
 
 func newStateUpgradeCommand() *cobra.Command {

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -13,14 +13,15 @@ import (
 	"github.com/Netflix/go-expect"
 	"github.com/creack/pty"
 	"github.com/hinshun/vt10x"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStateUpgradeCommand_parseArgs(t *testing.T) {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -29,14 +29,13 @@ import (
 	"strconv"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/spf13/pflag"
-
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	git "github.com/go-git/go-git/v5"
+	multierror "github.com/hashicorp/go-multierror"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/spf13/pflag"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"

--- a/pkg/cmd/pulumi/version.go
+++ b/pkg/cmd/pulumi/version.go
@@ -17,9 +17,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 func newVersionCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/view-trace.go
+++ b/pkg/cmd/pulumi/view-trace.go
@@ -21,10 +21,10 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pulumi/appdash"
-	"github.com/pulumi/appdash/traceapp"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/appdash"
+	"github.com/pulumi/appdash/traceapp"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/spf13/cobra"
 )
 
 func newWhoAmICmd() *cobra.Command {

--- a/pkg/cmd/pulumi/whoami_test.go
+++ b/pkg/cmd/pulumi/whoami_test.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWhoAmICmd_default(t *testing.T) {

--- a/pkg/codegen/convert/plugin_mapper_test.go
+++ b/pkg/codegen/convert/plugin_mapper_test.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-
 	"github.com/pgavlin/goldmark"
 
 	"github.com/pulumi/pulumi-java/pkg/codegen/java"

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -18,9 +18,10 @@ package dotnet
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 var testPackageSpec = schema.PackageSpec{

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type nameInfo int

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 var testPackageSpec = schema.PackageSpec{

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/stretchr/testify/assert"
 )
 
 type exprTestCase struct {

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const keywordRange = "range"

--- a/pkg/codegen/go/gen_program_inline_invoke.go
+++ b/pkg/codegen/go/gen_program_inline_invoke.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"

--- a/pkg/codegen/go/gen_program_json.go
+++ b/pkg/codegen/go/gen_program_json.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/go/gen_program_optionals.go
+++ b/pkg/codegen/go/gen_program_optionals.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"

--- a/pkg/codegen/go/gen_program_read_dir.go
+++ b/pkg/codegen/go/gen_program_read_dir.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/go/gen_program_splat.go
+++ b/pkg/codegen/go/gen_program_splat.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/go/gen_program_ternaries.go
+++ b/pkg/codegen/go/gen_program_ternaries.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +17,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")

--- a/pkg/codegen/go/gen_spill.go
+++ b/pkg/codegen/go/gen_spill.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/hcl2/model/attribute.go
+++ b/pkg/codegen/hcl2/model/attribute.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -19,9 +19,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	_syntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type BindOption func(options *bindOptions)

--- a/pkg/codegen/hcl2/model/binder_expression_test.go
+++ b/pkg/codegen/hcl2/model/binder_expression_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 
 func assertConvertibleFrom(t *testing.T, to, from Type) {

--- a/pkg/codegen/hcl2/model/block.go
+++ b/pkg/codegen/hcl2/model/block.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 

--- a/pkg/codegen/hcl2/model/body.go
+++ b/pkg/codegen/hcl2/model/body.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // Expression represents a semantically-analyzed HCL2 expression.

--- a/pkg/codegen/hcl2/model/functions.go
+++ b/pkg/codegen/hcl2/model/functions.go
@@ -17,6 +17,7 @@ package model
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 

--- a/pkg/codegen/hcl2/model/scope.go
+++ b/pkg/codegen/hcl2/model/scope.go
@@ -17,8 +17,9 @@ package model
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 
 // Definition represents a single definition in a Scope.

--- a/pkg/codegen/hcl2/model/traversable.go
+++ b/pkg/codegen/hcl2/model/traversable.go
@@ -18,8 +18,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // Traversable represents an entity that can be traversed by an HCL2 traverser.

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/hcl2/model/type_scope.go
+++ b/pkg/codegen/hcl2/model/type_scope.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )
 

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/pretty"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"

--- a/pkg/codegen/hcl2/model/visitor.go
+++ b/pkg/codegen/hcl2/model/visitor.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -21,8 +21,9 @@ package nodejs
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 var testPackageSpec = schema.PackageSpec{

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"
@@ -35,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const PulumiToken = "pulumi"

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -2,6 +2,7 @@ package nodejs
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -3,10 +3,11 @@ package nodejs
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateProgramVersionSelection(t *testing.T) {

--- a/pkg/codegen/nodejs/tstypes/tstypes_test.go
+++ b/pkg/codegen/nodejs/tstypes/tstypes_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/stretchr/testify/assert"
 	"pgregory.net/rapid"
 )

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // isReservedWord returns true if s is a reserved word as per ECMA-262.

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const (

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	syntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 )

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -17,6 +17,7 @@ package pcl
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -19,12 +19,13 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func getResourceToken(node *Resource) (string, hcl.Range) {

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestBindResourceOptions(t *testing.T) {

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -22,12 +22,13 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type packageSchema struct {

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -4,11 +4,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/zclconf/go-cty/cty"
 )
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -6,21 +6,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
-	"github.com/spf13/afero"
-
 	"github.com/hashicorp/hcl/v2"
-
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")

--- a/pkg/codegen/pcl/component.go
+++ b/pkg/codegen/pcl/component.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/config.go
+++ b/pkg/codegen/pcl/config.go
@@ -17,6 +17,7 @@ package pcl
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/diagnostics.go
+++ b/pkg/codegen/pcl/diagnostics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -16,6 +16,7 @@ package pcl
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -3,10 +3,11 @@ package pcl_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSingleOrNoneErrorsWithoutArguments(t *testing.T) {

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -19,9 +19,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const Invoke = "invoke"

--- a/pkg/codegen/pcl/local.go
+++ b/pkg/codegen/pcl/local.go
@@ -17,6 +17,7 @@ package pcl
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/output.go
+++ b/pkg/codegen/pcl/output.go
@@ -17,6 +17,7 @@ package pcl
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 

--- a/pkg/codegen/pcl/program.go
+++ b/pkg/codegen/pcl/program.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/spf13/afero"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/spf13/afero"
 )
 
 // Node represents a single definition in a program or component.

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -17,6 +17,7 @@ package pcl
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -19,10 +19,11 @@ import (
 
 	"github.com/gedex/inflector"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type NameInfo interface {

--- a/pkg/codegen/pcl/rewrite_apply_test.go
+++ b/pkg/codegen/pcl/rewrite_apply_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/stretchr/testify/assert"
 )
 
 type nameInfo int

--- a/pkg/codegen/pcl/rewrite_convert.go
+++ b/pkg/codegen/pcl/rewrite_convert.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 func sameSchemaTypes(xt, yt model.Type) bool {

--- a/pkg/codegen/pcl/rewrite_convert_test.go
+++ b/pkg/codegen/pcl/rewrite_convert_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRewriteConversions(t *testing.T) {

--- a/pkg/codegen/pcl/rewrite_properties.go
+++ b/pkg/codegen/pcl/rewrite_properties.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func RewritePropertyReferences(expr model.Expression) model.Expression {

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -21,14 +21,14 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // titleCase replaces the first character in the given string with its upper-case equivalent.

--- a/pkg/codegen/pcl/utilities_test.go
+++ b/pkg/codegen/pcl/utilities_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -23,9 +23,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expression,

--- a/pkg/codegen/python/gen_program_quotes_test.go
+++ b/pkg/codegen/python/gen_program_quotes_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLowerPropertyAccess(t *testing.T) {

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -3,12 +3,12 @@ package python
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func TestFunctionInvokeBindsArgumentObjectType(t *testing.T) {

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"

--- a/pkg/codegen/report/report_test.go
+++ b/pkg/codegen/report/report_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
@@ -12,8 +15,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/report"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/pulumi/pulumi/pkg/v3/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -29,11 +29,12 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/segmentio/encoding/json"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/santhosh-tekuri/jsonschema/v5"
-	"github.com/segmentio/encoding/json"
 )
 
 //go:embed pulumi.json

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pgavlin/goldmark/renderer"
 	"github.com/pgavlin/goldmark/renderer/markdown"
 	"github.com/pgavlin/goldmark/util"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/blang/semver"
 	"github.com/pgavlin/goldmark/ast"
 	"github.com/pgavlin/goldmark/testutil"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 )
 
 // Note to future engineers: keep each file tested as a single test, do not use `t.Run` in the inner

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -23,10 +23,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/edsrzf/mmap-go"
 	"github.com/natefinch/atomic"
-
-	"github.com/blang/semver"
 	"github.com/segmentio/encoding/json"
 
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"

--- a/pkg/codegen/schema/loader_client.go
+++ b/pkg/codegen/schema/loader_client.go
@@ -17,16 +17,16 @@ package schema
 import (
 	"context"
 
+	"github.com/blang/semver"
+	"github.com/segmentio/encoding/json"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
-	"github.com/segmentio/encoding/json"
 )
 
 // loaderClient reflects a loader service, loaded dynamically from the engine process over gRPC.

--- a/pkg/codegen/schema/loader_server.go
+++ b/pkg/codegen/schema/loader_server.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver"
+	"github.com/segmentio/encoding/json"
 	"google.golang.org/grpc"
 
-	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
-	"github.com/segmentio/encoding/json"
 )
 
 type loaderServer struct {

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
-	"github.com/stretchr/testify/require"
 )
 
 func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/segmentio/encoding/json"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/segmentio/encoding/json"
 )
 
 // A PackageReference represents a references Pulumi Package. Applications that do not need access to the entire

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-
 	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // TODO:

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -27,10 +27,11 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 )
 
 func readSchemaFile(file string) (pkgSpec PackageSpec) {

--- a/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
+++ b/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	other "git.example.org/thirdparty/sdk/go/pkg"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go-extras/tests/codegen_test.go
@@ -16,12 +16,12 @@ package codegentest
 
 import (
 	"fmt"
-	"output-funcs-tfbridge20/mypkg"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"output-funcs-tfbridge20/mypkg"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"

--- a/pkg/codegen/testing/test/testdata/output-funcs/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go-extras/tests/codegen_test.go
@@ -16,11 +16,11 @@ package codegentest
 
 import (
 	"fmt"
-	"output-funcs/mypkg"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"output-funcs/mypkg"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go-extras/tests/codegen_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"plain-and-default/foo"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/stretchr/testify/assert"
-
-	"plain-and-default/foo"
 )
 
 type mocks int

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
@@ -16,11 +16,11 @@ package codegentest
 
 import (
 	"fmt"
-	"plain-object-defaults/example"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"plain-object-defaults/example"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"

--- a/pkg/codegen/testing/test/testdata/regress-go-12971/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-12971/go-extras/tests/codegen_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"regress-go-12971/example"
 	"regress-go-12971/example/config"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //nolint:paralleltest // modifies environment variables

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go-extras/tests/go_test.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go-extras/tests/go_test.go
@@ -4,9 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"resource-args-python-case-insensitive/example"
-
 	"github.com/stretchr/testify/assert"
+	"resource-args-python-case-insensitive/example"
 )
 
 func TestArrayElemType(t *testing.T) {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go-extras/tests/go_test.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go-extras/tests/go_test.go
@@ -4,9 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"resource-args-python/example"
-
 	"github.com/stretchr/testify/assert"
+	"resource-args-python/example"
 )
 
 func TestArrayElemType(t *testing.T) {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"resource-property-overlap/example"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"resource-property-overlap/example"
 )
 
 // Tests that XArray{x}.ToXArrayOutput().Index(pulumi.Int(0)) == x.

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go-extras/tests/go_test.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go-extras/tests/go_test.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"simple-enum-schema/plant"
+	tree "simple-enum-schema/plant/tree/v1"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"simple-enum-schema/plant"
-	tree "simple-enum-schema/plant/tree/v1"
 )
 
 func TestEnumUsage(t *testing.T) {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go-extras/tests/codegen_test.go
@@ -19,11 +19,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"simple-resource-schema/example"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"simple-resource-schema/example"
 )
 
 type mocks int

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"git.example.org/pulumi-synthetic/resourceProperties"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
+++ b/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
@@ -3,6 +3,7 @@ package main
 import (
 	other "git.example.org/thirdparty/sdk/go/pkg"
 	"git.example.org/thirdparty/sdk/go/pkg/module"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/type_driver.go
+++ b/pkg/codegen/testing/test/type_driver.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 type typeTestCase struct {

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"

--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -17,8 +17,9 @@ package codegen
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 func TestStringSetContains(t *testing.T) {

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
 )
 
 type testRequiredPolicy struct {

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -28,13 +28,12 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"google.golang.org/protobuf/types/known/emptypb"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"

--- a/pkg/engine/lifecycletest/source_query_test.go
+++ b/pkg/engine/lifecycletest/source_query_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -27,8 +30,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunQuery_nocreate(t *testing.T) {

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestDuplicateURN tests that duplicate URNs are disallowed.

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/opentracing/opentracing-go"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -5,11 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAbbreviateFilePath(t *testing.T) {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -20,6 +20,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -29,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Null represents Pulumi HCL2's `null` variable.

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -24,6 +24,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
@@ -36,8 +39,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
-	"github.com/zclconf/go-cty/cty"
 )
 
 var testdataPath = filepath.Join("..", "codegen", "testing", "test", "testdata")

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
@@ -26,7 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateLanguageDefinition(t *testing.T) {

--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"

--- a/pkg/resource/analyzer/config.go
+++ b/pkg/resource/analyzer/config.go
@@ -21,10 +21,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/xeipuuv/gojsonschema"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 // LoadPolicyPackConfigFromFile loads the JSON config from a file.

--- a/pkg/resource/analyzer/config_test.go
+++ b/pkg/resource/analyzer/config_test.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
 )
 
 type JSONTestCaseSuccess struct {

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuiltinProvider(t *testing.T) {

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -16,9 +16,10 @@ package deploy
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/stretchr/testify/assert"
 )
 
 // Note: the only valid way to add a resource to the node list is via the `add` method.

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func newResource(name string) *resource.State {

--- a/pkg/resource/deploy/deploytest/analyzer_test.go
+++ b/pkg/resource/deploy/deploytest/analyzer_test.go
@@ -17,10 +17,11 @@ package deploytest
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAnalyzer(t *testing.T) {

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"

--- a/pkg/resource/deploy/deploytest/languageruntime_test.go
+++ b/pkg/resource/deploy/deploytest/languageruntime_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLanguageRuntime(t *testing.T) {

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -23,10 +23,9 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"google.golang.org/protobuf/types/known/emptypb"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestNewAnalyzerLoaderWithHost(t *testing.T) {

--- a/pkg/resource/deploy/deploytest/provider_test.go
+++ b/pkg/resource/deploy/deploytest/provider_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProvider(t *testing.T) {

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -22,15 +22,16 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 )
 
 type ResourceMonitor struct {

--- a/pkg/resource/deploy/deploytest/resourcemonitor_test.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Verifies that ReturnDependencies in a ResourceMonitor.Call

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestImportDeployment(t *testing.T) {

--- a/pkg/resource/deploy/manifest.go
+++ b/pkg/resource/deploy/manifest.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )

--- a/pkg/resource/deploy/manifest_test.go
+++ b/pkg/resource/deploy/manifest_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestManifest(t *testing.T) {

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -18,8 +18,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestPlan(t *testing.T) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -3,8 +3,9 @@ package deploy
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func createSnapshot() Snapshot {

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"io"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // A ProviderSource allows a Source to lookup provider plugins.

--- a/pkg/resource/deploy/source_error_test.go
+++ b/pkg/resource/deploy/source_error_test.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func TestErrorSource(t *testing.T) {

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -21,9 +21,8 @@ import (
 	"math"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"google.golang.org/protobuf/types/known/emptypb"
-
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -32,8 +35,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestQuerySource_Trivial_Wait(t *testing.T) {

--- a/pkg/resource/deploy/state_builder_test.go
+++ b/pkg/resource/deploy/state_builder_test.go
@@ -18,8 +18,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestStateBuilder(t *testing.T) {

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -19,10 +19,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRegisterResourceErrorsOnMissingPendingNew(t *testing.T) {

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -18,12 +18,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIgnoreChanges(t *testing.T) {

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -18,13 +18,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRawPrefix(t *testing.T) {

--- a/pkg/resource/deploy/target_test.go
+++ b/pkg/resource/deploy/target_test.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTarget(t *testing.T) {

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -18,17 +18,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func NewResource(name string, provider *resource.State, deps ...resource.URN) *resource.State {

--- a/pkg/resource/graph/dependency_graph_rapid_test.go
+++ b/pkg/resource/graph/dependency_graph_rapid_test.go
@@ -37,11 +37,11 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Models ------------------------------------------------------------------------------------------

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -5,10 +5,11 @@ package graph
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func NewProviderResource(pkg, name, id string, deps ...resource.URN) *resource.State {

--- a/pkg/resource/provider/component_provider.go
+++ b/pkg/resource/provider/component_provider.go
@@ -17,13 +17,13 @@ package provider
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type componentProvider struct {

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -19,21 +19,22 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/grpclog"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // HostClient is a client interface into the host's engine RPC interface.
 type HostClient struct {
 	conn   *grpc.ClientConn
-	client lumirpc.EngineClient
+	client pulumirpc.EngineClient
 }
 
 // NewHostClient dials the target address, connects over gRPC, and returns a client interface.
@@ -53,7 +54,7 @@ func NewHostClient(addr string) (*HostClient, error) {
 	}
 	return &HostClient{
 		conn:   conn,
-		client: lumirpc.NewEngineClient(conn),
+		client: pulumirpc.NewEngineClient(conn),
 	}, nil
 }
 
@@ -70,20 +71,20 @@ func (host *HostClient) EngineConn() *grpc.ClientConn {
 func (host *HostClient) log(
 	context context.Context, sev diag.Severity, urn resource.URN, msg string, ephemeral bool,
 ) error {
-	var rpcsev lumirpc.LogSeverity
+	var rpcsev pulumirpc.LogSeverity
 	switch sev {
 	case diag.Debug:
-		rpcsev = lumirpc.LogSeverity_DEBUG
+		rpcsev = pulumirpc.LogSeverity_DEBUG
 	case diag.Info:
-		rpcsev = lumirpc.LogSeverity_INFO
+		rpcsev = pulumirpc.LogSeverity_INFO
 	case diag.Warning:
-		rpcsev = lumirpc.LogSeverity_WARNING
+		rpcsev = pulumirpc.LogSeverity_WARNING
 	case diag.Error:
-		rpcsev = lumirpc.LogSeverity_ERROR
+		rpcsev = pulumirpc.LogSeverity_ERROR
 	default:
 		contract.Failf("Unrecognized log severity type: %v", sev)
 	}
-	_, err := host.client.Log(context, &lumirpc.LogRequest{
+	_, err := host.client.Log(context, &pulumirpc.LogRequest{
 		Severity:  rpcsev,
 		Message:   strings.ToValidUTF8(msg, "�"),
 		Urn:       string(urn),

--- a/pkg/resource/stack/checkpoint_test.go
+++ b/pkg/resource/stack/checkpoint_test.go
@@ -18,8 +18,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 )
 
 func TestLoadV0Checkpoint(t *testing.T) {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -31,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 const (

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testSecretsManager struct {

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func getAzureCaller(ctx context.Context, t *testing.T) *azidentity.DefaultAzureCredential {

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -22,11 +22,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/secrets"
 	"gocloud.dev/secrets/driver"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // the main testing function, takes a kms url and tries to make a new secret manager out of it and encrypt and

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -36,6 +36,8 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	user "github.com/tweekmonster/luser"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"gopkg.in/yaml.v3"
@@ -54,8 +56,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	user "github.com/tweekmonster/luser"
 )
 
 const (

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -21,9 +21,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 )
 
 // Test that RunCommand writes the command's output to a log file.

--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -19,9 +19,10 @@ import (
 	"path"
 	"strings"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
 )
 
 // CreateBasicPulumiRepo will initialize the environment with a basic Pulumi repository and

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )

--- a/pkg/util/rpcdebug/interceptors.go
+++ b/pkg/util/rpcdebug/interceptors.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	"google.golang.org/grpc"
-
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func TestValidateStackTag(t *testing.T) {

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -19,9 +19,9 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestInstallPluginErrorText(t *testing.T) {

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/python"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConcurrentUpdateError(t *testing.T) {

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -19,11 +19,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const testPermalink = "Permalink: https://gotest"

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/sdk/go/common/apitype/migrate/checkpoint_test.go
+++ b/sdk/go/common/apitype/migrate/checkpoint_test.go
@@ -17,10 +17,11 @@ package migrate
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckpointV1ToV2(t *testing.T) {

--- a/sdk/go/common/apitype/migrate/deployment_test.go
+++ b/sdk/go/common/apitype/migrate/deployment_test.go
@@ -17,9 +17,10 @@ package migrate
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentV1ToV2(t *testing.T) {

--- a/sdk/go/common/apitype/migrate/resource_test.go
+++ b/sdk/go/common/apitype/migrate/resource_test.go
@@ -17,10 +17,11 @@ package migrate
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestV1ToV2(t *testing.T) {

--- a/sdk/go/common/channel/channel_test.go
+++ b/sdk/go/common/channel/channel_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 )
 
 func TestFilterRead(t *testing.T) {

--- a/sdk/go/common/encoding/marshal.go
+++ b/sdk/go/common/encoding/marshal.go
@@ -22,8 +22,9 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/yamlutil"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/yamlutil"
 )
 
 var (

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -27,9 +27,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -25,8 +25,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // Encrypter encrypts plaintext into its encrypted ciphertext.

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestMarshalMap(t *testing.T) {

--- a/sdk/go/common/resource/config/object_test.go
+++ b/sdk/go/common/resource/config/object_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestEmptyObject(t *testing.T) {

--- a/sdk/go/common/resource/config/plaintext_test.go
+++ b/sdk/go/common/resource/config/plaintext_test.go
@@ -19,10 +19,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func TestPlaintextReserved(t *testing.T) {

--- a/sdk/go/common/resource/config/repr_test.go
+++ b/sdk/go/common/resource/config/repr_test.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 // mapPaths returns the set of all possible paths in c.

--- a/sdk/go/common/resource/plugin/check.go
+++ b/sdk/go/common/resource/plugin/check.go
@@ -16,29 +16,29 @@ package plugin
 
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // NewCheckResponse produces a response with property validation failures from the given array of mapper failures.
-func NewCheckResponse(err error) *lumirpc.CheckResponse {
-	var failures []*lumirpc.CheckFailure
+func NewCheckResponse(err error) *pulumirpc.CheckResponse {
+	var failures []*pulumirpc.CheckFailure
 	if err != nil {
 		switch e := err.(type) {
 		case mapper.MappingError:
 			for _, failure := range e.Failures() {
 				switch f := failure.(type) {
 				case mapper.FieldError:
-					failures = append(failures, &lumirpc.CheckFailure{
+					failures = append(failures, &pulumirpc.CheckFailure{
 						Property: f.Field(),
 						Reason:   f.Reason(),
 					})
 				default:
-					failures = append(failures, &lumirpc.CheckFailure{Reason: f.Error()})
+					failures = append(failures, &pulumirpc.CheckFailure{Reason: f.Error()})
 				}
 			}
 		default:
-			failures = append(failures, &lumirpc.CheckFailure{Reason: e.Error()})
+			failures = append(failures, &pulumirpc.CheckFailure{Reason: e.Error()})
 		}
 	}
-	return &lumirpc.CheckResponse{Failures: failures}
+	return &pulumirpc.CheckResponse{Failures: failures}
 }

--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go/mocktracer"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 )
 
 func TestContextRequest_race(t *testing.T) {

--- a/sdk/go/common/resource/plugin/converter_plugin_test.go
+++ b/sdk/go/common/resource/plugin/converter_plugin_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 type testConverterClient struct {

--- a/sdk/go/common/resource/plugin/converter_server_test.go
+++ b/sdk/go/common/resource/plugin/converter_server_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 type testConverter struct{}

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -26,12 +26,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // hostServer is the server side of the host RPC machinery.
 type hostServer struct {
-	lumirpc.UnsafeEngineServer // opt out of forward compat
+	pulumirpc.UnsafeEngineServer // opt out of forward compat
 
 	host   Host         // the host for this RPC server.
 	ctx    *Context     // the associated plugin context.
@@ -56,7 +56,7 @@ func newHostServer(host Host, ctx *Context) (*hostServer, error) {
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: engine.cancel,
 		Init: func(srv *grpc.Server) error {
-			lumirpc.RegisterEngineServer(srv, engine)
+			pulumirpc.RegisterEngineServer(srv, engine)
 			return nil
 		},
 		Options: rpcutil.OpenTracingServerInterceptorOptions(ctx.tracingSpan),
@@ -87,16 +87,16 @@ func (eng *hostServer) Cancel() error {
 }
 
 // Log logs a global message in the engine, including errors and warnings.
-func (eng *hostServer) Log(ctx context.Context, req *lumirpc.LogRequest) (*emptypb.Empty, error) {
+func (eng *hostServer) Log(ctx context.Context, req *pulumirpc.LogRequest) (*emptypb.Empty, error) {
 	var sev diag.Severity
 	switch req.Severity {
-	case lumirpc.LogSeverity_DEBUG:
+	case pulumirpc.LogSeverity_DEBUG:
 		sev = diag.Debug
-	case lumirpc.LogSeverity_INFO:
+	case pulumirpc.LogSeverity_INFO:
 		sev = diag.Info
-	case lumirpc.LogSeverity_WARNING:
+	case pulumirpc.LogSeverity_WARNING:
 		sev = diag.Warning
-	case lumirpc.LogSeverity_ERROR:
+	case pulumirpc.LogSeverity_ERROR:
 		sev = diag.Error
 	default:
 		return nil, errors.Errorf("Unrecognized logging severity: %v", req.Severity)
@@ -113,9 +113,9 @@ func (eng *hostServer) Log(ctx context.Context, req *lumirpc.LogRequest) (*empty
 // GetRootResource returns the current root resource's URN, which will serve as the parent of resources that are
 // otherwise left unparented.
 func (eng *hostServer) GetRootResource(ctx context.Context,
-	req *lumirpc.GetRootResourceRequest,
-) (*lumirpc.GetRootResourceResponse, error) {
-	var response lumirpc.GetRootResourceResponse
+	req *pulumirpc.GetRootResourceRequest,
+) (*pulumirpc.GetRootResourceResponse, error) {
+	var response pulumirpc.GetRootResourceResponse
 	response.Urn = eng.rootUrn.Load().(string)
 	return &response, nil
 }
@@ -123,9 +123,9 @@ func (eng *hostServer) GetRootResource(ctx context.Context,
 // SetRootResource sets the current root resource's URN. Generally only called on startup when the Stack resource is
 // registered.
 func (eng *hostServer) SetRootResource(ctx context.Context,
-	req *lumirpc.SetRootResourceRequest,
-) (*lumirpc.SetRootResourceResponse, error) {
-	var response lumirpc.SetRootResourceResponse
+	req *pulumirpc.SetRootResourceRequest,
+) (*pulumirpc.SetRootResourceResponse, error) {
+	var response pulumirpc.SetRootResourceResponse
 	eng.rootUrn.Store(req.GetUrn())
 	return &response, nil
 }

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -18,8 +18,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 )
 
 func TestClosePanic(t *testing.T) {

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Validate that Configure can read inputs from variables instead of args.

--- a/sdk/go/common/resource/plugin/provider_test.go
+++ b/sdk/go/common/resource/plugin/provider_test.go
@@ -17,10 +17,10 @@ package plugin
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestNewDetailedDiff(t *testing.T) {

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -16,11 +16,12 @@
 package plugin
 
 import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // UnimplementedProvider can be embedded to have forward compatible implementations.

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -3,8 +3,9 @@ package resource
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 )
 
 func TestPropertyPath(t *testing.T) {

--- a/sdk/go/common/testing/diagtest/sink_test.go
+++ b/sdk/go/common/testing/diagtest/sink_test.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 )
 
 func TestLogSink(t *testing.T) {

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -26,9 +26,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tools"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/sdk/go/common/util/buildutil/semver.go
+++ b/sdk/go/common/util/buildutil/semver.go
@@ -21,8 +21,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/semver"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 var (

--- a/sdk/go/common/util/cmdutil/args.go
+++ b/sdk/go/common/util/cmdutil/args.go
@@ -17,8 +17,9 @@ package cmdutil
 import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // ArgsFunc wraps a standard cobra argument validator with standard Pulumi error handling.

--- a/sdk/go/common/util/cmdutil/console_test.go
+++ b/sdk/go/common/util/cmdutil/console_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 func TestMeasureText(t *testing.T) {

--- a/sdk/go/common/util/cmdutil/diag.go
+++ b/sdk/go/common/util/cmdutil/diag.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"

--- a/sdk/go/common/util/cmdutil/exit_test.go
+++ b/sdk/go/common/util/cmdutil/exit_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 func TestRunFunc_Bail(t *testing.T) {

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -28,9 +28,10 @@ import (
 	"time"
 
 	ps "github.com/mitchellh/go-ps"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 )
 
 func TestTerminate_gracefulShutdown(t *testing.T) {

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -26,11 +26,12 @@ import (
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/transport/zipkin"
+
 	"github.com/pulumi/appdash"
 	appdash_opentracing "github.com/pulumi/appdash/opentracing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	jaeger "github.com/uber/jaeger-client-go"
-	"github.com/uber/jaeger-client-go/transport/zipkin"
 )
 
 // TracingEndpoint is the Zipkin-compatible tracing endpoint where tracing data will be sent.

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -3,8 +3,9 @@ package env_test
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
 
 func init() {

--- a/sdk/go/common/util/httputil/http_test.go
+++ b/sdk/go/common/util/httputil/http_test.go
@@ -23,9 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/http2"
-
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/http2"
 )
 
 func http2ServerAndClient(handler http.Handler) (*httptest.Server, *http.Client) {

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 

--- a/sdk/go/common/util/result/result.go
+++ b/sdk/go/common/util/result/result.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -19,8 +19,9 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"google.golang.org/grpc"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 // Configures interceptors to propagate OpenTracing metadata through headers. If parentSpan is non-nil, it becomes the

--- a/sdk/go/common/util/rpcutil/writer.go
+++ b/sdk/go/common/util/rpcutil/writer.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"

--- a/sdk/go/common/util/rpcutil/writer_test.go
+++ b/sdk/go/common/util/rpcutil/writer_test.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"testing"
 
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/term"
 	"google.golang.org/grpc"
 
-	"golang.org/x/term"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 func makeStreamMock() *streamMock {

--- a/sdk/go/common/workspace/loaders_test.go
+++ b/sdk/go/common/workspace/loaders_test.go
@@ -17,9 +17,10 @@ package workspace
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 )
 
 func TestUnmarshallNil(t *testing.T) {

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -19,9 +19,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // In the tests below we use temporary directories and then expect DetectProjectAndPath to return a path to

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -29,11 +29,12 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLegacyPluginSelection_Prerelease(t *testing.T) {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -26,18 +26,18 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pulumi/esc/ast"
-	"github.com/pulumi/esc/eval"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/pgavlin/fx"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/esc/ast"
+	"github.com/pulumi/esc/eval"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/santhosh-tekuri/jsonschema/v5"
-	"golang.org/x/exp/maps"
-	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	"github.com/pulumi/esc"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func TestProjectRuntimeInfoRoundtripYAML(t *testing.T) {

--- a/sdk/go/internal/gen-pux-applyn/main.go
+++ b/sdk/go/internal/gen-pux-applyn/main.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -39,6 +39,10 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -53,11 +57,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 // This function takes a file target to specify where to compile to.

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -23,12 +23,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParseRunParams(t *testing.T) {

--- a/sdk/go/pulumi/asset.go
+++ b/sdk/go/pulumi/asset.go
@@ -17,8 +17,9 @@ package pulumi
 import (
 	"reflect"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/net/context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // AssetOrArchive represents either an Asset or an Archive.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -31,6 +31,10 @@ import (
 	"sync"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -40,9 +44,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var disableResourceReferences = cmdutil.IsTruthy(os.Getenv("PULUMI_DISABLE_RESOURCE_REFERENCES"))

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -19,9 +19,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func await(out pulumi.Output) (interface{}, bool, bool, []pulumi.Resource, error) {

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -19,8 +19,9 @@ package pulumi
 import (
 	"strings"
 
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"golang.org/x/net/context"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Log is a group of logging functions that can be called from a Go application that will be logged

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -22,14 +22,14 @@ import (
 	"sort"
 	"strings"
 
+	"google.golang.org/grpc"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
-
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/grpc"
 )
 
 type constructFunc func(ctx *Context, typ, name string, inputs map[string]interface{},

--- a/sdk/go/pulumi/provider/provider.go
+++ b/sdk/go/pulumi/provider/provider.go
@@ -17,10 +17,10 @@ package provider
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/grpc"
 )
 
 // This file relies on implementations in ../provider_linked.go that are made available in this package via

--- a/sdk/go/pulumi/provider_linked.go
+++ b/sdk/go/pulumi/provider_linked.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	_ "unsafe" // unsafe is needed to use go:linkname
 
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
 	"google.golang.org/grpc"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // We want the public provider-related APIs to be exported from the provider package, but need to make use of unexported

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 )
 
 type simpleComponentResource struct {

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -23,13 +23,12 @@ import (
 	"strconv"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/grpc"
 )
 
 var ErrPlugins = errors.New("pulumi: plugins requested")

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
 )
 
 // WithDryRun is an internal, test-only option

--- a/sdk/go/pulumi/stack_reference_test.go
+++ b/sdk/go/pulumi/stack_reference_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestStackReference(t *testing.T) {

--- a/sdk/go/pulumi/types_contravariance_test.go
+++ b/sdk/go/pulumi/types_contravariance_test.go
@@ -19,9 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
 // asAnySlice converts []T to []interface{} by reflection, simulating covariance.

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 )
 
 func await(out Output) (interface{}, bool, bool, []Resource, error) {

--- a/sdk/go/pulumix/array_test.go
+++ b/sdk/go/pulumix/array_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestArray(t *testing.T) {

--- a/sdk/go/pulumix/combinators_test.go
+++ b/sdk/go/pulumix/combinators_test.go
@@ -20,11 +20,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFlatten(t *testing.T) {

--- a/sdk/go/pulumix/context_test.go
+++ b/sdk/go/pulumix/context_test.go
@@ -18,10 +18,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/require"
 )
 
 type testResourceInputs struct {

--- a/sdk/go/pulumix/map_test.go
+++ b/sdk/go/pulumix/map_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMap(t *testing.T) {

--- a/sdk/go/pulumix/ptr_test.go
+++ b/sdk/go/pulumix/ptr_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPtr(t *testing.T) {

--- a/sdk/go/pulumix/types_ext_test.go
+++ b/sdk/go/pulumix/types_ext_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Tests that use the full machinery of inputs, outputs, etc.

--- a/sdk/go/pulumix/types_test.go
+++ b/sdk/go/pulumix/types_test.go
@@ -19,9 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 )
 
 // legacyIntOutput is a pulumi.Output that does not implement pulumix.Input[T].

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -23,14 +23,15 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 )
 
 func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -51,6 +51,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -63,11 +67,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 const (

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 func TestArgumentConstruction(t *testing.T) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
@@ -19,11 +19,10 @@ import (
 	"encoding/binary"
 	"io"
 
-	"google.golang.org/protobuf/types/known/emptypb"
-
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -30,10 +30,11 @@ import (
 	"strconv"
 	"testing"
 
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 )
 
 // chdir temporarily changes the current directory of the program.

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -42,6 +42,14 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -53,14 +61,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/pulumi/pulumi/sdk/v3/python"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/types/known/emptypb"
-
-	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
-	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 const (

--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -19,9 +19,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAboutCommands(t *testing.T) {

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -16,9 +16,10 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
-	"github.com/stretchr/testify/assert"
 )
 
 // deleteIfNotFailed deletes the files in the testing environment if the testcase has

--- a/tests/integration/aliases/go/retype_remote_component_and_child/provider/main.go
+++ b/tests/integration/aliases/go/retype_remote_component_and_child/provider/main.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Bucket struct {

--- a/tests/integration/construct_component/testcomponent-go/main.go
+++ b/tests/integration/construct_component/testcomponent-go/main.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -17,8 +19,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Resource struct {

--- a/tests/integration/construct_component/testcomponent2-go/main.go
+++ b/tests/integration/construct_component/testcomponent2-go/main.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"strings"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -18,8 +20,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Resource struct {

--- a/tests/integration/construct_component_plain/testcomponent-go/main.go
+++ b/tests/integration/construct_component_plain/testcomponent-go/main.go
@@ -9,14 +9,14 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Resource struct {

--- a/tests/integration/construct_component_provider_explicit/testcomponent-go/main.go
+++ b/tests/integration/construct_component_provider_explicit/testcomponent-go/main.go
@@ -8,14 +8,14 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (

--- a/tests/integration/construct_component_resource_options/testcomponent-go/main.go
+++ b/tests/integration/construct_component_resource_options/testcomponent-go/main.go
@@ -10,13 +10,14 @@ import (
 	"strconv"
 	"sync/atomic"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type ComponentArgs struct {

--- a/tests/integration/construct_component_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_unknown/testcomponent-go/main.go
@@ -10,14 +10,14 @@ import (
 	"fmt"
 	"reflect"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Component struct {

--- a/tests/integration/double_pending_delete/double_pending_delete_test.go
+++ b/tests/integration/double_pending_delete/double_pending_delete_test.go
@@ -6,10 +6,11 @@ package ints
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test that the engine tolerates two deletions of the same URN in the same plan.

--- a/tests/integration/go/component-configure-panic/testcomponent-go/main.go
+++ b/tests/integration/go/component-configure-panic/testcomponent-go/main.go
@@ -10,13 +10,14 @@ import (
 	"strconv"
 	"sync/atomic"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Component struct {

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -27,10 +27,10 @@ import (
 	"testing"
 
 	"github.com/grapl-security/pulumi-hcp/sdk/go/hcp"
-	"github.com/pulumi/appdash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/appdash"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
@@ -35,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestPrintfNodeJS tests that we capture stdout and stderr streams properly, even when the last line lacks an \n.

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -32,6 +32,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
@@ -39,10 +44,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const WindowsOS = "windows"

--- a/tests/integration/partial_state/partial_state_test.go
+++ b/tests/integration/partial_state/partial_state_test.go
@@ -6,10 +6,11 @@ package ints
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestPartialState tests that the engine persists partial state of a resource if a provider

--- a/tests/integration/resource_refs_get_resource/go/main.go
+++ b/tests/integration/resource_refs_get_resource/go/main.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/internals"
 )

--- a/tests/integration/targets/targets_test.go
+++ b/tests/integration/targets/targets_test.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUntargetedCreateDuringTargetedUpdate(t *testing.T) {

--- a/tests/integration/transformations/transformations_test.go
+++ b/tests/integration/transformations/transformations_test.go
@@ -6,10 +6,11 @@ package ints
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/assert"
 )
 
 var Dirs = []string{

--- a/tests/integration/types/types_test.go
+++ b/tests/integration/types/types_test.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
 func TestPythonTypes(t *testing.T) {

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-
-	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 var Runtimes = []string{"python", "java", "go", "yaml", "nodejs", "dotnet"}

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -28,6 +28,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -37,8 +40,6 @@ import (
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //nolint:paralleltest // mutates environment variables

--- a/tests/testprovider/echo.go
+++ b/tests/testprovider/echo.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type echoResourceProvider struct {

--- a/tests/testprovider/fails_on_create.go
+++ b/tests/testprovider/fails_on_create.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 
-	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type failsOnCreateResourceProvider struct{}

--- a/tests/testprovider/fails_on_delete.go
+++ b/tests/testprovider/fails_on_delete.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"fmt"
 
-	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type failsOnDeleteResourceProvider struct {

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (

--- a/tests/testprovider/random.go
+++ b/tests/testprovider/random.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type randomResourceProvider struct{}


### PR DESCRIPTION
While adding depguard in https://github.com/pulumi/pulumi/pull/15158 I noticed these two linters to enforce consistent import names and order. 

Opted to not make importas too strict to start. It still allows individual go files to import modules with ad-hoc names, but at least makes sure the "pulumirpc" module is always named the same.

Import order is standardised to: std, other, pulumi