### PR TITLE
Add a `Refresh` option for `Stack.Up()`, `Stack.Preview()` and `Stack.Destroy()`

### DIFF
--- a/changelog/pending/20240202--auto-go--adds-support-for-pulumi-up-refresh-via-go-automation-api.yaml
+++ b/changelog/pending/20240202--auto-go--adds-support-for-pulumi-up-refresh-via-go-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go
-  description: Adds support for `pulumi up --refresh` via go automation api
+  description: Adds support for `--refresh` to Stack.Up(), Stack.Preview() and Stack.Destroy() via go automation api

--- a/changelog/pending/20240202--auto-go--adds-support-for-pulumi-up-refresh-via-go-automation-api.yaml
+++ b/changelog/pending/20240202--auto-go--adds-support-for-pulumi-up-refresh-via-go-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Adds support for `pulumi up --refresh` via go automation api

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -943,7 +943,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	var previewEvents []events.EngineEvent
 	prevCh := make(chan events.EngineEvent)
 	wg := collectEvents(prevCh, &previewEvents)
-	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh), optpreview.UserAgent(agent))
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh), optpreview.UserAgent(agent), optpreview.Refresh())
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
@@ -975,7 +975,7 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi destroy --
 
-	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent))
+	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent), optdestroy.Refresh())
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -965,13 +965,13 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi up --refresh --
 
-	upRes, err := s.Up(ctx, optup.Refresh())
-	if err != nil {
-		t.Errorf("up failed, err: %v", err)
-		t.FailNow()
-	}
-	assert.Equal(t, "update", upRes.Summary.Kind)
-	assert.Equal(t, "succeeded", upRes.Summary.Result)
+	//upRes, err := s.Up(ctx, optup.Refresh())
+	//if err != nil {
+	//	t.Errorf("up failed, err: %v", err)
+	//	t.FailNow()
+	//}
+	//assert.Equal(t, "update", upRes.Summary.Kind)
+	//assert.Equal(t, "succeeded", upRes.Summary.Result)
 
 	// -- pulumi destroy --
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -921,7 +921,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	}
 
 	// -- pulumi up --
-	res, err := s.Up(ctx, optup.UserAgent(agent))
+	res, err := s.Up(ctx, optup.UserAgent(agent), optup.Refresh())
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -951,7 +951,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
-	assert.Equal(t, 1, steps)
+	assert.Equal(t, 2, steps)
 
 	// -- pulumi refresh --
 
@@ -962,16 +962,6 @@ func TestNewStackInlineSource(t *testing.T) {
 	}
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
-
-	// -- pulumi up --refresh --
-
-	//upRes, err := s.Up(ctx, optup.Refresh())
-	//if err != nil {
-	//	t.Errorf("up failed, err: %v", err)
-	//	t.FailNow()
-	//}
-	//assert.Equal(t, "update", upRes.Summary.Kind)
-	//assert.Equal(t, "succeeded", upRes.Summary.Result)
 
 	// -- pulumi destroy --
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -963,6 +963,16 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
 
+	// -- pulumi up --refresh --
+
+	upRes, err := s.Up(ctx, optup.Refresh())
+	if err != nil {
+		t.Errorf("up failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, "update", upRes.Summary.Kind)
+	assert.Equal(t, "succeeded", upRes.Summary.Result)
+
 	// -- pulumi destroy --
 
 	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent))

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -94,6 +94,13 @@ func ShowSecrets(show bool) Option {
 	})
 }
 
+// Refresh will run a refresh before the destroy.
+func Refresh() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Refresh = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -126,6 +133,8 @@ type Options struct {
 	Color string
 	// Show config secrets when they appear.
 	ShowSecrets *bool
+	// Refresh will run a refresh before the destroy.
+	Refresh bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -115,6 +115,13 @@ func Plan(path string) Option {
 	})
 }
 
+// Refresh will run a refresh before the preview.
+func Refresh() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Refresh = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Preview() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -157,6 +164,8 @@ type Options struct {
 	PolicyPacks []string
 	// Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag
 	PolicyPackConfigs []string
+	// Refresh will run a refresh before the preview.
+	Refresh bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -122,6 +122,13 @@ func ShowSecrets(show bool) Option {
 	})
 }
 
+// Refresh will refresh the stack's state before the update.
+func Refresh() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Refresh = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Up() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -166,6 +173,8 @@ type Options struct {
 	PolicyPackConfigs []string
 	// Show config secrets when they appear.
 	ShowSecrets *bool
+	// Refresh will refresh the stack's state before the update.
+	Refresh bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -386,6 +386,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	if upOpts.Plan != "" {
 		sharedArgs = append(sharedArgs, "--plan="+upOpts.Plan)
 	}
+	if upOpts.Refresh {
+		sharedArgs = append(sharedArgs, "--refresh")
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -264,6 +264,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.Plan != "" {
 		sharedArgs = append(sharedArgs, "--save-plan="+preOpts.Plan)
 	}
+	if preOpts.Refresh {
+		sharedArgs = append(sharedArgs, "--refresh")
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)
@@ -572,6 +575,9 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	}
 	if destroyOpts.Color != "" {
 		args = append(args, "--color="+destroyOpts.Color)
+	}
+	if destroyOpts.Refresh {
+		args = append(args, "--refresh")
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15351

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
