### PR TITLE
Test main in conformance tests

### DIFF
--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -104,10 +104,13 @@ func (h *L1EmptyLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
 	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
 	}
 	if req.Info.ProgramDirectory != req.Info.RootDirectory {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
 	}
 	return nil
 }
@@ -266,7 +269,7 @@ func TestL1Empty_BadSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := &languageTestServer{DisableSnapshotWriting: true}
 	runtime := &L1EmptyLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/l1main_test.go
+++ b/cmd/pulumi-test-language/l1main_test.go
@@ -1,0 +1,185 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
+	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v2"
+)
+
+type L1MainLanguageHost struct {
+	pulumirpc.UnimplementedLanguageRuntimeServer
+
+	tempDir string
+}
+
+func (h *L1MainLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackRequest) (*pulumirpc.PackResponse, error) {
+	if !strings.HasSuffix(req.PackageDirectory, "/sdk/dir") {
+		return nil, fmt.Errorf("unexpected package directory %s", req.PackageDirectory)
+	}
+
+	if req.DestinationDirectory != filepath.Join(h.tempDir, "artifacts") {
+		return nil, fmt.Errorf("unexpected destination directory %s", req.DestinationDirectory)
+	}
+
+	if req.Version != "1.0.0" {
+		return nil, fmt.Errorf("unexpected version %s", req.Version)
+	}
+
+	return &pulumirpc.PackResponse{
+		ArtifactPath: filepath.Join(req.DestinationDirectory, "core.sdk"),
+	}, nil
+}
+
+func (h *L1MainLanguageHost) GenerateProject(
+	ctx context.Context, req *pulumirpc.GenerateProjectRequest,
+) (*pulumirpc.GenerateProjectResponse, error) {
+	if req.LocalDependencies["pulumi"] != filepath.Join(h.tempDir, "artifacts", "core.sdk") {
+		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
+	}
+	if !req.Strict {
+		return nil, fmt.Errorf("expected strict to be true")
+	}
+	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
+		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)
+	}
+	var project workspace.Project
+	if err := json.Unmarshal([]byte(req.Project), &project); err != nil {
+		return nil, err
+	}
+	if project.Name != "l1-main" {
+		return nil, fmt.Errorf("unexpected project name %s", project.Name)
+	}
+	project.Runtime = workspace.NewProjectRuntimeInfo("mock", nil)
+	projectYaml, err := yaml.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal project: %w", err)
+	}
+
+	// Write the minimal project file.
+	if err := os.WriteFile(filepath.Join(req.TargetDirectory, "Pulumi.yaml"), projectYaml, 0o600); err != nil {
+		return nil, err
+	}
+
+	return &pulumirpc.GenerateProjectResponse{}, nil
+}
+
+func (h *L1MainLanguageHost) InstallDependencies(
+	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
+) error {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l1-main", "subdir") {
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
+	}
+	return nil
+}
+
+func (h *L1MainLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
+	conn, err := grpc.Dial(
+		req.MonitorAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		rpcutil.GrpcChannelOptions(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to resource monitor: %w", err)
+	}
+	defer conn.Close()
+
+	monitor := pulumirpc.NewResourceMonitorClient(conn)
+
+	resp, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type: string(resource.RootStackType),
+		Name: req.Stack,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register stack: %w", err)
+	}
+
+	outputs, err := structpb.NewStruct(map[string]interface{}{
+		"output_true": true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal outputs: %w", err)
+	}
+
+	_, err = monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
+		Urn:     resp.Urn,
+		Outputs: outputs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register outputs: %w", err)
+	}
+
+	return &pulumirpc.RunResponse{}, nil
+}
+
+// Run a simple successful test
+func TestL1Main(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	engine := &languageTestServer{}
+	runtime := &L1MainLanguageHost{tempDir: tempDir}
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterLanguageRuntimeServer(srv, runtime)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	prepareResponse, err := engine.PrepareLanguageTests(ctx, &testingrpc.PrepareLanguageTestsRequest{
+		LanguagePluginName:   "mock",
+		LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		TemporaryDirectory:   tempDir,
+		SnapshotDirectory:    "./testdata/snapshots",
+		CoreSdkDirectory:     "sdk/dir",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, prepareResponse.Token)
+
+	runResponse, err := engine.RunLanguageTest(ctx, &testingrpc.RunLanguageTestRequest{
+		Token: prepareResponse.Token,
+		Test:  "l1-main",
+	})
+	require.NoError(t, err)
+	t.Logf("stdout: %s", runResponse.Stdout)
+	t.Logf("stderr: %s", runResponse.Stderr)
+	assert.True(t, runResponse.Success)
+	assert.Empty(t, runResponse.Messages)
+}

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -150,10 +150,13 @@ func (h *L2ResourceSimpleLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
 	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
 	}
 	if req.Info.ProgramDirectory != req.Info.RootDirectory {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
 	}
 	return nil
 }
@@ -243,7 +246,7 @@ func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	tempDir := t.TempDir()
-	engine := &languageTestServer{}
+	engine := &languageTestServer{DisableSnapshotWriting: true}
 	runtime := &L2ResourceSimpleLanguageHost{tempDir: tempDir}
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {

--- a/cmd/pulumi-test-language/testdata/l1-main/main.pp
+++ b/cmd/pulumi-test-language/testdata/l1-main/main.pp
@@ -1,0 +1,3 @@
+output "output_true" "bool" {
+    value = true
+}

--- a/cmd/pulumi-test-language/testdata/snapshots/projects/l1-main/Pulumi.yaml
+++ b/cmd/pulumi-test-language/testdata/snapshots/projects/l1-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-main
+runtime: mock
+main: subdir

--- a/cmd/pulumi-test-language/testdata/snapshots_bad/projects/l2-resource-simple/Pulumi.yaml
+++ b/cmd/pulumi-test-language/testdata/snapshots_bad/projects/l2-resource-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-simple
+runtime: mock


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This makes two changes to conformance testing.

Firstly we've added support to run a setup function after project generation but before snapshots and testing. This allows us to write a test that sets up "main" in a Pulumi.yaml file and test that "program directory" and "entry point" are respected. Doing this correctly also required some bug fixes in the conformance interface itself.

I've also added a `DisableSnapshotWriting` flag to the conformance interface so that the tests we write for conformance itself that generate bad snapshots can opt out of `PULUMI_ACCEPT` behaviour. I tripped myself up earlier by running all the tests with `PULUMI_ACCEPT=1` and then getting confused on why the bad snapshot tests were suddenly failing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
