### PR TITLE
Fix infinite loop bug in plugin_mapper

### DIFF
--- a/changelog/pending/20240122--engine--fix-a-bug-where-mapping-lookup-could-sometimes-lead-to-an-infinite-loop.yaml
+++ b/changelog/pending/20240122--engine--fix-a-bug-where-mapping-lookup-could-sometimes-lead-to-an-infinite-loop.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a bug where mapping lookup could sometimes lead to an infinite loop.

--- a/pkg/codegen/convert/plugin_mapper_test.go
+++ b/pkg/codegen/convert/plugin_mapper_test.go
@@ -568,3 +568,55 @@ func TestPluginMapper_GetMappingIsntCalledOnValidMappings(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("dataaws"), data)
 }
+
+func TestPluginMapper_InfiniteLoopRegression(t *testing.T) {
+	t.Parallel()
+
+	// Test that the mapping loop doesn't end up in an infinite loop in some cases where no mapping is found.
+
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "pulumiProviderAws",
+				Kind:    workspace.ResourcePlugin,
+				Version: semverMustParse("1.0.0"),
+			},
+		},
+	}
+	testProviderAws := &testProvider{
+		pkg: tokens.Package("pulumiProviderAws"),
+		mapping: func(key, provider string) ([]byte, string, error) {
+			assert.Equal(t, "key", key)
+			assert.Equal(t, "aws", provider)
+			return []byte("dataaws"), "aws", nil
+		},
+		mappings: func(key string) ([]string, error) {
+			assert.Equal(t, "key", key)
+			return []string{"aws"}, nil
+		},
+	}
+
+	providerFactory := func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+		if pkg == testProviderAws.pkg {
+			return testProviderAws, nil
+		}
+		assert.Fail(t, "unexpected package %s", pkg)
+		return nil, fmt.Errorf("unexpected package %s", pkg)
+	}
+
+	installPlugin := func(pkg tokens.Package) *semver.Version {
+		assert.Contains(t, []string{"gcp"}, string(pkg))
+		return nil
+	}
+
+	mapper, err := NewPluginMapper(ws, providerFactory, "key", nil, installPlugin)
+	assert.NoError(t, err)
+	assert.NotNil(t, mapper)
+
+	ctx := context.Background()
+
+	// Get the mapping for the GCP provider, which we don't have a plugin for.
+	data, err := mapper.GetMapping(ctx, "gcp", "")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, data)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Found by @GeoffMillerAZ a while back. Just tracked down exactly what caused it. The test added hangs if ran on the current version of the code.

Issue was we used to assume that we'd only stop looking for plugins once there weren't any more plugins to look at. But then we added `GetMappings` so we could see which providers a plugin mapped to up-front. So the check needs to actually be stop looking when there's no plugins _or_ when all the plugins left explicitly say they aren't for the current lookup.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
