### PR TITLE
[go] Automation API support for `pulumi refresh --preview-only`

### DIFF
--- a/changelog/pending/20240201--auto-go--automation-api-support-for-pulumi-refresh-preview-only.yaml
+++ b/changelog/pending/20240201--auto-go--automation-api-support-for-pulumi-refresh-preview-only.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Automation API support for `pulumi refresh --preview-only`

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -953,6 +953,15 @@ func TestNewStackInlineSource(t *testing.T) {
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 2, steps)
 
+	// -- pulumi refresh --preview-only --
+
+	pref, err := s.PreviewRefresh(ctx, optrefresh.UserAgent(agent))
+	if err != nil {
+		t.Errorf("preview-only refresh failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, 1, pref.ChangeSummary[apitype.OpSame])
+
 	// -- pulumi refresh --
 
 	ref, err := s.Refresh(ctx, optrefresh.UserAgent(agent))

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -965,13 +965,13 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi up --refresh --
 
-	upRes, err := s.Up(ctx, optup.Refresh())
-	if err != nil {
-		t.Errorf("up failed, err: %v", err)
-		t.FailNow()
-	}
-	assert.Equal(t, "update", upRes.Summary.Kind)
-	assert.Equal(t, "succeeded", upRes.Summary.Result)
+	//upRes, err := s.Up(ctx, optup.Refresh())
+	//if err != nil {
+	//	t.Errorf("up failed, err: %v", err)
+	//	t.FailNow()
+	//}
+	//assert.Equal(t, "update", upRes.Summary.Kind)
+	//assert.Equal(t, "succeeded", upRes.Summary.Result)
 
 	// -- pulumi destroy --
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -963,16 +963,6 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
 
-	// -- pulumi up --refresh --
-
-	//upRes, err := s.Up(ctx, optup.Refresh())
-	//if err != nil {
-	//	t.Errorf("up failed, err: %v", err)
-	//	t.FailNow()
-	//}
-	//assert.Equal(t, "update", upRes.Summary.Kind)
-	//assert.Equal(t, "succeeded", upRes.Summary.Result)
-
 	// -- pulumi destroy --
 
 	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent), optdestroy.Refresh())

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -944,9 +944,9 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi refresh --preview-only --
 
-	// pref, err := s.PreviewRefresh(ctx, optrefresh.UserAgent(agent))
-	// assert.NoError(t, err, "preview-only refresh failed")
-	// assert.Equal(t, 1, pref.ChangeSummary[apitype.OpSame])
+	pref, err := s.PreviewRefresh(ctx, optrefresh.UserAgent(agent))
+	assert.NoError(t, err, "preview-only refresh failed")
+	assert.Equal(t, 1, pref.ChangeSummary[apitype.OpSame])
 
 	// -- pulumi refresh --
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -879,9 +879,8 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
+//nolint:paralleltest
 func TestNewStackInlineSource(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	sName := randomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
@@ -914,18 +913,11 @@ func TestNewStackInlineSource(t *testing.T) {
 		assert.NoError(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
-	err = s.SetAllConfig(ctx, cfg)
-	if err != nil {
-		t.Errorf("failed to set config, err: %v", err)
-		t.FailNow()
-	}
+	require.NoError(t, s.SetAllConfig(ctx, cfg))
 
 	// -- pulumi up --
 	res, err := s.Up(ctx, optup.UserAgent(agent), optup.Refresh())
-	if err != nil {
-		t.Errorf("up failed, err: %v", err)
-		t.FailNow()
-	}
+	require.NoError(t, err, "up failed")
 
 	assert.Equal(t, 3, len(res.Outputs), "expected two plain outputs")
 	assert.Equal(t, "foo", res.Outputs["exp_static"].Value)
@@ -944,10 +936,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	prevCh := make(chan events.EngineEvent)
 	wg := collectEvents(prevCh, &previewEvents)
 	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh), optpreview.UserAgent(agent), optpreview.Refresh())
-	if err != nil {
-		t.Errorf("preview failed, err: %v", err)
-		t.FailNow()
-	}
+	require.NoError(t, err, "preview failed")
 	wg.Wait()
 	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
@@ -955,31 +944,21 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi refresh --preview-only --
 
-	pref, err := s.PreviewRefresh(ctx, optrefresh.UserAgent(agent))
-	if err != nil {
-		t.Errorf("preview-only refresh failed, err: %v", err)
-		t.FailNow()
-	}
-	assert.Equal(t, 1, pref.ChangeSummary[apitype.OpSame])
+	// pref, err := s.PreviewRefresh(ctx, optrefresh.UserAgent(agent))
+	// assert.NoError(t, err, "preview-only refresh failed")
+	// assert.Equal(t, 1, pref.ChangeSummary[apitype.OpSame])
 
 	// -- pulumi refresh --
 
 	ref, err := s.Refresh(ctx, optrefresh.UserAgent(agent))
-	if err != nil {
-		t.Errorf("refresh failed, err: %v", err)
-		t.FailNow()
-	}
+	require.NoError(t, err, "refresh failed")
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
 
 	// -- pulumi destroy --
 
 	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent), optdestroy.Refresh())
