### PR TITLE
Fix hang in --preview-file

### DIFF
--- a/changelog/pending/20240122--engine--fix-a-hang-in-preview-import-file.yaml
+++ b/changelog/pending/20240122--engine--fix-a-hang-in-preview-import-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a hang in preview --import-file.

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -44,6 +44,13 @@ import (
 // buildImportFile takes an event stream from the engine and builds an import file from it for every create.
 func buildImportFile(events <-chan engine.Event) *promise.Promise[importFile] {
 	return promise.Run(func() (importFile, error) {
+		// We may exit the below loop early if we encounter an error, so we need to make sure we drain the events
+		// channel.
+		defer func() {
+			for range events {
+			}
+		}()
+
 		// A mapping of every URN we see to it's name, used to build later resourceSpecs
 		fullNameTable := map[resource.URN]string{}
 		// A set of all URNs we've added to the import list, used to avoid adding parents to NameTable.


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15068.

We can exit the loop building the preview file early if we encounter any errors. If we do that we stop reading the events channel which was causing the writers of that channel (the main engine loop) to block. This adds a deferred function to just make sure we fully drain that channel. 

P.S. Don't tempt me to write `channel.Scan`.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
