### PR TITLE
debug flake in venv creation tests

### DIFF
--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -19,6 +19,7 @@ package ints
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -254,6 +255,17 @@ func TestAutomaticVenvCreation(t *testing.T) {
 		defer func() {
 			if !t.Failed() {
 				e.DeleteEnvironment()
+			} else {
+				if strings.HasSuffix(dir, "-with-main") {
+					stdOut, stdErr := e.RunCommand("ls", "-l", path.Join(e.RootPath, "infra"))
+					t.Logf("\n%s\n%s\n", stdOut, stdErr)
+					reqs, err := os.ReadFile(filepath.Join(e.RootPath, "infra", "requirements.txt"))
+					if err != nil {
+						t.Logf("failed to read requirements.txt: %v", err)
+					} else {
+						t.Logf("requirements.txt:\n%s\n", string(reqs))
+					}
+				}
 			}
 		}()
 

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -244,7 +244,6 @@ func TestConstructComponentConfigureProviderPython(t *testing.T) {
 // Regresses https://github.com/pulumi/pulumi/issues/6471
 func TestAutomaticVenvCreation(t *testing.T) {
 	t.Parallel()
-	t.Skip("Temporarily skipping test - pulumi/pulumi#15195")
 
 	// Do not use integration.ProgramTest to avoid automatic venv
 	// handling by test harness; we actually are testing venv


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
