### PR TITLE
define necessary secret in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ on:
       AZURE_CLIENT_SECRET:
         required: false
         description: "Azure clients secret, needs to be rotated before 2025-12-21 (see the pulumi-test user in Azure portal)"
+      GCP_SERVICE_ACCOUNT:
+        required: false
+        description: "GCP service account, required to run tests against GCP"
 
 jobs:
   matrix:


### PR DESCRIPTION
This secret needs to be defined here, so we can pass it through from the job dispatch.  This was missed in https://github.com/pulumi/pulumi/pull/15175.