### PR TITLE
[tests] testBuilder: Use specified package name

### DIFF
--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -468,9 +468,10 @@ func newTestBuilder(t *testing.T, snap *deploy.Snapshot) *testBuilder {
 }
 
 func (b *testBuilder) WithProvider(name string, version string, prov *deploytest.Provider) *testBuilder {
-	loader := deploytest.NewProviderLoader("pkgA", semver.MustParse(version), func() (plugin.Provider, error) {
-		return prov, nil
-	})
+	loader := deploytest.NewProviderLoader(
+		tokens.Package(name), semver.MustParse(version), func() (plugin.Provider, error) {
+			return prov, nil
+		})
 	b.loaders = append(b.loaders, loader)
 	return b
 }


### PR DESCRIPTION
I noticed that `testBuilder.WithProvider(name, ...)` wasn't actually passing the name through to `deploytest.NewProviderLoader` and instead is always passing `"pkgA"`. This commit fixes that. No current tests are affected, as they all pass `"pkgA"` for the name anyway.