### PR TITLE
Implement preview-only refresh

### DIFF
--- a/changelog/pending/20240131--cli--adds-a-preview-only-flag-to-pulumi-refresh.yaml
+++ b/changelog/pending/20240131--cli--adds-a-preview-only-flag-to-pulumi-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds a `preview-only` flag to `pulumi refresh`.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -297,6 +297,8 @@ type UpdateOptions struct {
 	AutoApprove bool
 	// SkipPreview, when true, causes the preview step to be skipped.
 	SkipPreview bool
+	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
+	PreviewOnly bool
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -929,6 +929,19 @@ func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 	}
 	defer b.Unlock(ctx, stack.Ref())
 
+	if op.Opts.PreviewOnly {
+		// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
+		opts := backend.ApplierOptions{
+			DryRun:   true,
+			ShowLink: true,
+		}
+
+		op.Opts.Engine.GeneratePlan = false
+		_, changes, res := b.apply(
+			ctx, apitype.RefreshUpdate, stack, op, opts, nil /*events*/)
+		return changes, res
+	}
+
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1078,7 +1078,7 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stack backend.Stack,
 func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
-	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.
+	// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
 	opts := backend.ApplierOptions{
 		DryRun:   true,
 		ShowLink: true,
@@ -1103,6 +1103,18 @@ func (b *cloudBackend) Import(ctx context.Context, stack backend.Stack,
 func (b *cloudBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, result.Result) {
+	if op.Opts.PreviewOnly {
+		// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
+		opts := backend.ApplierOptions{
+			DryRun:   true,
+			ShowLink: true,
+		}
+
+		op.Opts.Engine.GeneratePlan = false
+		_, changes, res := b.apply(
+			ctx, apitype.RefreshUpdate, stack, op, opts, nil /*events*/)
+		return changes, res
+	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -100,17 +100,17 @@ func (persister *cloudSnapshotPersister) saveFullVerbatim(ctx context.Context,
 
 var _ backend.SnapshotPersister = (*cloudSnapshotPersister)(nil)
 
-func (cb *cloudBackend) newSnapshotPersister(ctx context.Context, update client.UpdateIdentifier,
+func (b *cloudBackend) newSnapshotPersister(ctx context.Context, update client.UpdateIdentifier,
 	tokenSource tokenSourceCapability,
 ) *cloudSnapshotPersister {
 	p := &cloudSnapshotPersister{
 		context:     ctx,
 		update:      update,
 		tokenSource: tokenSource,
-		backend:     cb,
+		backend:     b,
 	}
 
-	caps := cb.capabilities(ctx)
+	caps := b.capabilities(ctx)
 	deltaCaps := caps.deltaCheckpointUpdates
 	if deltaCaps != nil {
 		p.deploymentDiffState = newDeploymentDiffState(deltaCaps.CheckpointCutoffSizeBytes)

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -34,15 +34,15 @@ import (
 
 // Stack is used to manage stacks of resources against a pluggable backend.
 type Stack interface {
-	// this stack's identity.
+	// Ref returns this stack's identity.
 	Ref() StackReference
-	// the latest deployment snapshot.
+	// Snapshot returns the latest deployment snapshot.
 	Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
-	// the backend this stack belongs to.
+	// Backend returns the backend this stack belongs to.
 	Backend() Backend
-	// the stack's existing tags.
+	// Tags return the stack's existing tags.
 	Tags() map[apitype.StackTagName]string
-	// Preview changes to this stack.
+	// Preview changes to this stack if an Update was run.
 	Preview(
 		ctx context.Context, op UpdateOperation, events chan<- engine.Event,
 	) (*deploy.Plan, display.ResourceChanges, result.Result)
@@ -52,24 +52,23 @@ type Stack interface {
 	Import(ctx context.Context, op UpdateOperation, imports []deploy.Import) (display.ResourceChanges, result.Result)
 	// Refresh this stack's state from the cloud provider.
 	Refresh(ctx context.Context, op UpdateOperation) (display.ResourceChanges, result.Result)
-	// Destroy this stack's resources.
 	Destroy(ctx context.Context, op UpdateOperation) (display.ResourceChanges, result.Result)
 	// Watch this stack.
 	Watch(ctx context.Context, op UpdateOperation, paths []string) result.Result
 
-	// remove this stack.
+	// Remove this stack.
 	Remove(ctx context.Context, force bool) (bool, error)
-	// rename this stack.
+	// Rename this stack.
 	Rename(ctx context.Context, newName tokens.QName) (StackReference, error)
-	// list log entries for this stack.
+	// GetLogs lists log entries for this stack.
 	GetLogs(ctx context.Context, secretsProvider secrets.Provider,
 		cfg StackConfiguration, query operations.LogQuery) ([]operations.LogEntry, error)
-	// export this stack's deployment.
+	// ExportDeployment exports this stack's deployment.
 	ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error)
-	// import the given deployment into this stack.
+	// ImportDeployment imports the given deployment into this stack.
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 
-	// Return the default secrets manager to use for this stack.
+	// DefaultSecretManager returns the default secrets manager to use for this stack.
 	DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error)
 }
 

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -106,7 +106,7 @@ func newDestroyCmd() *cobra.Command {
 					errors.New("--yes or --skip-preview must be passed in to proceed when running in non-interactive mode"))
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes)
+			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -779,7 +779,7 @@ func newImportCmd() *cobra.Command {
 					errors.New("--yes or --skip-preview must be passed in to proceed when running in non-interactive mode"))
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes)
+			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"strings"
 
-	survey "github.com/AlecAivazis/survey/v2"
-	terminal "github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -54,6 +54,7 @@ func newRefreshCmd() *cobra.Command {
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
+	var previewOnly bool
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
@@ -96,12 +97,13 @@ func newRefreshCmd() *cobra.Command {
 
 			yes = yes || skipPreview || skipConfirmations()
 			interactive := cmdutil.Interactive()
-			if !interactive && !yes {
+			if !interactive && !yes && !previewOnly {
 				return result.FromError(
-					errors.New("--yes or --skip-preview must be passed in to proceed when running in non-interactive mode"))
+					errors.New("--yes or --skip-preview or --preview-only " +
+						"must be passed in to proceed when running in non-interactive mode"))
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes)
+			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -318,6 +320,9 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")
+	cmd.PersistentFlags().BoolVar(
+		&previewOnly, "preview-only", false,
+		"Only show a preview of the refresh, but don't perform the refresh itself")
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
 		"Show detailed resource replacement creates and deletes instead of a single step")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -441,7 +441,7 @@ func newUpCmd() *cobra.Command {
 					errors.New("--yes or --skip-preview must be passed in to proceed when running in non-interactive mode"))
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes)
+			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -919,12 +919,12 @@ func updateFlagsToOptions(interactive, skipPreview, yes, previewOnly bool) (back
 	case !interactive && !yes && !skipPreview && !previewOnly:
 		return backend.UpdateOptions{},
 			errors.New("one of --yes, --skip-preview, or --preview-only must be specified in non-interactive mode")
-	case yes && previewOnly:
-		return backend.UpdateOptions{},
-			errors.New("--yes and --preview-only cannot be used together")
 	case skipPreview && previewOnly:
 		return backend.UpdateOptions{},
 			errors.New("--skip-preview and --preview-only cannot be used together")
+	case yes && previewOnly:
+		return backend.UpdateOptions{},
+			errors.New("--yes and --preview-only cannot be used together")
 	default:
 		return backend.UpdateOptions{
 			AutoApprove: yes,

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -68,7 +68,8 @@ func newWatchCmd() *cobra.Command {
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := cmd.Context()
 
-			opts, err := updateFlagsToOptions(false /* interactive */, true /* skippreview*/, true /* autoapprove*/)
+			opts, err := updateFlagsToOptions(false /* interactive */, true /* skipPreview */, true, /* autoApprove */
+				false /* previewOnly */)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/tests/preview_only_test.go
+++ b/tests/preview_only_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+)
+
+func TestPreviewOnlyFlag(t *testing.T) {
+	t.Run("PreviewOnlyRefresh", func(t *testing.T) {
+		t.Parallel()
+
+		e := ptesting.NewEnvironment(t)
+		defer func() {
+			if !t.Failed() {
+				e.DeleteEnvironment()
+			}
+		}()
+
+		integration.CreateBasicPulumiRepo(e)
+		e.ImportDirectory("integration/single_resource")
+		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		e.RunCommand("yarn", "install")
+		e.SetBackend(e.LocalURL())
+		e.RunCommand("pulumi", "stack", "init", "foo")
+		e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
+
+		// Try some invalid flag combinations.
+		_, stderr := e.RunCommandExpectError("pulumi", "refresh", "--preview-only", "--yes")
+		assert.Equal(t,
+			"error: --yes and --preview-only cannot be used together",
+			strings.Trim(stderr, "\r\n"))
+		_, stderr = e.RunCommandExpectError("pulumi", "refresh", "--skip-preview", "--preview-only")
+		assert.Equal(t,
+			"error: --skip-preview and --preview-only cannot be used together",
+			strings.Trim(stderr, "\r\n"))
+		_, stderr = e.RunCommandExpectError("pulumi", "refresh", "--non-interactive")
+		assert.Equal(t,
+			"error: --yes or --skip-preview or --preview-only must be passed in to proceed when "+
+				"running in non-interactive mode",
+			strings.Trim(stderr, "\r\n"))
+
+		// Now try just the flag.
+		stdout, _ := e.RunCommand("pulumi", "refresh", "--preview-only")
+		assert.NotContains(t, stdout, "Do you want to perform this refresh?")
+		// Make sure it works with --non-interactive too.
+		e.RunCommand("pulumi", "refresh", "--preview-only", "--non-interactive")
+
+		e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes")
+		// Remove the stack.
+		e.RunCommand("pulumi", "stack", "rm", "foo", "--yes")
+	})
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a `preview-only` flag to `pulumi refresh`.

Fixes #15301 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
