### PR TITLE
Clean up legacy Py 3.7 support

### DIFF
--- a/changelog/pending/20240127--sdk-python--remove-compatability-code-for-python-3-7-and-below.yaml
+++ b/changelog/pending/20240127--sdk-python--remove-compatability-code-for-python-3-7-and-below.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Remove compatability code for Python 3.7 and below.

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -120,21 +120,15 @@ if __name__ == "__main__":
 
     successful = False
 
-    # asyncio.get_running_loop was only added in python 3.7 but we still support python 3.6
-    # In python 3.10, asyncio.get_event_loop prints a deprecation warning if no loop is present
-    # This code will be cleaned up as part of https://github.com/pulumi/pulumi/issues/8131
-    if sys.version_info[0] == 3 and sys.version_info[1] < 7:
-        loop = asyncio.get_event_loop()
-    else:
-        try:
-            # The docs for get_running_loop are somewhat misleading because they state:
-            # This function can only be called from a coroutine or a callback. However, if the function is
-            # called from outside a coroutine or callback (the standard case when running `pulumi up`), the function
-            # raises a RuntimeError as expected and falls through to the exception clause below.
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+    try:
+        # The docs for get_running_loop are somewhat misleading because they state:
+        # This function can only be called from a coroutine or a callback. However, if the function is
+        # called from outside a coroutine or callback (the standard case when running `pulumi up`), the function
+        # raises a RuntimeError as expected and falls through to the exception clause below.
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     
     # Configure the event loop to respect the parallelism value provided as input.
     _set_default_executor(loop, settings.parallel)

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -688,66 +688,17 @@ def set(self, name: str, value: Any) -> None:
     )
 
 
-# Use the built-in `get_origin` and `get_args` functions on Python 3.8+,
-# otherwise fallback to downlevel implementations.
-if sys.version_info[:2] >= (3, 8):
-    # pylint: disable=no-member
-    get_origin = typing.get_origin  # type: ignore
-    # pylint: disable=no-member
-    get_args = typing.get_args  # type: ignore
-elif sys.version_info[:2] >= (3, 7):
-
-    def get_origin(tp):
-        if isinstance(tp, typing._GenericAlias):  # type: ignore
-            return tp.__origin__
-        return None
-
-    def get_args(tp):
-        if isinstance(tp, typing._GenericAlias):  # type: ignore
-            return tp.__args__
-        return ()
-
-else:
-
-    def get_origin(tp):
-        if hasattr(tp, "__origin__"):
-            return tp.__origin__
-        return None
-
-    def get_args(tp):
-        # Emulate the behavior of get_args for Union on Python 3.6.
-        if _is_union_type(tp) and hasattr(tp, "_subs_tree"):
-            tree = tp._subs_tree()
-            if isinstance(tree, tuple) and len(tree) > 1:
-
-                def _eval(args):
-                    return tuple(
-                        arg if not isinstance(arg, tuple) else arg[0][_eval(arg[1:])]
-                        for arg in args
-                    )
-
-                return _eval(tree[1:])
-        if hasattr(tp, "__args__"):
-            return tp.__args__
-        return ()
-
-
 def _is_union_type(tp):
-    if sys.version_info[:2] >= (3, 7):
-        return (
-            tp is Union
-            or isinstance(tp, typing._GenericAlias)
-            and tp.__origin__ is Union
-        )  # type: ignore
-    # pylint: disable=unidiomatic-typecheck, no-member
-    return type(tp) is typing._Union  # type: ignore
+    return (
+        tp is Union or isinstance(tp, typing._GenericAlias) and tp.__origin__ is Union
+    )
 
 
 def _is_optional_type(tp):
     if tp is type(None):
         return True
     if _is_union_type(tp):
-        return any(_is_optional_type(tt) for tt in get_args(tp))
+        return any(_is_optional_type(tt) for tt in typing.get_args(tp))
     return False
 
 
@@ -955,7 +906,7 @@ def unwrap_optional_type(val: type) -> type:
     # and any nested Unions are flattened, so Optional[Union[T, U], None] is Union[T, U, None].
     # We'll only "unwrap" for the common case of a single arg T for Union[T, None].
     if _is_optional_type(val):
-        args = get_args(val)
+        args = typing.get_args(val)
         if len(args) == 2:
             assert args[1] is type(None)
             val = args[0]
@@ -970,11 +921,11 @@ def unwrap_type(val: type) -> type:
     # pylint: disable=import-outside-toplevel
     from . import Output
 
-    origin = get_origin(val)
+    origin = typing.get_origin(val)
 
     # If it is an Output[T], extract the T arg.
     if origin is Output:
-        args = get_args(val)
+        args = typing.get_args(val)
         assert len(args) == 1
         val = args[0]
 
@@ -986,17 +937,19 @@ def unwrap_type(val: type) -> type:
             return (
                 is_input_type(args[0])
                 and args[1] is dict
-                or get_origin(args[1]) in [dict, Dict, Mapping, collections.abc.Mapping]
+                or typing.get_origin(args[1])
+                in [dict, Dict, Mapping, collections.abc.Mapping]
             )
 
         def isInput(args, i=1):
             assert len(args) > i + 1
             return (
-                get_origin(args[i]) in {typing.Awaitable, collections.abc.Awaitable}
-                and get_origin(args[i + 1]) is Output
+                typing.get_origin(args[i])
+                in {typing.Awaitable, collections.abc.Awaitable}
+                and typing.get_origin(args[i + 1]) is Output
             )
 
