### PR TITLE
[auto/python] Add new API to install the Pulumi CLI

### DIFF
--- a/changelog/pending/20240122--auto-python--add-new-api-to-install-the-pulumi-cli.yaml
+++ b/changelog/pending/20240122--auto-python--add-new-api-to-install-the-pulumi-cli.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Add new API to install the Pulumi CLI

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -32,6 +32,7 @@ ensure:: $(PYTHON).ensure .ensure.phony
 build_package:: ensure
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
 	sed -i.bak 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
+	sed -i.bak 's/^_VERSION = .*/_VERSION = "$(VERSION)"/g' $(PYENVSRC)/pulumi/_version.py && rm $(PYENVSRC)/pulumi/_version.py.bak
 	cp ../../README.md $(PYENVSRC)
 	. venv/*/activate && cd $(PYENVSRC) && \
 		python setup.py build bdist_wheel --universal

--- a/sdk/python/lib/pulumi/_version.py
+++ b/sdk/python/lib/pulumi/_version.py
@@ -1,0 +1,20 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from semver import VersionInfo
+
+_VERSION = "3.0.0"
+
+version = VersionInfo.parse(_VERSION)
+"""Version is the Pulumi SDK's release version."""

--- a/sdk/python/lib/pulumi/automation/__init__.py
+++ b/sdk/python/lib/pulumi/automation/__init__.py
@@ -98,7 +98,7 @@ from pulumi.automation._remote_workspace import (
 
 from pulumi.automation._remote_stack import RemoteStack
 
-from ._cmd import CommandResult, OnOutput
+from ._cmd import CommandResult, OnOutput, PulumiCommand
 
 from ._config import ConfigMap, ConfigValue
 
@@ -175,6 +175,7 @@ from ._stack import (
 __all__ = [
     # _cmd
     "CommandResult",
+    "PulumiCommand",
     "OnOutput",
     # _config
     "ConfigMap",

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import os
 import subprocess
 import tempfile
-from typing import List, Mapping, Optional, Callable, Any
+import urllib.request
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
-from .errors import create_command_error
+from semver import VersionInfo
+
+from .._version import version as sdk_version
+from ._env import _SKIP_VERSION_CHECK_VAR
+from ._minimum_version import _MINIMUM_VERSION
+from .errors import InvalidVersionError, create_command_error
 
 OnOutput = Callable[[str], Any]
 
@@ -35,46 +42,247 @@ class CommandResult:
         return f"\n code: {self.code}\n stdout: {self.stdout}\n stderr: {self.stderr}"
 
 
-def _run_pulumi_cmd(
-    args: List[str],
-    cwd: str,
-    additional_env: Mapping[str, str],
-    on_output: Optional[OnOutput] = None,
-) -> CommandResult:
-    # All commands should be run in non-interactive mode.
-    # This causes commands to fail rather than prompting for input (and thus hanging indefinitely).
-    if "--non-interactive" not in args:
-        args.append("--non-interactive")
-    env = {**os.environ, **additional_env}
-    cmd = ["pulumi"]
-    cmd.extend(args)
+class PulumiCommand:
+    """
+    PulumiCommand manages the Pulumi CLI. It can be used to to install the CLI and run commands.
+    """
 
-    stdout_chunks: List[str] = []
+    command: str
+    version: Optional[VersionInfo]
 
-    with tempfile.TemporaryFile() as stderr_file:
-        with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=stderr_file, cwd=cwd, env=env
-        ) as process:
-            assert process.stdout is not None
-            while True:
-                output = process.stdout.readline().decode(encoding="utf-8")
-                if output == "" and process.poll() is not None:
-                    break
-                if output:
-                    text = output.rstrip()
-                    if on_output:
-                        on_output(text)
-                    stdout_chunks.append(text)
+    def __init__(
+        self,
+        root: Optional[str] = None,
+        version: Optional[VersionInfo] = None,
+        skip_version_check: bool = False,
+    ):
+        """
+        Creates a new PulumiCommand.
 
-            code = process.returncode
+        :param root: The directory where to look for the Pulumi installation. Defaults to running `pulumi` from $PATH.
+        :param version: The minimum version of the Pulumi CLI to use and validates that it is compatbile with this version.
+        :param skip_version_check: If true the version validation will be skipped. The env variable
+                `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` also disable this check, and takes precendence. If it is set it
+                is not possible to re-enable the validation even if `skip_version_check` is `True`.
+        """
+        self.command = os.path.join(root, "bin", "pulumi") if root else "pulumi"
+        min_version = _MINIMUM_VERSION
+        if version and version.compare(min_version) > 0:
+            min_version = version
+        current_version = (
+            subprocess.check_output([self.command, "version"]).decode("utf-8").strip()
+        )
+        if current_version.startswith("v"):
+            current_version = current_version[1:]
+        opt_out = skip_version_check or os.getenv(_SKIP_VERSION_CHECK_VAR) is not None
+        self.version = _parse_and_validate_pulumi_version(
+            min_version=min_version,
+            current_version=current_version,
+            opt_out=opt_out,
+        )
 
-        stderr_file.seek(0)
-        stderr_contents = stderr_file.read().decode("utf-8")
+    @classmethod
+    def install(
+        cls,
+        root: Optional[str] = None,
+        version: Optional[VersionInfo] = None,
+        skip_version_check: bool = False,
+    ) -> PulumiCommand:
+        """
+        Downloads and installs the Pulumi CLI.  By default the CLI version
+        matching the current SDK release is installed in
+        $HOME/.pulumi/versions/$VERSION. Set `root` to specify a
+        different directory, and `version` to install a custom version.
 
-    result = CommandResult(
-        stderr=stderr_contents, stdout="\n".join(stdout_chunks), code=code
-    )
-    if code != 0:
-        raise create_command_error(result)
+        :param root: The root directory to install the CLI to. Defaults to `~/.pulumi/versions/<version>`
+        :param version: The version of the CLI to install. Defaults to the version matching the SDK version.
+        :skip_version_check: If true, the version validation will be skipped.
+               See parameter `skip_version_check` in `__init__`."""
+        if not version:
+            version = sdk_version
+        if not root:
+            root = os.path.join(
+                os.path.expanduser("~"), ".pulumi", "versions", str(version)
+            )
 
-    return result
+        try:
+            return PulumiCommand(
+                root=root, version=version, skip_version_check=skip_version_check
+            )
+        except Exception:
+            pass  # Ignore
+
+        if os.name == "nt":
+            cls._install_windows(root, version)
+        else:
+            cls._install_posix(root, version)
+
+        return PulumiCommand(
+            root=root, version=version, skip_version_check=skip_version_check
+        )
+
+    @classmethod
+    def _install_windows(cls, root: str, version: VersionInfo):
+        # TODO: Once we're on python 3.12 we can use a `with` context manager with `delete_on_close=False` and `delete=True` here
+        # pylint: disable-next=consider-using-with
+        script = tempfile.NamedTemporaryFile(delete=False, suffix=".ps1")
+        try:
+            _download_to_file("https://get.pulumi.com/install.ps1", script.name)
+            script.close()  # The file was opened for writing, so we need to close it before executing it.
+            command = "powershell.exe"
+            sys_root = os.getenv("SystemRoot")
+            if sys_root:
+                command = os.path.join(
+                    sys_root,
+                    "System32",
+                    "WindowsPowerShell",
+                    "v1.0",
+                    "powershell.exe",
+                )
+            subprocess.check_output(
+                [
+                    command,
+                    "-NoProfile",
+                    "-InputFormat",
+                    "None",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    script.name,
+                    "-NoEditPath",
+                    "-InstallRoot",
+                    root,
+                    "-Version",
+                    str(version),
+                ],
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            os.remove(script.name)
+
+    @classmethod
+    def _install_posix(cls, root: str, version: VersionInfo):
+        # TODO: Once we're on python 3.12 we can use a `with` context manager with `delete_on_close=False` and `delete=True` here
+        # pylint: disable-next=consider-using-with
+        script = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            _download_to_file("https://get.pulumi.com/install.sh", script.name)
+            os.chmod(script.name, 0o700)
+            script.close()  # The file was opened for writing, so we need to close it before executing it.
+            subprocess.check_output(
+                [
+                    script.name,
+                    "--no-edit-path",
+                    "--install-root",
+                    root,
+                    "--version",
+                    str(version),
+                ],
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            os.remove(script.name)
+
+    def run(
+        self,
+        args: List[str],
+        cwd: str,
+        additional_env: Mapping[str, str],
+        on_output: Optional[OnOutput] = None,
+    ) -> CommandResult:
+        """
+        Runs a Pulumi command, returning a CommandResult. If the command fails, a CommandError is raised.
+
+        :param args: The arguments to pass to the Pulumi CLI, for example `["stack", "ls"]`.
+        :param cwd: The working directory to run the command in.
+        :param additional_env: Additional environment variables to set when running the command.
+        :param on_output: A callback to invoke when the command outputs data.
+        """
+
+        # All commands should be run in non-interactive mode.
+        # This causes commands to fail rather than prompting for input (and thus hanging indefinitely).
+        if "--non-interactive" not in args:
+            args.append("--non-interactive")
+        env = {**os.environ, **additional_env}
+        if os.path.isabs(self.command):
+            env = _fixup_path(env, os.path.dirname(self.command))
+        cmd = ["pulumi"]
+        cmd.extend(args)
+
+        stdout_chunks: List[str] = []
+
+        with tempfile.TemporaryFile() as stderr_file:
+            with subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=stderr_file, cwd=cwd, env=env
+            ) as process:
+                assert process.stdout is not None
+                while True:
+                    output = process.stdout.readline().decode(encoding="utf-8")
+                    if output == "" and process.poll() is not None:
+                        break
+                    if output:
+                        text = output.rstrip()
+                        if on_output:
+                            on_output(text)
+                        stdout_chunks.append(text)
+
+                code = process.returncode
+
+            stderr_file.seek(0)
+            stderr_contents = stderr_file.read().decode("utf-8")
+
+        result = CommandResult(
+            stderr=stderr_contents, stdout="\n".join(stdout_chunks), code=code
+        )
+        if code != 0:
+            raise create_command_error(result)
+
+        return result
+
+
+def _download_to_file(url: str, path: str):
+    with urllib.request.urlopen(url) as response, open(path, "wb") as out_file:
+        data = response.read()
+        out_file.write(data)
+
+
+def _fixup_path(env: Dict[str, str], pulumiBin: str) -> Dict[str, str]:
+    """
+    Fixup path so that we prioritize up the bundled plugins next to the pulumi binary.
+    """
+    new_env = dict(env)
+    new_env["PATH"] = os.pathsep.join([pulumiBin, env["PATH"]])
+    return new_env
+
+
+def _parse_and_validate_pulumi_version(
+    min_version: VersionInfo, current_version: str, opt_out: bool
+) -> Optional[VersionInfo]:
+    """
+    Parse and return a version. An error is raised if the version is not
+    valid. If *current_version* is not a valid version but *opt_out* is true,
+    *None* is returned.
+    """
+    try:
+        version: Optional[VersionInfo] = VersionInfo.parse(current_version)
+    except ValueError:
+        version = None
+    if opt_out:
+        return version
+    if version is None:
+        raise InvalidVersionError(
+            f"Could not parse the Pulumi CLI version. This is probably an internal error. "
+            f"If you are sure you have the correct version, set {_SKIP_VERSION_CHECK_VAR}=true."
+        )
+    if min_version.major < version.major:
+        raise InvalidVersionError(
+            f"Major version mismatch. You are using Pulumi CLI version {version} with "
+            f"Automation SDK v{min_version.major}. Please update the SDK."
+        )
+    if min_version.compare(version) == 1:
+        raise InvalidVersionError(
+            f"Minimum version requirement failed. The minimum CLI version requirement is "
+            f"{min_version}, your current CLI version is {version}. "
+            f"Please update the Pulumi CLI."
+        )
+    return version

--- a/sdk/python/lib/pulumi/automation/_env.py
+++ b/sdk/python/lib/pulumi/automation/_env.py
@@ -1,0 +1,15 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_SKIP_VERSION_CHECK_VAR = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -23,9 +23,9 @@ from typing import TYPE_CHECKING, Callable, List, Mapping, Optional, Union
 import yaml
 from semver import VersionInfo
 
-from ._cmd import CommandResult, OnOutput, _run_pulumi_cmd
+from ._cmd import CommandResult, OnOutput, PulumiCommand
 from ._config import _SECRET_SENTINEL, ConfigMap, ConfigValue
-from ._minimum_version import _MINIMUM_VERSION
+from ._env import _SKIP_VERSION_CHECK_VAR
 from ._output import OutputMap, OutputValue
 from ._project_settings import ProjectSettings
 from ._stack import _DATETIME_FORMAT, Stack
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
 
 _setting_extensions = [".yaml", ".yml", ".json"]
 
-_SKIP_VERSION_CHECK_VAR = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"
-
 
 class Secret(str):
     """
@@ -63,6 +61,7 @@ class LocalWorkspaceOptions:
     secrets_provider: Optional[str] = None
     project_settings: Optional[ProjectSettings] = None
     stack_settings: Optional[Mapping[str, StackSettings]] = None
+    pulumi_command: Optional[PulumiCommand] = None
 
     def __init__(
         self,
@@ -73,6 +72,7 @@ class LocalWorkspaceOptions:
         secrets_provider: Optional[str] = None,
         project_settings: Optional[ProjectSettings] = None,
         stack_settings: Optional[Mapping[str, StackSettings]] = None,
+        pulumi_command: Optional[PulumiCommand] = None,
     ):
         self.work_dir = work_dir
         self.pulumi_home = pulumi_home
@@ -81,6 +81,7 @@ class LocalWorkspaceOptions:
         self.secrets_provider = secrets_provider
         self.project_settings = project_settings
         self.stack_settings = stack_settings
+        self.pulumi_command = pulumi_command
 
 
 class LocalWorkspace(Workspace):
@@ -115,6 +116,7 @@ class LocalWorkspace(Workspace):
         secrets_provider: Optional[str] = None,
         project_settings: Optional[ProjectSettings] = None,
         stack_settings: Optional[Mapping[str, StackSettings]] = None,
+        pulumi_command: Optional[PulumiCommand] = None,
     ):
         self.pulumi_home = pulumi_home
         self.program = program
@@ -124,12 +126,9 @@ class LocalWorkspace(Workspace):
             dir=tempfile.gettempdir(), prefix="automation-"
         )
 
-        pulumi_version = self._get_pulumi_version()
-        opt_out = self._version_check_opt_out()
-        version = _parse_and_validate_pulumi_version(
-            _MINIMUM_VERSION, pulumi_version, opt_out
+        self.pulumi_command = pulumi_command or PulumiCommand(
+            skip_version_check=self._version_check_opt_out()
         )
-        self.__pulumi_version = str(version) if version else None
 
         if project_settings:
             self.save_project_settings(project_settings)
@@ -140,13 +139,10 @@ class LocalWorkspace(Workspace):
     # mypy does not support properties: https://github.com/python/mypy/issues/1362
     @property  # type: ignore
     def pulumi_version(self) -> str:  # type: ignore
-        if self.__pulumi_version:
-            return self.__pulumi_version
+        v = self.pulumi_command.version
+        if v:
+            return str(v)
         raise InvalidVersionError("Could not get Pulumi CLI version")
-
-    @pulumi_version.setter  # type: ignore
-    def pulumi_version(self, v: str):
-        self.__pulumi_version = v
 
     def __repr__(self):
         return (
@@ -219,8 +215,8 @@ class LocalWorkspace(Workspace):
     def add_environments(self, stack_name: str, *environment_names: str) -> None:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.95.
         ver = VersionInfo(3)
-        if self.__pulumi_version is not None:
-            ver = VersionInfo.parse(self.__pulumi_version)
+        if self.pulumi_command.version is not None:
+            ver = self.pulumi_command.version
 
         # 3.95 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.95.0)
         if ver >= VersionInfo(3, 95):
@@ -237,8 +233,8 @@ class LocalWorkspace(Workspace):
     def list_environments(self, stack_name: str) -> List[str]:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.99.
         ver = VersionInfo(3)
-        if self.__pulumi_version is not None:
-            ver = VersionInfo.parse(self.__pulumi_version)
+        if self.pulumi_command.version is not None:
+            ver = self.pulumi_command.version
 
         # 3.99 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.99.0)
         if ver >= VersionInfo(3, 99):
@@ -255,8 +251,8 @@ class LocalWorkspace(Workspace):
     def remove_environment(self, stack_name: str, environment_name: str) -> None:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.95.
         ver = VersionInfo(3)
-        if self.__pulumi_version is not None:
-            ver = VersionInfo.parse(self.__pulumi_version)
+        if self.pulumi_command.version is not None:
+            ver = self.pulumi_command.version
 
         # 3.95 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.95.0)
         if ver >= VersionInfo(3, 95):
@@ -377,8 +373,8 @@ class LocalWorkspace(Workspace):
     def who_am_i(self) -> WhoAmIResult:
         # Assume an old version. Doesn't really matter what this is as long as it's pre-3.58.
         ver = VersionInfo(3)
-        if self.__pulumi_version is not None:
-            ver = VersionInfo.parse(self.__pulumi_version)
+        if self.pulumi_command.version is not None:
+            ver = self.pulumi_command.version
 
         # 3.58 added the --json flag (https://github.com/pulumi/pulumi/releases/tag/v3.58.0)
         if ver >= VersionInfo(3, 58):
@@ -521,13 +517,6 @@ class LocalWorkspace(Workspace):
             or self.env_vars.get(_SKIP_VERSION_CHECK_VAR) is not None
         )
 
-    def _get_pulumi_version(self) -> str:
-        result = self._run_pulumi_cmd_sync(["version"])
-        version_string = result.stdout.strip()
-        if version_string[0] == "v":
-            version_string = version_string[1:]
-        return version_string
-
     def _remote_supported(self) -> bool:
         # See if `--remote` is present in `pulumi preview --help`'s output.
         result = self._run_pulumi_cmd_sync(["preview", "--help"])
@@ -541,7 +530,7 @@ class LocalWorkspace(Workspace):
         if self._remote:
             envs["PULUMI_EXPERIMENTAL"] = "true"
         envs = {**envs, **self.env_vars}
-        return _run_pulumi_cmd(args, self.work_dir, envs, on_output)
+        return self.pulumi_command.run(args, self.work_dir, envs, on_output)
 
     def _remote_args(self) -> List[str]:
         args: List[str] = []
@@ -828,39 +817,6 @@ def get_stack_settings_name(name: str) -> str:
     if len(parts) < 1:
         return name
     return parts[-1]
-
-
-def _parse_and_validate_pulumi_version(
-    min_version: VersionInfo, current_version: str, opt_out: bool
-) -> Optional[VersionInfo]:
-    """
-    Parse and return a version. An error is raised if the version is not
-    valid. If *current_version* is not a valid version but *opt_out* is true,
-    *None* is returned.
-    """
-    try:
-        version: Optional[VersionInfo] = VersionInfo.parse(current_version)
-    except ValueError:
-        version = None
-    if opt_out:
-        return version
-    if version is None:
-        raise InvalidVersionError(
-            f"Could not parse the Pulumi CLI version. This is probably an internal error. "
-            f"If you are sure you have the correct version, set {_SKIP_VERSION_CHECK_VAR}=true."
-        )
-    if min_version.major < version.major:
-        raise InvalidVersionError(
-            f"Major version mismatch. You are using Pulumi CLI version {version} with "
-            f"Automation SDK v{min_version.major}. Please update the SDK."
-        )
-    if min_version.compare(version) == 1:
-        raise InvalidVersionError(
-            f"Minimum version requirement failed. The minimum CLI version requirement is "
-            f"{min_version}, your current CLI version is {version}. "
-            f"Please update the Pulumi CLI."
-        )
-    return version
 
 
 def _load_project_settings(work_dir: str) -> ProjectSettings:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from typing import List, Any, Mapping, MutableMapping, Optional, Callable, Tuple
 import grpc
 
-from ._cmd import CommandResult, _run_pulumi_cmd, OnOutput
+from ._cmd import CommandResult, OnOutput
 from ._config import ConfigValue, ConfigMap
 from .errors import StackAlreadyExistsError, StackNotFoundError
 from .events import OpMap, EngineEvent, SummaryEvent
@@ -808,7 +808,9 @@ class Stack:
         additional_args = self.workspace.serialize_args_for_op(self.name)
         args.extend(additional_args)
         args.extend(["--stack", self.name])
-        result = _run_pulumi_cmd(args, self.workspace.work_dir, envs, on_output)
+        result = self.workspace.pulumi_command.run(
+            args, self.workspace.work_dir, envs, on_output
+        )
         self.workspace.post_command_callback(self.name)
         return result
 

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Callable, List, Mapping, Optional
 
+from ._cmd import PulumiCommand
 from ._config import ConfigMap, ConfigValue
 from ._output import OutputMap
 from ._project_settings import ProjectSettings
@@ -149,6 +150,11 @@ class Workspace(ABC):
     pulumi_version: str
     """
     The version of the underlying Pulumi CLI/Engine.
+    """
+
+    pulumi_command: PulumiCommand
+    """
+    The underlying PulumiCommand instance that is used to execute CLI commands.
     """
 
     @abstractmethod

--- a/sdk/python/lib/test/automation/test_cmd.py
+++ b/sdk/python/lib/test/automation/test_cmd.py
@@ -1,0 +1,123 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+from semver import VersionInfo
+
+from pulumi.automation import InvalidVersionError, PulumiCommand
+from pulumi.automation._cmd import _fixup_path, _parse_and_validate_pulumi_version
+
+
+def test_install_default_root():
+    requested_version = VersionInfo.parse("3.101.0")
+
+    p = PulumiCommand.install(version=requested_version)
+
+    pulumiBin = (
+        Path.home() / ".pulumi" / "versions" / str(requested_version) / "bin" / "pulumi"
+    )
+    try:
+        pulumiBin.stat()
+    except Exception as exception:
+        pytest.fail(f"did not find pulumi binary: {exception}")
+    assert p.version == "3.101.0"
+    out = subprocess.check_output([pulumiBin, "version"])
+    assert out.decode("utf-8").strip() == "v" + str(requested_version)
+
+
+def test_install_twice():
+    with tempfile.TemporaryDirectory(prefix="automation-test-") as root:
+        requested_version = VersionInfo.parse("3.101.0")
+        pulumiBin = Path(root) / "bin" / "pulumi"
+
+        PulumiCommand.install(version=requested_version, root=root)
+        stat1 = pulumiBin.stat()
+
+        PulumiCommand.install(version=requested_version, root=root)
+        stat2 = pulumiBin.stat()
+
+        assert stat1.st_ino == stat2.st_ino
+
+
+def test_incompatible_version():
+    with tempfile.TemporaryDirectory(prefix="automation-test-") as root:
+        installed_version = VersionInfo.parse("3.99.0")
+        PulumiCommand.install(version=installed_version, root=root)
+        requested_version = VersionInfo.parse("3.101.0")
+        # Try getting an incompatible version
+        try:
+            PulumiCommand(root=root, version=requested_version)
+            pytest.fail("expected an exception")
+        except InvalidVersionError as exception:
+            assert "Minimum version requirement failed" in str(exception)
+        # Succeeds when disabling version check
+        PulumiCommand(root=root, version=requested_version, skip_version_check=True)
+
+
+def test_fixup_env():
+    env = {"PATH": "/usr/bin", "SOME_VAR": "some value"}
+    new_env = _fixup_path(env, "/tmp/pulumi-install/bin")
+    if os.name == "nt":
+        assert new_env["PATH"] == "/tmp/pulumi-install/bin;/usr/bin"
+    else:
+        assert new_env["PATH"] == "/tmp/pulumi-install/bin:/usr/bin"
+
+
+MAJOR = "Major version mismatch."
+MINIMAL = "Minimum version requirement failed."
+PARSE = "Could not parse the Pulumi CLI"
+version_tests = [
+    # current_version, expected_error regex, opt_out
+    ("100.0.0", MAJOR, False),
+    ("1.0.0", MINIMAL, False),
+    ("2.22.0", None, False),
+    ("2.1.0", MINIMAL, False),
+    ("2.21.2", None, False),
+    ("2.21.1", None, False),
+    ("2.21.0", MINIMAL, False),
+    # Note that prerelease < release so this case will error
+    ("2.21.1-alpha.1234", MINIMAL, False),
+    # Test opting out of version check
+    ("2.20.0", None, True),
+    ("2.22.0", None, True),
+    # Test invalid version
+    ("invalid", PARSE, False),
+    ("invalid", None, True),
+]
+test_min_version = VersionInfo.parse("2.21.1")
+
+
+class TestParseAndValidatePulumiVersion(unittest.TestCase):
+    def test_validate_pulumi_version(self):
+        for current_version, expected_error, opt_out in version_tests:
+            with self.subTest():
+                if expected_error:
+                    with self.assertRaisesRegex(
+                        InvalidVersionError,
+                        expected_error,
+                        msg=f"min_version:{test_min_version}, current_version:{current_version}",
+                    ):
+                        _parse_and_validate_pulumi_version(
+                            test_min_version, current_version, opt_out
+                        )
+                else:
+                    _parse_and_validate_pulumi_version(
+                        test_min_version, current_version, opt_out
+                    )

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -15,7 +15,6 @@
 import json
 import os
 import unittest
-from semver import VersionInfo
 from typing import List, Optional
 
 import pytest
@@ -28,46 +27,22 @@ from pulumi.automation import (
     ConfigMap,
     ConfigValue,
     EngineEvent,
-    InvalidVersionError,
     LocalWorkspace,
     LocalWorkspaceOptions,
     OpType,
     PluginInfo,
     ProjectSettings,
+    PulumiCommand,
     StackSummary,
     Stack,
     StackSettings,
     StackAlreadyExistsError,
     fully_qualified_stack_name,
 )
-from pulumi.automation._local_workspace import _parse_and_validate_pulumi_version
 
 from .test_utils import get_test_org, get_test_suffix, stack_namer
 
 extensions = ["json", "yaml", "yml"]
-
-MAJOR = "Major version mismatch."
-MINIMAL = "Minimum version requirement failed."
-PARSE = "Could not parse the Pulumi CLI"
-version_tests = [
-    # current_version, expected_error regex, opt_out
-    ("100.0.0", MAJOR, False),
-    ("1.0.0", MINIMAL, False),
-    ("2.22.0", None, False),
-    ("2.1.0", MINIMAL, False),
-    ("2.21.2", None, False),
-    ("2.21.1", None, False),
-    ("2.21.0", MINIMAL, False),
-    # Note that prerelease < release so this case will error
-    ("2.21.1-alpha.1234", MINIMAL, False),
-    # Test opting out of version check
-    ("2.20.0", None, True),
-    ("2.22.0", None, True),
-    # Test invalid version
-    ("invalid", PARSE, False),
-    ("invalid", None, True),
-]
-test_min_version = VersionInfo.parse("2.21.1")
 
 def get_test_path(*paths):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), *paths)
@@ -673,19 +648,13 @@ class TestLocalWorkspace(unittest.TestCase):
         ws = LocalWorkspace()
         self.assertIsNotNone(ws.pulumi_version)
         self.assertRegex(ws.pulumi_version, r"(\d+\.)(\d+\.)(\d+)(-.*)?")
-
-    def test_validate_pulumi_version(self):
-        for current_version, expected_error, opt_out in version_tests:
-            with self.subTest():
-                if expected_error:
-                    with self.assertRaisesRegex(
-                            InvalidVersionError,
-                            expected_error,
-                            msg=f"min_version:{test_min_version}, current_version:{current_version}"
-                    ):
-                        _parse_and_validate_pulumi_version(test_min_version, current_version, opt_out)
-                else:
-                    _parse_and_validate_pulumi_version(test_min_version, current_version, opt_out)
+    
+    def test_pulumi_command(self):
+        p = PulumiCommand()
+        ws = LocalWorkspace(pulumi_command=p)
+        self.assertIsNotNone(ws.pulumi_version)
+        self.assertRegex(ws.pulumi_version, r"(\d+\.)(\d+\.)(\d+)(-.*)?")
+        self.assertEqual(p.version, ws.pulumi_command.version)
 
     def test_project_settings_respected(self):
         project_name = "correct_project"


### PR DESCRIPTION

# Description

Provide a way for the Automation API to install the Pulumi CLI so that Automation API can be used in a more standalone manner.

https://github.com/pulumi/pulumi/issues/14987

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
