### PR TITLE
Don't encrypt secrets to get ciphertext that isn't actually used

### DIFF
--- a/changelog/pending/20240129--engine--fix-a-performance-issue-doing-unneeded-secret-encryption.yaml
+++ b/changelog/pending/20240129--engine--fix-a-performance-issue-doing-unneeded-secret-encryption.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a performance issue doing unneeded secret encryption.

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -498,6 +498,23 @@ func TestSerializePropertyValue(t *testing.T) {
 	})
 }
 
+// Test that if ShowSecrets is set the encrypter is not called into at all.
+func TestSerializePropertyValue_ShowSecrets(t *testing.T) {
+	t.Parallel()
+
+	crypter := config.NewPanicCrypter()
+
+	secret := resource.MakeSecret(resource.NewStringProperty("secret"))
+	_, err := SerializePropertyValue(secret, crypter, true)
+	assert.NoError(t, err)
+
+	secret = resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+		resource.MakeSecret(resource.NewStringProperty("secret")),
+	}))
+	_, err = SerializePropertyValue(secret, crypter, true)
+	assert.NoError(t, err)
+}
+
 func TestDeserializePropertyValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

While investigating into https://github.com/pulumi/pulumi/issues/15293 I noticed that `SerializePropertyValue` was always calling into `Encrypter.EncryptValue` (or `cachingCrypter.encryptSecret`) even when `showSecrets` was true and the cipher text wasn't being returned.

This is a simple move of that logic into the `!showSecrets` branch so it gets skipped entirely when the cipher text isn't needed.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
