### PR TITLE
Publish dev versions of the python and node SDKs

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -144,8 +144,11 @@ jobs:
           mkdir -p artifacts
           (
             cd artifacts.tmp/artifacts-nodejs-sdk
+            version="${{ inputs.version }}"
+            dev_version="${{ needs.gather-info.outputs.dev-version }}"
             for file in *.tgz ; do
-              mv -vT "$file" "../../artifacts/sdk-nodejs-$file"
+              name=${file//$version/$dev_version}
+              mv -vT "$file" "../../artifacts/sdk-nodejs-$name"
             done
           )
       - name: Set up Node ${{ fromJson(needs.matrix.outputs.version-set).nodejs }}
@@ -186,12 +189,13 @@ jobs:
           mkdir -p artifacts
           version="${{ inputs.version }}"
           # Python dev versions have a suffix of "a<sha>".
-          dev_version="a${{ needs.gather-info.outputs.dev-sha }}"
+          dev_version=${{ needs.gather-info.outputs.dev-sha }}
+          dev_version="${version}a${dev_version}"
           mkdir -p artifacts
           (
             cd artifacts.tmp/artifacts-python-sdk
             for file in *.whl ; do
-              new_name="${file//-$version/$dev_version}"
+              new_name="${file//$version/$dev_version}"
               mv -vT "$file" "../../artifacts/sdk-python-$new_name"
             done
           )

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -142,7 +142,12 @@ jobs:
       - name: Move artifacts to the right place
         run: |
           mkdir -p artifacts
-          mv artifacts.tmp/artifacts-nodejs-sdk/*.tgz artifacts
+          (
+            cd artifacts.tmp/artifacts-nodejs-sdk
+            for file in *.tgz ; do
+              mv -vT "$file" "../../artifacts/sdk-nodejs-$file"
+            done
+          )
       - name: Publish nodejs release
         run: |
           make -C sdk/nodejs publish
@@ -170,14 +175,15 @@ jobs:
       - name: Move artifacts to the right place
         run: |
           mkdir -p artifacts
-          mv artifacts.tmp/artifacts-python-sdk/*.whl artifacts
           version="${{ inputs.version }}"
           # Python dev versions have a suffix of "a<sha>".
           dev_version="a${{ needs.gather-info.outputs.dev-sha }}"
+          mkdir -p artifacts
           (
-            cd artifacts
-            for file in *.whl; do
-              mv "$file" "${file//$version/$dev_version}"
+            cd artifacts.tmp/artifacts-python-sdk
+            for file in *.whl ; do
+              new_name="${file//$version/$dev_version}"
+              mv -vT "$file" "../../artifacts/sdk-python-$new_name"
             done
           )
 

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -89,6 +89,16 @@ jobs:
       enable-coverage: false
     secrets: inherit
 
+  build-sdks:
+    name: Build SDKs
+    needs: [matrix]
+    uses: ./.github/workflows/ci-build-sdks.yml
+    with:
+      ref: ${{ inputs.ref }}
+      version: ${{ needs.gather-info.outputs.dev-version }}
+      version-set: ${{ needs.matrix.outputs.version-set }}
+    secrets: inherit
+
   sign:
     name: sign
     needs: [build-release]
@@ -126,7 +136,7 @@ jobs:
 
 
   nodejs-dev-sdk-release:
-    needs: [gather-info, build-release, sdk-check-release, matrix]
+    needs: [gather-info, build-sdks, sdk-check-release, matrix]
     runs-on: ubuntu-latest
 #    if: ${{ needs.sdk-check-release.outputs.nodejs-release }} #TODO: enable this after testing
     steps:
@@ -171,7 +181,7 @@ jobs:
 
 
   python-dev-sdk-release:
-    needs: [gather-info, build-release, sdk-check-release]
+    needs: [gather-info, build-build-sdks, sdk-check-release]
     runs-on: ubuntu-latest
 #    if: ${{ needs.sdk-check-release.outputs.python-release }} # TODO: enable this after testing
     steps:
@@ -188,8 +198,8 @@ jobs:
         run: |
           mkdir -p artifacts
           version="${{ inputs.version }}"
-          # Python dev versions have a suffix of "a<sha>".
-          dev_version=${{ needs.gather-info.outputs.dev-sha }}
+          # Python dev versions have a suffix of "a<epoch>".
+          dev_version=$(date +%s)
           dev_version="${version}a${dev_version}"
           mkdir -p artifacts
           (

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -128,8 +128,7 @@ jobs:
   nodejs-dev-sdk-release:
     needs: [gather-info, build-release, sdk-check-release]
     runs-on: ubuntu-latest
-    if: ${{ needs.sdk-check-release.outputs.nodejs-release }}
-
+#    if: ${{ needs.sdk-check-release.outputs.nodejs-release }} #TODO: enable this after testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -155,7 +154,7 @@ jobs:
   python-dev-sdk-release:
     needs: [gather-info, build-release, sdk-check-release]
     runs-on: ubuntu-latest
-    if: ${{ needs.sdk-check-release.outputs.python-release }}
+#    if: ${{ needs.sdk-check-release.outputs.python-release }} # TODO: enable this after testing
     steps:
       - name: Make artifacts directory
         run: |

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -150,12 +150,16 @@ jobs:
           PULUMI_VERSION: ${{ needs.gather-info.outputs.dev-version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_REF: ${{ inputs.ref }}
+
 
   python-dev-sdk-release:
     needs: [gather-info, build-release, sdk-check-release]
     runs-on: ubuntu-latest
 #    if: ${{ needs.sdk-check-release.outputs.python-release }} # TODO: enable this after testing
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Make artifacts directory
         run: |
           mkdir -p artifacts.tmp

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -126,7 +126,7 @@ jobs:
 
 
   nodejs-dev-sdk-release:
-    needs: [gather-info, build-release, sdk-check-release]
+    needs: [gather-info, build-release, sdk-check-release, matrix]
     runs-on: ubuntu-latest
 #    if: ${{ needs.sdk-check-release.outputs.nodejs-release }} #TODO: enable this after testing
     steps:
@@ -148,6 +148,15 @@ jobs:
               mv -vT "$file" "../../artifacts/sdk-nodejs-$file"
             done
           )
+      - name: Set up Node ${{ fromJson(needs.matrix.outputs.version-set).nodejs }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ fromJson(needs.matrix.outputs.version-set).nodejs }}
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish nodejs release
         run: |
           make -C sdk/nodejs publish
@@ -182,11 +191,13 @@ jobs:
           (
             cd artifacts.tmp/artifacts-python-sdk
             for file in *.whl ; do
-              new_name="${file//$version/$dev_version}"
+              new_name="${file//-$version/$dev_version}"
               mv -vT "$file" "../../artifacts/sdk-python-$new_name"
             done
           )
-
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Publish python release
         run: |
           make -C sdk/python publish

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -36,8 +36,10 @@ jobs:
           version="${{ steps.ghd.outputs.describe }}"
           version="${version#v}"
           echo dev-version="$version" >>"${GITHUB_OUTPUT}"
+          echo dev-sha="${{ steps.ghd.outputs.short-sha }}" >>"${GITHUB_OUTPUT}"
     outputs:
       dev-version: ${{ steps.strip-prefix.outputs.dev-version }}
+      dev-sha: ${{ steps.strip-prefix.outputs.dev-sha }}
       version: ${{ inputs.version }}
 
   matrix:
@@ -94,6 +96,94 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
+
+  # Check if we need to create a new SDK dev release
+  sdk-check-release:
+    name: sdk-check-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --exit-code master...HEAD sdk/nodejs; then
+            echo "nodejs-release=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "nodejs-release=false" >>"${GITHUB_OUTPUT}"
+          fi
+
+          if git diff --exit-code master...HEAD sdk/python; then
+            echo "python-release=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "python-release=false" >>"${GITHUB_OUTPUT}"
+          fi
+    outputs:
+      nodejs-release: ${{ steps.check-changes.outputs.nodejs-release }}
+      python-release: ${{ steps.check-changes.outputs.python-release }}
+
+
+
+  nodejs-dev-sdk-release:
+    needs: [gather-info, build-release, sdk-check-release]
+    runs-on: ubuntu-latest
+    if: ${{ needs.sdk-check-release.outputs.nodejs-release }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Make artifacts directory
+        run: |
+          mkdir -p artifacts.tmp
+      - name: Download artifacts from previous step
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts.tmp
+      - name: Move artifacts to the right place
+        run: |
+          mkdir -p artifacts
+          mv artifacts.tmp/artifacts-nodejs-sdk/*.tgz artifacts
+      - name: Publish nodejs release
+        run: |
+          make -C sdk/nodejs publish
+        env:
+          PULUMI_VERSION: ${{ needs.gather-info.outputs.dev-version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  python-dev-sdk-release:
+    needs: [gather-info, build-release, sdk-check-release]
+    runs-on: ubuntu-latest
+    if: ${{ needs.sdk-check-release.outputs.python-release }}
+    steps:
+      - name: Make artifacts directory
+        run: |
+          mkdir -p artifacts.tmp
+      - name: Download artifacts from previous step
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts.tmp
+      - name: Move artifacts to the right place
+        run: |
+          mkdir -p artifacts
+          mv artifacts.tmp/artifacts-python-sdk/*.whl artifacts
+          version="${{ inputs.version }}"
+          # Python dev versions have a suffix of "a<sha>".
+          dev_version="a${{ needs.gather-info.outputs.dev-sha }}"
+          (
+            cd artifacts
+            for file in *.whl; do
+              mv "$file" "${file//$version/$dev_version}"
+            done
+          )
+
+      - name: Publish python release
+        run: |
+          make -C sdk/python publish
+        env:
+          PYPI_USERNAME: __token__
+          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
   s3-blobs:
     name: s3 blobs

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -33,13 +33,12 @@ jobs:
       - name: strip prefix
         id: strip-prefix
         run: |
-          version="${{ steps.ghd.outputs.describe }}"
-          version="${version#v}"
+          short_sha="${{ steps.ghd.outputs.short-sha }}"
+          version="${{ inputs.version }}"
+          version="${version#v}-alpha.${short_sha}"
           echo dev-version="$version" >>"${GITHUB_OUTPUT}"
-          echo dev-sha="${{ steps.ghd.outputs.short-sha }}" >>"${GITHUB_OUTPUT}"
     outputs:
       dev-version: ${{ steps.strip-prefix.outputs.dev-version }}
-      dev-sha: ${{ steps.strip-prefix.outputs.dev-sha }}
       version: ${{ inputs.version }}
 
   matrix:
@@ -91,7 +90,7 @@ jobs:
 
   build-sdks:
     name: Build SDKs
-    needs: [matrix]
+    needs: [matrix, gather-info]
     uses: ./.github/workflows/ci-build-sdks.yml
     with:
       ref: ${{ inputs.ref }}
@@ -133,8 +132,6 @@ jobs:
       nodejs-release: ${{ steps.check-changes.outputs.nodejs-release }}
       python-release: ${{ steps.check-changes.outputs.python-release }}
 
-
-
   nodejs-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release, matrix]
     runs-on: ubuntu-latest
@@ -155,10 +152,8 @@ jobs:
           (
             cd artifacts.tmp/artifacts-nodejs-sdk
             version="${{ inputs.version }}"
-            dev_version="${{ needs.gather-info.outputs.dev-version }}"
-            for file in *.tgz ; do
-              name=${file//$version/$dev_version}
-              mv -vT "$file" "../../artifacts/sdk-nodejs-$name"
+            for file in *"${version}"-alpha*.tgz ; do
+              mv -vT "$file" "../../artifacts/sdk-nodejs-${file}"
             done
           )
       - name: Set up Node ${{ fromJson(needs.matrix.outputs.version-set).nodejs }}
@@ -172,6 +167,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish nodejs release
         run: |
+          find artifacts
           make -C sdk/nodejs publish
         env:
           PULUMI_VERSION: ${{ needs.gather-info.outputs.dev-version }}
@@ -181,7 +177,7 @@ jobs:
 
 
   python-dev-sdk-release:
-    needs: [gather-info, build-build-sdks, sdk-check-release]
+    needs: [gather-info, build-sdks, sdk-check-release]
     runs-on: ubuntu-latest
 #    if: ${{ needs.sdk-check-release.outputs.python-release }} # TODO: enable this after testing
     steps:
@@ -198,15 +194,11 @@ jobs:
         run: |
           mkdir -p artifacts
           version="${{ inputs.version }}"
-          # Python dev versions have a suffix of "a<epoch>".
-          dev_version=$(date +%s)
-          dev_version="${version}a${dev_version}"
           mkdir -p artifacts
           (
             cd artifacts.tmp/artifacts-python-sdk
-            for file in *.whl ; do
-              new_name="${file//$version/$dev_version}"
-              mv -vT "$file" "../../artifacts/sdk-python-$new_name"
+            for file in *"${version}a"*.whl ; do
+              mv -vT "$file" "../../artifacts/sdk-python-${file}"
             done
           )
       - name: Install Python deps
@@ -214,6 +206,7 @@ jobs:
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Publish python release
         run: |
+          find artifacts
           make -C sdk/python publish
         env:
           PYPI_USERNAME: __token__

--- a/changelog/pending/20240129--sdk-nodejs-python--publish-dev-versions-of-the-nodejs-and-python-sdks.yaml
+++ b/changelog/pending/20240129--sdk-nodejs-python--publish-dev-versions-of-the-nodejs-and-python-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs,python
+  description: Publish dev versions of the nodejs and python SDKs

--- a/scripts/publish_npm.sh
+++ b/scripts/publish_npm.sh
@@ -30,7 +30,7 @@ PKG_VERSION="${PULUMI_VERSION}"
 # version string), use the tag of latest instead of
 # dev. NPM uses this tag as the default version to add, so we want it to mean
 # the newest released version.
-if [[ "${PKG_VERSION}" != *-g* ]]; then
+if [[ "${PKG_VERSION}" != *-alpha* ]]; then
     NPM_TAG="latest"
 fi
 

--- a/scripts/publish_npm.sh
+++ b/scripts/publish_npm.sh
@@ -26,20 +26,12 @@ PKG_NAME=$(jq -r .name < "${ROOT}/sdk/nodejs/package.json")
 # shellcheck disable=SC2154 # assigned by release.yml
 PKG_VERSION="${PULUMI_VERSION}"
 
-# If the package doesn't have an alpha tag, use the tag of latest instead of
+# If the package isn't a dev version (includes the git describe output in its
+# version string), use the tag of latest instead of
 # dev. NPM uses this tag as the default version to add, so we want it to mean
 # the newest released version.
-if [[ "${PKG_VERSION}" != *-alpha* ]]; then
+if [[ "${PKG_VERSION}" != *-g* ]]; then
     NPM_TAG="latest"
-fi
-
-# we need to set explicit beta and rc tags to ensure that we don't mutate to use the latest tag
-if [[ "${PKG_VERSION}" == *-beta* ]]; then
-    NPM_TAG="beta"
-fi
-
-if [[ "${PKG_VERSION}" == *-rc* ]]; then
-    NPM_TAG="rc"
 fi
 
 # Now, perform the publish. The logic here is a little goofy because npm provides

--- a/scripts/pulumi-version.sh
+++ b/scripts/pulumi-version.sh
@@ -17,7 +17,7 @@ fi
 
 case "${LANGUAGE}" in
   python)
-    echo -n "${VERSION}" | sed 's/-alpha./a/; s/-beta./b/; s/-rc./rc/; s/-dev./dev/'
+    echo -n "${VERSION}" | sed "s/-alpha.*/a$(date +%s)/"
     ;;
   *)
     echo -n "${VERSION}"


### PR DESCRIPTION
Publish dev versions of the python and node SDKs, so we can consume them pre-release and make our releases more stable.

Also clean up the publish_npm.sh script a little bit, removing now unused cruft.
