### PR TITLE
Test runtime options in conformance tests

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -792,7 +792,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		projectDir, /* rootDirectory */
 		pwd,        /* programDirectory */
 		main,
-		map[string]interface{}{})
+		project.Runtime.Options())
 
 	// TODO(https://github.com/pulumi/pulumi/issues/13941): We don't capture stdout/stderr from the language
 	// plugin, so we can't show it back to the test.

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -1,0 +1,220 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
+	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"gopkg.in/yaml.v2"
+)
+
+type RuntimeOptionsLanguageHost struct {
+	pulumirpc.UnimplementedLanguageRuntimeServer
+
+	tempDir string
+}
+
+func assertOptions(options map[string]interface{}) error {
+	if options["bool_option"] != true {
+		return fmt.Errorf("unexpected bool_option %v", options["bool_option"])
+	}
+	if options["number_option"] != 42.0 {
+		return fmt.Errorf("unexpected number_option %v", options["number_option"])
+	}
+	if options["string_option"] != "hello" {
+		return fmt.Errorf("unexpected string_option %v", options["string_option"])
+	}
+	if !reflect.DeepEqual(options["list_option"], []interface{}{"a", "b", "c"}) {
+		return fmt.Errorf("unexpected list_option %v", options["list_option"])
+	}
+	if len(options) != 4 {
+		return fmt.Errorf("unexpected options %v", options)
+	}
+
+	return nil
+}
+
+func (h *RuntimeOptionsLanguageHost) Pack(
+	ctx context.Context, req *pulumirpc.PackRequest,
+) (*pulumirpc.PackResponse, error) {
+	if !strings.HasSuffix(req.PackageDirectory, "/sdk/dir") {
+		return nil, fmt.Errorf("unexpected package directory %s", req.PackageDirectory)
+	}
+
+	if req.DestinationDirectory != filepath.Join(h.tempDir, "artifacts") {
+		return nil, fmt.Errorf("unexpected destination directory %s", req.DestinationDirectory)
+	}
+
+	if req.Version != "1.0.0" {
+		return nil, fmt.Errorf("unexpected version %s", req.Version)
+	}
+
+	return &pulumirpc.PackResponse{
+		ArtifactPath: filepath.Join(req.DestinationDirectory, "core.sdk"),
+	}, nil
+}
+
+func (h *RuntimeOptionsLanguageHost) GenerateProject(
+	ctx context.Context, req *pulumirpc.GenerateProjectRequest,
+) (*pulumirpc.GenerateProjectResponse, error) {
+	if req.LocalDependencies["pulumi"] != filepath.Join(h.tempDir, "artifacts", "core.sdk") {
+		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
+	}
+	if !req.Strict {
+		return nil, fmt.Errorf("expected strict to be true")
+	}
+	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)
+	}
+	var project workspace.Project
+	if err := json.Unmarshal([]byte(req.Project), &project); err != nil {
+		return nil, err
+	}
+	if project.Name != "l1-empty" {
+		return nil, fmt.Errorf("unexpected project name %s", project.Name)
+	}
+	project.Runtime = workspace.NewProjectRuntimeInfo("mock", map[string]interface{}{
+		"bool_option":   true,
+		"number_option": 42,
+		"string_option": "hello",
+		"list_option":   []interface{}{"a", "b", "c"},
+	})
+	projectYaml, err := yaml.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal project: %w", err)
+	}
+
+	// Write the minimal project file.
+	if err := os.WriteFile(filepath.Join(req.TargetDirectory, "Pulumi.yaml"), projectYaml, 0o600); err != nil {
+		return nil, err
+	}
+
+	return &pulumirpc.GenerateProjectResponse{}, nil
+}
+
+func (h *RuntimeOptionsLanguageHost) InstallDependencies(
+	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
+) error {
+	err := assertOptions(req.Info.Options.AsMap())
+	if err != nil {
+		return err
+	}
+
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return fmt.Errorf("unexpected root directory to install dependencies %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
+		return fmt.Errorf("unexpected program directory to install dependencies %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return fmt.Errorf("unexpected entry point to install dependencies %s", req.Info.EntryPoint)
+	}
+
+	return nil
+}
+
+func (h *RuntimeOptionsLanguageHost) Run(
+	ctx context.Context, req *pulumirpc.RunRequest,
+) (*pulumirpc.RunResponse, error) {
+	err := assertOptions(req.Info.Options.AsMap())
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Info.RootDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
+		return nil, fmt.Errorf("unexpected root directory to run %s", req.Info.RootDirectory)
+	}
+	if req.Info.ProgramDirectory != req.Info.RootDirectory {
+		return nil, fmt.Errorf("unexpected program directory to run %s", req.Info.ProgramDirectory)
+	}
+	if req.Info.EntryPoint != "." {
+		return nil, fmt.Errorf("unexpected entry point to run %s", req.Info.EntryPoint)
+	}
+
+	conn, err := grpc.Dial(
+		req.MonitorAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		rpcutil.GrpcChannelOptions(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to resource monitor: %w", err)
+	}
+	defer conn.Close()
+
+	monitor := pulumirpc.NewResourceMonitorClient(conn)
+
+	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type: string(resource.RootStackType),
+		Name: req.Stack,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register stack: %w", err)
+	}
+
+	return &pulumirpc.RunResponse{}, nil
+}
+
+// Run a simple test with a mocked runtime that uses runtime options
+func TestRuntimeOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	engine := &languageTestServer{}
+	runtime := &RuntimeOptionsLanguageHost{tempDir: tempDir}
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterLanguageRuntimeServer(srv, runtime)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	prepareResponse, err := engine.PrepareLanguageTests(ctx, &testingrpc.PrepareLanguageTestsRequest{
+		LanguagePluginName:   "mock",
+		LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		TemporaryDirectory:   tempDir,
+		SnapshotDirectory:    "./testdata/snapshots_runtime_options",
+		CoreSdkDirectory:     "sdk/dir",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, prepareResponse.Token)
+
+	runResponse, err := engine.RunLanguageTest(ctx, &testingrpc.RunLanguageTestRequest{
+		Token: prepareResponse.Token,
+		Test:  "l1-empty",
+	})
+	require.NoError(t, err)
+	t.Logf("stdout: %s", runResponse.Stdout)
+	t.Logf("stderr: %s", runResponse.Stderr)
+	assert.True(t, runResponse.Success)
+	assert.Empty(t, runResponse.Messages)
+}

--- a/cmd/pulumi-test-language/testdata/snapshots_runtime_options/projects/l1-empty/Pulumi.yaml
+++ b/cmd/pulumi-test-language/testdata/snapshots_runtime_options/projects/l1-empty/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: l1-empty
+runtime:
+  name: mock
+  options:
+    bool_option: true
+    list_option:
+    - a
+    - b
+    - c
+    number_option: 42
+    string_option: hello


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a test that the conformance suite correctly passes on runtime options that a language emits during project code generation.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
