### PR TITLE
Propagte cobra command context correctly

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -64,7 +64,7 @@ func newAboutCmd() *cobra.Command {
 			" - the current backend\n",
 		Args: cmdutil.MaximumNArgs(0),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			summary := getSummaryAbout(ctx, transitiveDependencies, stack)
 			if jsonOut {
 				return printJSON(summary)

--- a/pkg/cmd/pulumi/ai.go
+++ b/pkg/cmd/pulumi/ai.go
@@ -54,7 +54,7 @@ func newAICommand() *cobra.Command {
 		Hidden: !hasExperimentalCommands(),
 		Args:   cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			if len(args) == 0 {
 				return cmd.Help()
 			}

--- a/pkg/cmd/pulumi/ai_web.go
+++ b/pkg/cmd/pulumi/ai_web.go
@@ -142,7 +142,7 @@ by passing the --no-auto-submit flag.
 `,
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return aiwebcmd.Run(ctx, args)
 		},
 		),

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -43,7 +43,7 @@ func newCancelCmd() *cobra.Command {
 			"After this command completes successfully, the stack will be ready for further\n" +
 			"updates.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -61,7 +61,7 @@ func newConfigCmd() *cobra.Command {
 			"for a specific configuration key, use `pulumi config get <key-name>`.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -121,7 +121,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			"then all of the config from the current stack will be copied to the destination stack.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -300,7 +300,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -342,7 +342,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -396,7 +396,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 			"    `outer.inner`, `foo[0]` and `key1` keys",
 		Args: cmdutil.MinimumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -445,7 +445,7 @@ func newConfigRefreshCmd(stk *string) *cobra.Command {
 		Short: "Update the local configuration based on the most recent deployment of the stack",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -564,7 +564,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			"    `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -682,7 +682,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			"    value of `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/config_env_add.go
+++ b/pkg/cmd/pulumi/config_env_add.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -30,7 +32,7 @@ func newConfigEnvAddCmd(parent *configEnvCmd) *cobra.Command {
 			"per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous\n" +
 			"environment.",
 		Args: cmdutil.MinimumNArgs(1),
-		Run:  cmdutil.RunFunc(impl.run),
+		Run:  cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
 	}
 
 	cmd.Flags().BoolVar(
@@ -50,9 +52,10 @@ type configEnvAddCmd struct {
 	yes         bool
 }
 
-func (cmd *configEnvAddCmd) run(_ *cobra.Command, args []string) error {
-	return cmd.parent.editStackEnvironment(cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
-		stack.Environment = stack.Environment.Append(args...)
-		return nil
-	})
+func (cmd *configEnvAddCmd) run(ctx context.Context, args []string) error {
+	return cmd.parent.editStackEnvironment(
+		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
+			stack.Environment = stack.Environment.Append(args...)
+			return nil
+		})
 }

--- a/pkg/cmd/pulumi/config_env_add_test.go
+++ b/pkg/cmd/pulumi/config_env_add_test.go
@@ -34,8 +34,6 @@ runtime: yaml`
 	t.Run("no imports", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -47,9 +45,10 @@ runtime: yaml`
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent}
-		err := add.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY         VALUE
@@ -70,8 +69,6 @@ Save? Yes
 	t.Run("no imports, yes", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -83,9 +80,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent, yes: true}
-		err := add.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY         VALUE
@@ -104,16 +102,15 @@ aws:region  us-west-2
 	t.Run("no effects", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{}
 
 		var newStackYAML string
 		stdin := strings.NewReader("n")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent}
-		err := add.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env"})
 		require.Error(t, err)
 
 		const expectedOut = "KEY  VALUE\n" +
@@ -129,15 +126,14 @@ aws:region  us-west-2
 	t.Run("no effects, yes", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{}
 
 		var newStackYAML string
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, nil, &stdout, projectYAML, "", env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(nil, &stdout, projectYAML, "", env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent, yes: true}
-		err := add.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = "KEY  VALUE\n" +
@@ -156,8 +152,6 @@ aws:region  us-west-2
 	t.Run("one import, secrets", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -174,9 +168,10 @@ aws:region  us-west-2
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent}
-		err := add.run(nil, []string{"env2"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env2"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY           VALUE
@@ -199,8 +194,6 @@ Save? Yes
 	t.Run("one import, secrets", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -217,9 +210,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
 		add := &configEnvAddCmd{parent: parent, showSecrets: true}
-		err := add.run(nil, []string{"env2"})
+		ctx := context.Background()
+		err := add.run(ctx, []string{"env2"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY           VALUE

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -50,7 +50,7 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 			"then replaces the stack's configuration values with a reference to that environment.\n" +
 			"The environment will be created in the same organization as the stack.",
 		Args: cmdutil.NoArgs,
-		Run:  cmdutil.RunFunc(impl.run),
+		Run:  cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
 	}
 
 	cmd.Flags().StringVar(
@@ -89,12 +89,10 @@ type configEnvInitCmd struct {
 	yes         bool
 }
 
-func (cmd *configEnvInitCmd) run(_ *cobra.Command, args []string) error {
+func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	if !cmd.yes && !cmd.parent.interactive {
 		return errors.New("--yes must be passed in to proceed when running in non-interactive mode")
 	}
-
-	ctx := cmd.parent.ctx
 
 	opts := display.Options{Color: cmd.parent.color}
 

--- a/pkg/cmd/pulumi/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config_env_init_test.go
@@ -58,14 +58,13 @@ runtime: yaml`
 	t.Run("no config", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, "", &newStackYAML, envDefMap{})
+		parent := newConfigEnvCmdForInitTest(stdin, &stdout, projectYAML, "", &newStackYAML, envDefMap{})
 		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, yes: true}
-		err := init.run(nil, nil)
+		ctx := context.Background()
+		err := init.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "Creating environment test-stack for stack stack...\n" +
@@ -122,9 +121,9 @@ runtime: yaml`
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
+		parent := newConfigEnvCmdForInitTest(stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
 		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, yes: true}
-		err = init.run(nil, nil)
+		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "Creating environment test-stack for stack stack...\n" +
@@ -199,9 +198,9 @@ runtime: yaml`
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
+		parent := newConfigEnvCmdForInitTest(stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
 		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, showSecrets: true, yes: true}
-		err = init.run(nil, nil)
+		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "Creating environment test-stack for stack stack...\n" +
@@ -278,11 +277,11 @@ runtime: yaml`
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForInitTest(ctx, stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{
+		parent := newConfigEnvCmdForInitTest(stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{
 			"env": `{"values": {"pulumiConfig": {"app:tags": {"name": "project"}}}}`,
 		})
 		init := &configEnvInitCmd{parent: parent, newCrypter: newBase64EvalCrypter, showSecrets: true, yes: true}
-		err = init.run(nil, nil)
+		err = init.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "Creating environment test-stack for stack stack...\n" +

--- a/pkg/cmd/pulumi/config_env_ls.go
+++ b/pkg/cmd/pulumi/config_env_ls.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +31,7 @@ func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Lists imported environments.",
 		Long:  "Lists the environments imported into a stack's configuration.",
 		Args:  cmdutil.NoArgs,
-		Run:   cmdutil.RunFunc(impl.run),
+		Run:   cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
 	}
 
 	cmd.Flags().BoolVarP(
@@ -45,6 +47,6 @@ type configEnvLsCmd struct {
 	jsonOut *bool
 }
 
-func (cmd *configEnvLsCmd) run(_ *cobra.Command, _ []string) error {
-	return cmd.parent.listStackEnvironments(*cmd.jsonOut)
+func (cmd *configEnvLsCmd) run(ctx context.Context, _ []string) error {
+	return cmd.parent.listStackEnvironments(ctx, *cmd.jsonOut)
 }

--- a/pkg/cmd/pulumi/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config_env_ls_test.go
@@ -38,8 +38,6 @@ runtime: yaml`
 	t.Run("no imports", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -50,9 +48,10 @@ runtime: yaml`
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "This stack configuration has no environments listed. " +
@@ -64,8 +63,6 @@ runtime: yaml`
 	t.Run("no imports, json", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -76,9 +73,10 @@ runtime: yaml`
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = "[]\n"
@@ -88,8 +86,6 @@ runtime: yaml`
 
 	t.Run("with imports", func(t *testing.T) {
 		t.Parallel()
-
-		ctx := context.Background()
 
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
@@ -108,9 +104,10 @@ runtime: yaml`
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = `ENVIRONMENTS
@@ -125,8 +122,6 @@ thirdEnv
 	t.Run("with imports, json", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -144,9 +139,10 @@ thirdEnv
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = `[
@@ -162,8 +158,6 @@ thirdEnv
 	t.Run("with imports", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -181,9 +175,10 @@ thirdEnv
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = `ENVIRONMENTS
@@ -198,8 +193,6 @@ thirdEnv
 	t.Run("repeated imports", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -218,9 +211,10 @@ thirdEnv
 
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
 		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
-		err := ls.run(nil, nil)
+		ctx := context.Background()
+		err := ls.run(ctx, nil)
 		require.NoError(t, err)
 
 		const expectedOut = `[

--- a/pkg/cmd/pulumi/config_env_rm.go
+++ b/pkg/cmd/pulumi/config_env_rm.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
@@ -28,7 +30,7 @@ func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Remove environments from a stack",
 		Long:  "Removes an environment from a stack's import list.",
 		Args:  cmdutil.ExactArgs(1),
-		Run:   cmdutil.RunFunc(impl.run),
+		Run:   cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
 	}
 
 	cmd.Flags().BoolVar(
@@ -48,9 +50,10 @@ type configEnvRmCmd struct {
 	yes         bool
 }
 
-func (cmd *configEnvRmCmd) run(_ *cobra.Command, args []string) error {
-	return cmd.parent.editStackEnvironment(cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
-		stack.Environment = stack.Environment.Remove(args[0])
-		return nil
-	})
+func (cmd *configEnvRmCmd) run(ctx context.Context, args []string) error {
+	return cmd.parent.editStackEnvironment(
+		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
+			stack.Environment = stack.Environment.Remove(args[0])
+			return nil
+		})
 }

--- a/pkg/cmd/pulumi/config_env_rm_test.go
+++ b/pkg/cmd/pulumi/config_env_rm_test.go
@@ -34,14 +34,13 @@ runtime: yaml`
 	t.Run("no imports", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, "", nil, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", nil, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent}
-		err := rm.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY  VALUE
@@ -59,13 +58,12 @@ Save? Yes
 	t.Run("no imports, yes", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		var newStackYAML string
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, nil, &stdout, projectYAML, "", nil, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(nil, &stdout, projectYAML, "", nil, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent, yes: true}
-		err := rm.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = "KEY  VALUE\n"
@@ -80,8 +78,6 @@ Save? Yes
 	t.Run("one import", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		const stackYAML = `environment:
   - env
 `
@@ -89,9 +85,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, nil, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, nil, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent, yes: true}
-		err := rm.run(nil, []string{"env"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env"})
 		require.NoError(t, err)
 
 		const expectedOut = "KEY  VALUE\n"
@@ -106,8 +103,6 @@ Save? Yes
 	t.Run("effects -> no effects", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		const stackYAML = `environment:
   - env
   - env2
@@ -118,9 +113,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("n")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent}
-		err := rm.run(nil, []string{"env2"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env2"})
 		require.Error(t, err)
 
 		const expectedOut = "KEY  VALUE\n" +
@@ -133,8 +129,6 @@ Save? Yes
 
 	t.Run("two imports, secrets", func(t *testing.T) {
 		t.Parallel()
-
-		ctx := context.Background()
 
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
@@ -153,9 +147,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent}
-		err := rm.run(nil, []string{"env2"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env2"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY           VALUE
@@ -177,8 +172,6 @@ Save? Yes
 	t.Run("two imports, secrets", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-
 		env := &esc.Environment{
 			Properties: map[string]esc.Value{
 				"pulumiConfig": esc.NewValue(map[string]esc.Value{
@@ -196,9 +189,10 @@ Save? Yes
 		var newStackYAML string
 		stdin := strings.NewReader("y")
 		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(ctx, stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
+		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, &newStackYAML)
 		rm := &configEnvRmCmd{parent: parent, showSecrets: true}
-		err := rm.run(nil, []string{"env2"})
+		ctx := context.Background()
+		err := rm.run(ctx, []string{"env2"})
 		require.NoError(t, err)
 
 		const expectedOut = `KEY           VALUE

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -39,7 +39,6 @@ func cleanStdout(s string) string {
 }
 
 func newConfigEnvCmdForTest(
-	ctx context.Context,
 	stdin io.Reader,
 	stdout io.Writer,
 	projectYAML string,
@@ -49,7 +48,6 @@ func newConfigEnvCmdForTest(
 	newStackYAML *string,
 ) *configEnvCmd {
 	return newConfigEnvCmdForTestWithCheckYAMLEnvironment(
-		ctx,
 		stdin,
 		stdout,
 		projectYAML,
@@ -67,7 +65,6 @@ func newConfigEnvCmdForTest(
 }
 
 func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
-	ctx context.Context,
 	stdin io.Reader,
 	stdout io.Writer,
 	projectYAML string,
@@ -87,7 +84,6 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 ) *configEnvCmd {
 	stackRef := "stack"
 	return &configEnvCmd{
-		ctx:         ctx,
 		stdin:       stdin,
 		stdout:      stdout,
 		interactive: true,
@@ -190,7 +186,6 @@ func (m envDefMap) LoadEnvironment(ctx context.Context, name string) ([]byte, ev
 }
 
 func newConfigEnvCmdForInitTest(
-	ctx context.Context,
 	stdin io.Reader,
 	stdout io.Writer,
 	projectYAML string,
@@ -199,7 +194,6 @@ func newConfigEnvCmdForInitTest(
 	envs envDefMap,
 ) *configEnvCmd {
 	return newConfigEnvCmdForTestWithCheckYAMLEnvironment(
-		ctx,
 		stdin,
 		stdout,
 		projectYAML,

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -36,7 +36,7 @@ func newConsoleCmd() *cobra.Command {
 		Short: "Opens the current stack in the Pulumi Console",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -92,7 +92,7 @@ func newDestroyCmd() *cobra.Command {
 			"Warning: this command is generally irreversible and should be used with great care.",
 		Args: cmdArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.remote {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -634,7 +634,7 @@ func newImportCmd() *cobra.Command {
 			"type, parent and provider information for you and just require you to fill in resource\n" +
 			"IDs and any properties.\n",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -44,7 +44,7 @@ func newInstallCmd() *cobra.Command {
 			"\n" +
 			"This command is used to manually install packages and plugins required by your program.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -87,7 +87,7 @@ func newLoginCmd() *cobra.Command {
 			"    $ pulumi login azblob://my-pulumi-state-bucket\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			displayOptions := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -55,7 +55,7 @@ func newLogsCmd() *cobra.Command {
 			"CloudWatch Logs for log data relevant to resources in a stack.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -503,7 +503,7 @@ func newNewCmd() *cobra.Command {
 			"Any missing but required information will be prompted for.\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -85,7 +85,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			"If you try and set a default organization for a backend that does not \n" +
 			"support create organizations, then an error will be returned by the CLI",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -130,7 +130,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			"\n" +
 			"Currently, only the managed and self-hosted backends support organizations.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/org_search.go
+++ b/pkg/cmd/pulumi/org_search.go
@@ -191,7 +191,7 @@ func newSearchCmd() *cobra.Command {
 		Long:  "Search for resources in Pulumi Cloud.",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			if len(scmd.queryParams) == 0 {
 				return cmd.Help()
 			}

--- a/pkg/cmd/pulumi/org_search_ai.go
+++ b/pkg/cmd/pulumi/org_search_ai.go
@@ -121,7 +121,7 @@ func newSearchAICmd() *cobra.Command {
 		Long:  "Search for resources in Pulumi Cloud using Pulumi AI",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return scmd.Run(ctx, args)
 		},
 		),

--- a/pkg/cmd/pulumi/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/package_pack_sdk.go
@@ -37,7 +37,7 @@ func newPackagePackCmd() *cobra.Command {
 		Short:  "Pack a package SDK to a language specific artifact.",
 		Hidden: !env.Dev.Value(),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return packCmd.Run(ctx, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/package_publish.go
+++ b/pkg/cmd/pulumi/package_publish.go
@@ -39,7 +39,7 @@ func newPackagePublishCmd() *cobra.Command {
 		Short:  "Publish a package SDK to supported package registries.",
 		Hidden: !env.Dev.Value(),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return publCmd.Run(ctx, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -55,7 +55,7 @@ func newPluginInstallCmd() *cobra.Command {
 			"If VERSION is unspecified, Pulumi will attempt to look up the latest version of\n" +
 			"the plugin, though the result is not guaranteed.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return picmd.Run(ctx, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -34,7 +34,7 @@ func newPolicyDisableCmd() *cobra.Command {
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			var err error
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -41,7 +41,7 @@ func newPolicyEnableCmd() *cobra.Command {
 		Long: "Enable a Policy Pack for a Pulumi organization. " +
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -47,7 +47,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 		Short: "List all Policy Groups for a Pulumi organization",
 		Long:  "List all Policy Groups for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			// Try to read the current project
 			project, _, err := readProject()

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -37,7 +37,7 @@ func newPolicyLsCmd() *cobra.Command {
 		Short: "List all Policy Packs for a Pulumi organization",
 		Long:  "List all Policy Packs for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			// Try to read the current project
 			project, _, err := readProject()

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -60,7 +60,7 @@ func newPolicyNewCmd() *cobra.Command {
 			"Only organization administrators can publish a Policy Pack.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -40,7 +40,7 @@ func newPolicyPublishCmd() *cobra.Command {
 			"\n" +
 			"If an organization name is not specified, the default org (if set) or the current user account is used.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			return policyPublishCmd.Run(commandContext(), args)
+			return policyPublishCmd.Run(cmd.Context(), args)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -36,7 +36,7 @@ func newPolicyRmCmd() *cobra.Command {
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, args[0], loginToCloud)

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -32,7 +32,7 @@ func newPolicyValidateCmd() *cobra.Command {
 		Short: "Validate a Policy Pack configuration",
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi Cloud backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0], loginToCloud)
 			if err != nil {

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -293,7 +293,7 @@ func newPreviewCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			displayType := display.DisplayProgress
 			if diffDisplay {
 				displayType = display.DisplayDiff

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -48,7 +48,7 @@ func newQueryCmd() *cobra.Command {
 		Args:   cmdutil.NoArgs,
 		Hidden: !hasExperimentalCommands() && !hasDebugCommands(),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			interactive := cmdutil.Interactive()
 
 			opts := backend.UpdateOptions{}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -87,7 +87,7 @@ func newRefreshCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.remote {

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -51,7 +51,7 @@ func newStackCmd() *cobra.Command {
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -66,7 +66,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			"\"gcpkms://projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>\"`\n" +
 			"* `pulumi stack change-secrets-provider \"hashivault://mykey\"`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return scspcmd.Run(ctx, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -45,7 +45,7 @@ func newStackExportCmd() *cobra.Command {
 			"in a stack's state due to failed deployments, manual changes to cloud\n" +
 			"resources, etc.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -65,7 +65,7 @@ func newStackGraphCmd() *cobra.Command {
 			"emitted when it was run. This graph is output in the DOT format. This command operates\n" +
 			"on your stack's most recent deployment.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -37,7 +37,7 @@ func newStackHistoryCmd() *cobra.Command {
 
 This command displays data about previous updates for a stack.`,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -49,7 +49,7 @@ func newStackImportCmd() *cobra.Command {
 			"to cloud resources, etc. can be reimported to the stack using this command.\n" +
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -68,7 +68,7 @@ func newStackInitCmd() *cobra.Command {
 			"`--copy-config-from` flag.\n" +
 			"* `pulumi stack init --copy-config-from dev`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			return sicmd.Run(ctx, args)
 		}),
 	}

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -57,7 +57,7 @@ func newStackLsCmd() *cobra.Command {
 			"'environment=production' or just 'gcp:project'.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, _ []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			cmdArgs := stackLSArgs{
 				jsonOut:    jsonOut,
 				allStacks:  allStacks,

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -47,7 +47,7 @@ func newStackOutputCmd() *cobra.Command {
 			"By default, this command lists all output properties exported from a stack.\n" +
 			"If a specific property-name is supplied, just that property's value is shown.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			return socmd.Run(commandContext(), args)
+			return socmd.Run(cmd.Context(), args)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -45,7 +45,7 @@ func newStackRenameCmd() *cobra.Command {
 			"'robot-co/new-project-name/production'. However in order to update the stack again, you would also need\n" +
 			"to update the name field of Pulumi.yaml, so the project names match.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -48,7 +48,7 @@ func newStackRmCmd() *cobra.Command {
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -44,7 +44,7 @@ func newStackSelectCmd() *cobra.Command {
 			"If provided stack name is not found you may pass the --create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -59,7 +59,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 		Short: "Get a single stack tag value",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			name := args[0]
 
 			opts := display.Options{
@@ -93,7 +93,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 		Short: "List all stack tags",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -149,7 +149,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 		Short: "Remove a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			name := args[0]
 
 			opts := display.Options{
@@ -179,7 +179,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 		Short: "Set a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			name := args[0]
 			value := args[1]
 

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -52,7 +52,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		Args:    cmdutil.MaximumNArgs(1),
 
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			var urn resource.URN
 			if len(args) == 0 {

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -38,7 +38,6 @@ import (
 func newStateEditCommand() *cobra.Command {
 	var stackName string
 	stateEdit := &stateEditCmd{
-		Ctx:       commandContext(),
 		Colorizer: cmdutil.GetGlobalColorization(),
 	}
 	cmd := &cobra.Command{
@@ -56,7 +55,7 @@ a preview showing a diff of the altered state.`,
 			if !cmdutil.Interactive() {
 				return result.Error("pulumi state edit must be run in interactive mode")
 			}
-			s, err := requireStack(commandContext(), stackName, stackLoadOnly, display.Options{
+			s, err := requireStack(cmd.Context(), stackName, stackLoadOnly, display.Options{
 				Color:         cmdutil.GetGlobalColorization(),
 				IsInteractive: true,
 			})

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -166,7 +166,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		Example: "pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:kubernetes::eks-provider' new-name-here",
 		Args:    cmdutil.MaximumNArgs(2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 
 			if len(args) < 2 && !cmdutil.Interactive() {

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -44,7 +44,7 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -45,7 +45,7 @@ This only has an effect on self-managed backends.
 `,
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			if err := sucmd.Run(commandContext()); err != nil {
+			if err := sucmd.Run(cmd.Context()); err != nil {
 				return result.FromError(err)
 			}
 			return nil

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -426,7 +426,7 @@ func newUpCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.remote {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/spf13/pflag"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -47,7 +46,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
-	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
@@ -173,25 +171,6 @@ func currentBackend(ctx context.Context, project *workspace.Project, opts displa
 	}
 
 	return loginToCloud(ctx, url, project, workspace.GetCloudInsecure(url), opts)
-}
-
-// This is used to control the contents of the tracing header.
-var tracingHeader = os.Getenv("PULUMI_TRACING_HEADER")
-
-func commandContext() context.Context {
-	ctx := context.Background()
-	if cmdutil.IsTracingEnabled() {
-		if cmdutil.TracingRootSpan != nil {
-			ctx = opentracing.ContextWithSpan(ctx, cmdutil.TracingRootSpan)
-		}
-
-		tracingOptions := tracing.Options{
-			PropagateSpans: true,
-			TracingHeader:  tracingHeader,
-		}
-		ctx = tracing.ContextWithOptions(ctx, tracingOptions)
-	}
-	return ctx
 }
 
 func createSecretsManager(

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -66,7 +66,7 @@ func newWatchCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skippreview*/, true /* autoapprove*/)
 			if err != nil {

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -39,7 +39,7 @@ func newWhoAmICmd() *cobra.Command {
 			"Displays the username of the currently logged in user.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			return whocmd.Run(commandContext())
+			return whocmd.Run(cmd.Context())
 		}),
 	}
 


### PR DESCRIPTION
All our commands were calling `commandContext()` to get a `context.Context` to use for the command, but this was totally ignoring the context on the `cobra.Command` that would have already been set, and could have been updated higher up in the command chain.

Fixing these to instead look at the `cobra.Command.Context()` means we can move the tracing setup `commandContext()` did into the top level pulumi command code. This also saves mutating a global variable.