### PR TITLE
Support async inline programs

### DIFF
--- a/changelog/pending/20240127--auto-python--inline-programs-can-now-be-defined-as-async-functions.yaml
+++ b/changelog/pending/20240127--auto-python--inline-programs-can-now-be-defined-as-async-functions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Inline programs can now be defined as async functions.

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         user_program_abspath = os.path.abspath(args.PROGRAM)
         def run():
             try:
-                return runpy.run_path(args.PROGRAM, run_name='__main__')
+                runpy.run_path(args.PROGRAM, run_name='__main__')
             except ImportError as e:
                 def fix_module_file(m: str) -> str:
                     # Work around python 11 reporting "<frozen runpy>" rather

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -33,7 +33,7 @@ class LanguageServer(LanguageRuntimeServicer):
     program: PulumiFn
 
     def __init__(self, program: PulumiFn) -> None:
-        self.program = program  # type: ignore
+        self.program = program
 
     @staticmethod
     def on_pulumi_exit():

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Callable, List, Mapping, Optional
+from typing import Any, Callable, List, Mapping, Optional, Awaitable
 
 from ._cmd import PulumiCommand
 from ._config import ConfigMap, ConfigValue
@@ -23,7 +23,7 @@ from ._project_settings import ProjectSettings
 from ._stack_settings import StackSettings
 from ._tag import TagMap
 
-PulumiFn = Callable[[], None]
+PulumiFn = Callable[[], Optional[Awaitable[None]]]
 
 
 class StackSummary:

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -168,7 +168,6 @@ class Stack(ComponentResource):
             # This _should_ be an awaitable but old pulumi executors returned modules here, so we need to handle that
             # with a type check rather than just `is not None`.
             if isawaitable(awaitable):
-                print(awaitable)
                 _sync_await(awaitable)
         finally:
             self.register_outputs(massage(self.outputs, []))

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -17,7 +17,7 @@ Support for automatic stack components.
 """
 import asyncio
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Any, Callable, Dict, List
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Awaitable, Optional
 
 from .. import log
 from ..resource import ComponentResource, Resource, ResourceTransformation
@@ -29,7 +29,7 @@ from .settings import (
     is_dry_run,
     set_root_resource,
 )
-from .sync_await import _all_tasks, _get_current_task
+from .sync_await import _all_tasks, _get_current_task, _sync_await
 
 if TYPE_CHECKING:
     from .. import Output
@@ -44,7 +44,7 @@ def _get_running_tasks() -> List[asyncio.Task]:
     return pending
 
 
-async def run_pulumi_func(func: Callable):
+async def run_pulumi_func(func: Callable[[], None]):
     try:
         func()
     finally:
@@ -128,13 +128,17 @@ async def wait_for_rpcs(await_all_outstanding_tasks=True) -> None:
             break
 
 
-async def run_in_stack(func: Callable):
+async def run_in_stack(func: Callable[[], Optional[Awaitable[None]]]):
     """
     Run the given function inside of a new stack resource.  This ensures that any stack export calls
     will end up as output properties on the resulting stack component in the checkpoint file.  This
     is meant for internal runtime use only and is used by the Python SDK entrypoint program.
     """
-    await run_pulumi_func(lambda: Stack(func))
+
+    def run() -> None:
+        Stack(func)
+
+    await run_pulumi_func(run)
 
 
 class Stack(ComponentResource):
@@ -144,7 +148,7 @@ class Stack(ComponentResource):
 
     outputs: Dict[str, Any]
 
-    def __init__(self, func: Callable) -> None:
+    def __init__(self, func: Callable[[], Optional[Awaitable[None]]]) -> None:
         # Ensure we don't already have a stack registered.
         if get_root_resource() is not None:
             raise Exception("Only one root Pulumi Stack may be active at once")
@@ -153,11 +157,19 @@ class Stack(ComponentResource):
         name = f"{get_project()}-{get_stack()}"
         super().__init__("pulumi:pulumi:Stack", name, None, None)
 
-        # Invoke the function while this stack is active and then register its outputs.
+        # Invoke the function while this stack is active and then register its outputs. func might return an awaitable
+        # so we need to await it, ideally we'd do this in a standard way but alas back compatibility means we do
+        # everything in stack constructors, so we have to use sync_await here.
+
         self.outputs = {}
         set_root_resource(self)
         try:
-            func()
+            awaitable = func()
+            # This _should_ be an awaitable but old pulumi executors returned modules here, so we need to handle that
+            # with a type check rather than just `is not None`.
+            if isawaitable(awaitable):
+                print(awaitable)
+                _sync_await(awaitable)
         finally:
             self.register_outputs(massage(self.outputs, []))
             # Intentionally leave this resource installed in case subsequent async work uses it.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This updates the typing annotations and semantics of Python Automation API inline programs. It's now defined to be a callable that returns an optional awaitable of `None`. This supports both existing synchronous functions (should just return `None`) and now also supports async functions that return an `Awaitable` that eventually resolves to `None`.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
