### PR TITLE
Update python langhost test for pulumi-random change

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -146,7 +146,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 		assert.NotEmpty(t, packages)
 		assert.Equal(t, 1, len(packages))
 		random := packages[0]
-		assert.Equal(t, "pulumi-random", random.Name)
+		assert.Equal(t, "pulumi_random", random.Name)
 		assert.NotEmpty(t, random.Location)
 	})
 	t.Run("pulumiplugin", func(t *testing.T) {


### PR DESCRIPTION
When creating a PyPi package, Python setuptools prior to v69 would record the name of a package in egg_info by replacing underscores with dashes. So after installing `pulumi-random==4.15.0`, `pip list` would report the package name as `pulumi-random`.

However, setuptools >= 69 now retains the underscore in egg_info (https://github.com/pypa/setuptools/pull/4159). So after installing the latest version of `pulumi-random==4.15.1`, `pip list` now reports the package name as `pulumi_random` instead of `pulumi-random`.

We use pip to list installed packages so we can determine which ones are Pulumi packages for `GetRequiredPlugins`.

It turns out that this change is largely benign for us. We don't really care if the reported name is `pulumi-random` or `pulumi_random`, because we will replace dashes with underscores in the returned name anyway, because the location the package is installed on disk is going to have the underscore, and it's in this location where we look for `pulumi-plugin.json`.

https://github.com/pulumi/pulumi/blob/8bcef51fb8a781fcb9b9b630b4cc96fecc859640/sdk/python/cmd/pulumi-language-python/main.go#L393-L398

All that's required is updating the test's expected value, which is now `pulumi_random` as of 4.15.1 of that package.

Fixes #15192