-        args = get_args(val)
+        args = typing.get_args(val)
         if len(args) == 2:
             if isInputType(args):  # InputType[T]
                 return args[0]

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -26,8 +26,6 @@ from ..runtime import reset_options, run_in_stack, set_all_config
 from ..runtime.proto import LanguageRuntimeServicer, language_pb2, plugin_pb2
 from ._workspace import PulumiFn
 
-_py_version_less_than_3_7 = sys.version_info[0] == 3 and sys.version_info[1] < 7
-
 
 class LanguageServer(LanguageRuntimeServicer):
     program: PulumiFn
@@ -109,10 +107,7 @@ class LanguageServer(LanguageRuntimeServicer):
             # closing the loop.
             pending = (
                 # lint safety: we use the python version here to track deprecations
-                # pylint: disable=no-member
-                asyncio.Task.all_tasks(loop)
-                if _py_version_less_than_3_7
-                else asyncio.all_tasks(loop)
+                asyncio.all_tasks(loop)
             )  # pylint: disable=no-member
             log.debug(f"Cancelling {len(pending)} tasks.")
             for task in pending:

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -35,6 +35,8 @@ from typing import (
     Set,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 
 import six
@@ -157,9 +159,9 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
 
     # If typ is a list, get the type for its values, to pass
     # along for each item.
-    origin = _types.get_origin(typ)
+    origin = get_origin(typ)
     if typ is list or origin in [list, List, Sequence, abc.Sequence]:
-        args = _types.get_args(typ)
+        args = get_args(typ)
         if len(args) == 1:
             return args[0]
 
@@ -535,9 +537,9 @@ async def serialize_property(
                 get_type = types.get
             else:
                 # Otherwise, don't do any translation of user-defined dict keys.
-                origin = _types.get_origin(typ)
+                origin = get_origin(typ)
                 if typ is dict or origin in [dict, Dict, Mapping, abc.Mapping]:
-                    args = _types.get_args(typ)
+                    args = get_args(typ)
                     if len(args) == 2 and args[0] is str:
                         # pylint: disable=C3001
                         get_type = lambda k: args[1]
@@ -965,9 +967,9 @@ def translate_output_properties(
                 return _types.output_type_from_dict(typ, translated_values)
 
             # If typ is a dict, get the type for its values, to pass along for each key.
-            origin = _types.get_origin(typ)
+            origin = get_origin(typ)
             if typ is dict or origin in [dict, Dict, Mapping, abc.Mapping]:
-                args = _types.get_args(typ)
+                args = get_args(typ)
                 if len(args) == 2 and args[0] is str:
                     # pylint: disable=C3001
                     get_type = lambda k: args[1]

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -29,7 +29,7 @@ from .settings import (
     is_dry_run,
     set_root_resource,
 )
-from .sync_await import _all_tasks, _get_current_task, _sync_await
+from .sync_await import _sync_await
 
 if TYPE_CHECKING:
     from .. import Output
@@ -37,9 +37,9 @@ if TYPE_CHECKING:
 
 def _get_running_tasks() -> List[asyncio.Task]:
     pending = []
-    for task in _all_tasks():
+    for task in asyncio.all_tasks():
         # Don't kill ourselves, that would be silly.
-        if not task == _get_current_task():
+        if not task == asyncio.current_task():
             pending.append(task)
     return pending
 

--- a/sdk/python/lib/pulumi/runtime/sync_await.py
+++ b/sdk/python/lib/pulumi/runtime/sync_await.py
@@ -12,30 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import sys
 from typing import Awaitable, TypeVar
-
-# If we are not running on Python 3.7 or later, we need to swap the Python implementation of Task in for the C
-# implementation in order to support synchronous invokes.
-if sys.version_info[0] == 3 and sys.version_info[1] < 7:
-    asyncio.Task = asyncio.tasks._PyTask
-    asyncio.tasks.Task = asyncio.tasks._PyTask
-
-    def enter_task(loop, task):
-        task.__class__._current_tasks[loop] = task
-
-    def leave_task(loop, task):
-        task.__class__._current_tasks.pop(loop)
-
-    _enter_task = enter_task
-    _leave_task = leave_task
-    _all_tasks = asyncio.Task.all_tasks
-    _get_current_task = asyncio.Task.current_task
-else:
-    _enter_task = asyncio.tasks._enter_task  # type: ignore
-    _leave_task = asyncio.tasks._leave_task  # type: ignore
-    _all_tasks = asyncio.all_tasks  # type: ignore
-    _get_current_task = asyncio.current_task  # type: ignore
 
 T = TypeVar("T")
 
@@ -57,9 +34,9 @@ def _sync_await(awaitable: Awaitable[T]) -> T:
 
     # If we are executing inside a task, pretend we've returned from its current callback--effectively yielding to
     # the event loop--by calling _leave_task.
-    task = _get_current_task(loop)
+    task = asyncio.current_task(loop)
     if task is not None:
-        _leave_task(loop, task)
+        asyncio.tasks._leave_task(loop, task)
 
     # Pump the event loop until the future is complete. This is the kernel of BaseEventLoop.run_forever, and may not
     # work with alternative event loop implementations.
@@ -83,7 +60,7 @@ def _sync_await(awaitable: Awaitable[T]) -> T:
 
     # If we were executing inside a task, restore its context and continue on.
     if task is not None:
-        _enter_task(loop, task)
+        asyncio.tasks._enter_task(loop, task)
 
     # Return the result of the future.
     return fut.result()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We've bumped the minimum version on the package and haven't officially supported versions before 3.8 for a while now. 

This cleans up a load of code we had just for compat with 3.7 and lower.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
