### PR TITLE
set up secrets in acceptance test job

### DIFF
--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -69,3 +69,7 @@ jobs:
       # Scope secrets to the minimum required:
       PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       PULUMI_PROD_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
These secrets are required for the acceptance tests to run correctly, as we're getting false failures otherwise.  This is safe, since we're also using these secrets in other CI jobs, and always review code before running the acceptance tests.

I noticed in https://github.com/pulumi/pulumi/pull/15173 that the tests introduced in https://github.com/pulumi/pulumi/pull/14649 are failing.