### PR TITLE
Don't omit an empty detailedDiff

### DIFF
--- a/changelog/pending/20240122--sdk-go--removes-omitempty-from-stepeventmetadata-detaileddiff.yaml
+++ b/changelog/pending/20240122--sdk-go--removes-omitempty-from-stepeventmetadata-detaileddiff.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Removes `omitempty` from StepEventMetadata.DetailedDiff

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -139,7 +139,7 @@ type StepEventMetadata struct {
 	// Keys that changed with this step.
 	Diffs []string `json:"diffs,omitempty"`
 	// The diff for this step as a list of property paths and difference types.
-	DetailedDiff map[string]PropertyDiff `json:"detailedDiff,omitempty"`
+	DetailedDiff map[string]PropertyDiff `json:"detailedDiff"`
 	// Logical is set if the step is a logical operation in the program.
 	Logical bool `json:"logical,omitempty"`
 	// Provider actually performing the step.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When the detailedDiff object is empty, i.e. `{}`, it is dropped from the serialized json due to the `omitempty`. When it is rehydrated on the service, it is rehydrated as `nil` because it is not present in the json object. That causes [this line](https://github.com/pulumi/pulumi/blob/516979770f11d3a426239429731cf9f327c38836/pkg/backend/display/rows.go#L442) to be passed through and results in an input diff, which leads to the output we see in the cloud of an import showing a lot of changed properties when it should not (See issue for screenshots).

Fixes https://github.com/pulumi/pulumi-cloud-requests/issues/339

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
