### PR TITLE
State: fix panic when deleting non-unique Provider

### DIFF
--- a/changelog/pending/20240131--cli-state--fix-a-panic-when-trying-to-delete-a-provider-from-the-state-thats-still-referenced.yaml
+++ b/changelog/pending/20240131--cli-state--fix-a-panic-when-trying-to-delete-a-provider-from-the-state-thats-still-referenced.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix a panic when trying to delete a provider from the state that's still referenced

--- a/changelog/pending/20240131--cli-state--fix-a-panic-when-trying-to-delete-a-provider-from-the-state-thats-still-referenced.yaml
+++ b/changelog/pending/20240131--cli-state--fix-a-panic-when-trying-to-delete-a-provider-from-the-state-thats-still-referenced.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/state
-  description: Fix a panic when trying to delete a provider from the state that's still referenced
+  description: Fix a panic when trying to delete a provider from the state that's still referenced.

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -31,7 +31,7 @@ func newStateDeleteCommand() *cobra.Command {
 	var force bool // Force deletion of protected resources
 	var stack string
 	var yes bool
-	var targetDepenedents bool
+	var targetDependents bool
 
 	cmd := &cobra.Command{
 		Use:   "delete [resource URN]",
@@ -81,7 +81,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 						return edit.UnprotectResource(nil, res)
 					}
 				}
