### PR TITLE
[conformance tests] Fix run root and use program info everywhere

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -405,9 +405,9 @@ func (h *testHost) CloseProvider(provider plugin.Provider) error {
 	return nil
 }
 
-func (h *testHost) LanguageRuntime(
-	root, pwd, runtime string, options map[string]interface{},
-) (plugin.LanguageRuntime, error) {
+// LanguageRuntime returns the language runtime initialized by the test host.
+// ProgramInfo is only used here for compatibility reasons and will be removed from this function.
+func (h *testHost) LanguageRuntime(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 	if runtime != h.runtimeName {
 		return nil, fmt.Errorf("unexpected runtime %s", runtime)
 	}
@@ -771,7 +771,13 @@ func (eng *languageTestServer) RunLanguageTest(
 
 	// TODO(https://github.com/pulumi/pulumi/issues/13941): We don't capture stdout/stderr from the language
 	// plugin, so we can't show it back to the test.
-	err = languageClient.InstallDependencies(projectDir, ".")
+	programInfo := plugin.NewProgramInfo(
+		projectDir, /* rootDirectory */
+		projectDir, /* programDirectory */
+		"index",
+		map[string]interface{}{})
+
+	err = languageClient.InstallDependencies(programInfo)
 	if err != nil {
 		return makeTestResponse(fmt.Sprintf("install dependencies: %v", err)), nil
 	}

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -103,7 +103,10 @@ func (h *L1EmptyLanguageHost) GenerateProject(
 func (h *L1EmptyLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
-	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
 		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
 	}
 	return nil

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -149,7 +149,10 @@ func (h *L2ResourceSimpleLanguageHost) GetRequiredPlugins(
 func (h *L2ResourceSimpleLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
-	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
+		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
 		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
 	}
 	return nil

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -145,7 +145,8 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 				result.Plugins = plugins
 			}
 
-			lang, err := pluginContext.Host.LanguageRuntime(projinfo.Root, pwd, proj.Runtime.Name(), proj.Runtime.Options())
+			programInfo := plugin.NewProgramInfo(projinfo.Root, pwd, program, proj.Runtime.Options())
+			lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
 			if err != nil {
 				addError(err, "Failed to load language plugin "+proj.Runtime.Name())
 			} else {
@@ -161,8 +162,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 					}
 				}
 
-				progInfo := plugin.ProgInfo{Pwd: pwd, Program: program}
-				deps, err := lang.GetProgramDependencies(progInfo, transitiveDependencies)
+				deps, err := lang.GetProgramDependencies(programInfo, transitiveDependencies)
 				if err != nil {
 					addError(err, "Failed to get information about the Pulumi program's dependencies")
 				} else {
@@ -588,8 +588,8 @@ func getProjectPluginsSilently(
 	defer func() { os.Stdout = stdout }()
 	os.Stdout = w
 
-	return plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
-		Pwd:     pwd,
-		Program: main,
-	}, proj, plugin.AllPlugins)
+	programInfo := plugin.NewProgramInfo(ctx.Root, pwd, main, proj.Runtime.Options())
+	runtimeName := proj.Runtime.Name()
+	projectName := string(proj.Name)
+	return plugin.GetRequiredPlugins(ctx.Host, runtimeName, projectName, programInfo, plugin.AllPlugins)
 }

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -279,7 +279,8 @@ func runConvert(
 		) (hcl.Diagnostics, error) {
 			contract.Requiref(proj != nil, "proj", "must not be nil")
 
-			languagePlugin, err := pCtx.Host.LanguageRuntime(cwd, cwd, language, nil)
+			programInfo := plugin.NewProgramInfo(cwd, cwd, "entry", nil)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -860,8 +860,8 @@ func newImportCmd() *cobra.Command {
 						return nil, nil, err
 					}
 					defer contract.IgnoreClose(pCtx.Host)
-
-					languagePlugin, err := ctx.Host.LanguageRuntime(cwd, cwd, proj.Runtime.Name(), nil)
+					programInfo := plugin.NewProgramInfo(cwd, cwd, "entry", nil)
+					languagePlugin, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
 					if err != nil {
 						return nil, nil, err
 					}

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -75,20 +75,18 @@ func newInstallCmd() *cobra.Command {
 			// First make sure the language plugin is present.  We need this to load the required resource plugins.
 			// TODO: we need to think about how best to version this.  For now, it always picks the latest.
 			runtime := proj.Runtime
-			lang, err := pctx.Host.LanguageRuntime(pctx.Root, pctx.Pwd, runtime.Name(), runtime.Options())
+			programInfo := plugin.NewProgramInfo(pctx.Root, pwd, main, runtime.Options())
+			lang, err := pctx.Host.LanguageRuntime(runtime.Name(), programInfo)
 			if err != nil {
 				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
 			}
 
-			if err = lang.InstallDependencies(pwd, main); err != nil {
+			if err = lang.InstallDependencies(programInfo); err != nil {
 				return fmt.Errorf("installing dependencies: %w", err)
 			}
 
 			// Compute the set of plugins the current project needs.
-			installs, err := lang.GetRequiredPlugins(plugin.ProgInfo{
-				Pwd:     pwd,
-				Program: main,
-			})
+			installs, err := lang.GetRequiredPlugins(programInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -141,8 +141,8 @@ func genSDK(language, out string, pkg *schema.Package, overlays string) error {
 				return fmt.Errorf("create plugin context: %w", err)
 			}
 			defer contract.IgnoreClose(pCtx.Host)
-
-			languagePlugin, err := pCtx.Host.LanguageRuntime(cwd, cwd, language, nil)
+			programInfo := plugin.NewProgramInfo(cwd, cwd, ".", nil)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/package_pack_sdk.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/spf13/cobra"
@@ -64,8 +66,8 @@ func (cmd *packCmd) Run(ctx context.Context, args []string) error {
 	if v, err = semver.ParseTolerant(version); err != nil {
 		return fmt.Errorf("invalid version %q: %w", version, err)
 	}
-
-	languagePlugin, err := pCtx.Host.LanguageRuntime(cwd, cwd, language, nil)
+	programInfo := plugin.NewProgramInfo(pCtx.Root, cwd, "", nil)
+	languagePlugin, err := pCtx.Host.LanguageRuntime(language, programInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -66,13 +66,15 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	}
 
 	defer ctx.Close()
-
+	runtimeOptions := proj.Runtime.Options()
+	programInfo := plugin.NewProgramInfo(root, pwd, main, runtimeOptions)
 	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
-	plugins, err := plugin.GetRequiredPlugins(ctx.Host, ctx.Root, plugin.ProgInfo{
-		Pwd:     pwd,
-		Program: main,
-	}, proj, plugin.AllPlugins)
+	plugins, err := plugin.GetRequiredPlugins(
+		ctx.Host,
+		proj.Runtime.Name(),
+		string(proj.Name),
+		programInfo, plugin.AllPlugins)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -227,12 +227,13 @@ func installPolicyPackDependencies(ctx *plugin.Context,
 ) error {
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	lang, err := ctx.Host.LanguageRuntime(ctx.Root, ctx.Pwd, proj.Runtime.Name(), proj.Runtime.Options())
+	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, proj.Runtime.Options())
+	lang, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}
 
-	if err = lang.InstallDependencies(ctx.Pwd, main); err != nil {
+	if err = lang.InstallDependencies(programInfo); err != nil {
 		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
 			"then run `pulumi up` to perform an initial deployment: %w", err)
 	}

--- a/pkg/engine/lifecycletest/source_query_test.go
+++ b/pkg/engine/lifecycletest/source_query_test.go
@@ -65,6 +65,9 @@ func TestRunQuery_nocreate(t *testing.T) {
 	assert.NoError(t, err)
 
 	src, err := deploy.NewQuerySource(context.Background(), plugCtx, &deploytest.BackendClient{}, &deploy.EvalRunInfo{
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
 		Proj: &workspace.Project{
 			Name: "query-program",
 		},
@@ -137,6 +140,9 @@ func TestRunQuery_call_invoke(t *testing.T) {
 	require.NoError(t, err)
 
 	src, err := deploy.NewQuerySource(context.Background(), plugCtx, &deploytest.BackendClient{}, &deploy.EvalRunInfo{
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
 		Proj: &workspace.Project{
 			Name: "query-program",
 		},

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -35,7 +35,8 @@ type updateInfo struct {
 }
 
 func (u *updateInfo) GetRoot() string {
-	return ""
+	// These tests run in-memory, so we don't have a real root. Just pretend we're at the filesystem root.
+	return "/"
 }
 
 func (u *updateInfo) GetProject() *workspace.Project {

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -46,7 +46,8 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 }
 
 func (host *clientLanguageRuntimeHost) LanguageRuntime(
-	root, pwd, runtime string, options map[string]interface{},
+	runtime string,
+	info plugin.ProgramInfo,
 ) (plugin.LanguageRuntime, error) {
 	return host.languageRuntime, nil
 }

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -119,12 +119,11 @@ func newPluginSet(plugins ...workspace.PluginSpec) pluginSet {
 
 // gatherPluginsFromProgram inspects the given program and returns the set of plugins that the program requires to
 // function. If the language host does not support this operation, the empty set is returned.
-func gatherPluginsFromProgram(
-	plugctx *plugin.Context, prog plugin.ProgInfo, proj *workspace.Project,
-) (pluginSet, error) {
+func gatherPluginsFromProgram(plugctx *plugin.Context, runtime string, prog plugin.ProgramInfo) (pluginSet, error) {
 	logging.V(preparePluginLog).Infof("gatherPluginsFromProgram(): gathering plugins from language host")
 	set := newPluginSet()
-	langhostPlugins, err := plugin.GetRequiredPlugins(plugctx.Host, plugctx.Root, prog, proj, plugin.AllPlugins)
+
+	langhostPlugins, err := plugin.GetRequiredPlugins(plugctx.Host, runtime, prog.RootDirectory(), prog, plugin.AllPlugins)
 	if err != nil {
 		return set, err
 	}

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -114,9 +114,10 @@ func newQuerySource(cancel context.Context, client deploy.BackendClient, q Query
 	// If that succeeded, create a new source that will perform interpretation of the compiled program.
 	// TODO[pulumi/pulumi#88]: we are passing `nil` as the arguments map; we need to allow a way to pass these.
 	return deploy.NewQuerySource(cancel, opts.plugctx, client, &deploy.EvalRunInfo{
-		Proj:    q.GetProject(),
-		Pwd:     opts.pwd,
-		Program: opts.main,
+		ProjectRoot: q.GetRoot(),
+		Proj:        q.GetProject(),
+		Pwd:         opts.pwd,
+		Program:     opts.main,
 	}, defaultProviderVersions, nil)
 }
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -238,10 +238,14 @@ func installPlugins(ctx context.Context,
 	//
 	// In order to get a complete view of the set of plugins that we need for an update or query, we must
 	// consult both sources and merge their results into a list of plugins.
-	languagePlugins, err := gatherPluginsFromProgram(plugctx, plugin.ProgInfo{
-		Pwd:     pwd,
-		Program: main,
-	}, proj)
+	runtime := proj.Runtime.Name()
+	programInfo := plugin.NewProgramInfo(
+		/* rootDirectory */ plugctx.Root,
+		/* programDirectory */ pwd,
+		/* entryPoint */ main,
+		/* options */ proj.Runtime.Options(),
+	)
+	languagePlugins, err := gatherPluginsFromProgram(plugctx, runtime, programInfo)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -56,7 +56,7 @@ func (p *languageRuntime) Close() error {
 	return nil
 }
 
-func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
+func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgramInfo) ([]workspace.PluginSpec, error) {
 	if p.closed {
 		return nil, ErrLanguageRuntimeIsClosed
 	}
@@ -91,7 +91,7 @@ func (p *languageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{Name: "TestLanguage"}, nil
 }
 
-func (p *languageRuntime) InstallDependencies(pwd, main string) error {
+func (p *languageRuntime) InstallDependencies(info plugin.ProgramInfo) error {
 	if p.closed {
 		return ErrLanguageRuntimeIsClosed
 	}
@@ -106,7 +106,7 @@ func (p *languageRuntime) About() (plugin.AboutInfo, error) {
 }
 
 func (p *languageRuntime) GetProgramDependencies(
-	info plugin.ProgInfo, transitiveDependencies bool,
+	info plugin.ProgramInfo, transitiveDependencies bool,
 ) ([]plugin.DependencyInfo, error) {
 	if p.closed {
 		return nil, ErrLanguageRuntimeIsClosed

--- a/pkg/resource/deploy/deploytest/languageruntime_test.go
+++ b/pkg/resource/deploy/deploytest/languageruntime_test.go
@@ -45,7 +45,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("GetRequiredPlugins", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.GetRequiredPlugins(plugin.ProgInfo{})
+			_, err := p.GetRequiredPlugins(plugin.ProgramInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("GetPluginInfo", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			err := p.InstallDependencies("", "")
+			err := p.InstallDependencies(plugin.ProgramInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("About", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("GetProgramDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.GetProgramDependencies(plugin.ProgInfo{}, false)
+			_, err := p.GetProgramDependencies(plugin.ProgramInfo{}, false)
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 	})
@@ -94,7 +94,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			assert.NoError(t, p.InstallDependencies("", ""))
+			assert.NoError(t, p.InstallDependencies(plugin.ProgramInfo{}))
 		})
 		t.Run("About", func(t *testing.T) {
 			t.Parallel()
@@ -106,7 +106,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("GetProgramDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			res, err := p.GetProgramDependencies(plugin.ProgInfo{}, false)
+			res, err := p.GetProgramDependencies(plugin.ProgramInfo{}, false)
 			assert.NoError(t, err)
 			assert.Nil(t, res)
 		})

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -382,9 +382,7 @@ func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (p
 	return plug.(plugin.Provider), nil
 }
 
-func (host *pluginHost) LanguageRuntime(
-	root, pwd, runtime string, options map[string]interface{},
-) (plugin.LanguageRuntime, error) {
+func (host *pluginHost) LanguageRuntime(root string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}
@@ -500,7 +498,8 @@ func (host *pluginHost) ResolvePlugin(
 	return match, nil
 }
 
-func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
+func (host *pluginHost) GetRequiredPlugins(
+	info plugin.ProgramInfo,
 	kinds plugin.Flags,
 ) ([]workspace.PluginSpec, error) {
 	return host.languageRuntime.GetRequiredPlugins(info)

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -138,7 +138,8 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("LanguageRuntime", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.LanguageRuntime("", "", "", nil)
+			programInfo := plugin.NewProgramInfo("/", "/", ".", nil)
+			_, err := host.LanguageRuntime("", programInfo)
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 		t.Run("SignalCancellation", func(t *testing.T) {
@@ -179,7 +180,8 @@ func TestPluginHostProvider(t *testing.T) {
 				closed: true,
 			},
 		}
-		_, err := host.GetRequiredPlugins(plugin.ProgInfo{}, 0)
+
+		_, err := host.GetRequiredPlugins(plugin.ProgramInfo{}, 0)
 		assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 	})
 	t.Run("Close", func(t *testing.T) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -82,9 +82,7 @@ func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 	return host.closeProvider(provider)
 }
 
-func (host *testPluginHost) LanguageRuntime(
-	root, pwd, runtime string, options map[string]interface{},
-) (plugin.LanguageRuntime, error) {
+func (host *testPluginHost) LanguageRuntime(root string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
 
@@ -102,7 +100,7 @@ func (host *testPluginHost) GetProjectPlugins() []workspace.ProjectPlugin {
 	return nil
 }
 
-func (host *testPluginHost) GetRequiredPlugins(info plugin.ProgInfo,
+func (host *testPluginHost) GetRequiredPlugins(project string, info plugin.ProgramInfo,
 	kinds plugin.Flags,
 ) ([]workspace.PluginInfo, error) {
 	return nil, nil

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -221,8 +221,15 @@ func (iter *evalSourceIterator) forkRun(
 		// Next, launch the language plugin.
 		run := func() error {
 			rt := iter.src.runinfo.Proj.Runtime.Name()
+
 			rtopts := iter.src.runinfo.Proj.Runtime.Options()
-			langhost, err := iter.src.plugctx.Host.LanguageRuntime(iter.src.plugctx.Root, iter.src.plugctx.Pwd, rt, rtopts)
+			programInfo := plugin.NewProgramInfo(
+				/* rootDirectory */ iter.src.runinfo.ProjectRoot,
+				/* programDirectory */ iter.src.runinfo.Pwd,
+				/* entryPoint */ iter.src.runinfo.Program,
+				/* options */ rtopts)
+
+			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt, programInfo)
 			if err != nil {
 				return fmt.Errorf("failed to launch language host %s: %w", rt, err)
 			}
@@ -234,7 +241,6 @@ func (iter *evalSourceIterator) forkRun(
 				Stack:             iter.src.runinfo.Target.Name.String(),
 				Project:           string(iter.src.runinfo.Proj.Name),
 				Pwd:               iter.src.runinfo.Pwd,
-				Program:           iter.src.runinfo.Program,
 				Args:              iter.src.runinfo.Args,
 				Config:            config,
 				ConfigSecretKeys:  configSecretKeys,
@@ -242,6 +248,7 @@ func (iter *evalSourceIterator) forkRun(
 				DryRun:            iter.src.dryRun,
 				Parallel:          opts.Parallel,
 				Organization:      string(iter.src.runinfo.Target.Organization),
+				Info:              programInfo,
 			})
 
 			// Check if we were asked to Bail.  This a special random constant used for that

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -158,8 +158,11 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 	t.Parallel()
 
 	runInfo := &EvalRunInfo{
-		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: tokens.MustParseStackName("test")},
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
+		Proj:        &workspace.Project{Name: "test"},
+		Target:      &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -257,8 +260,11 @@ func TestRegisterDefaultProviders(t *testing.T) {
 	t.Parallel()
 
 	runInfo := &EvalRunInfo{
-		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: tokens.MustParseStackName("test")},
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
+		Proj:        &workspace.Project{Name: "test"},
+		Target:      &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -351,8 +357,11 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	t.Parallel()
 
 	runInfo := &EvalRunInfo{
-		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: tokens.MustParseStackName("test")},
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
+		Proj:        &workspace.Project{Name: "test"},
+		Target:      &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -443,8 +452,11 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 	t.Parallel()
 
 	runInfo := &EvalRunInfo{
-		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: tokens.MustParseStackName("test")},
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
+		Proj:        &workspace.Project{Name: "test"},
+		Target:      &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -584,8 +596,11 @@ func TestDisableDefaultProviders(t *testing.T) {
 			t.Parallel()
 
 			runInfo := &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "test"},
-				Target: &Target{Name: tokens.MustParseStackName("test")},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "test"},
+				Target:      &Target{Name: tokens.MustParseStackName("test")},
 			}
 			if tt.disableDefault {
 				disableDefaultProviders(runInfo, "pkgA")
@@ -727,8 +742,11 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 	}
 
 	runInfo := &EvalRunInfo{
-		Proj:   &workspace.Project{Name: "test"},
-		Target: &Target{Name: tokens.MustParseStackName("test")},
+		ProjectRoot: "/",
+		Pwd:         "/",
+		Program:     ".",
+		Proj:        &workspace.Project{Name: "test"},
+		Target:      &Target{Name: tokens.MustParseStackName("test")},
 	}
 
 	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
@@ -932,6 +950,9 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 // for #2753.
 // func TestReadResourceAndInvokeVersion(t *testing.T) {
 // 	runInfo := &EvalRunInfo{
+//      ProjectRoot: "/",
+// 		Pwd:         "/",
+// 		Program:     ".",
 // 		Proj:   &workspace.Project{Name: "test"},
 // 		Target: &Target{Name: "test"},
 // 	}
@@ -1381,8 +1402,11 @@ func TestStreamInvoke(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -1438,8 +1462,11 @@ func TestStreamInvoke(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -1494,8 +1521,11 @@ func TestStreamInvoke(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -1566,8 +1596,11 @@ func TestStreamInvoke(t *testing.T) {
 		providerRegChan := make(chan *registerResourceEvent, 100)
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, reg, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
@@ -1644,7 +1677,10 @@ func TestStreamInvokeQuery(t *testing.T) {
 
 		mon, err := newQueryResourceMonitor(builtins, nil, nil, reg, plugctx,
 			providerRegErrChan, opentracing.SpanFromContext(cancel), &EvalRunInfo{
-				Proj: &workspace.Project{Name: "test"},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "test"},
 			})
 		require.NoError(t, err)
 
@@ -1702,7 +1738,10 @@ func TestStreamInvokeQuery(t *testing.T) {
 		providerRegErrChan := make(chan error)
 		mon, err := newQueryResourceMonitor(builtins, nil, nil, reg, plugctx,
 			providerRegErrChan, opentracing.SpanFromContext(cancel), &EvalRunInfo{
-				Proj: &workspace.Project{Name: "test"},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "test"},
 			})
 		require.NoError(t, err)
 
@@ -1777,7 +1816,10 @@ func TestEvalSource(t *testing.T) {
 				},
 
 				runinfo: &EvalRunInfo{
-					Proj: &workspace.Project{Name: "proj"},
+					ProjectRoot: "/",
+					Pwd:         "/",
+					Program:     ".",
+					Proj:        &workspace.Project{Name: "proj"},
 					Target: &Target{
 						Name: tokens.MustParseStackName("target-name"),
 						Config: config.Map{
@@ -1806,6 +1848,9 @@ func TestEvalSource(t *testing.T) {
 					Diag: &deploytest.NoopSink{},
 				},
 				runinfo: &EvalRunInfo{
+					ProjectRoot: "/",
+					Pwd:         "/",
+					Program:     ".",
 					Target: &Target{
 						Config: config.Map{
 							config.MustMakeKey("test", "secret"): config.NewSecureValue("secret"),
@@ -2270,8 +2315,11 @@ func TestInvoke(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -2323,8 +2371,11 @@ func TestInvoke(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -2397,8 +2448,11 @@ func TestCall(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -2467,8 +2521,11 @@ func TestCall(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -2549,8 +2606,11 @@ func TestCall(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{
@@ -2613,8 +2673,11 @@ func TestCall(t *testing.T) {
 
 		mon, err := newResourceMonitor(&evalSource{
 			runinfo: &EvalRunInfo{
-				Proj:   &workspace.Project{Name: "proj"},
-				Target: &Target{},
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
+				Proj:        &workspace.Project{Name: "proj"},
+				Target:      &Target{},
 			},
 			plugctx: plugctx,
 		}, &providerSourceMock{

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -142,7 +142,12 @@ func (src *querySource) forkRun() {
 func runLangPlugin(src *querySource) error {
 	rt := src.runinfo.Proj.Runtime.Name()
 	rtopts := src.runinfo.Proj.Runtime.Options()
-	langhost, err := src.plugctx.Host.LanguageRuntime(src.plugctx.Root, src.plugctx.Pwd, rt, rtopts)
+	programInfo := plugin.NewProgramInfo(
+		/* rootDirectory */ src.runinfo.ProjectRoot,
+		/* programDirectory */ src.runinfo.Pwd,
+		/* entryPoint */ src.runinfo.Program,
+		/* options */ rtopts)
+	langhost, err := src.plugctx.Host.LanguageRuntime(rt, programInfo)
 	if err != nil {
 		return fmt.Errorf("failed to launch language host %s: %w", rt, err)
 	}
@@ -169,13 +174,13 @@ func runLangPlugin(src *querySource) error {
 		Stack:          name,
 		Project:        string(src.runinfo.Proj.Name),
 		Pwd:            src.runinfo.Pwd,
-		Program:        src.runinfo.Program,
 		Args:           src.runinfo.Args,
 		Config:         config,
 		DryRun:         true,
 		QueryMode:      true,
 		Parallel:       math.MaxInt32,
 		Organization:   organization,
+		Info:           programInfo,
 	})
 
 	// Check if we were asked to Bail.  This a special random constant used for that

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -428,12 +428,15 @@ func TestRunLangPlugin(t *testing.T) {
 		assert.ErrorContains(t, runLangPlugin(&querySource{
 			plugctx: &plugin.Context{
 				Host: &mockHost{
-					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+					LanguageRuntimeF: func(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 						return nil, errors.New("expected error")
 					},
 				},
 			},
 			runinfo: &EvalRunInfo{
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
 				Proj: &workspace.Project{
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
 				},
@@ -446,12 +449,15 @@ func TestRunLangPlugin(t *testing.T) {
 		err := runLangPlugin(&querySource{
 			plugctx: &plugin.Context{
 				Host: &mockHost{
-					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+					LanguageRuntimeF: func(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 						return &mockLanguageRuntime{}, nil
 					},
 				},
 			},
 			runinfo: &EvalRunInfo{
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
 				Proj: &workspace.Project{
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
 				},
@@ -477,7 +483,7 @@ func TestRunLangPlugin(t *testing.T) {
 		err := runLangPlugin(&querySource{
 			plugctx: &plugin.Context{
 				Host: &mockHost{
-					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+					LanguageRuntimeF: func(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 						return &mockLanguageRuntime{
 							RunF: func(info plugin.RunInfo) (string, bool, error) {
 								return "bail should override progerr", true /* bail */, nil
@@ -491,6 +497,9 @@ func TestRunLangPlugin(t *testing.T) {
 				AddressF: func() string { return "" },
 			},
 			runinfo: &EvalRunInfo{
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
 				Proj: &workspace.Project{
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
 				},
@@ -503,7 +512,7 @@ func TestRunLangPlugin(t *testing.T) {
 		err := runLangPlugin(&querySource{
 			plugctx: &plugin.Context{
 				Host: &mockHost{
-					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+					LanguageRuntimeF: func(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 						return &mockLanguageRuntime{
 							RunF: func(info plugin.RunInfo) (string, bool, error) {
 								return "expected progerr", false /* bail */, nil
@@ -517,6 +526,9 @@ func TestRunLangPlugin(t *testing.T) {
 				AddressF: func() string { return "" },
 			},
 			runinfo: &EvalRunInfo{
+				ProjectRoot: "/",
+				Pwd:         "/",
+				Program:     ".",
 				Proj: &workspace.Project{
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
 				},
@@ -530,7 +542,7 @@ func TestRunLangPlugin(t *testing.T) {
 		err := runLangPlugin(&querySource{
 			plugctx: &plugin.Context{
 				Host: &mockHost{
-					LanguageRuntimeF: func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error) {
+					LanguageRuntimeF: func(runtime string, p plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 						return &mockLanguageRuntime{
 							RunF: func(info plugin.RunInfo) (string, bool, error) {
 								runCalled = true
@@ -538,7 +550,7 @@ func TestRunLangPlugin(t *testing.T) {
 								assert.Equal(t, "expected-stack", info.Stack)
 								assert.Equal(t, "expected-project", info.Project)
 								assert.Equal(t, "expected-pwd", info.Pwd)
-								assert.Equal(t, "expected-program", info.Program)
+								assert.Equal(t, "expected-program", p.EntryPoint())
 								assert.Equal(t, []string{"expected", "args"}, info.Args)
 								assert.Equal(t, "secret-value", info.Config[config.MustMakeKey("test", "secret")])
 								assert.Equal(t, "regular-value", info.Config[config.MustMakeKey("test", "regular")])
@@ -557,6 +569,7 @@ func TestRunLangPlugin(t *testing.T) {
 				AddressF: func() string { return "expected-address" },
 			},
 			runinfo: &EvalRunInfo{
+				ProjectRoot: "/",
 				Proj: &workspace.Project{
 					Name:    "expected-project",
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
@@ -603,7 +616,7 @@ type mockHost struct {
 
 	CloseProviderF func(provider plugin.Provider) error
 
-	LanguageRuntimeF func(root, pwd, runtime string, options map[string]interface{}) (plugin.LanguageRuntime, error)
+	LanguageRuntimeF func(language string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error)
 
 	EnsurePluginsF func(plugins []workspace.PluginSpec, kinds plugin.Flags) error
 
@@ -678,11 +691,9 @@ func (h *mockHost) CloseProvider(provider plugin.Provider) error {
 	panic("unimplemented")
 }
 
-func (h *mockHost) LanguageRuntime(
-	root, pwd, runtime string, options map[string]interface{},
-) (plugin.LanguageRuntime, error) {
+func (h *mockHost) LanguageRuntime(runtime string, info plugin.ProgramInfo) (plugin.LanguageRuntime, error) {
 	if h.LanguageRuntimeF != nil {
-		return h.LanguageRuntimeF(root, pwd, runtime, options)
+		return h.LanguageRuntimeF(runtime, info)
 	}
 	panic("unimplemented")
 }
@@ -728,18 +739,18 @@ func (h *mockHost) Close() error {
 type mockLanguageRuntime struct {
 	CloseF func() error
 
-	GetRequiredPluginsF func(info plugin.ProgInfo) ([]workspace.PluginSpec, error)
+	GetRequiredPluginsF func(info plugin.ProgramInfo) ([]workspace.PluginSpec, error)
 
 	RunF func(info plugin.RunInfo) (string, bool, error)
 
 	GetPluginInfoF func() (workspace.PluginInfo, error)
 
-	InstallDependenciesF func(pwd, main string) error
+	InstallDependenciesF func(info plugin.ProgramInfo) error
 
 	AboutF func() (plugin.AboutInfo, error)
 
 	GetProgramDependenciesF func(
-		info plugin.ProgInfo, transitiveDependencies bool,
+		info plugin.ProgramInfo, transitiveDependencies bool,
 	) ([]plugin.DependencyInfo, error)
 
 	RunPluginF func(
@@ -777,7 +788,7 @@ func (rt *mockLanguageRuntime) Close() error {
 	panic("unimplemented")
 }
 
-func (rt *mockLanguageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
+func (rt *mockLanguageRuntime) GetRequiredPlugins(info plugin.ProgramInfo) ([]workspace.PluginSpec, error) {
 	if rt.GetRequiredPluginsF != nil {
 		return rt.GetRequiredPluginsF(info)
 	}
@@ -798,9 +809,9 @@ func (rt *mockLanguageRuntime) GetPluginInfo() (workspace.PluginInfo, error) {
 	panic("unimplemented")
 }
 
-func (rt *mockLanguageRuntime) InstallDependencies(pwd, main string) error {
+func (rt *mockLanguageRuntime) InstallDependencies(info plugin.ProgramInfo) error {
 	if rt.InstallDependenciesF != nil {
-		return rt.InstallDependenciesF(pwd, main)
+		return rt.InstallDependenciesF(info)
 	}
 	panic("unimplemented")
 }
@@ -813,7 +824,7 @@ func (rt *mockLanguageRuntime) About() (plugin.AboutInfo, error) {
 }
 
 func (rt *mockLanguageRuntime) GetProgramDependencies(
-	info plugin.ProgInfo, transitiveDependencies bool,
+	info plugin.ProgramInfo, transitiveDependencies bool,
 ) ([]plugin.DependencyInfo, error) {
 	if rt.GetProgramDependenciesF != nil {
 		return rt.GetProgramDependenciesF(info, transitiveDependencies)

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -16,14 +16,92 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
+
+// ProgramInfo contains minimal information about the program to be run.
+type ProgramInfo struct {
+	root       string
+	program    string
+	entryPoint string
+	options    map[string]any
+}
+
+func NewProgramInfo(rootDirectory, programDirectory, entryPoint string, options map[string]any) ProgramInfo {
+	isValidPath := func(path string) bool {
+		return filepath.IsLocal(path) || filepath.IsAbs(path)
+	}
+	isFileName := func(path string) bool {
+		return filepath.Base(path) == path
+	}
+
+	if !isValidPath(rootDirectory) {
+		panic(fmt.Sprintf("rootDirectory '%s' is not a valid path when creating ProgramInfo", rootDirectory))
+	}
+
+	if !isValidPath(programDirectory) {
+		panic(fmt.Sprintf("programDirectory '%s' is not a valid path when creating ProgramInfo", programDirectory))
+	}
+
+	if !isFileName(entryPoint) && entryPoint != "." {
+		panic(fmt.Sprintf("entryPoint '%s' was not a valid file name when creating ProgramInfo", entryPoint))
+	}
+
+	return ProgramInfo{
+		root:       rootDirectory,
+		program:    programDirectory,
+		entryPoint: entryPoint,
+		options:    options,
+	}
+}
+
+// The programs root directory, i.e. where the Pulumi.yaml file is.
+func (info ProgramInfo) RootDirectory() string {
+	return info.root
+}
+
+// The programs directory, generally the same as or a subdirectory of the root directory.
+func (info ProgramInfo) ProgramDirectory() string {
+	return info.program
+}
+
+// The programs main entrypoint, either a file path relative to the program directory or "." for the program directory.
+func (info ProgramInfo) EntryPoint() string {
+	return info.entryPoint
+}
+
+// Runtime plugin options for the program
+func (info ProgramInfo) Options() map[string]any {
+	return info.options
+}
+
+func (info ProgramInfo) String() string {
+	return fmt.Sprintf("root=%s, program=%s, entryPoint=%s", info.root, info.program, info.entryPoint)
+}
+
+func (info ProgramInfo) Marshal() (*pulumirpc.ProgramInfo, error) {
+	opts, err := structpb.NewStruct(info.options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal options: %w", err)
+	}
+
+	return &pulumirpc.ProgramInfo{
+		RootDirectory:    info.root,
+		ProgramDirectory: info.program,
+		EntryPoint:       info.entryPoint,
+		Options:          opts,
+	}, nil
+}
 
 // LanguageRuntime is a convenient interface for interacting with language runtime plugins.  These tend to be
 // dynamically loaded as plugins, although this interface hides this fact from the calling code.
@@ -31,7 +109,7 @@ type LanguageRuntime interface {
 	// Closer closes any underlying OS resources associated with this plugin (like processes, RPC channels, etc).
 	io.Closer
 	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error)
+	GetRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec, error)
 	// Run executes a program in the language runtime for planning or deployment purposes.  If
 	// info.DryRun is true, the code must not assume that side-effects or final values resulting
 	// from resource deployments are actually available.  If it is false, on the other hand, a real
@@ -44,13 +122,13 @@ type LanguageRuntime interface {
 	GetPluginInfo() (workspace.PluginInfo, error)
 
 	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-	InstallDependencies(pwd, main string) error
+	InstallDependencies(info ProgramInfo) error
 
 	// About returns information about the language runtime.
 	About() (AboutInfo, error)
 
 	// GetProgramDependencies returns information about the dependencies for the given program.
-	GetProgramDependencies(info ProgInfo, transitiveDependencies bool) ([]DependencyInfo, error)
+	GetProgramDependencies(info ProgramInfo, transitiveDependencies bool) ([]DependencyInfo, error)
 
 	// RunPlugin executes a plugin program and returns its result asynchronously.
 	RunPlugin(info RunPluginInfo) (io.Reader, io.Reader, context.CancelFunc, error)
@@ -85,25 +163,19 @@ type AboutInfo struct {
 }
 
 type RunPluginInfo struct {
-	Pwd     string
-	Program string
-	Args    []string
-	Env     []string
-}
-
-// ProgInfo contains minimal information about the program to be run.
-type ProgInfo struct {
-	Pwd     string // the program's working directory.
-	Program string // the path to the program to execute.
+	Info             ProgramInfo
+	WorkingDirectory string
+	Args             []string
+	Env              []string
 }
 
 // RunInfo contains all of the information required to perform a plan or deployment operation.
 type RunInfo struct {
+	Info              ProgramInfo           // the information about the program to run.
 	MonitorAddress    string                // the RPC address to the host resource monitor.
 	Project           string                // the project name housing the program being run.
 	Stack             string                // the stack name being evaluated.
 	Pwd               string                // the program's working directory.
-	Program           string                // the path to the program to execute.
 	Args              []string              // any arguments to pass to the program.
 	Config            map[config.Key]string // the configuration variables to apply before running.
 	ConfigSecretKeys  []config.Key          // the configuration keys that have secret values.

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -346,16 +346,17 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 
 		logging.V(9).Infof("Launching plugin '%v' from '%v' via runtime '%s'", prefix, pluginDir, runtimeInfo.Name())
 
-		runtime, err := ctx.Host.LanguageRuntime(pluginDir, pluginDir, runtimeInfo.Name(), runtimeInfo.Options())
+		info := NewProgramInfo(pluginDir, pluginDir, ".", runtimeInfo.Options())
+		runtime, err := ctx.Host.LanguageRuntime(runtimeInfo.Name(), info)
 		if err != nil {
 			return nil, fmt.Errorf("loading runtime: %w", err)
 		}
 
 		stdout, stderr, kill, err := runtime.RunPlugin(RunPluginInfo{
-			Pwd:     pwd,
-			Program: pluginDir,
-			Args:    pluginArgs,
-			Env:     env,
+			Info:             info,
+			WorkingDirectory: ctx.Pwd,
+			Args:             pluginArgs,
+			Env:              env,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

This PR introduces `ProgramInfo` to replace the old `ProgInfo` and consistently use it where we require plugin, install dependencies and initialize language runtimes.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
