### PR TITLE
Unskip tests

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -93,7 +93,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 func TestLanguage(t *testing.T) {
 	t.Parallel()
-	t.Skip("Temporarily skipping test to unblock CI - pulumi/pulumi#15250")
 
 	engineAddress, engine := runTestingHost(t)
 

--- a/tests/integration/construct_component_configure_provider/python/requirements.txt
+++ b/tests/integration/construct_component_configure_provider/python/requirements.txt
@@ -1,1 +1,9 @@
 pulumi_tls==4.10.0
+
+# TODO[pulumi/pulumi#12414]: Remove our implicit dependency on setuptools.
+# Python 3.12 doesn't include setuptools in virtual environments created by
+# `python -m venv`, so we need to add it to the requirements file here.
+# Otherwise, on Python 3.12, when running this test we'll get an error from
+# the generated example library's _utilities.py file:
+#     ModuleNotFoundError: No module named 'pkg_resources'
+setuptools

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -223,7 +223,6 @@ func optsForConstructPython(
 
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
 	t.Parallel()
-	t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
 
 	const testDir = "construct_component_configure_provider"
 	runComponentSetup(t, testDir)
@@ -243,7 +242,6 @@ func TestConstructComponentConfigureProviderPython(t *testing.T) {
 // Regresses https://github.com/pulumi/pulumi/issues/6471
 func TestAutomaticVenvCreation(t *testing.T) {
 	t.Parallel()
-	t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
 
 	// Do not use integration.ProgramTest to avoid automatic venv
 	// handling by test harness; we actually are testing venv

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -39,10 +39,6 @@ func TestLanguageNewSmoke(t *testing.T) {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest
 
-			if runtime == "python" {
-				t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
-			}
-
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)
 
@@ -102,10 +98,6 @@ func TestLanguageConvertSmoke(t *testing.T) {
 		runtime := runtime
 		t.Run(runtime, func(t *testing.T) {
 			t.Parallel()
-
-			if runtime == "python" {
-				t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
-			}
 
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)
@@ -169,10 +161,6 @@ func TestLanguageConvertComponentSmoke(t *testing.T) {
 			}
 			if runtime == "java" {
 				t.Skip("java doesn't support components")
-			}
-
-			if runtime == "python" {
-				t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
 			}
 
 			e := ptesting.NewEnvironment(t)
@@ -314,10 +302,6 @@ func TestLanguageImportSmoke(t *testing.T) {
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest
-
-			if runtime == "python" {
-				t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
-			}
 
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)


### PR DESCRIPTION
- Unskip Python tests that needed to be skipped until v3.103.0 of the `pulumi` PyPi package was released with support for Python 3.12.
- Unskip Node.js test that needed to be skipped until v3.103.1 of the `@pulumi/pulumi` NPM package was published with a fix for the semver type issue.

Fixes #15195