### PR TITLE
Ensure automation tests run on windows

### DIFF
--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -131,6 +131,14 @@ func TestFixupPathExistingPath(t *testing.T) {
 	require.Contains(t, env, "PATH=/pulumi-root/bin"+string(os.PathListSeparator)+"/usr/local/bin")
 }
 
+func TestWindowsFailure(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.FailNow()
+	}
+}
+
 const (
 	PARSE   = `Unable to parse`
 	MAJOR   = `Major version mismatch.`

--- a/sdk/nodejs/tests/automation/cmd.spec.ts
+++ b/sdk/nodejs/tests/automation/cmd.spec.ts
@@ -77,6 +77,12 @@ describe("automation/cmd", () => {
             assert.rejects(PulumiCommand.get({ version: requestedVersion }));
             assert.doesNotReject(PulumiCommand.get({ version: installedVersion, skipVersionCheck: true }));
         });
+
+        it("fails on windows", async () => {
+            if (process.platform === "win32") {
+                assert.strictEqual(true, false);
+            }
+        });
     });
 
     describe(`checkVersionIsValid`, () => {

--- a/sdk/python/lib/test/automation/test_cmd.py
+++ b/sdk/python/lib/test/automation/test_cmd.py
@@ -79,6 +79,9 @@ def test_fixup_env():
     else:
         assert new_env["PATH"] == "/tmp/pulumi-install/bin:/usr/bin"
 
+def test_fail_on_windows():
+    if os.name == "nt":
+        pytest.fail("test should fail on windows!")
 
 MAJOR = "Major version mismatch."
 MINIMAL = "Minimum version requirement failed."


### PR DESCRIPTION
# Description

Automation tests should run on windows

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
