### PR TITLE
Upgrade pylint to 3.0.3

### DIFF
--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -90,7 +90,9 @@ disable=raw-checker-failed,
         unsubscriptable-object,
         line-too-long,
         too-many-lines,
-        cyclic-import
+        cyclic-import,
+        duplicate-code,
+        broad-exception-raised
 
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -503,4 +505,4 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -8,7 +8,7 @@ semver~=2.13
 pyyaml~=6.0
 
 # Dev packages only needed during development.
-pylint==2.15.5
+pylint==3.0.3
 mypy==0.991
 pytest
 pytest-timeout


### PR DESCRIPTION
In preparation for supporting Python 3.12...

We need to be running a more recent version of pylint that runs on Python 3.12 (otherwise it errors). This required disabling some new lints that were resulting in new lint errors and fixing how `overgeneral-exceptions` is specified.