### PR TITLE
local workspace project validation should include error message

### DIFF
--- a/changelog/pending/20240127--sdk-go--include-error-message-in-local-workspace-validation.yaml
+++ b/changelog/pending/20240127--sdk-go--include-error-message-in-local-workspace-validation.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: include error message in local workspace validation
+  description: Include error message in local workspace validation.

--- a/changelog/pending/20240127--sdk-go--include-error-message-in-local-workspace-validation.yaml
+++ b/changelog/pending/20240127--sdk-go--include-error-message-in-local-workspace-validation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: include error message in local workspace validation

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -532,7 +532,7 @@ func (proj *Project) Save(path string) error {
 	contract.Requiref(proj != nil, "proj", "must not be nil")
 
 	err := proj.Validate()
-	contract.Requiref(err == nil, "proj", fmt.Sprintf("Validate(): %v", err))
+	contract.Requiref(err == nil, "proj", "Validate(): %v", err)
 
 	return save(path, proj, false /*mkDirAll*/)
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -530,7 +530,10 @@ func (proj *Project) TrustResourceDependencies() bool {
 func (proj *Project) Save(path string) error {
 	contract.Requiref(path != "", "path", "must not be empty")
 	contract.Requiref(proj != nil, "proj", "must not be nil")
-	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
+
+	err := proj.Validate()
+	contract.Requiref(err == nil, "proj", fmt.Sprintf("Validate(): %v", err))
+
 	return save(path, proj, false /*mkDirAll*/)
 }
 


### PR DESCRIPTION
# Description

If project settings are not valid `contract.Requiref(proj.Validate() == nil, "proj", "Validate()")` just returns `Validate()` which makes it difficult to debug why the call to `proj.Validate()` failed. This change captures the error returned by `proj.Validate()` and includes that as part of the message.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
