### PR TITLE
Add RequireEmptyPreviewAfterRefresh option to ProgramTest

### DIFF
--- a/changelog/pending/20240130--pkg-testing--add-requireemptypreviewafterrefresh-option-to-programtest.yaml
+++ b/changelog/pending/20240130--pkg-testing--add-requireemptypreviewafterrefresh-option-to-programtest.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg/testing
+  description: Add RequireEmptyPreviewAfterRefresh option to ProgramTest


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

While working on [this issue in Azure Native](https://github.com/pulumi/pulumi-azure-native/issues/2798), I realized that I don't see how to test the scenario that I care about. I need the following workflow:

1. Run `pulumi up` for the initial deployment.
2. Run `pulumi refresh` to pull changes from API.
3. Run `pulumi preview --expect-no-changes` to guarantee that there is no loop of `refresh/up` stepping over each other.

The existing `ExpectRefreshChanges` option is different. If it's set to false, the test would require no changes on step (2) above, which is a stronger requirement. Unfortunately, it's not always true in Azure Native, e.g. when a subresource changes properties of its parent resource. I want to enable "ExpectRefreshChanges: false" where possible, but I also want to require step (3) to succeed for all tests in Azure Native (and potentially everywhere, eventually). I've already found three issues while drafting that.

Therefore, this PR proposes a new option for ProgramTest: `RequireEmptyPreviewAfterRefresh`. It defaults to false, so no behavior changes unless users opt in. If set to true, it runs an extra preview after refreshing, i.e. the step (3).

Let me know if I missed a better way of achieving the same.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
