### PR TITLE
[Feat] S3 backend: support loading creds by explicitly configured profile name

### DIFF
--- a/changelog/pending/20240119--backend-filestate--s3-backend-configurable-aws-profile.yaml
+++ b/changelog/pending/20240119--backend-filestate--s3-backend-configurable-aws-profile.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/filestate
+  description: Add configurable AWS profile setting for authentication to S3 and compatible backends

--- a/pkg/authhelpers/s3auth.go
+++ b/pkg/authhelpers/s3auth.go
@@ -7,23 +7,41 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/s3blob"
 )
 
+const (
+	logPrefix                      string = "S3 Backend: "
+	profileNameEnvironmentVariable string = "PULUMI_BACKEND_AWS_PROFILE_NAME"
+)
+
 func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBackend) (*session.Options, error) {
 	// Select the session options based on the backend setting, superceded by the PULUMI_ env var if set.
 	// If neither set, fall back to default session builder (Which interprets AWS_ environment vars first)
+	log := logging.V(5)
 
 	definitiveProfileName := ""
 	if backend != nil && backend.AwsProfileName != "" {
 		definitiveProfileName = backend.AwsProfileName
+		log.Infof(
+			"%sUsing aws profile \"%s\" from project configuration",
+			logPrefix,
+			definitiveProfileName,
+		)
 	}
 
-	profileNameEnv := os.Getenv("PULUMI_BACKEND_AWS_PROFILE_NAME")
+	profileNameEnv := os.Getenv(profileNameEnvironmentVariable)
 	if profileNameEnv != "" {
 		definitiveProfileName = profileNameEnv
+		log.Infof(
+			"%sOverriding aws profile \"%s\" from environment configuration (%s)",
+			logPrefix,
+			definitiveProfileName,
+			profileNameEnvironmentVariable,
+		)
 	}
 
 	opts := session.Options{}
@@ -37,6 +55,17 @@ func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBacken
 		opts.Config = aws.Config{
 			Region: &profileConfig.Region,
 		}
+		log.Infof(
+			"%sSelected profile \"%s\" and region \"%s\" from profile config for backend auth",
+			logPrefix,
+			definitiveProfileName,
+			profileConfig.Region,
+		)
+	} else {
+		log.Infof(
+			"%sNo profile configuration was provided for S3 auth.  Defaulting to environment then default aws profile",
+			logPrefix,
+		)
 	}
 	return &opts, nil
 }

--- a/pkg/authhelpers/s3auth.go
+++ b/pkg/authhelpers/s3auth.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"os"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/s3blob"
 )
 
-func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBackend) session.Options {
+func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBackend) (*session.Options, error) {
 	// Select the session options based on the backend setting, superceded by the PULUMI_ env var if set.
 	// If neither set, fall back to default session builder (Which interprets AWS_ environment vars first)
 
@@ -24,18 +26,30 @@ func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBacken
 		definitiveProfileName = profileNameEnv
 	}
 
