### PR TITLE
Enable importas linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - paralleltest
     - perfsprint
     - depguard
+    - importas
 
 linters-settings:
   nakedret:
@@ -56,6 +57,14 @@ linters-settings:
         deny:
           - pkg: "github.com/golang/protobuf"
             desc: Use google.golang.org/protobuf instead
+  importas:
+    alias:
+    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go
+      alias: pulumirpc
+    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go/testing
+      alias: testingrpc
+    - pkg: github.com/deckarep/golang-set/v2
+      alias: mapset
 
 issues:
   exclude-rules:

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -33,7 +33,7 @@ import (
 // HostClient is a client interface into the host's engine RPC interface.
 type HostClient struct {
 	conn   *grpc.ClientConn
-	client lumirpc.EngineClient
+	client pulumirpc.EngineClient
 }
 
 // NewHostClient dials the target address, connects over gRPC, and returns a client interface.
@@ -53,7 +53,7 @@ func NewHostClient(addr string) (*HostClient, error) {
 	}
 	return &HostClient{
 		conn:   conn,
-		client: lumirpc.NewEngineClient(conn),
+		client: pulumirpc.NewEngineClient(conn),
 	}, nil
 }
 
@@ -70,20 +70,20 @@ func (host *HostClient) EngineConn() *grpc.ClientConn {
 func (host *HostClient) log(
 	context context.Context, sev diag.Severity, urn resource.URN, msg string, ephemeral bool,
 ) error {
-	var rpcsev lumirpc.LogSeverity
+	var rpcsev pulumirpc.LogSeverity
 	switch sev {
 	case diag.Debug:
-		rpcsev = lumirpc.LogSeverity_DEBUG
+		rpcsev = pulumirpc.LogSeverity_DEBUG
 	case diag.Info:
-		rpcsev = lumirpc.LogSeverity_INFO
+		rpcsev = pulumirpc.LogSeverity_INFO
 	case diag.Warning:
-		rpcsev = lumirpc.LogSeverity_WARNING
+		rpcsev = pulumirpc.LogSeverity_WARNING
 	case diag.Error:
-		rpcsev = lumirpc.LogSeverity_ERROR
+		rpcsev = pulumirpc.LogSeverity_ERROR
 	default:
 		contract.Failf("Unrecognized log severity type: %v", sev)
 	}
-	_, err := host.client.Log(context, &lumirpc.LogRequest{
+	_, err := host.client.Log(context, &pulumirpc.LogRequest{
 		Severity:  rpcsev,
 		Message:   strings.ToValidUTF8(msg, "�"),
 		Urn:       string(urn),

--- a/sdk/go/common/resource/plugin/check.go
+++ b/sdk/go/common/resource/plugin/check.go
@@ -16,29 +16,29 @@ package plugin
 
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // NewCheckResponse produces a response with property validation failures from the given array of mapper failures.
-func NewCheckResponse(err error) *lumirpc.CheckResponse {
-	var failures []*lumirpc.CheckFailure
+func NewCheckResponse(err error) *pulumirpc.CheckResponse {
+	var failures []*pulumirpc.CheckFailure
 	if err != nil {
 		switch e := err.(type) {
 		case mapper.MappingError:
 			for _, failure := range e.Failures() {
 				switch f := failure.(type) {
 				case mapper.FieldError:
-					failures = append(failures, &lumirpc.CheckFailure{
+					failures = append(failures, &pulumirpc.CheckFailure{
 						Property: f.Field(),
 						Reason:   f.Reason(),
 					})
 				default:
-					failures = append(failures, &lumirpc.CheckFailure{Reason: f.Error()})
+					failures = append(failures, &pulumirpc.CheckFailure{Reason: f.Error()})
 				}
 			}
 		default:
-			failures = append(failures, &lumirpc.CheckFailure{Reason: e.Error()})
+			failures = append(failures, &pulumirpc.CheckFailure{Reason: e.Error()})
 		}
 	}
-	return &lumirpc.CheckResponse{Failures: failures}
+	return &pulumirpc.CheckResponse{Failures: failures}
 }

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -26,12 +26,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // hostServer is the server side of the host RPC machinery.
 type hostServer struct {
-	lumirpc.UnsafeEngineServer // opt out of forward compat
+	pulumirpc.UnsafeEngineServer // opt out of forward compat
 
 	host   Host         // the host for this RPC server.
 	ctx    *Context     // the associated plugin context.
@@ -56,7 +56,7 @@ func newHostServer(host Host, ctx *Context) (*hostServer, error) {
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: engine.cancel,
 		Init: func(srv *grpc.Server) error {
-			lumirpc.RegisterEngineServer(srv, engine)
+			pulumirpc.RegisterEngineServer(srv, engine)
 			return nil
 		},
 		Options: rpcutil.OpenTracingServerInterceptorOptions(ctx.tracingSpan),
@@ -87,16 +87,16 @@ func (eng *hostServer) Cancel() error {
 }
 
 // Log logs a global message in the engine, including errors and warnings.
-func (eng *hostServer) Log(ctx context.Context, req *lumirpc.LogRequest) (*emptypb.Empty, error) {
+func (eng *hostServer) Log(ctx context.Context, req *pulumirpc.LogRequest) (*emptypb.Empty, error) {
 	var sev diag.Severity
 	switch req.Severity {
-	case lumirpc.LogSeverity_DEBUG:
+	case pulumirpc.LogSeverity_DEBUG:
 		sev = diag.Debug
-	case lumirpc.LogSeverity_INFO:
+	case pulumirpc.LogSeverity_INFO:
 		sev = diag.Info
-	case lumirpc.LogSeverity_WARNING:
+	case pulumirpc.LogSeverity_WARNING:
 		sev = diag.Warning
-	case lumirpc.LogSeverity_ERROR:
+	case pulumirpc.LogSeverity_ERROR:
 		sev = diag.Error
 	default:
 		return nil, errors.Errorf("Unrecognized logging severity: %v", req.Severity)
@@ -113,9 +113,9 @@ func (eng *hostServer) Log(ctx context.Context, req *lumirpc.LogRequest) (*empty
 // GetRootResource returns the current root resource's URN, which will serve as the parent of resources that are
 // otherwise left unparented.
 func (eng *hostServer) GetRootResource(ctx context.Context,
-	req *lumirpc.GetRootResourceRequest,
-) (*lumirpc.GetRootResourceResponse, error) {
-	var response lumirpc.GetRootResourceResponse
+	req *pulumirpc.GetRootResourceRequest,
+) (*pulumirpc.GetRootResourceResponse, error) {
+	var response pulumirpc.GetRootResourceResponse
 	response.Urn = eng.rootUrn.Load().(string)
 	return &response, nil
 }
@@ -123,9 +123,9 @@ func (eng *hostServer) GetRootResource(ctx context.Context,
 // SetRootResource sets the current root resource's URN. Generally only called on startup when the Stack resource is
 // registered.
 func (eng *hostServer) SetRootResource(ctx context.Context,
-	req *lumirpc.SetRootResourceRequest,
-) (*lumirpc.SetRootResourceResponse, error) {
-	var response lumirpc.SetRootResourceResponse
+	req *pulumirpc.SetRootResourceRequest,
+) (*pulumirpc.SetRootResourceResponse, error) {
+	var response pulumirpc.SetRootResourceResponse
 	eng.rootUrn.Store(req.GetUrn())
 	return &response, nil
 }


### PR DESCRIPTION
Follow on from https://github.com/pulumi/pulumi/pull/15164 after team discussion that importas was more value.

Opted to not make importas too strict to start. It still allows individual go files to import modules with ad-hoc names, but at least makes sure the "pulumirpc" module is always named the same.