### PR TITLE
Test main in conformance tests

### DIFF
--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -104,15 +104,28 @@ func (h *L1EmptyLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
 	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
 	}
 	if req.Info.ProgramDirectory != req.Info.RootDirectory {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
 	}
 	return nil
 }
 
 func (h *L1EmptyLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return nil, fmt.Errorf("unexpected root directory to run %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
+		return nil, fmt.Errorf("unexpected program directory to run %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return nil, fmt.Errorf("unexpected entry point to run %s", req.Info.EntryPoint)
+	}
+
 	if !h.skipStack {
 		conn, err := grpc.Dial(
 			req.MonitorAddress,

--- a/cmd/pulumi-test-language/l1main_test.go
+++ b/cmd/pulumi-test-language/l1main_test.go
@@ -1,0 +1,202 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
+	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v2"
+)
+
+type L1MainLanguageHost struct {
+	pulumirpc.UnimplementedLanguageRuntimeServer
+
+	tempDir string
+}
+
+func (h *L1MainLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackRequest) (*pulumirpc.PackResponse, error) {
+	if !strings.HasSuffix(req.PackageDirectory, "/sdk/dir") {
+		return nil, fmt.Errorf("unexpected package directory %s", req.PackageDirectory)
+	}
+
+	if req.DestinationDirectory != filepath.Join(h.tempDir, "artifacts") {
+		return nil, fmt.Errorf("unexpected destination directory %s", req.DestinationDirectory)
+	}
+
+	if req.Version != "1.0.0" {
+		return nil, fmt.Errorf("unexpected version %s", req.Version)
+	}
+
+	return &pulumirpc.PackResponse{
+		ArtifactPath: filepath.Join(req.DestinationDirectory, "core.sdk"),
+	}, nil
+}
+
+func (h *L1MainLanguageHost) GenerateProject(
+	ctx context.Context, req *pulumirpc.GenerateProjectRequest,
+) (*pulumirpc.GenerateProjectResponse, error) {
+	if req.LocalDependencies["pulumi"] != filepath.Join(h.tempDir, "artifacts", "core.sdk") {
+		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
+	}
+	if !req.Strict {
+		return nil, fmt.Errorf("expected strict to be true")
+	}
+	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
+		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)
+	}
+	var project workspace.Project
+	if err := json.Unmarshal([]byte(req.Project), &project); err != nil {
+		return nil, err
+	}
+	if project.Name != "l1-main" {
+		return nil, fmt.Errorf("unexpected project name %s", project.Name)
+	}
+	if project.Main != "subdir" {
+		return nil, fmt.Errorf("unexpected project main %s", project.Main)
+	}
+	project.Runtime = workspace.NewProjectRuntimeInfo("mock", nil)
+	projectYaml, err := yaml.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("marshal project: %w", err)
+	}
+
+	// Write the minimal project file.
+	if err := os.WriteFile(filepath.Join(req.TargetDirectory, "Pulumi.yaml"), projectYaml, 0o600); err != nil {
+		return nil, fmt.Errorf("write project file: %w", err)
+	}
+	// And the main subdir, although nothing is in it
+	if err := os.MkdirAll(filepath.Join(req.TargetDirectory, "subdir"), 0o700); err != nil {
+		return nil, fmt.Errorf("make main directory: %w", err)
+	}
+
+	return &pulumirpc.GenerateProjectResponse{}, nil
+}
+
+func (h *L1MainLanguageHost) InstallDependencies(
+	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
+) error {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l1-main", "subdir") {
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
+	}
+	return nil
+}
+
+func (h *L1MainLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
+		return nil, fmt.Errorf("unexpected root directory to run %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != filepath.Join(h.tempDir, "projects", "l1-main", "subdir") {
+		return nil, fmt.Errorf("unexpected program directory to run %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return nil, fmt.Errorf("unexpected entry point to run %s", req.Info.EntryPoint)
+	}
+
+	conn, err := grpc.Dial(
+		req.MonitorAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		rpcutil.GrpcChannelOptions(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to resource monitor: %w", err)
+	}
+	defer conn.Close()
+
+	monitor := pulumirpc.NewResourceMonitorClient(conn)
+
+	resp, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type: string(resource.RootStackType),
+		Name: req.Stack,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register stack: %w", err)
+	}
+
+	outputs, err := structpb.NewStruct(map[string]interface{}{
+		"output_true": true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal outputs: %w", err)
+	}
+
+	_, err = monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
+		Urn:     resp.Urn,
+		Outputs: outputs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register outputs: %w", err)
+	}
+
+	return &pulumirpc.RunResponse{}, nil
+}
+
+// Run a simple successful test
+func TestL1Main(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	engine := &languageTestServer{}
+	runtime := &L1MainLanguageHost{tempDir: tempDir}
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterLanguageRuntimeServer(srv, runtime)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	prepareResponse, err := engine.PrepareLanguageTests(ctx, &testingrpc.PrepareLanguageTestsRequest{
+		LanguagePluginName:   "mock",
+		LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		TemporaryDirectory:   tempDir,
+		SnapshotDirectory:    "./testdata/snapshots",
+		CoreSdkDirectory:     "sdk/dir",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, prepareResponse.Token)
+
+	runResponse, err := engine.RunLanguageTest(ctx, &testingrpc.RunLanguageTestRequest{
+		Token: prepareResponse.Token,
+		Test:  "l1-main",
+	})
+	require.NoError(t, err)
+	t.Logf("stdout: %s", runResponse.Stdout)
+	t.Logf("stderr: %s", runResponse.Stderr)
+	assert.True(t, runResponse.Success)
+	assert.Empty(t, runResponse.Messages)
+}

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -150,10 +150,13 @@ func (h *L2ResourceSimpleLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
 	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.RootDirectory)
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
 	}
 	if req.Info.ProgramDirectory != req.Info.RootDirectory {
-		return fmt.Errorf("unexpected directory to install dependencies %s", req.Info.ProgramDirectory)
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
 	}
 	return nil
 }
