### PR TITLE
Disable `--rerun-fails` in tests

### DIFF
--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args


### PR DESCRIPTION
When `--rerun-fails` is specified and a test is re-run, the produced coverage data only contains the coverage from the failed but re-executed sub-tests. See https://github.com/gotestyourself/gotestsum/issues/274

This change sees how we fare with this disabled as we've recently done some work to address test flakiness. We'll be relying on the much less granular `./scripts/retry` for retries, which doesn't have the coverage problem. The downside is it will re-run all the tests.