### PR TITLE
Add kubernetes as supported pulumi convert language

### DIFF
--- a/changelog/pending/20240202--docs--add-kubernetes-as-a-supported-pulumi-convert-language.yaml
+++ b/changelog/pending/20240202--docs--add-kubernetes-as-a-supported-pulumi-convert-language.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: docs
+  description: Add kubernetes as a supported pulumi convert language

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -109,7 +109,7 @@ func newConvertCmd() *cobra.Command {
 			"\n" +
 			"The source program to convert will default to the current working directory.\n" +
 			"\n" +
-			"Valid source languages: yaml, terraform, bicep, arm\n" +
+			"Valid source languages: yaml, terraform, bicep, arm, kubernetes\n" +
 			"\n" +
 			"Valid target languages: typescript, python, csharp, go, java, yaml" +
 			"\n" +


### PR DESCRIPTION
# Description

Adds `kubernetes` as a supported pulumi convert language. This will use https://github.com/pulumi/pulumi-converter-kubernetes.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
