### PR TITLE
Allows SKIP_CHECKPOINTS without EXPERIMENTAL

### DIFF
--- a/changelog/pending/20240130--backend--allows-the-pulumi_skip_checkpoints-environment-variable-to-be-set-without-requiring-the-pulumi_experimental-flag.yaml
+++ b/changelog/pending/20240130--backend--allows-the-pulumi_skip_checkpoints-environment-variable-to-be-set-without-requiring-the-pulumi_experimental-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend
+  description: Allows the PULUMI_SKIP_CHECKPOINTS environment variable to be set without requiring the PULUMI_EXPERIMENTAL flag

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -260,7 +260,6 @@ func TestSamesWithDependencyChanges(t *testing.T) {
 //
 //nolint:paralleltest // mutates environment variables
 func TestWriteCheckpointOnceUnsafe(t *testing.T) {
-	t.Setenv(env.Experimental.Var().Name(), "1")
 	t.Setenv(env.SkipCheckpoints.Var().Name(), "1")
 
 	provider := NewResource("urn:pulumi:foo::bar::pulumi:providers:pkgUnsafe::provider")

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -43,8 +43,8 @@ var SkipUpdateCheck = env.Bool("SKIP_UPDATE_CHECK", "Disable checking for a new 
 
 var Dev = env.Bool("DEV", "Enable features for hacking on pulumi itself.")
 
-var SkipCheckpoints = env.Bool("SKIP_CHECKPOINTS", "Experimental flag to skip saving state "+
-	"checkpoints and only save the final deployment. See #10668.", env.Needs(Experimental))
+var SkipCheckpoints = env.Bool("SKIP_CHECKPOINTS", "Skip saving state checkpoints and only save "+
+	"the final deployment. See #10668.")
 
 var DebugCommands = env.Bool("DEBUG_COMMANDS", "List commands helpful for debugging pulumi itself.")
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1409,29 +1409,57 @@ func TestTSConfigOption(t *testing.T) {
 }
 
 // This tests that despite an exception, that the snapshot is still written.
-//
-//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestUnsafeSnapshotManagerRetainsResourcesOnError(t *testing.T) {
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:          filepath.Join("unsafe_snapshot_tests", "bad_resource"),
-		Dependencies: []string{"@pulumi/pulumi"},
-		Env: []string{
-			"PULUMI_EXPERIMENTAL=1",
-			"PULUMI_SKIP_CHECKPOINTS=1",
-		},
-		Quick: true,
-		// The program throws an exception and 1 resource fails to be created.
-		ExpectFailure: true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			// Ensure the checkpoint contains the 1003 other resources that were created
-			// - stack
-			// - provider
-			// - `base` resource
-			// - 1000 resources(via a for loop)
-			// - NOT a resource that failed to be created dependent on the `base` resource output
-			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 3+1000, len(stackInfo.Deployment.Resources))
-		},
+	t.Parallel()
+
+	//nolint:paralleltest // ProgramTest calls t.Parallel()
+	t.Run("Check with experimental flag", func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir:          filepath.Join("unsafe_snapshot_tests", "bad_resource"),
+			Dependencies: []string{"@pulumi/pulumi"},
+			Env: []string{
+				"PULUMI_EXPERIMENTAL=1",
+				"PULUMI_SKIP_CHECKPOINTS=1",
+			},
+			Quick: true,
+			// The program throws an exception and 1 resource fails to be created.
+			ExpectFailure: true,
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Ensure the checkpoint contains the 1003 other resources that were created
+				// - stack
+				// - provider
+				// - `base` resource
+				// - 1000 resources(via a for loop)
+				// - NOT a resource that failed to be created dependent on the `base` resource output
+				assert.NotNil(t, stackInfo.Deployment)
+				assert.Equal(t, 3+1000, len(stackInfo.Deployment.Resources))
+			},
+		})
+	})
+
+	//nolint:paralleltest // ProgramTest calls t.Parallel()
+	t.Run("Check without experimental flag", func(t *testing.T) {
+		integration.ProgramTest(t, &integration.ProgramTestOptions{
+			Dir:          filepath.Join("unsafe_snapshot_tests", "bad_resource"),
+			Dependencies: []string{"@pulumi/pulumi"},
+			Env: []string{
+				"PULUMI_EXPERIMENTAL=0",
+				"PULUMI_SKIP_CHECKPOINTS=1",
+			},
+			Quick: true,
+			// The program throws an exception and 1 resource fails to be created.
+			ExpectFailure: true,
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Ensure the checkpoint contains the 1003 other resources that were created
+				// - stack
+				// - provider
+				// - `base` resource
+				// - 1000 resources(via a for loop)
+				// - NOT a resource that failed to be created dependent on the `base` resource output
+				assert.NotNil(t, stackInfo.Deployment)
+				assert.Equal(t, 3+1000, len(stackInfo.Deployment.Resources))
+			},
+		})
 	})
 }
 


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This relaxes the requirement on the `PULUMI_SKIP_CHECKPOINTS` env var to also have `PULUMI_EXPERIMENTAL` set.

Because `PULUMI_EXPERIMENTAL` introduces other behavior, this decouples the `PULUMI_SKIP_CHECKPOINTS` behavior from that.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
