### PR TITLE
auto.FullyQualifiedStackName doc fix

### DIFF
--- a/changelog/pending/20240127--auto-go--remove-obsolete-note-from-fullyqualifiedstackname-comment.yaml
+++ b/changelog/pending/20240127--auto-go--remove-obsolete-note-from-fullyqualifiedstackname-comment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: auto/go
+  description: Remove obsolete note from FullyQualifiedStackName comment.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -142,6 +142,10 @@ type Stack struct {
 // FullyQualifiedStackName returns a stack name formatted with the greatest possible specificity:
 // org/project/stack or user/project/stack
 // Using this format avoids ambiguity in stack identity guards creating or selecting the wrong stack.
+// Note that legacy filestate backends (local file, S3, Azure Blob) do not support stack names in this
+// format, and instead only use the stack name without an org/user or project to qualify it.
+// See: https://github.com/pulumi/pulumi/issues/2522. Non-legacy filestate backends do support
+// the org/project/stack format but org must be set to "organization".
 func FullyQualifiedStackName(org, project, stack string) string {
 	return fmt.Sprintf("%s/%s/%s", org, project, stack)
 }

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -142,9 +142,6 @@ type Stack struct {
 // FullyQualifiedStackName returns a stack name formatted with the greatest possible specificity:
 // org/project/stack or user/project/stack
 // Using this format avoids ambiguity in stack identity guards creating or selecting the wrong stack.
-// Note that filestate backends (local file, S3, Azure Blob) do not support stack names in this
-// format, and instead only use the stack name without an org/user or project to qualify it.
-// See: https://github.com/pulumi/pulumi/issues/2522
 func FullyQualifiedStackName(org, project, stack string) string {
 	return fmt.Sprintf("%s/%s/%s", org, project, stack)
 }


### PR DESCRIPTION
# Description

There is an obsolete note in the comment for `auto.FullyQualifiedStackName` regarding not using an FQDN with filestate backends which can cause some confusion since it is now supported.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
