### PR TITLE
ci: remove unnecessary TODO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
 
       test-name: ${{ matrix.test-suite.name || matrix.test-suite.command }} on ${{ matrix.platform }}/${{ matrix.version-set.name }}
       test-command: ${{ matrix.test-suite.command }}
-      is-integration-test: true # TODO: set to true here
+      is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -369,7 +369,7 @@ jobs:
 
       test-name: ${{ matrix.test-suite.name || matrix.test-suite.command }} on ${{ matrix.platform }}/${{ matrix.version-set.name }}
       test-command: ${{ matrix.test-suite.command }}
-      is-integration-test: true # TODO: set to true here
+      is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -395,7 +395,7 @@ jobs:
 
       test-name: ${{ matrix.test-suite.name || matrix.test-suite.command }} on ${{ matrix.platform }}/${{ matrix.version-set.name }}
       test-command: ${{ matrix.test-suite.command }}
-      is-integration-test: true # TODO: set to true here
+      is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 


### PR DESCRIPTION
This TODO has been there since this 6ef7ef64d620dafda126e1623c92ea2ff4823031 was merged to the main branch, but the flag was always true, and the comment also tells us to set it to true.  Setting it to true is still the right thing, so let's just get rid of the confusing comment.

Just a minor cleanup I noticed while working on some CI stuff.