### PR TITLE
Upgrade output values in source_eval

### DIFF
--- a/changelog/pending/20240206--engine--translate-all-computed-and-secret-values-to-outputvalues-for-construct-and-call-methods.yaml
+++ b/changelog/pending/20240206--engine--translate-all-computed-and-secret-values-to-outputvalues-for-construct-and-call-methods.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Translate all Computed and Secret values to OutputValues for Construct and Call methods.

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -394,8 +394,10 @@ func (rm *ResourceMonitor) Call(tok tokens.ModuleMember, inputs resource.Propert
 ) {
 	// marshal inputs
 	ins, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
-		KeepUnknowns:  true,
-		KeepResources: true,
+		KeepUnknowns:     true,
+		KeepResources:    true,
+		KeepSecrets:      true,
+		KeepOutputValues: true,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -419,8 +421,10 @@ func (rm *ResourceMonitor) Call(tok tokens.ModuleMember, inputs resource.Propert
 
 	// unmarshal outputs
 	outs, err := plugin.UnmarshalProperties(resp.Return, plugin.MarshalOptions{
-		KeepUnknowns:  true,
-		KeepResources: true,
+		KeepUnknowns:     true,
+		KeepResources:    true,
+		KeepSecrets:      true,
+		KeepOutputValues: true,
 	})
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Stage 1 of updating how we deal with OutputValues in source_eval for transforms.

This makes two changes that should result in basically a no-op for standard resources, but update all Computed/Secret values to OutputValues for Call and Construct.

This is a no-op for standard resources because previously we set "KeepOutputs" to false when we unmarshalled them. That replaced all OutputValues with Computed/Secret. Now we do "UpdgradeOutputs" at the start of source_eval but then call "DowngradeOutputs" before passing the properties on to the rest of the system. So this is a complete no-op.

But for Call/Construct we used to use "KeepOutputs" but now we do "UpgradeOutputs". So values that previously got sent as Computed/Secret will now get sent as OutputValue. This _should_ be fine, all users of Construct/Call already had to handle OutputValue on their interface, so this just means a few more cases of seeing those values.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
