### PR TITLE
improve display for policy packs

### DIFF
--- a/changelog/pending/20240119--cli-display--improve-output-when-installing-policy-packs.yaml
+++ b/changelog/pending/20240119--cli-display--improve-output-when-installing-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Improve output when installing policy packs

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -67,7 +67,7 @@ func (rp *cloudRequiredPolicy) Install(ctx context.Context) (string, error) {
 		return policyPackPath, nil
 	}
 
-	fmt.Printf("Installing policy pack %s %s...\n", policy.Name, version)
+	fmt.Printf("Installing policy pack %s %s...\r\n", policy.Name, version)
 
 	// PolicyPack has not been downloaded and installed. Do this now.
 	policyPackTarball, err := rp.client.DownloadPolicyPack(ctx, policy.PackLocation)
@@ -300,7 +300,7 @@ func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadClos
 		}
 	}
 
-	fmt.Println("Finished installing policy pack")
+	fmt.Println("Finished installing policy pack\r")
 	fmt.Println()
 
 	return nil


### PR DESCRIPTION
Our display code sets up the terminal so it doesn't automatically do a CR for every new line (amongst other modifications).  However the policy pack code just uses regular Println's for output, messing up the formatting.

Fix this by manually adding the CR, improving this output.

Example output before:

```
$ pulumi preview
Previewing update (tgummerer-test/dev)

View in Browser (Ctrl+O): https://app.pulumi.com/tgummerer-test/pulumi-test-go/dev/previews/af23b7b8-6dd4-4e4e-b635-47eab4270b19

Installing policy pack aws-iso27001-compliance-ready-policies-typescript 0.0.1...
                                                                                 Loading policy packs...

Finished installing policy pack

                               Installing policy pack aws-python 0.0.1...
                                                                         Finished installing policy pack
[...]
```

and after this change:

```
$ pulumi preview
Previewing update (tgummerer-test/dev)

View in Browser (Ctrl+O): https://app.pulumi.com/tgummerer-test/pulumi-test-go/dev/previews/b972324a-5859-49b0-b0f1-edbc547d786a

Installing policy pack aws-typescript 0.0.1...
Loading policy packs...

Finished installing policy pack

Installing policy pack aws-iso27001-compliance-ready-policies-typescript 0.0.1...
Finished installing policy pack
```

There's an argument to be made that we shouldn't display the `Loading policy packs...` message at all when we're installing the policy packs, but that's probably a little more involved, so I'm tempted to just ship this improvement first, and then maybe do that in the future.

Fixes #15183