### PR TITLE
[sdk/python] Require Python >=3.8

### DIFF
--- a/changelog/pending/20240203--sdk-python--require-python-3-8-or-greater.yaml
+++ b/changelog/pending/20240203--sdk-python--require-python-3-8-or-greater.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Require Python 3.8 or greater.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 The Pulumi Python SDK (pulumi) is the core package used when writing Pulumi programs in Python. It contains everything that you’ll need in order to interact with Pulumi resource providers and express infrastructure using Python code. Pulumi resource providers all depend on this library and express their resources in terms of the types defined in this module.
 
-The Pulumi Python SDK requires [Python version 3.7 or greater](https://www.python.org/downloads/) through official python installer
+The Pulumi Python SDK requires a [supported version](https://devguide.python.org/versions/#versions) of Python.
 
 note:
 pip is required to install dependencies. If you installed Python from source, with an installer from [python.org](https://python.org/), or via [Homebrew](https://brew.sh/) you should already have pip. If Python is installed using your OS package manager, you may have to install pip separately, see [Installing pip/setuptools/wheel with Linux Package Managers](https://packaging.python.org/guides/installing-using-linux-tools/). For example, on Debian/Ubuntu you must run sudo apt install python3-venv python3-pip.

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -40,7 +40,7 @@ setup(name='pulumi',
               'py.typed'
           ]
       },
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',


### PR DESCRIPTION
Python 3.7 is unsupported and has been end-of-life since 6/27/2023. See https://devguide.python.org/versions/

This change updates the core SDK package to indicate that Python 3.8 or greater is required.

Fixes #15364