### PR TITLE
[program-gen/ts] Fixes generated expression for filebase64 function to use fs.readFileSync directly

### DIFF
--- a/changelog/pending/20240125--programgen-nodejs--fixes-generated-expression-for-filebase64-function-to-use-fs-readfilesync-directly-with-base64-encoding-option.yaml
+++ b/changelog/pending/20240125--programgen-nodejs--fixes-generated-expression-for-filebase64-function-to-use-fs-readfilesync-directly-with-base64-encoding-option.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fixes generated expression for filebase64 function to use fs.readFileSync directly with base64 encoding option

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -408,7 +408,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "remoteAsset":
 		g.Fgenf(w, "new pulumi.asset.RemoteAsset(%.v)", expr.Args[0])
 	case "filebase64":
-		g.Fgenf(w, "Buffer.from(fs.readFileSync(%v, 'binary')).toString('base64')", expr.Args[0])
+		g.Fgenf(w, "fs.readFileSync(%v, { encoding: \"base64\" })", expr.Args[0])
 	case "filebase64sha256":
 		// Assuming the existence of the following helper method
 		g.Fgenf(w, "computeFilebase64sha256(%v)", expr.Args[0])

--- a/pkg/codegen/testing/test/testdata/functions-pp/nodejs/functions.ts
+++ b/pkg/codegen/testing/test/testdata/functions-pp/nodejs/functions.ts
@@ -33,7 +33,7 @@ const fileMimeType = mimeType("./base64.txt");
 // using the filebase64 function
 const first = new aws.s3.BucketObject("first", {
     bucket: bucket.id,
-    source: new pulumi.asset.StringAsset(Buffer.from(fs.readFileSync("./base64.txt", 'binary')).toString('base64')),
+    source: new pulumi.asset.StringAsset(fs.readFileSync("./base64.txt", { encoding: "base64" })),
     contentType: fileMimeType,
     tags: {
         stack: currentStack,


### PR DESCRIPTION
### Description

Fixes #15246 by correcting the generated expression for the `filebase64` function

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
-  [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
