### PR TITLE
Fix context in state edit command

### DIFF
--- a/changelog/pending/20240202--cli-state--fix-a-nil-reference-panic-in-the-state-edit-command.yaml
+++ b/changelog/pending/20240202--cli-state--fix-a-nil-reference-panic-in-the-state-edit-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix a nil reference panic in the `state edit` command.

--- a/pkg/cmd/pulumi/state_edit_encoder.go
+++ b/pkg/cmd/pulumi/state_edit_encoder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type snapshotText []byte
@@ -30,12 +31,10 @@ type snapshotEncoder interface {
 	// Convert snapshot to bytes for use with a backing file.
 	SnapshotToText(*deploy.Snapshot) (snapshotText, error)
 	// Convert bytes to a snapshot.
-	TextToSnapshot(snapshotText) (*deploy.Snapshot, error)
+	TextToSnapshot(context.Context, snapshotText) (*deploy.Snapshot, error)
 }
 
-type jsonSnapshotEncoder struct {
-	ctx context.Context
-}
+type jsonSnapshotEncoder struct{}
 
 var _ snapshotEncoder = &jsonSnapshotEncoder{}
 
@@ -49,8 +48,10 @@ func (se *jsonSnapshotEncoder) SnapshotToText(snap *deploy.Snapshot) (snapshotTe
 	return snapshotText(s), err
 }
 
-func (se *jsonSnapshotEncoder) TextToSnapshot(s snapshotText) (*deploy.Snapshot, error) {
-	dep, err := stack.DeserializeUntypedDeployment(se.ctx, &apitype.UntypedDeployment{
+func (se *jsonSnapshotEncoder) TextToSnapshot(ctx context.Context, s snapshotText) (*deploy.Snapshot, error) {
+	contract.Requiref(ctx != nil, "ctx", "must not be nil")
+
+	dep, err := stack.DeserializeUntypedDeployment(ctx, &apitype.UntypedDeployment{
 		Version:    3,
 		Deployment: []byte(s),
 	}, stack.DefaultSecretsProvider)

--- a/pkg/cmd/pulumi/state_edit_test.go
+++ b/pkg/cmd/pulumi/state_edit_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -75,7 +76,8 @@ func TestSnapshotFrontendRoundTrip(t *testing.T) {
 	assert.NotEmpty(t, text)
 
 	// Convert the text back to a snapshot.
-	roundTrippedSnapshot, err := encoder.TextToSnapshot(text)
+	ctx := context.Background()
+	roundTrippedSnapshot, err := encoder.TextToSnapshot(ctx, text)
 	require.NoError(t, err)
 
 	// Convert the snapshot back to text.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15345.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
