### PR TITLE
Replace a type used by the service

### DIFF
--- a/changelog/pending/20240123--sdk-go--replace-a-deleted-type-used-by-pulumi-cloud-code.yaml
+++ b/changelog/pending/20240123--sdk-go--replace-a-deleted-type-used-by-pulumi-cloud-code.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Replace a deleted type used by Pulumi Cloud code.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1036,8 +1036,8 @@ func (b *localBackend) apply(
 		_, changes, updateErr = engine.Refresh(update, engineCtx, op.Opts.Engine, opts.DryRun)
 	case apitype.DestroyUpdate:
 		_, changes, updateErr = engine.Destroy(update, engineCtx, op.Opts.Engine, opts.DryRun)
-	case apitype.StackImportUpdate:
-		contract.Failf("unexpected stack import event")
+	case apitype.StackImportUpdate, apitype.RenameUpdate:
+		contract.Failf("unexpected %s event", kind)
 	default:
 		contract.Failf("Unrecognized update kind: %s", kind)
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1358,8 +1358,8 @@ func (b *cloudBackend) runEngineAction(
 		_, changes, updateErr = engine.Refresh(u, engineCtx, op.Opts.Engine, dryRun)
 	case apitype.DestroyUpdate:
 		_, changes, updateErr = engine.Destroy(u, engineCtx, op.Opts.Engine, dryRun)
-	case apitype.StackImportUpdate:
-		contract.Failf("unexpected stack import event")
+	case apitype.StackImportUpdate, apitype.RenameUpdate:
+		contract.Failf("unexpected %s event", kind)
 	default:
 		contract.Failf("Unrecognized update kind: %s", kind)
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -642,8 +642,8 @@ func (pc *Client) CreateUpdate(
 		endpoint = "refresh"
 	case apitype.DestroyUpdate:
 		endpoint = "destroy"
-	case apitype.StackImportUpdate:
-		contract.Failf("Stack import updates are not supported")
+	case apitype.StackImportUpdate, apitype.RenameUpdate:
+		contract.Failf("%s updates are not supported", kind)
 	default:
 		contract.Failf("Unknown kind: %s", kind)
 	}

--- a/sdk/go/common/apitype/history.go
+++ b/sdk/go/common/apitype/history.go
@@ -29,6 +29,9 @@ const (
 	PreviewUpdate UpdateKind = "preview"
 	// RefreshUpdate is an update that came from a refresh operation.
 	RefreshUpdate UpdateKind = "refresh"
+	// RenameUpdate is an update that changes the stack name or project name of a Pulumi program.
+	// NOTE: Do not remove this type - it is used by Pulumi Cloud code.
+	RenameUpdate UpdateKind = "rename"
 	// DestroyUpdate is an update which removes all resources.
 	DestroyUpdate UpdateKind = "destroy"
 	// StackImportUpdate is an update that entails importing a raw checkpoint file.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

A type that is used by the Pulumi Cloud code was removed in [#15028](https://github.com/pulumi/pulumi/pull/15028/files#diff-52b25675ac0d98614d062fc1d1c9e60759f905cf7c60a9339402a62c23cc2c55L32-L33) - this PR replaces it.

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