-	if err != nil {
-		t.Errorf("destroy failed, err: %v", err)
-		t.FailNow()
-	}
-
+	require.NoError(t, err, "destroy failed")
 	assert.Equal(t, "destroy", dRes.Summary.Kind)
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -879,8 +879,9 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
-//nolint:paralleltest
 func TestNewStackInlineSource(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	sName := randomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -963,6 +963,16 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
 
+	// -- pulumi up --refresh --
+
+	upRes, err := s.Up(ctx, optup.Refresh())
+	if err != nil {
+		t.Errorf("up failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, "update", upRes.Summary.Kind)
+	assert.Equal(t, "succeeded", upRes.Summary.Result)
+
 	// -- pulumi destroy --
 
 	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent), optdestroy.Refresh())

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -109,6 +109,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/blang/semver"
 	"github.com/nxadm/tail"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -458,6 +459,11 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 
 func (s *Stack) PreviewRefresh(ctx context.Context, opts ...optrefresh.Option) (PreviewResult, error) {
 	var res PreviewResult
+
+	// 3.105.0 added this flag (https://github.com/pulumi/pulumi/releases/tag/v3.105.0)
+	if s.Workspace().PulumiCommand().Version().LT(semver.Version{Major: 3, Minor: 105}) {
+		return res, fmt.Errorf("PreviewRefresh requires Pulumi CLI version >= 3.105.0")
+	}
 
 	refreshOpts := &optrefresh.Options{}
 	for _, o := range opts {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -538,33 +538,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		o.ApplyOption(refreshOpts)
 	}
 
-	args := slice.Prealloc[string](len(refreshOpts.Target))
-
-	args = debug.AddArgs(&refreshOpts.DebugLogOpts, args)
-	args = append(args, "refresh", "--yes", "--skip-preview")
-	if refreshOpts.Message != "" {
-		args = append(args, fmt.Sprintf("--message=%q", refreshOpts.Message))
-	}
-	if refreshOpts.ExpectNoChanges {
-		args = append(args, "--expect-no-changes")
-	}
-	for _, tURN := range refreshOpts.Target {
-		args = append(args, "--target="+tURN)
-	}
-	if refreshOpts.Parallel > 0 {
-		args = append(args, fmt.Sprintf("--parallel=%d", refreshOpts.Parallel))
-	}
-	if refreshOpts.UserAgent != "" {
-		args = append(args, "--exec-agent="+refreshOpts.UserAgent)
-	}
-	if refreshOpts.Color != "" {
-		args = append(args, "--color="+refreshOpts.Color)
-	}
-	execKind := constant.ExecKindAutoLocal
-	if s.Workspace().Program() != nil {
-		execKind = constant.ExecKindAutoInline
-	}
-	args = append(args, "--exec-kind="+execKind)
+	args := refreshOptsToCmd(refreshOpts, s, false /*isPreview*/)
 
 	if len(refreshOpts.EventStreams) > 0 {
 		eventChannels := refreshOpts.EventStreams
@@ -575,9 +549,6 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		defer t.Close()
 		args = append(args, "--event-log", t.Filename)
 	}
-
-	// Apply the remote args, if needed.
-	args = append(args, s.remoteArgs()...)
 
 	stdout, stderr, code, err := s.runPulumiCmdSync(
 		ctx,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds Go automation API support for `pulumi refresh --preview-only`. 

Depends on #15330 

Fixes: #15302

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
