### PR TITLE
add a CR before when finishing the progress bar

### DIFF
--- a/changelog/pending/20240122--cli-display--incremental-improvement-on-the-output-when-installing-plugins.yaml
+++ b/changelog/pending/20240122--cli-display--incremental-improvement-on-the-output-when-installing-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Incremental improvement on the output when installing plugins

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2177,6 +2177,6 @@ func (bc *barCloser) Read(dest []byte) (int, error) {
 }
 
 func (bc *barCloser) Close() error {
-	bc.bar.Finish()
+	bc.bar.FinishPrint("\r")
 	return bc.readCloser.Close()
 }


### PR DESCRIPTION
We are using our terminal in raw mode, which means we're not getting CRs automatically added.  Add one after a progress bar has finished to improve the output slightly.

The final output after this looks like: 

```
$ pulumi preview                     
Please choose a stack, or create a new one: dev
Previewing update (dev):
Downloading plugin: 18.39 MiB / 18.39 MiB [========================] 100.00% 15s

[resource plugin docker-3.6.1] installing
Downloading plugin: 20.19 MiB / 20.19 MiB [========================] 100.00% 15s

[resource plugin awsx-1.0.5] installing
Downloading plugin: 164.18 MiB / 164.18 MiB [======================] 100.00% 32s

[resource plugin aws-5.42.0] installing
[...]
```

Which seems slightly better, but not a huge improvement, and the progress bar is unfortunately also still jumpy.  I'll write down the rest of my learnings here in https://github.com/pulumi/pulumi/issues/14250.

I'm not entirely sure it's even worth merging this, but I'm putting this up as a PR for further discussion and to show where the investigation led.