### PR TITLE
Fix a datarace

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -870,11 +870,12 @@ func (pkg *Package) TokenToModule(tok string) string {
 	case "providers":
 		return ""
 	default:
-		if pkg.moduleFormat == nil {
-			pkg.moduleFormat = defaultModuleFormat
+		format := pkg.moduleFormat
+		if format == nil {
+			format = defaultModuleFormat
 		}
 
-		matches := pkg.moduleFormat.FindStringSubmatch(components[1])
+		matches := format.FindStringSubmatch(components[1])
 		if len(matches) < 2 || strings.HasPrefix(matches[1], "index") {
 			return ""
 		}


### PR DESCRIPTION
Seen while running tests for another PR: https://github.com/pulumi/pulumi/actions/runs/7639934341/job/20814238592?pr=15232

```
WARNING: DATA RACE
Read at 0x00c0009e8480 by goroutine 46:
  github.com/pulumi/pulumi/pkg/v3/codegen/schema.(*Package).TokenToModule()
      /home/runner/work/pulumi/pulumi/pkg/codegen/schema/schema.go:873 +0x13e
  github.com/pulumi/pulumi/pkg/v3/codegen/schema.packageDefRef.TokenToModule()
      /home/runner/work/pulumi/pulumi/pkg/codegen/schema/package_reference.go:171 +0x84
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.canonicalizeToken()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:181 +0x10d
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*packageSchema).initResourceMap()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:111 +0x124
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*packageSchema).LookupResource()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:84 +0xf7
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindResourceTypes()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource.go:197 +0xeb8
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindResource()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource.go:37 +0x79
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindNode()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_nodes.go:62 +0x819
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.BindProgram()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder.go:219 +0x1a31
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.TestBindResourceOptions.func1()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource_test.go:104 +0x6f8
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44

Previous write at 0x00c0009e8480 by goroutine 42:
  github.com/pulumi/pulumi/pkg/v3/codegen/schema.(*Package).TokenToModule()
      /home/runner/work/pulumi/pulumi/pkg/codegen/schema/schema.go:874 +0x17c
  github.com/pulumi/pulumi/pkg/v3/codegen/schema.packageDefRef.TokenToModule()
      /home/runner/work/pulumi/pulumi/pkg/codegen/schema/package_reference.go:171 +0x84
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.canonicalizeToken()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:181 +0x10d
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*packageSchema).initResourceMap()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:111 +0x124
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*packageSchema).LookupResource()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_schema.go:84 +0xf7
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindResourceTypes()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource.go:197 +0xeb8
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindResource()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource.go:37 +0x79
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.(*binder).bindNode()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_nodes.go:62 +0x819
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.BindProgram()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder.go:219 +0x1a31
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.TestBindResourceOptions.func1()
      /home/runner/work/pulumi/pulumi/pkg/codegen/pcl/binder_resource_test.go:104 +0x6f8
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44
```