### PR TITLE
Rename self-managed to diy-backend

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -336,7 +336,7 @@ func newLocalBackend(
 		fmt.Fprintf(&msg, "  - %s\n", ref.Name())
 	}
 	msg.WriteString("Please run 'pulumi state upgrade' to migrate them to the new format.\n")
-	msg.WriteString("Set PULUMI_SELF_MANAGED_STATE_NO_LEGACY_WARNING=1 to disable this warning.")
+	msg.WriteString("Set PULUMI_DIY_BACKEND_NO_LEGACY_WARNING=1 to disable this warning.")
 	d.Warningf(diag.Message("", msg.String()))
 	return backend, nil
 }

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -885,7 +885,7 @@ func TestNew_legacyFileWarning(t *testing.T) {
 				"  - a\n" +
 				"  - b\n" +
 				"Please run 'pulumi state upgrade' to migrate them to the new format.\n" +
-				"Set PULUMI_SELF_MANAGED_STATE_NO_LEGACY_WARNING=1 to disable this warning.\n",
+				"Set PULUMI_DIY_BACKEND_NO_LEGACY_WARNING=1 to disable this warning.\n",
 		},
 		{
 			desc: "warning opt-out",
@@ -894,7 +894,7 @@ func TestNew_legacyFileWarning(t *testing.T) {
 				".pulumi/stacks/b.json": "{}",
 			},
 			env: map[string]string{
-				"PULUMI_SELF_MANAGED_STATE_NO_LEGACY_WARNING": "true",
+				"PULUMI_DIY_BACKEND_NO_LEGACY_WARNING": "true",
 			},
 		},
 	}
@@ -1301,7 +1301,7 @@ func TestCreateStack_gzip(t *testing.T) {
 	_, err = b.CreateStack(ctx, fooRef, "", nil)
 	require.NoError(t, err)
 
-	// With PULUMI_SELF_MANAGED_STATE_GZIP enabled,
+	// With PULUMI_DIY_BACKEND_GZIP enabled,
 	// we'll store state into gzipped files.
 	assert.FileExists(t, filepath.Join(stateDir, ".pulumi", "stacks", "testproj", "foo.json.gz"))
 }

