### PR TITLE
[sdk-gen/go] Remove pulumix references from generated enums in non-generic SDKs

### DIFF
--- a/changelog/pending/20240127--sdkgen-go--remove-pulumix-references-from-generated-enums.yaml
+++ b/changelog/pending/20240127--sdkgen-go--remove-pulumix-references-from-generated-enums.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Remove pulumix references from generated enums

--- a/pkg/codegen/testing/test/testdata/array-of-enum-map/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/array-of-enum-map/go/example/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type AnnotationStoreSchemaValueType string
@@ -182,12 +181,6 @@ func (in *annotationStoreSchemaValueTypePtr) ToAnnotationStoreSchemaValueTypePtr
 
 func (in *annotationStoreSchemaValueTypePtr) ToAnnotationStoreSchemaValueTypePtrOutputWithContext(ctx context.Context) AnnotationStoreSchemaValueTypePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(AnnotationStoreSchemaValueTypePtrOutput)
-}
-
-func (in *annotationStoreSchemaValueTypePtr) ToOutput(ctx context.Context) pulumix.Output[*AnnotationStoreSchemaValueType] {
-	return pulumix.Output[*AnnotationStoreSchemaValueType]{
-		OutputState: in.ToAnnotationStoreSchemaValueTypePtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // AnnotationStoreSchemaValueTypeMapInput is an input type that accepts AnnotationStoreSchemaValueTypeMap and AnnotationStoreSchemaValueTypeMapOutput values.

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -185,12 +184,6 @@ func (in *cloudAuditOptionsLogNamePtr) ToCloudAuditOptionsLogNamePtrOutputWithCo
 	return pulumi.ToOutputWithContext(ctx, in).(CloudAuditOptionsLogNamePtrOutput)
 }
 
-func (in *cloudAuditOptionsLogNamePtr) ToOutput(ctx context.Context) pulumix.Output[*CloudAuditOptionsLogName] {
-	return pulumix.Output[*CloudAuditOptionsLogName]{
-		OutputState: in.ToCloudAuditOptionsLogNamePtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 type ContainerBrightness float64
 
 const (
@@ -354,12 +347,6 @@ func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutput() ContainerBrig
 
 func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerBrightnessPtrOutput)
-}
-
-func (in *containerBrightnessPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
-	return pulumix.Output[*ContainerBrightness]{
-		OutputState: in.ToContainerBrightnessPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // plant container colors
@@ -530,12 +517,6 @@ func (in *containerColorPtr) ToContainerColorPtrOutputWithContext(ctx context.Co
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerColorPtrOutput)
 }
 
-func (in *containerColorPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
-	return pulumix.Output[*ContainerColor]{
-		OutputState: in.ToContainerColorPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 // plant container sizes
 type ContainerSize int
 
@@ -702,12 +683,6 @@ func (in *containerSizePtr) ToContainerSizePtrOutput() ContainerSizePtrOutput {
 
 func (in *containerSizePtr) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerSizePtrOutput)
-}
-
-func (in *containerSizePtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
-	return pulumix.Output[*ContainerSize]{
-		OutputState: in.ToContainerSizePtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Diameter float64
@@ -176,12 +175,6 @@ func (in *diameterPtr) ToDiameterPtrOutputWithContext(ctx context.Context) Diame
 	return pulumi.ToOutputWithContext(ctx, in).(DiameterPtrOutput)
 }
 
-func (in *diameterPtr) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
-	return pulumix.Output[*Diameter]{
-		OutputState: in.ToDiameterPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 type Farm string
 
 const (
@@ -345,12 +338,6 @@ func (in *farmPtr) ToFarmPtrOutput() FarmPtrOutput {
 
 func (in *farmPtr) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(FarmPtrOutput)
-}
-
-func (in *farmPtr) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
-	return pulumix.Output[*Farm]{
-		OutputState: in.ToFarmPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // types of rubber trees
@@ -522,12 +509,6 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutput() RubberTreeVariety
 
 func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
-}
-
-func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
-	return pulumix.Output[*RubberTreeVariety]{
-		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // RubberTreeVarietyArrayInput is an input type that accepts RubberTreeVarietyArray and RubberTreeVarietyArrayOutput values.
@@ -740,12 +721,6 @@ func (in *treeSizePtr) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (in *treeSizePtr) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(TreeSizePtrOutput)
-}
-
-func (in *treeSizePtr) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
-	return pulumix.Output[*TreeSize]{
-		OutputState: in.ToTreeSizePtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // TreeSizeMapInput is an input type that accepts TreeSizeMap and TreeSizeMapOutput values.

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // The log_name to populate in the Cloud Audit Record. This is added to regress pulumi/pulumi issue #7913
@@ -190,12 +189,6 @@ func (in *containerBrightnessPtr) ToContainerBrightnessPtrOutputWithContext(ctx 
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerBrightnessPtrOutput)
 }
 
-func (in *containerBrightnessPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerBrightness] {
-	return pulumix.Output[*ContainerBrightness]{
-		OutputState: in.ToContainerBrightnessPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 // plant container colors
 type ContainerColor string
 
@@ -364,12 +357,6 @@ func (in *containerColorPtr) ToContainerColorPtrOutputWithContext(ctx context.Co
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerColorPtrOutput)
 }
 
-func (in *containerColorPtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerColor] {
-	return pulumix.Output[*ContainerColor]{
-		OutputState: in.ToContainerColorPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 // plant container sizes
 type ContainerSize int
 
@@ -536,12 +523,6 @@ func (in *containerSizePtr) ToContainerSizePtrOutput() ContainerSizePtrOutput {
 
 func (in *containerSizePtr) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ContainerSizePtrOutput)
-}
-
-func (in *containerSizePtr) ToOutput(ctx context.Context) pulumix.Output[*ContainerSize] {
-	return pulumix.Output[*ContainerSize]{
-		OutputState: in.ToContainerSizePtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Diameter float64
@@ -176,12 +175,6 @@ func (in *diameterPtr) ToDiameterPtrOutputWithContext(ctx context.Context) Diame
 	return pulumi.ToOutputWithContext(ctx, in).(DiameterPtrOutput)
 }
 
-func (in *diameterPtr) ToOutput(ctx context.Context) pulumix.Output[*Diameter] {
-	return pulumix.Output[*Diameter]{
-		OutputState: in.ToDiameterPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 type Farm string
 
 const (
@@ -345,12 +338,6 @@ func (in *farmPtr) ToFarmPtrOutput() FarmPtrOutput {
 
 func (in *farmPtr) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(FarmPtrOutput)
-}
-
-func (in *farmPtr) ToOutput(ctx context.Context) pulumix.Output[*Farm] {
-	return pulumix.Output[*Farm]{
-		OutputState: in.ToFarmPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // types of rubber trees
@@ -522,12 +509,6 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutput() RubberTreeVariety
 
 func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
-}
-
-func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
-	return pulumix.Output[*RubberTreeVariety]{
-		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // RubberTreeVarietyArrayInput is an input type that accepts RubberTreeVarietyArray and RubberTreeVarietyArrayOutput values.
@@ -740,12 +721,6 @@ func (in *treeSizePtr) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (in *treeSizePtr) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(TreeSizePtrOutput)
-}
-
-func (in *treeSizePtr) ToOutput(ctx context.Context) pulumix.Output[*TreeSize] {
-	return pulumix.Output[*TreeSize]{
-		OutputState: in.ToTreeSizePtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 // TreeSizeMapInput is an input type that accepts TreeSizeMap and TreeSizeMapOutput values.

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/local/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type MyEnum float64
@@ -174,12 +173,6 @@ func (in *myEnumPtr) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (in *myEnumPtr) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(MyEnumPtrOutput)
-}
-
-func (in *myEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
-	return pulumix.Output[*MyEnum]{
-		OutputState: in.ToMyEnumPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type ExampleEnum string
@@ -176,12 +175,6 @@ func (in *exampleEnumPtr) ToExampleEnumPtrOutputWithContext(ctx context.Context)
 	return pulumi.ToOutputWithContext(ctx, in).(ExampleEnumPtrOutput)
 }
 
-func (in *exampleEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnum] {
-	return pulumix.Output[*ExampleEnum]{
-		OutputState: in.ToExampleEnumPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 type ExampleEnumInputEnum string
 
 const (
@@ -347,12 +340,6 @@ func (in *exampleEnumInputEnumPtr) ToExampleEnumInputEnumPtrOutputWithContext(ct
 	return pulumi.ToOutputWithContext(ctx, in).(ExampleEnumInputEnumPtrOutput)
 }
 
-func (in *exampleEnumInputEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ExampleEnumInputEnum] {
-	return pulumix.Output[*ExampleEnumInputEnum]{
-		OutputState: in.ToExampleEnumInputEnumPtrOutputWithContext(ctx).OutputState,
-	}
-}
-
 type ResourceTypeEnum string
 
 const (
@@ -516,12 +503,6 @@ func (in *resourceTypeEnumPtr) ToResourceTypeEnumPtrOutput() ResourceTypeEnumPtr
 
 func (in *resourceTypeEnumPtr) ToResourceTypeEnumPtrOutputWithContext(ctx context.Context) ResourceTypeEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ResourceTypeEnumPtrOutput)
-}
-
-func (in *resourceTypeEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*ResourceTypeEnum] {
-	return pulumix.Output[*ResourceTypeEnum]{
-		OutputState: in.ToResourceTypeEnumPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 // Type of product filter.
@@ -177,12 +176,6 @@ func (in *supportedFilterTypesPtr) ToSupportedFilterTypesPtrOutput() SupportedFi
 
 func (in *supportedFilterTypesPtr) ToSupportedFilterTypesPtrOutputWithContext(ctx context.Context) SupportedFilterTypesPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(SupportedFilterTypesPtrOutput)
-}
-
-func (in *supportedFilterTypesPtr) ToOutput(ctx context.Context) pulumix.Output[*SupportedFilterTypes] {
-	return pulumix.Output[*SupportedFilterTypes]{
-		OutputState: in.ToSupportedFilterTypesPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type Color string
@@ -174,12 +173,6 @@ func (in *colorPtr) ToColorPtrOutput() ColorPtrOutput {
 
 func (in *colorPtr) ToColorPtrOutputWithContext(ctx context.Context) ColorPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(ColorPtrOutput)
-}
-
-func (in *colorPtr) ToOutput(ctx context.Context) pulumix.Output[*Color] {
-	return pulumix.Output[*Color]{
-		OutputState: in.ToColorPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type MyEnum string
@@ -174,12 +173,6 @@ func (in *myEnumPtr) ToMyEnumPtrOutput() MyEnumPtrOutput {
 
 func (in *myEnumPtr) ToMyEnumPtrOutputWithContext(ctx context.Context) MyEnumPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(MyEnumPtrOutput)
-}
-
-func (in *myEnumPtr) ToOutput(ctx context.Context) pulumix.Output[*MyEnum] {
-	return pulumix.Output[*MyEnum]{
-		OutputState: in.ToMyEnumPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type OutputOnlyEnumType string
@@ -290,12 +289,6 @@ func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutput() RubberTreeVariety
 
 func (in *rubberTreeVarietyPtr) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return pulumi.ToOutputWithContext(ctx, in).(RubberTreeVarietyPtrOutput)
-}
-
-func (in *rubberTreeVarietyPtr) ToOutput(ctx context.Context) pulumix.Output[*RubberTreeVariety] {
-	return pulumix.Output[*RubberTreeVariety]{
-		OutputState: in.ToRubberTreeVarietyPtrOutputWithContext(ctx).OutputState,
-	}
 }
 
 func init() {


### PR DESCRIPTION
### Description

This PR fixes build issues for Go SDKs where enums import the `pulumix` package without using it or sometimes using it with generated input interfaces for the enums for non-generic sdks. The problem was using the function `goPackageInfo` which reads the package info from the language section of the schema but not initializing `Generics` field to `none` when it is empty. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
