### PR TITLE
Test that an empty parent URN in an alias is treated as the default parent

### DIFF
--- a/changelog/pending/20240124--engine--engine-will-now-error-if-aliases-request-a-parent-with-no-urn.yaml
+++ b/changelog/pending/20240124--engine--engine-will-now-error-if-aliases-request-a-parent-with-no-urn.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine will now error if aliases request a parent with no URN.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -2301,7 +2301,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 					var err error
 					urn, _, _, err := monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{
 						Parent:  parent,
-						Aliases: options.Aliases,
+						Aliases: aliasesFromAliases(options.Aliases),
 						Protect: options.Protect,
 					})
 					assert.NoError(t, err)
@@ -2451,7 +2451,7 @@ func TestSingleComponentDefaultProviderLifecycle(t *testing.T) {
 			) (plugin.ConstructResult, error) {
 				urn, _, _, err := monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{
 					Parent:  parent,
-					Aliases: options.Aliases,
+					Aliases: aliasesFromAliases(options.Aliases),
 					Protect: options.Protect,
 				})
 				assert.NoError(t, err)
@@ -2633,7 +2633,7 @@ func TestSingleComponentGetResourceDefaultProviderLifecycle(t *testing.T) {
 				urn, _, _, err := monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{
 					Parent:       parent,
 					Protect:      options.Protect,
-					Aliases:      options.Aliases,
+					Aliases:      aliasesFromAliases(options.Aliases),
 					Dependencies: options.Dependencies,
 				})
 				assert.NoError(t, err)
@@ -2785,7 +2785,7 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 				var err error
 				urn, _, _, err = monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{
 					Parent:  parent,
-					Aliases: options.Aliases,
+					Aliases: aliasesFromAliases(options.Aliases),
 					Protect: options.Protect,
 				})
 				assert.NoError(t, err)
@@ -2878,7 +2878,7 @@ func TestSingleComponentMethodResourceDefaultProviderLifecycle(t *testing.T) {
 				var err error
 				urn, _, _, err = monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{
 					Parent:  parent,
-					Aliases: options.Aliases,
+					Aliases: aliasesFromAliases(options.Aliases),
 					Protect: options.Protect,
 				})
 				assert.NoError(t, err)
@@ -4589,7 +4589,9 @@ func TestBadResourceOptionURNs(t *testing.T) {
 		{
 			name: "malformed alias urn",
 			opts: deploytest.ResourceOptions{
-				Aliases: []resource.Alias{{URN: "very-bad urn"}},
+				Aliases: []*pulumirpc.Alias{
+					makeUrnAlias("very-bad urn"),
+				},
 			},
 			assertFn: func(err error) {
 				assert.ErrorContains(t, err, "invalid alias URN: invalid URN \"very-bad urn\"")
@@ -4598,7 +4600,9 @@ func TestBadResourceOptionURNs(t *testing.T) {
 		{
 			name: "malformed alias parent urn",
 			opts: deploytest.ResourceOptions{
-				Aliases: []resource.Alias{{Parent: "very-bad urn"}},
+				Aliases: []*pulumirpc.Alias{
+					makeSpecAliasWithParent("", "", "", "", "very-bad urn"),
+				},
 			},
 			assertFn: func(err error) {
 				assert.ErrorContains(t, err, "invalid parent alias URN: invalid URN \"very-bad urn\"")

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -133,7 +133,7 @@ type ResourceOptions struct {
 	IgnoreChanges           []string
 	ReplaceOnChanges        []string
 	AliasURNs               []resource.URN
-	Aliases                 []resource.Alias
+	Aliases                 []*pulumirpc.Alias
 	ImportID                resource.ID
 	CustomTimeouts          *resource.CustomTimeouts
 	RetainOnDelete          bool
@@ -181,28 +181,6 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 	aliasStrings := []string{}
 	for _, a := range opts.AliasURNs {
 		aliasStrings = append(aliasStrings, string(a))
-	}
-
-	aliasObjects := []*pulumirpc.Alias{}
-	for _, a := range opts.Aliases {
-		var obj *pulumirpc.Alias
-		if a.URN == "" {
-			alias := &pulumirpc.Alias_Spec{
-				Name:    a.Name,
-				Type:    a.Type,
-				Project: a.Project,
-				Stack:   a.Stack,
-			}
-			if a.NoParent {
-				alias.Parent = &pulumirpc.Alias_Spec_NoParent{NoParent: a.NoParent}
-			} else if a.Parent != "" {
-				alias.Parent = &pulumirpc.Alias_Spec_ParentUrn{ParentUrn: string(a.Parent)}
-			}
-			obj = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Spec_{Spec: alias}}
-		} else {
-			obj = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Urn{Urn: string(a.URN)}}
-		}
-		aliasObjects = append(aliasObjects, obj)
 	}
 
 	inputDeps := make(map[string]*pulumirpc.RegisterResourceRequest_PropertyDependencies)
@@ -273,7 +251,7 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 		PluginChecksums:            opts.PluginChecksums,
 		RetainOnDelete:             opts.RetainOnDelete,
 		AdditionalSecretOutputs:    additionalSecretOutputs,
-		Aliases:                    aliasObjects,
+		Aliases:                    opts.Aliases,
 		DeletedWith:                string(opts.DeletedWith),
 		AliasSpecs:                 opts.AliasSpecs,
 		SourcePosition:             sourcePosition,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Title sums it up. Some SDKs are sending `parent=""` rather than no parent at all to specify to the engine to use the default parent. Technically this isn't the intention of the protocol but given the SDKs are out we now need to support it. I've added a test to check this works and left a comment that it would be a nice tidy up to make in V4.

I've also changed the deploy tests to directly use the rpc protocol rather than `resource.Alias` this lets us write tests like "send an empty parent URN" which `resource.Alias` wasn't capable of expressing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
