### PR TITLE
ProgramTest: Python: Use correct venv path for projects with `main` option

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2198,6 +2198,10 @@ func (pt *ProgramTester) preparePythonProject(projinfo *engine.Projinfo) error {
 		}
 	} else {
 		venvPath := "venv"
+		if cwd != projinfo.Root {
+			venvPath = filepath.Join(cwd, "venv")
+		}
+
 		if pt.opts.GetUseSharedVirtualEnv() {
 			requirementsPath := filepath.Join(cwd, "requirements.txt")
 			requirementsmd5, err := hashFile(requirementsPath)


### PR DESCRIPTION
In preparation for supporting Python 3.12...

I'm planning to remove `pulumi` from `requirements.txt` in a bunch of the integration tests (at least temporarily) because the current published version of `pulumi` can't be installed on Python 3.12 due to its dependency on `grpcio` which is broken on Python 3.12, and the tests specify a dependency on the locally built Pulumi Python SDK via `ProgramTestOptions.Dependencies`.

However, after removing `pulumi` from `requirements.txt` for `TestPythonStackTruncate/main_dir_specified`, the test started to fail due to a missing `pulumi` package. It shouldn't fail because the test additionally requires the locally built SDK via `ProgramTestOptions.Dependencies`.

The reason for the failure is because this test had a `main` specified in the project to a sub directory (`bar/`). Because of this, the venv created by `ProgramTest` is inside the sub directory. It would install the `requirements.txt` in that venv, and then install any `ProgramTestOptions.Dependencies` deps. Then it would record the `virtualenv` option in the project as just `venv`. But this option is relative to the project file and a `venv` directory next to the project doesn't exist -- it exists in the sub directory.

So when the first `pulumi` operation was run, `pulumi` would see that the `venv` directory next to the project doesn't exist, and create it, installing the dependencies from `requirements.txt` in it and carrying on.

With the change to remove `pulumi` from `requirements.txt` for this test, this would no longer work. When `pulumi` created the venv, it'd install an empty `requirements.txt` in the venv it created. And since it didn't have a `pulumi` package, it fails with a missing module.

This change fixes `ProgramTest` to record the correct path to the venv in the project file. In most cases, this continues to be just `venv`. But if `main` is specified in the project such that the "cwd" path is different from the project file root, then that path is used for the venv. This way, the CLI will use the correct venv that includes dependencies from `ProgramTestOptions.Dependencies`.