--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -59,7 +59,7 @@ type pulumiMeta struct {
 // If the bucket is empty, this will create a new metadata file
 // with the latest version number.
 // This can be overridden by setting the environment variable
-// "PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT" to "1".
+// "PULUMI_DIY_BACKEND_LEGACY_LAYOUT" to "1".
 // ensurePulumiMeta uses the provided 'getenv' function
 // to read the environment variable.
 func ensurePulumiMeta(ctx context.Context, b Bucket, e env.Env) (*pulumiMeta, error) {

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -158,7 +158,7 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// by default, we are going to suppress the permalink when using self-managed backends
+			// by default, we are going to suppress the permalink when using DIY backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
 			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermalink = true

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -812,7 +812,7 @@ func newImportCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// by default, we are going to suppress the permalink when using self-managed backends
+			// by default, we are going to suppress the permalink when using DIY backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
 			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermalink = true

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -343,7 +343,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// by default, we are going to suppress the permalink when using self-managed backends
+			// by default, we are going to suppress the permalink when using DIY backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
 			if suppressPermalink != "false" && filestateBackend {
 				displayOpts.SuppressPermalink = true

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -153,7 +153,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// by default, we are going to suppress the permalink when using self-managed backends
+			// by default, we are going to suppress the permalink when using DIY backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
 			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermalink = true

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -41,7 +41,7 @@ func newStateUpgradeCommand() *cobra.Command {
 		Short: "Migrates the current backend to the latest supported version",
 		Long: `Migrates the current backend to the latest supported version
 
-This only has an effect on self-managed backends.
+This only has an effect on DIY backends.
 `,
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -500,7 +500,7 @@ func newUpCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// by default, we are going to suppress the permalink when using self-managed backends
+			// by default, we are going to suppress the permalink when using DIY backends
 			// this can be re-enabled by explicitly passing "false" to the `suppress-permalink` flag
 			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermalink = true

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1034,7 +1034,7 @@ func buildStackName(stackName string) (string, error) {
 }
 
 // we only want to log a secrets decryption for a Pulumi Cloud backend project
-// we will allow any secrets provider to be used (Pulumi Cloud or self managed)
+// we will allow any secrets provider to be used (Pulumi Cloud or passphrase/cloud/etc)
 // we will log the message and not worry about the response. The types
 // of messages we will log here will range from single secret decryption events
 // to requesting a list of secrets in an individual event e.g. stack export

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -84,22 +84,27 @@ var ErrorOnDependencyCycles = env.Bool("ERROR_ON_DEPENDENCY_CYCLES",
 var SkipVersionCheck = env.Bool("AUTOMATION_API_SKIP_VERSION_CHECK",
 	"If set skip validating the version number reported by the CLI.")
 
-// Environment variables that affect the self-managed backend.
+// Environment variables that affect the DIY backend.
 var (
-	SelfManagedStateNoLegacyWarning = env.Bool("SELF_MANAGED_STATE_NO_LEGACY_WARNING",
-		"Disables the warning about legacy stack files mixed with project-scoped stack files.")
+	SelfManagedStateNoLegacyWarning = env.Bool("DIY_BACKEND_NO_LEGACY_WARNING",
+		"Disables the warning about legacy stack files mixed with project-scoped stack files.",
+		env.Alternative("SELF_MANAGED_STATE_NO_LEGACY_WARNING"))
 
-	SelfManagedStateLegacyLayout = env.Bool("SELF_MANAGED_STATE_LEGACY_LAYOUT",
-		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.")
+	SelfManagedStateLegacyLayout = env.Bool("DIY_BACKEND_LEGACY_LAYOUT",
+		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.",
+		env.Alternative("SELF_MANAGED_STATE_LEGACY_LAYOUT"))
 
-	SelfManagedGzip = env.Bool("SELF_MANAGED_STATE_GZIP",
-		"Enables gzip compression when writing state files.")
+	SelfManagedGzip = env.Bool("DIY_BACKEND_GZIP",
+		"Enables gzip compression when writing state files.",
+		env.Alternative("SELF_MANAGED_STATE_GZIP"))
 
-	SelfManagedRetainCheckpoints = env.Bool("RETAIN_CHECKPOINTS",
-		"If set every checkpoint will be duplicated to a timestamped file.")
+	SelfManagedRetainCheckpoints = env.Bool("DIY_BACKEND_RETAIN_CHECKPOINTS",
+		"If set every checkpoint will be duplicated to a timestamped file.",
+		env.Alternative("RETAIN_CHECKPOINTS"))
 
-	SelfManagedDisableCheckpointBackups = env.Bool("DISABLE_CHECKPOINT_BACKUPS",
-		"If set checkpoint backups will not be written the to the backup folder.")
+	SelfManagedDisableCheckpointBackups = env.Bool("DIY_BACKEND_DISABLE_CHECKPOINT_BACKUPS",
+		"If set checkpoint backups will not be written the to the backup folder.",
+		env.Alternative("DISABLE_CHECKPOINT_BACKUPS"))
 )
 
 // Environment variables which affect Pulumi AI integrations

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -11,11 +11,12 @@ func init() {
 	env.Global = env.MapStore{
 		"PULUMI_FOO": "1",
 		// "PULUMI_NOT_SET": explicitly not set
-		"FOO":           "bar",
-		"PULUMI_MY_INT": "3",
-		"PULUMI_SECRET": "hidden",
-		"PULUMI_SET":    "SET",
-		"UNSET":         "SET",
+		"FOO":                "bar",
+		"PULUMI_MY_INT":      "3",
+		"PULUMI_SECRET":      "hidden",
+		"PULUMI_SET":         "SET",
+		"UNSET":              "SET",
+		"PULUMI_ALTERNATIVE": "SET",
 	}
 }
 
@@ -27,6 +28,7 @@ var (
 	UnsetString = env.String("PULUMI_UNSET", "Should be unset", env.Needs(SomeFalse))
 	SetString   = env.String("SET", "Should be set", env.Needs(SomeBool))
 	AnInt       = env.Int("MY_INT", "Should be 3")
+	Alternative = env.String("NOT_ALTERNATIVE", "Should be set with alt name", env.Alternative("ALTERNATIVE"))
 )
 
 func TestInt(t *testing.T) {
@@ -58,4 +60,9 @@ func TestNeeds(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "", UnsetString.Value())
 	assert.Equal(t, "SET", SetString.Value())
+}
+
+func TestAlternative(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "SET", Alternative.Value())
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -564,12 +564,22 @@ func TestDestroyStackRef_LocalProject(t *testing.T) {
 }
 
 //nolint:paralleltest // uses parallel programtest
-func TestDestroyStackRef_LocalNonProject(t *testing.T) {
+func TestDestroyStackRef_LocalNonProject_NewEnv(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
+		e.DeleteIfNotFailed()
+	}()
+
+	t.Setenv("PULUMI_DIY_BACKEND_LEGACY_LAYOUT", "true")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	testDestroyStackRef(e, "")
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestDestroyStackRef_LocalNonProject_OldEnv(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		e.DeleteIfNotFailed()
 	}()
 
 	t.Setenv("PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT", "true")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We're moving away from referring to filestate as "self managed" backends, preferring to refer to this as "DIY" backends going forward.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
