### PR TITLE
generate unique stack names for tests

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,6 +11,7 @@ replace (
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/protobuf v1.5.3
+	github.com/google/uuid v1.3.0
 	github.com/grapl-security/pulumi-hcp/sdk v0.1.14
 	github.com/hexops/autogold v1.3.0
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
@@ -96,7 +97,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect

--- a/tests/integration/backend/filestate/backend_azure_test.go
+++ b/tests/integration/backend/filestate/backend_azure_test.go
@@ -5,29 +5,32 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func loginAndCreateStack(t *testing.T, cloudURL string) {
 	t.Helper()
+
+	stackName := uuid.New().String()
 	out, err := exec.Command("pulumi", "login", cloudURL).CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "test")
-	out, err = exec.Command("pulumi", "stack", "init", "testing").CombinedOutput()
+	out, err = exec.Command("pulumi", "stack", "init", stackName).CombinedOutput()
 	require.NoError(t, err, string(out))
 	defer func() {
-		out, err := exec.Command("pulumi", "stack", "rm", "--yes", "-s", "testing").CombinedOutput()
+		out, err := exec.Command("pulumi", "stack", "rm", "--yes", "-s", stackName).CombinedOutput()
 		assert.NoError(t, err, string(out))
 	}()
 
-	out, err = exec.Command("pulumi", "stack", "select", "testing").CombinedOutput()
+	out, err = exec.Command("pulumi", "stack", "select", stackName).CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	out, err = exec.Command("pulumi", "stack", "ls").CombinedOutput()
 	assert.NoError(t, err, string(out))
-	assert.Contains(t, string(out), "testing*")
+	assert.Contains(t, string(out), stackName+"*")
 }
 
 //nolint:paralleltest // this test sets the global login state


### PR DESCRIPTION
Tests can run in parallel, e.g. on different PRs/same tests on different platforms, and if a single test gets killed by the CI runner without cleaning up all future tests will fail if the stack name is not unique.  Make sure the stack name is unique to avoid these failures.

I a CI failure that's `error: stack 'organization/project/testing' already exists`.  This PR should hopefully fix it.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
