### PR TITLE
[14573] Parse config paths strictly

### DIFF
--- a/changelog/pending/20240118--sdk-go--parse-config-paths-strictly.yaml
+++ b/changelog/pending/20240118--sdk-go--parse-config-paths-strictly.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Parse config paths strictly

--- a/sdk/go/common/resource/config/map.go
+++ b/sdk/go/common/resource/config/map.go
@@ -277,7 +277,7 @@ func (m *Map) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // path segment as the name.
 func parseKeyPath(k Key) (resource.PropertyPath, Key, error) {
 	// Parse the path, which will be in the name portion of the key.
-	p, err := resource.ParsePropertyPath(k.Name())
+	p, err := resource.ParsePropertyPathStrict(k.Name())
 	if err != nil {
 		return nil, Key{}, fmt.Errorf("invalid config key path: %w", err)
 	}

--- a/sdk/go/common/resource/config/map_test.go
+++ b/sdk/go/common/resource/config/map_test.go
@@ -1332,6 +1332,12 @@ func TestSetFail(t *testing.T) {
 			},
 			ExpectedError: "outer.inner: expected an array",
 		},
+
+		// Strict path parsing
+		{
+			Key:           `my:root.[1]"`,
+			ExpectedError: "invalid config key path: expected property name after '.'",
+		},
 	}
 
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -258,7 +258,7 @@ func TestPropertyPath(t *testing.T) {
 		`root.array.[1]`,
 		`root.["key with a ."]`,
 	}
-	//nolint:paralleltest
+	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
 	for _, c := range negativeCasesStrict {
 		c := c
 		t.Run(c, func(t *testing.T) {

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -252,6 +252,22 @@ func TestPropertyPath(t *testing.T) {
 			}
 		})
 	}
+
+	negativeCasesStrict := []string{
+		// Syntax erros
+		`root.array.[1]`,
+		`root.["key with a ."]`,
+	}
+	//nolint:paralleltest
+	for _, c := range negativeCasesStrict {
+		c := c
+		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParsePropertyPathStrict(c)
+			assert.NotNil(t, err)
+		})
+	}
 }
 
 func TestPropertyPathContains(t *testing.T) {


### PR DESCRIPTION
# Description

We want to parse config paths more strictly and not allow something like "foo.[0]", but property paths everywhere else in the system need to tolerate those keys.

Because of circular dependency on _pulumi/esc_ I kept a function with old signature and added a new one. (instead of refactoring by adding new parameter and exposing it)

Fixes https://github.com/pulumi/pulumi/issues/14573.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
