### PR TITLE
[sdk/go] Use `filepath.Join` rather than `path.Join`

### DIFF
--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -76,7 +76,7 @@ func (opts *PulumiCommandOptions) withDefaults() (*PulumiCommandOptions, error) 
 		if err != nil {
 			return nil, err
 		}
-		newOpts.Root = path.Join(home, ".pulumi", "versions", newOpts.Version.String())
+		newOpts.Root = filepath.Join(home, ".pulumi", "versions", newOpts.Version.String())
 	}
 
 	return newOpts, nil
@@ -102,7 +102,7 @@ func NewPulumiCommand(opts *PulumiCommandOptions) (PulumiCommand, error) {
 	}
 	command := "pulumi"
 	if opts.Root != "" {
-		command = path.Join(opts.Root, "bin", "pulumi")
+		command = filepath.Join(opts.Root, "bin", "pulumi")
 	}
 
 	cmd := exec.Command(command, "version")
@@ -207,7 +207,7 @@ func installWindows(ctx context.Context, version semver.Version, root string) er
 	defer os.Remove(scriptPath)
 	command := "powershell.exe"
 	if os.Getenv("SystemRoot") != "" {
-		command = path.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+		command = filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
 	}
 	args := []string{
 		"-NoProfile",
@@ -265,8 +265,8 @@ func (p pulumiCommand) Run(ctx context.Context,
 	cmd := exec.CommandContext(ctx, "pulumi", args...)
 	cmd.Dir = workdir
 	env := append(os.Environ(), additionalEnv...)
-	if path.IsAbs(p.command) {
-		pulumiBin := path.Dir(p.command)
+	if filepath.IsAbs(p.command) {
+		pulumiBin := filepath.Dir(p.command)
 		env = fixupPath(env, pulumiBin)
 	}
 	cmd.Env = env

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -103,6 +103,9 @@ func NewPulumiCommand(opts *PulumiCommandOptions) (PulumiCommand, error) {
 	command := "pulumi"
 	if opts.Root != "" {
 		command = filepath.Join(opts.Root, "bin", "pulumi")
+		if runtime.GOOS == "windows" {
+			command += ".exe"
+		}
 	}
 
 	cmd := exec.Command(command, "version")

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -38,6 +39,9 @@ func TestInstallDefaultRoot(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 	pulumiBin := filepath.Join(homeDir, ".pulumi", "versions", requestedVersion.String(), "bin", "pulumi")
+	if runtime.GOOS == "windows" {
+		pulumiBin += ".exe"
+	}
 	_, err = os.Stat(pulumiBin)
 	require.NoError(t, err, "did not find pulumi binary in the expected path")
 	cmd := exec.Command(pulumiBin, "version")
@@ -73,6 +77,9 @@ func TestInstallTwice(t *testing.T) {
 
 	require.NoError(t, err)
 	pulumiPath := filepath.Join(dir, "bin", "pulumi")
+	if runtime.GOOS == "windows" {
+		pulumiPath += ".exe"
+	}
 	stat, err := os.Stat(pulumiPath)
 	require.NoError(t, err, "did not find pulumi binary in the expected path")
 	modTime1 := stat.ModTime()

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestInstallDefaultRoot(t *testing.T) {
 	require.NoError(t, err)
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
-	pulumiBin := path.Join(homeDir, ".pulumi", "versions", requestedVersion.String(), "bin", "pulumi")
+	pulumiBin := filepath.Join(homeDir, ".pulumi", "versions", requestedVersion.String(), "bin", "pulumi")
 	_, err = os.Stat(pulumiBin)
 	require.NoError(t, err, "did not find pulumi binary in the expected path")
 	cmd := exec.Command(pulumiBin, "version")
@@ -56,7 +56,7 @@ func TestOptionDefaults(t *testing.T) {
 	require.NoError(t, err)
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
-	root := path.Join(homeDir, ".pulumi", "versions", sdk.Version.String())
+	root := filepath.Join(homeDir, ".pulumi", "versions", sdk.Version.String())
 	require.Equal(t, root, opts.Root)
 	require.Equal(t, sdk.Version, opts.Version)
 }
@@ -72,7 +72,7 @@ func TestInstallTwice(t *testing.T) {
 	_, err = InstallPulumiCommand(context.Background(), &PulumiCommandOptions{Root: dir, Version: version})
 
 	require.NoError(t, err)
-	pulumiPath := path.Join(dir, "bin", "pulumi")
+	pulumiPath := filepath.Join(dir, "bin", "pulumi")
 	stat, err := os.Stat(pulumiPath)
 	require.NoError(t, err, "did not find pulumi binary in the expected path")
 	modTime1 := stat.ModTime()


### PR DESCRIPTION
We're seeing Go Automation API test failures on Windows. Looks like it's likely due to the use of `path.Join` (introduced in https://github.com/pulumi/pulumi/pull/15049 which merged about an hour ago; it's a separate question on how it was able to merge with failures on Windows). This PR changes those uses of `path` to `filepath`.

Note: No changelog because this hasn't been released yet.

This is currently blocking merges.

Fixes #15272