### PR TITLE
[ci] Install `setuptools` in virtual environment

### DIFF
--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -65,7 +65,7 @@ jobs:
           rm setup.py.bak
           python3 -m venv venv
           source venv/bin/activate
-          python -m pip install wheel
+          python -m pip install wheel setuptools
           python setup.py build bdist_wheel --python-tag py3
       - name: Upload pulumi.whl
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
In preparation for supporting Python 3.12...

As of Python 3.12, `setuptools` is no longer installed by default into a virtual environment created with `python -m venv` (https://github.com/python/cpython/issues/95299). It must be explicitly installed via `python -m pip install setuptools`.