-	return session.Options{
-		// It's okay for the value to be "" here.  That will induce the fallback
-		// behavior when used in session.NewSessionWithOptions().  Which is checking
-		// for a non-zero-length string
-		Profile: definitiveProfileName,
+	opts := session.Options{}
+	if definitiveProfileName != "" {
+		// Get config for profile
+		profileConfig, err := config.LoadSharedConfigProfile(ctx, definitiveProfileName)
+		if err != nil {
+			return nil, err
+		}
+		opts.Profile = definitiveProfileName
+		opts.Config = aws.Config{
+			Region: &profileConfig.Region,
+		}
 	}
+	return &opts, nil
 
 }
 
 func S3CredentialsMux(ctx context.Context, backend *workspace.ProjectBackend) (*blob.URLMux, error) {
 	// Returns a blobmux only registered to handle s3, and do so in our specially defined way
-	sess, err := session.NewSessionWithOptions(S3BuildSessionOptions(ctx, backend))
+	opts, err := S3BuildSessionOptions(ctx, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	sess, err := session.NewSessionWithOptions(*opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authhelpers/s3auth.go
+++ b/pkg/authhelpers/s3auth.go
@@ -1,0 +1,49 @@
+package authhelpers
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/s3blob"
+)
+
+func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBackend) session.Options {
+	// Select the session options based on the backend setting, superceded by the PULUMI_ env var if set.
+	// If neither set, fall back to default session builder (Which interprets AWS_ environment vars first)
+
+	definitiveProfileName := ""
+	if backend != nil && backend.AwsProfileName != "" {
+		definitiveProfileName = backend.AwsProfileName
+	}
+
+	profileNameEnv := os.Getenv("PULUMI_BACKEND_AWS_PROFILE_NAME")
+	if profileNameEnv != "" {
+		definitiveProfileName = profileNameEnv
+	}
+
+	return session.Options{
+		// It's okay for the value to be "" here.  That will induce the fallback
+		// behavior when used in session.NewSessionWithOptions().  Which is checking
+		// for a non-zero-length string
+		Profile: definitiveProfileName,
+	}
+
+}
+
+func S3CredentialsMux(ctx context.Context, backend *workspace.ProjectBackend) (*blob.URLMux, error) {
+	// Returns a blobmux only registered to handle s3, and do so in our specially defined way
+	sess, err := session.NewSessionWithOptions(S3BuildSessionOptions(ctx, backend))
+	if err != nil {
+		return nil, err
+	}
+
+	blobmux := &blob.URLMux{}
+	blobmux.RegisterBucket(s3blob.Scheme, &s3blob.URLOpener{
+		ConfigProvider: sess,
+	})
+
+	return blobmux, nil
+}

--- a/pkg/authhelpers/s3auth.go
+++ b/pkg/authhelpers/s3auth.go
@@ -39,7 +39,6 @@ func S3BuildSessionOptions(ctx context.Context, backend *workspace.ProjectBacken
 		}
 	}
 	return &opts, nil