@@ -161,6 +164,16 @@ func (h *L2ResourceSimpleLanguageHost) InstallDependencies(
 func (h *L2ResourceSimpleLanguageHost) Run(
 	ctx context.Context, req *pulumirpc.RunRequest,
 ) (*pulumirpc.RunResponse, error) {
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
+		return nil, fmt.Errorf("unexpected root directory to run %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
+		return nil, fmt.Errorf("unexpected program directory to run %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return nil, fmt.Errorf("unexpected entry point to run %s", req.Info.EntryPoint)
+	}
+
 	conn, err := grpc.Dial(
 		req.MonitorAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/cmd/pulumi-test-language/testdata/l1-main/main.pp
+++ b/cmd/pulumi-test-language/testdata/l1-main/main.pp
@@ -1,0 +1,3 @@
+output "output_true" "bool" {
+    value = true
+}

--- a/cmd/pulumi-test-language/testdata/snapshots/projects/l1-main/Pulumi.yaml
+++ b/cmd/pulumi-test-language/testdata/snapshots/projects/l1-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-main
+runtime: mock
+main: subdir

--- a/cmd/pulumi-test-language/testdata/snapshots_bad/projects/l2-resource-simple/Pulumi.yaml
+++ b/cmd/pulumi-test-language/testdata/snapshots_bad/projects/l2-resource-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-simple
+runtime: mock

--- a/cmd/pulumi-test-language/tests.go
+++ b/cmd/pulumi-test-language/tests.go
@@ -31,6 +31,8 @@ type languageTest struct {
 	config config.Map
 	// TODO: This should be a function so we don't have to load all providers in memory all the time.
 	providers []plugin.Provider
+	// This can be used to set a main value for the test.
+	main string
 	// TODO: This should just return "string", if == "" then ok, else fail
 	assert func(*L, result.Result, *deploy.Snapshot, display.ResourceChanges)
 }
@@ -66,6 +68,21 @@ var languageTests = map[string]languageTest{
 
 			assertPropertyMapMember(l, outputs, "output_true", resource.NewBoolProperty(true))
 			assertPropertyMapMember(l, outputs, "output_false", resource.NewBoolProperty(false))
+		},
+	},
+	"l1-main": {
+		main: "subdir",
+		assert: func(l *L, res result.Result, snap *deploy.Snapshot, changes display.ResourceChanges) {
+			requireStackResource(l, res, changes)
+
+			// Check we have an output in the stack for true
+			require.NotEmpty(l, snap.Resources, "expected at least 1 resource")
+			stack := snap.Resources[0]
+			require.Equal(l, resource.RootStackType, stack.Type, "expected a stack resource")
+
+			outputs := stack.Outputs
+
+			assertPropertyMapMember(l, outputs, "output_true", resource.NewBoolProperty(true))
 		},
 	},
 	// ==========

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: l1-main
+runtime: nodejs
+main: subdir

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/index.ts
@@ -1,0 +1,3 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const output_true = true;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "l1-main",
+	"devDependencies": {
+		"@types/node": "^14"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-1.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This adds a main option to the test, that is put into the Pulumi.yaml and sent to codegen.  This allows us to write a test that sets up "main" in a Pulumi.yaml file and test that "program directory" and "entry point" are respected. Doing this correctly also required some bug fixes in the conformance interface itself.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
