### PR TITLE
upgrade grpc-js to latest release

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -9,7 +9,7 @@
         "directory": "sdk/nodejs"
     },
     "dependencies": {
-        "@grpc/grpc-js": "1.9.6",
+        "@grpc/grpc-js": "^1.9.14",
         "@logdna/tail-file": "^2.0.6",
         "@opentelemetry/api": "^1.2.0",
         "@opentelemetry/exporter-zipkin": "^1.6.0",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -285,10 +285,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@grpc/grpc-js@1.9.6":
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.6.tgz#c64a2db3cb1c73939d3d666fb1339775813c1cd8"
-  integrity sha512-yq3qTy23u++8zdvf+h4mz4ohDFi681JAkMZZPTKh8zmUVh0AKLisFlgxcn22FMNowXz15oJ6pqgwT7DJ+PdJvg==
+"@grpc/grpc-js@^1.9.14":
+  version "1.9.14"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.14.tgz#236378822876cbf7903f9d61a0330410e8dcc5a1"
+  integrity sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==
   dependencies:
     "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"


### PR DESCRIPTION
We've previously pinned this to 1.9.6, because there was a bug that caused an automation API hang in 1.9.7.  There's been a few patch releases since, so let's try to upgrade again, as this could potentially fix some flaky
tests (https://github.com/pulumi/pulumi/issues/14841).

The PR doing the downgrade originally also introduced a test, so as long as that test is passing upgrading should be safe.

Fixes https://github.com/pulumi/pulumi/issues/14841