### PR TITLE
Fix flakey test

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -373,14 +373,10 @@ func TestPreviewImportFile(t *testing.T) {
 
 	expectedResources := []interface{}{
 		map[string]interface{}{
-			"id": "<PLACEHOLDER>",
-			// This isn't ideal, we don't really need to change the "name" here because it isn't used as a
-			// parent, but currently we generate unique names for all resources rather than just unique names
-			// for all parent resources.
-			"name":        "usernameRandomPet",
-			"logicalName": "username",
-			"type":        "random:index/randomPet:RandomPet",
-			"version":     "4.12.0",
+			"id":      "<PLACEHOLDER>",
+			"name":    "username",
+			"type":    "random:index/randomPet:RandomPet",
+			"version": "4.12.0",
 		},
 		map[string]interface{}{
 			"name":      "component",
@@ -388,8 +384,12 @@ func TestPreviewImportFile(t *testing.T) {
 			"component": true,
 		},
 		map[string]interface{}{
-			"id":      "<PLACEHOLDER>",
-			"name":    "username",
+			"id":          "<PLACEHOLDER>",
+			"logicalName": "username",
+			// This isn't ideal, we don't really need to change the "name" here because it isn't used as a
+			// parent, but currently we generate unique names for all resources rather than just unique names
+			// for all parent resources.
+			"name":    "usernameRandomPet",
 			"type":    "random:index/randomPet:RandomPet",
 			"version": "4.12.0",
 			"parent":  "component",

--- a/tests/testdata/import_node/index.ts
+++ b/tests/testdata/import_node/index.ts
@@ -11,4 +11,9 @@ class MyComponent extends pulumi.ComponentResource {
 
 const username = new random.RandomPet("username", {});
 
-const component = new MyComponent("component", {});
+const component = new MyComponent("component", {
+    // Add a dependency on the username resource to ensure it is created first. Depending on the order the
+    // RandomPet resources are created the preview can generate different names for them. But our test expects
+    // the first resource to be the renamed one.
+    dependsOn: [username],
+});


### PR DESCRIPTION
TestPreviewImportFile could fail if the two resources registered in the opposite order to what the test expected.

https://github.com/pulumi/pulumi/actions/runs/7708946353/job/21009583196

This fixes the resources to always register in the same order via a `dependsOn` option, and then fixes the test to pass for that ordering.