-				return edit.DeleteResource(snap, res, handleProtected, targetDepenedents)
+				return edit.DeleteResource(snap, res, handleProtected, targetDependents)
 			})
 			if err != nil {
 				switch e := err.(type) {
@@ -112,6 +112,6 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.Flags().BoolVar(&force, "force", false, "Force deletion of protected resources")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
-	cmd.Flags().BoolVar(&targetDepenedents, "target-dependents", false, "Delete the URN and all its dependents")
+	cmd.Flags().BoolVar(&targetDependents, "target-dependents", false, "Delete the URN and all its dependents")
 	return cmd
 }

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -75,7 +75,7 @@ func DeleteResource(
 	deleteSet := make(map[resource.URN][]*resource.State)
 	dg := graph.NewDependencyGraph(snapshot.Resources)
 
-	deps := dg.DependingOnUniquely(condemnedRes)
+	deps := dg.OnlyDependsOn(condemnedRes)
 	if len(deps) != 0 {
 		if !targetDependents {
 			return ResourceHasDependenciesError{Condemned: condemnedRes, Dependencies: deps}

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -114,7 +114,7 @@ func TestDeletingDuplicateURNs(t *testing.T) {
 
 	// This test ensures that when targeting dependent resources, deleting a
 	// resource with a redundant URN will not delete dependent resources in
-	// state as it's ambiguous stince another URN can satisfy the dependency.
+	// state as it's ambiguous since another URN can satisfy the dependency.
 	t.Run("do-target-dependents", func(t *testing.T) {
 		t.Parallel()
 		snap := NewSnapshot([]*resource.State{

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -124,7 +124,6 @@ func TestDeletingDuplicateURNs(t *testing.T) {
 		err := DeleteResource(snap, b1, nil, true /* targetDependents */)
 		require.NoError(t, err)
 
-		// assert.Equals does a deep equals with the expected list.
 		assert.Equal(t, []*resource.State{
 			pA, a, b2, b3, c,
 		}, snap.Resources)
@@ -146,7 +145,6 @@ func TestDeletingDuplicateURNs(t *testing.T) {
 		err := DeleteResource(snap, b1, nil, false /* targetDependents */)
 		require.NoError(t, err)
 
-		// assert.Equals does a deep equals with the expected list.
 		assert.Equal(t, []*resource.State{
 			pA, a, b2, b3, c,
 		}, snap.Resources)
@@ -166,30 +164,30 @@ func TestDeletingDuplicateProviderURN(t *testing.T) {
 	pA1 := NewProviderResource("a", "p1", "1")
 
 	// Create a resource that depends on the duplicate Provider.
-	b1 := NewResource("b", pA0)
-	b2 := NewResource("b", pA1)
+	b0 := NewResource("b", pA0)
+	b1 := NewResource("b", pA1)
+	assert.Equal(t, b0.URN, b1.URN)
 
-	c := NewResource("c", pA1, b1.URN)
+	c := NewResource("c", pA1, b0.URN)
 
 	t.Run("do-target-dependents", func(t *testing.T) {
 		t.Parallel()
 		snap := NewSnapshot([]*resource.State{
-			pA0, pA1, b1, b2, c,
+			pA0, pA1, b0, b1, c,
 		})
 
 		err := DeleteResource(snap, pA0, nil, true /* targetDependents */)
 		require.NoError(t, err)
 
-		// assert.Equals does a deep equals with the expected list.
 		assert.Equal(t, []*resource.State{
-			pA1, b2, c,
+			pA1, b1, c,
 		}, snap.Resources)
 	})
 
 	t.Run("do-not-target-dependents", func(t *testing.T) {
 		t.Parallel()
 		snap := NewSnapshot([]*resource.State{
-			pA0, pA1, b1, b2, c,
+			pA0, pA1, b0, b1, c,
 		})
 
 		err := DeleteResource(snap, pA0, nil, false /* targetDependents */)
@@ -200,12 +198,11 @@ func TestDeletingDuplicateProviderURN(t *testing.T) {
 	t.Run("do-target-dependents-one-intermediate", func(t *testing.T) {
 		t.Parallel()
 		snap := NewSnapshot([]*resource.State{
-			pA0, pA1, b1, c,
+			pA0, pA1, b0, c,
 		})
 
 		err := DeleteResource(snap, pA0, nil, true /* targetDependents */)
 		require.NoError(t, err)
-		// assert.Equals does a deep equals with the expected list.
 		assert.Equal(t, []*resource.State{
 			pA1,
 		}, snap.Resources)
@@ -214,7 +211,49 @@ func TestDeletingDuplicateProviderURN(t *testing.T) {
 	t.Run("do-target-dependents-one-intermediate", func(t *testing.T) {
 		t.Parallel()
 		snap := NewSnapshot([]*resource.State{
-			pA0, pA1, b1, c,
+			pA0, pA1, b0, c,
+		})
+
+		err := DeleteResource(snap, pA0, nil, false /* targetDependents */)
+		require.ErrorContains(t, err,
+			"Can't delete resource \"urn:pulumi:test::test::pulumi:providers:a::p1\" due to dependent resources")
+	})
+}
+
+func TestDeletingDuplicateProviderURNWithDependents(t *testing.T) {
+	t.Parallel()
+
+	// Create duplicate provider resources
+	pA0 := NewProviderResource("a", "p1", "0")
+	pA1 := NewProviderResource("a", "p1", "1")
+
+	// Create a resource that depends on the duplicate Provider.
+	b0 := NewResource("b", pA0)
+
+	c0 := NewProviderResource("c", "p1", "0", b0.URN)
+	c1 := NewProviderResource("c", "p1", "1")
+
+	d0 := NewResource("d", c0)
+	d1 := NewResource("d", c1)
+
+	t.Run("do-target-dependents", func(t *testing.T) {
+		t.Parallel()
+		snap := NewSnapshot([]*resource.State{
+			pA0, pA1, b0, c0, c1, d0, d1,
+		})
+
+		err := DeleteResource(snap, pA0, nil, true /* targetDependents */)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*resource.State{
+			pA1, c1, d1,
+		}, snap.Resources)
+	})
+
+	t.Run("do-not-target-dependents", func(t *testing.T) {
+		t.Parallel()
+		snap := NewSnapshot([]*resource.State{
+			pA0, pA1, b0, c0, c1, d0, d1,
 		})
 
 		err := DeleteResource(snap, pA0, nil, false /* targetDependents */)

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -163,7 +163,7 @@ func TestDeletingDuplicateProviderURN(t *testing.T) {
 
 	// Create duplicate provider resources
 	pA := NewProviderResource("a", "p1", "0")
-	pB := NewProviderResource("a", "p2", "0")
+	pB := NewProviderResource("a", "p1", "1")
 
 	// Create a resource that depends on the duplicate Provider.
 	b1 := NewResource("b", pA)

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -82,13 +82,13 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 	return dependents
 }
 
-// DependingOnUniquely returns a slice containing all resources that directly or indirectly
+// OnlyDependsOn returns a slice containing all resources that directly or indirectly
 // depend upon *only* the given resource.  Resources that also depend on another resource with
 // the same URN will not be included in the returned slice.  The returned slice is guaranteed
 // to be in topological order with respect to the snapshot dependency graph.
 //
-// The time complexity of DependingOnUniquely is linear with respect to the number of resources.
-func (dg *DependencyGraph) DependingOnUniquely(res *resource.State) []*resource.State {
+// The time complexity of OnlyDependsOn is linear with respect to the number of resources.
+func (dg *DependencyGraph) OnlyDependsOn(res *resource.State) []*resource.State {
 	// This implementation relies on the detail that snapshots are stored in a valid
 	// topological order.
 	var dependents []*resource.State
@@ -126,10 +126,10 @@ func (dg *DependencyGraph) DependingOnUniquely(res *resource.State) []*resource.
 	// the graph that we actually want to operate upon. Edges in the snapshot graph
 	// originate in a resource and go to that resource's dependencies.
 	//
-	// The `DependingOnUniquely` is simpler when operating on the reverse of the snapshot graph,
+	// The `OnlyDependsOn` is simpler when operating on the reverse of the snapshot graph,
 	// where edges originate in a resource and go to resources that depend on that resource.
-	// In this graph, `DependingOn` for a resource is the set of resources that are reachable from the
-	// given resource.
+	// In this graph, `OnlyDependsOn` for a resource is the set of resources that are reachable from the
+	// given resource, and only from the given resource.
 	//
 	// To accomplish this without building up an entire graph data structure, we'll do a linear
 	// scan of the resource list starting at the requested resource and ending at the end of

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -82,6 +82,79 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 	return dependents
 }
 
+// DependingOnUniquely returns a slice containing all resources that directly or indirectly
+// depend upon *only* the given resource.  Resources that also depend on another resource with
+// the same URN will not be included in the returned slice.  The returned slice is guaranteed
+// to be in topological order with respect to the snapshot dependency graph.
+//
+// The time complexity of DependingOnUniquely is linear with respect to the number of resources.
+func (dg *DependencyGraph) DependingOnUniquely(res *resource.State) []*resource.State {
+	// This implementation relies on the detail that snapshots are stored in a valid
+	// topological order.
+	var dependents []*resource.State
+	dependentSet := make(map[resource.URN][]resource.ID)
+	nonDependentSet := make(map[resource.URN][]resource.ID)
+
+	cursorIndex, ok := dg.index[res]
+	contract.Assertf(ok, "could not determine index for resource %s", res.URN)
+	dependentSet[res.URN] = []resource.ID{res.ID}
+	isDependent := func(candidate *resource.State) bool {
+		if res.URN == candidate.URN && res.ID == candidate.ID {
+			return false
+		}
+		if len(dependentSet[candidate.Parent]) > 0 && len(nonDependentSet[candidate.Parent]) == 0 {
+			return true
+		}
+		for _, dependency := range candidate.Dependencies {
+			if len(dependentSet[dependency]) == 1 && len(nonDependentSet[dependency]) == 0 {
+				return true
+			}
+		}
+		if candidate.Provider != "" {
+			ref, err := providers.ParseReference(candidate.Provider)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", candidate.Provider)
+			for _, id := range dependentSet[ref.URN()] {
+				if id == ref.ID() {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// The dependency graph encoded directly within the snapshot is the reverse of
+	// the graph that we actually want to operate upon. Edges in the snapshot graph
+	// originate in a resource and go to that resource's dependencies.
+	//
+	// The `DependingOnUniquely` is simpler when operating on the reverse of the snapshot graph,
+	// where edges originate in a resource and go to resources that depend on that resource.
+	// In this graph, `DependingOn` for a resource is the set of resources that are reachable from the
+	// given resource.
+	//
+	// To accomplish this without building up an entire graph data structure, we'll do a linear
+	// scan of the resource list starting at the requested resource and ending at the end of
+	// the list. All resources that depend directly or indirectly on `res` are prepended
+	// onto `dependents`.
+	//
+	// We also walk through the the list of resources before the requested resource, as resources
+	// sorted later could still be dependent on the requested resource.
+	for i := 0; i < cursorIndex; i++ {
+		candidate := dg.resources[i]
+		nonDependentSet[candidate.URN] = append(nonDependentSet[candidate.URN], candidate.ID)
+	}
+	for i := cursorIndex + 1; i < len(dg.resources); i++ {
+		candidate := dg.resources[i]
+		if isDependent(candidate) {
+			dependents = append(dependents, candidate)
+			dependentSet[candidate.URN] = append(dependentSet[candidate.URN], candidate.ID)
+		} else {
+			nonDependentSet[candidate.URN] = append(nonDependentSet[candidate.URN], candidate.ID)
+		}
+	}
+
+	return dependents
+}
+
 // DependenciesOf returns a set of resources upon which the given resource depends. The resource's parent is
 // included in the returned set.
 func (dg *DependencyGraph) DependenciesOf(res *resource.State) mapset.Set[*resource.State] {

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -267,3 +267,59 @@ func TestTransitiveDependenciesOf(t *testing.T) {
 	assert.True(t, set.Contains(aws), "everything should depend on the provider")
 	assert.True(t, set.Contains(greatUncle), "child depends on greatUncle")
 }
+
+func TestOnlyDependsOn(t *testing.T) {
+	t.Parallel()
+
+	aws0 := NewProviderResource("aws", "default", "0")
+	aws1 := NewProviderResource("aws", "default", "1")
+	aws2 := NewProviderResource("aws", "default", "2")
+
+	b0 := NewResource("b", aws0)
+	b1 := NewResource("b", aws1)
+
+	c0 := NewResource("c0", aws2, b0.URN)
+
+	dg := NewDependencyGraph([]*resource.State{
+		aws0,
+		aws1,
+		aws2,
+		b0,
+		b1,
+		c0,
+	})
+
+	assert.Equal(t, []*resource.State{b1}, dg.OnlyDependsOn(aws1))
+	assert.Equal(t, []*resource.State{c0}, dg.OnlyDependsOn(aws2))
+	assert.Equal(t, []*resource.State(nil), dg.OnlyDependsOn(b0))
+}
+
+func TestOnlyDependsOnMultipleProviders(t *testing.T) {
+	t.Parallel()
+
+	aws0 := NewProviderResource("aws", "default", "0")
+	aws1 := NewProviderResource("aws", "default", "1")
+
+	b0 := NewResource("b", aws0)
+
+	c0 := NewProviderResource("aws", "non-default", "0", b0.URN)
+	c1 := NewProviderResource("aws", "non-default", "1")
+
+	d0 := NewResource("d", c0)
+	d1 := NewResource("d", c1)
+
+	dg := NewDependencyGraph([]*resource.State{
+		aws0,
+		aws1,
+		b0,
+		c0,
+		c1,
+		d0,
+		d1,
+	})
+
+	assert.Equal(t, []*resource.State{b0, c0, d0}, dg.OnlyDependsOn(aws0))
+	assert.Equal(t, []*resource.State(nil), dg.OnlyDependsOn(aws1))
+	assert.Equal(t, []*resource.State{c0, d0}, dg.OnlyDependsOn(b0))
+	assert.Equal(t, []*resource.State{d1}, dg.OnlyDependsOn(c1))
+}


### PR DESCRIPTION
# Description

In https://github.com/pulumi/pulumi/commit/30f59eb30a9b519766aa0e3d3e463a2b4667466b, we made sure that we
don't delete multiple resources, when a user is prompted to choose
between multiple resources with the same URN.

If there are non-unique URNs, we currently assume that we can just go
ahead and delete it, as there's still another resource that will
fulfill the requirements.

However that is not true if the dependent is a provider.  Providers
are identified by a {URN, ID} tuple.  Therefore even though after the
deletion of a provider with a specific URN there's still another one
with the same URN left, this is not good enough to fulfill the
dependency requirements.

If we don't have a unique URN, check again to make sure there's no
provider dependency on the condemned resource.  If there is one, we
either error out, or delete the dependencies depending on the options
passed in.

Note that I haven't managed to reproduce this by just issuing pulumi commands, but I did by editing the state in a way to reproduce the same issue.  

One unanswered question for me is how the deleted cluster in the original issue ended up lingering in the state.  While this PR fixes the panic, and will make it easier for the user to actually delete the cluster from the state (it's going to suggest `--target-dependents` which will do the right thing), it doesn't address that bit.

Fixes https://github.com/pulumi/pulumi/issues/15166

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
