### PR TITLE
Revert "Disable `--rerun-fails` in tests"

### DIFF
--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args


### PR DESCRIPTION
Reverts pulumi/pulumi#15217.  Unfortunately there seem to be too many flakes left that we should address before doing this.  