-
 }
 
 func S3CredentialsMux(ctx context.Context, backend *workspace.ProjectBackend) (*blob.URLMux, error) {

--- a/pkg/authhelpers/s3auth_test.go
+++ b/pkg/authhelpers/s3auth_test.go
@@ -1,0 +1,55 @@
+package authhelpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest
+func TestS3BuildSessionOptions_Unconfigured(t *testing.T) {
+	ctx := context.Background()
+	backendConfig := workspace.ProjectBackend{}
+
+	options := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.Equal(t, options.Profile, "")
+}
+
+//nolint:paralleltest
+func TestS3BuildSessionOptions_Backend(t *testing.T) {
+	ctx := context.Background()
+	backendConfig := workspace.ProjectBackend{
+		AwsProfileName: "distinct",
+	}
+
+	options := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.Equal(t, options.Profile, "distinct")
+}
+
+//nolint:paralleltest
+func TestS3BuildSessionOptions_EnvVar(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
+	backendConfig := workspace.ProjectBackend{}
+
+	options := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.Equal(t, options.Profile, "configuredwithenv")
+}
+
+//nolint:paralleltest
+func TestS3BuildSessionOptions_Superceded(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
+	backendConfig := workspace.ProjectBackend{
+		AwsProfileName: "distinct",
+	}
+
+	options := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.Equal(t, options.Profile, "configuredwithenv")
+}

--- a/pkg/authhelpers/s3auth_test.go
+++ b/pkg/authhelpers/s3auth_test.go
@@ -2,14 +2,30 @@ package authhelpers
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
+func mockRegionFinder(_ context.Context, _ string) (string, error) {
+	return "us-west-2", nil
+}
+
+func harnessTempAWSConfig(t *testing.T) {
+	// Mocks out any helper functions which have a hard time being run in the test environment
+
+	// RegionFinder is based on awsv2/config/LoadSharedConfigProfile.  This is really home-directory
+	// dependant.  For now, I'm not offerring the ability to configure static config and credential
+	// file locations, so we need to mock this out for testing.
+	regionFinder = mockRegionFinder
+}
+
 //nolint:paralleltest
 func TestS3BuildSessionOptions_Unconfigured(t *testing.T) {
+	harnessTempAWSConfig(t)
 	ctx := context.Background()
 	backendConfig := workspace.ProjectBackend{}
 
@@ -23,6 +39,9 @@ func TestS3BuildSessionOptions_Unconfigured(t *testing.T) {
 
 //nolint:paralleltest
 func TestS3BuildSessionOptions_Backend(t *testing.T) {
+	harnessTempAWSConfig(t)
+	hd, _ := os.UserHomeDir()
+	fmt.Println(hd)
 	ctx := context.Background()
 	backendConfig := workspace.ProjectBackend{
 		AwsProfileName: "distinct",
@@ -34,10 +53,12 @@ func TestS3BuildSessionOptions_Backend(t *testing.T) {
 	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "distinct")
+	assert.Equal(t, *options.Config.Region, "us-west-2")
 }
 
 //nolint:paralleltest
 func TestS3BuildSessionOptions_EnvVar(t *testing.T) {
+	harnessTempAWSConfig(t)
 	ctx := context.Background()
 	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
 	backendConfig := workspace.ProjectBackend{}
@@ -48,10 +69,12 @@ func TestS3BuildSessionOptions_EnvVar(t *testing.T) {
 	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "configuredwithenv")
+	assert.Equal(t, *options.Config.Region, "us-west-2")
 }
 
 //nolint:paralleltest
 func TestS3BuildSessionOptions_Superceded(t *testing.T) {
+	harnessTempAWSConfig(t)
 	ctx := context.Background()
 	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
 	backendConfig := workspace.ProjectBackend{
@@ -64,4 +87,5 @@ func TestS3BuildSessionOptions_Superceded(t *testing.T) {
 	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "configuredwithenv")
+	assert.Equal(t, *options.Config.Region, "us-west-2")
 }

--- a/pkg/authhelpers/s3auth_test.go
+++ b/pkg/authhelpers/s3auth_test.go
@@ -29,7 +29,7 @@ func TestS3BuildSessionOptions_Unconfigured(t *testing.T) {
 	ctx := context.Background()
 	backendConfig := workspace.ProjectBackend{}
 
-	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := s3BuildSessionOptions(ctx, &backendConfig)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, options)
@@ -47,7 +47,7 @@ func TestS3BuildSessionOptions_Backend(t *testing.T) {
 		AwsProfileName: "distinct",
 	}
 
-	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := s3BuildSessionOptions(ctx, &backendConfig)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, options)
@@ -63,7 +63,7 @@ func TestS3BuildSessionOptions_EnvVar(t *testing.T) {
 	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
 	backendConfig := workspace.ProjectBackend{}
 
-	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := s3BuildSessionOptions(ctx, &backendConfig)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, options)
@@ -81,7 +81,7 @@ func TestS3BuildSessionOptions_Superceded(t *testing.T) {
 		AwsProfileName: "distinct",
 	}
 
-	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := s3BuildSessionOptions(ctx, &backendConfig)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, options)

--- a/pkg/authhelpers/s3auth_test.go
+++ b/pkg/authhelpers/s3auth_test.go
@@ -13,7 +13,10 @@ func TestS3BuildSessionOptions_Unconfigured(t *testing.T) {
 	ctx := context.Background()
 	backendConfig := workspace.ProjectBackend{}
 
-	options := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "")
 }
@@ -25,7 +28,10 @@ func TestS3BuildSessionOptions_Backend(t *testing.T) {
 		AwsProfileName: "distinct",
 	}
 
-	options := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "distinct")
 }
@@ -36,7 +42,10 @@ func TestS3BuildSessionOptions_EnvVar(t *testing.T) {
 	t.Setenv("PULUMI_BACKEND_AWS_PROFILE_NAME", "configuredwithenv")
 	backendConfig := workspace.ProjectBackend{}
 
-	options := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "configuredwithenv")
 }
@@ -49,7 +58,10 @@ func TestS3BuildSessionOptions_Superceded(t *testing.T) {
 		AwsProfileName: "distinct",
 	}
 
