### PR TITLE
[sdk/python] Fix test to install local Pulumi SDK

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -137,6 +137,13 @@ func TestDeterminePulumiPackages(t *testing.T) {
 		cwd := t.TempDir()
 		_, err := runPythonCommand(context.Background(), "", cwd, "-m", "venv", "venv")
 		assert.NoError(t, err)
+
+		// Install the local Pulumi SDK into the virtual environment.
+		sdkDir, err := filepath.Abs(filepath.Join("..", "..", "env", "src"))
+		assert.NoError(t, err)
+		_, err = runPythonCommand(context.Background(), "venv", cwd, "-m", "pip", "install", "-e", sdkDir)
+		assert.NoError(t, err)
+
 		_, err = runPythonCommand(context.Background(), "venv", cwd, "-m", "pip", "install", "pulumi-random")
 		assert.NoError(t, err)
 		_, err = runPythonCommand(context.Background(), "venv", cwd, "-m", "pip", "install", "pip-install-test")


### PR DESCRIPTION
In preparation for supporting Python 3.12...

The test is installing `pulumi-random` which currently depends on `pulumi`, which will fail on Python 3.12 because the currently released version of `pulumi` is pinned to a version of `grpcio` that doesn't work on Python 3.12.

Instead of depending on the public `pulumi` package, install the locally built Python SDK. Then install `pulumi-random`. That way, it'll be using a version of `grpcio` that works with Python 3.12.