### PR TITLE
Use the Depth variants in glog calls

### DIFF
--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -62,7 +62,7 @@ type VerboseLogger glog.Verbose
 // See the documentation of V for usage.
 func (v VerboseLogger) Info(args ...interface{}) {
 	if v {
-		glog.Verbose(v).Info(FilterString(fmt.Sprint(args...)))
+		glog.Verbose(v).InfoDepth(1, FilterString(fmt.Sprint(args...)))
 	}
 }
 
@@ -78,7 +78,7 @@ func (v VerboseLogger) Infoln(args ...interface{}) {
 // See the documentation of V for usage.
 func (v VerboseLogger) Infof(format string, args ...interface{}) {
 	if v {
-		glog.Verbose(v).Infof("%s", FilterString(fmt.Sprintf(format, args...)))
+		glog.Verbose(v).InfoDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
 	}
 }
 
@@ -88,15 +88,15 @@ func V(level glog.Level) VerboseLogger {
 }
 
 func Errorf(format string, args ...interface{}) {
-	glog.Errorf("%s", FilterString(fmt.Sprintf(format, args...)))
+	glog.ErrorDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
 }
 
 func Infof(format string, args ...interface{}) {
-	glog.Infof("%s", FilterString(fmt.Sprintf(format, args...)))
+	glog.InfoDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
 }
 
 func Warningf(format string, args ...interface{}) {
-	glog.Warningf("%s", FilterString(fmt.Sprintf(format, args...)))
+	glog.WarningDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
 }
 
 func Flush() {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This allows pulumi's log output to contain the location of where the log call was made from, rather than it always reporting the line in `log.go` where the glog call was made.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This changes

```
I0124 20:53:35.244319  169013 log.go:81] skipping update check
I0124 20:53:36.262079  169013 log.go:81] found username for access token
```
to

```
I0129 14:08:42.918230   38925 pulumi.go:231] skipping update check
I0129 14:08:45.056866   38925 backend.go:615] found username for access token
```

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
  - This is hard to test because it is difficult to reliably intercept stderr from within go tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