-	options := S3BuildSessionOptions(ctx, &backendConfig)
+	options, err := S3BuildSessionOptions(ctx, &backendConfig)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, options)
 
 	assert.Equal(t, options.Profile, "configuredwithenv")
 }

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -36,7 +36,7 @@ import (
 	_ "gocloud.dev/blob/azureblob" // driver for azblob://
 	_ "gocloud.dev/blob/fileblob"  // driver for file://
 	"gocloud.dev/blob/gcsblob"     // driver for gs://
-	_ "gocloud.dev/blob/s3blob"    // driver for s3://
+	"gocloud.dev/blob/s3blob"      // driver for s3://
 	"gocloud.dev/gcerrors"
 
 	"github.com/pulumi/pulumi/pkg/v3/authhelpers"
@@ -232,10 +232,17 @@ func newLocalBackend(
 
 	blobmux := blob.DefaultURLMux()
 
-	// for gcp we want to support additional credentials
-	// schemes on top of go-cloud's default credentials mux.
+	// for gcp or s3 we want to support additional credentials
+	// schemes on top of how the default credentials mux sources credentials.
 	if p.Scheme == gcsblob.Scheme {
 		blobmux, err = authhelpers.GoogleCredentialsMux(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if p.Scheme == s3blob.Scheme {
+		blobmux, err = authhelpers.S3CredentialsMux(ctx, project.Backend)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -96,13 +96,13 @@ type ProjectTemplateConfigValue struct {
 type ProjectBackend struct {
 	// URL is optional field to explicitly set backend url
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+	// AWS Profile name to use a specific profile via the aws cli for s3 backend authentication
+	AwsProfileName string `json:"awsProfileName,omitempty" yaml:"awsProfileName,omitempty"`
 }
 
 type ProjectOptions struct {
 	// Refresh is the ability to always run a refresh as part of a pulumi update / preview / destroy
 	Refresh string `json:"refresh,omitempty" yaml:"refresh,omitempty"`
-	// AWS Profile name to use a specific profile via the aws cli for s3 backend authentication
-	AwsProfileName string `json:"awsProfileName,omitempty" yaml:"awsProfileName,omitempty"`
 }
 
 type PluginOptions struct {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -101,6 +101,8 @@ type ProjectBackend struct {
 type ProjectOptions struct {
 	// Refresh is the ability to always run a refresh as part of a pulumi update / preview / destroy
 	Refresh string `json:"refresh,omitempty" yaml:"refresh,omitempty"`
+	// AWS Profile name to use a specific profile via the aws cli for s3 backend authentication
+	AwsProfileName string `json:"awsProfileName,omitempty" yaml:"awsProfileName,omitempty"`
 }
 
 type PluginOptions struct {

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -122,6 +122,10 @@
                 "url":{
                     "description":"URL is optional field to explicitly set backend url",
                     "type":"string"
+                },
+                "awsProfileName":{
+                    "description":"For S3 state backends, attempt authentication with this profile name before environment",
+                    "type":"string"
                 }
             },
             "additionalProperties":false

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -50,14 +50,21 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.44.298 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.15 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.9 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect

--- a/sdk/nodejs/automation/projectSettings.ts
+++ b/sdk/nodejs/automation/projectSettings.ts
@@ -65,4 +65,5 @@ export interface ProjectTemplateConfigValue {
  */
 export interface ProjectBackend {
     url?: string;
+    awsProfileName?: string;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -50,14 +50,21 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.44.298 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.15 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.9 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -48,14 +48,21 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.44.298 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.15 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.9 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect

--- a/sdk/python/lib/pulumi/automation/_project_settings.py
+++ b/sdk/python/lib/pulumi/automation/_project_settings.py
@@ -69,9 +69,11 @@ class ProjectBackend:
     """Configuration for the project's Pulumi state storage backend."""
 
     url: Optional[str]
+    awsProfileName: Optional[str]
 
-    def __init__(self, url: Optional[str] = None):
+    def __init__(self, url: Optional[str] = None, awsProfileName: Optional[str] = None):
         self.url = url
+        self.awsProfileName = awsProfileName
 
 
 class ProjectSettings:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -53,14 +53,21 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.44.298 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.15 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.9 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Overview
Adds configurable AWS profile setting for authentication to S3 and compatible backends
This setting would force the use of shared credentials and config from that profile for authentication to S3, circumventing currently set AWS_ environment variables
This can be configured with backend.awsProfileName in Pulumi.yaml (project configuration) or, with more priority, via the `PULUMI_BACKEND_AWS_PROFILE_NAME` Environment variable.

Notably, if the setting is configured in neither place, the behavior remains how it existed before.

## Reasoning and Use-case
- Currently we only support the default behavior for building aws
  sessions for s3 blob backends.  This means AWS_ Env vars take
  precedence 100% of the time.
- There are situations where someone may want to maintain a seperate
  profile for their backend auth than what they use for other things.
  An instance of this might be s3-compatible backends where the "aws"
  tokens defined are not actually able to be used for AWS-cloud
  authentication. Having this configuration lets the user define
  custom profile names for backend, provider, and tooling outside of
  pulumi and use them simoultaneously.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
