### PR TITLE
[sdkgen/python] Use `importlib.metadata` instead of `pkg_resources`

### DIFF
--- a/changelog/pending/20230920--programgen--use-importlib-metadata-instead-of-pkg_resources.yaml
+++ b/changelog/pending/20230920--programgen--use-importlib-metadata-instead-of-pkg_resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Use importlib.metadata instead of pkg_resources

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3210,6 +3210,7 @@ func calculateDeps(requires map[string]string) ([][2]string, error) {
 	deps := []string{
 		"semver>=2.8.1",
 		"parver>=0.2.1",
+		"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"",
 	}
 	for dep := range requires {
 		deps = append(deps, dep)

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -292,6 +292,7 @@ func TestCalculateDeps(t *testing.T) {
 			// We expect three alphabetized deps,
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
+			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ""},
 			{"semver>=2.8.1"},
@@ -304,6 +305,7 @@ func TestCalculateDeps(t *testing.T) {
 		},
 		expected: [][2]string{
 			{"foobar", "7.10.8"},
+			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ">=3.0.0,<4.0.0"},
 			{"semver>=2.8.1"},
@@ -317,6 +319,7 @@ func TestCalculateDeps(t *testing.T) {
 		expected: [][2]string{
 			// We expect three alphabetized deps,
 			// with semver and parver formatted differently from Pulumi.
+			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ">=3.0.0,<3.50.0"},
 			{"semver>=2.8.1"},

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -289,7 +289,7 @@ func TestCalculateDeps(t *testing.T) {
 		// Test 1: Give no explicit deps.
 		inputDeps: map[string]string{},
 		expected: [][2]string{
-			// We expect three alphabetized deps,
+			// We expect four alphabetized deps,
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
 			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -4,7 +4,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -14,6 +13,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -68,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/assets-and-archives/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/assets-and-archives/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/assets-and-archives/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
@@ -37,6 +37,7 @@ setup(name='pulumi_azure_native',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_foo_bar',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-kubernetes>=3.0.0,<4.0.0',

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-google-native>=0.20.0,<1.0.0',

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_registrygeoreplication',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-azure-native>=1.0.0,<2.0.0',

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_repro',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_metaprovider',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
@@ -30,6 +30,7 @@ setup(name='foo_bar',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_myedgeorder',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_foobar',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_xyz',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.0.0,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_configstation',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_providerType',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_mongodbatlas',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_my8110',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-12980/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12980/python/setup.py
@@ -31,6 +31,7 @@ setup(name='pulumi_myPkg',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-14539/python/pyproject.toml
+++ b/pkg/codegen/testing/test/testdata/regress-py-14539/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_gcp"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
+  dependencies = ["importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", "parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
   requires-python = ">=3.7"
   version = "0.0.0"

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_aws',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -30,6 +30,7 @@ setup(name='custom_py_package',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python-extras/tests/test_codegen.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python-extras/tests/test_codegen.py
@@ -1,0 +1,23 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi_example import _utilities
+
+
+def test_get_version():
+    # Users should not be calling this directly.
+    # However, this tests that indeed the internal code we have to
+    # get the version of the package is working as expected.
+    assert _utilities.get_version() == "1.2.3"

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python-extras/tests/test_codegen.py
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python-extras/tests/test_codegen.py
@@ -1,0 +1,23 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi_example import _utilities
+
+
+def test_get_version():
+    # Users should not be calling this directly.
+    # However, this tests that indeed the internal code we have to
+    # get the version of the package is working as expected.
+    assert _utilities.get_version() == "0.0.1"

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/pulumi-plugin.json
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "example"
+  "name": "example",
+  "version": "0.0.1"
 }

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", "parver>=0.2.1", "pulumi", "semver>=2.8.1"]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.7"

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.7"
-  version = "0.0.0"
+  version = "0.0.1"
   [project.license]
     text = "MIT"
   [project.urls]

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/schema.json
@@ -17,7 +17,8 @@
     "python": {
       "pyproject": {
         "enabled": true
-      }
+      },
+      "respectSchemaVersion": true
     }
   }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/unions-inline/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/unions-inline/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/unions-inline/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/unions-inline/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/pulumi_example/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/setup.py
@@ -30,6 +30,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -8,7 +8,6 @@ import importlib.util
 import inspect
 import json
 import os
-import pkg_resources
 import sys
 import typing
 
@@ -18,6 +17,11 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +76,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = pkg_resources.require(root_package)[0].version
+    pep440_version_string = metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/urn-id-properties/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/urn-id-properties/python/setup.py
@@ -31,6 +31,7 @@ setup(name='pulumi_urnid',
           ]
       },
       install_requires=[
+          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'


### PR DESCRIPTION
This addresses two issues:

1. `pkg_resource` is deprecated in favor of `importlib.resources` and `importlib.metadata` (https://setuptools.pypa.io/en/latest/pkg_resources.html)

2. Generated provider SDKs don't indicate that they have a dependency on `setuptools` (which includes `pkg_resources`), which can cause problems when installing the package in environments that don't have `setuptools` installed. That's not often common in Pulumi projects, as the virtual environment created by the CLI will include `setuptools`, however, if creating the virtual environment manually with `python -m venv`, `setuptools` is no longer included in the created virtual environment as of Python 3.12.

Fixes #12414

Based on #14002, thanks @edgarrmondragon!