### PR TITLE
[sdk/python] Upgrade to grpcio 1.60.1

### DIFF
--- a/changelog/pending/20240203--sdk-python--upgrade-grpcio-to-1-60-1.yaml
+++ b/changelog/pending/20240203--sdk-python--upgrade-grpcio-to-1-60-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Upgrade grpcio to 1.60.1

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -58,26 +58,18 @@ def get_provider(props) -> ResourceProvider:
 
 class DynamicResourceProviderServicer(ResourceProviderServicer):
     def CheckConfig(self, request, context):
-        # CheckConfig is not implemented by the dynamic provider.
-        # Just return the news as if we're OK with them, which is the default behavior.
-        #
-        # Note: We're not using `context.set_code(grpc.StatusCode.UNIMPLEMENTED)` as grpcio
-        # 1.58.0 through 1.60.0 has a bug that causes the UNIMPLEMENTED error to be written
-        # to stderr, which users will see. 1.60.1 should include a fix for the stderr
-        # regression, but it hasn't been released yet. Once 1.60.1 is released, we can
-        # depend on that version and go back to returning UNIMPLEMENTED.
-        return proto.CheckResponse(inputs=request.news)
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("CheckConfig is not implemented by the dynamic provider")
+        raise NotImplementedError(
+            "CheckConfig is not implemented by the dynamic provider"
+        )
 
     def DiffConfig(self, request, context):
-        # DiffConfig is not implemented by the dynamic provider.
-        # Just return DIFF_UNKNOWN, which is the default behavior.
-        #
-        # Note: We're not using `context.set_code(grpc.StatusCode.UNIMPLEMENTED)` as grpcio
-        # 1.58.0 through 1.60.0 has a bug that causes the UNIMPLEMENTED error to be written
-        # to stderr, which users will see. 1.60.1 should include a fix for the stderr
-        # regression, but it hasn't been released yet. Once 1.60.1 is released, we can
-        # depend on that version and go back to returning UNIMPLEMENTED.
-        return proto.DiffResponse(changes=proto.DiffResponse.DIFF_UNKNOWN)
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("DiffConfig is not implemented by the dynamic provider")
+        raise NotImplementedError(
+            "DiffConfig is not implemented by the dynamic provider"
+        )
 
     def Invoke(self, request, context):
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -316,34 +316,6 @@ class ProviderServicer(ResourceProviderServicer):
         response = await self._invoke_response(result)
         return response
 
-    async def CheckConfig(  # pylint: disable=invalid-overridden-method
-        self, request, context
-    ) -> proto.CheckResponse:
-        # CheckConfig is not currently implemented.
-        # Just return the news as if we're OK with them, which is the default behavior.
-        #
-        # Note: We're not using `context.set_code(grpc.StatusCode.UNIMPLEMENTED)` as grpcio
-        # 1.58.0 through 1.60.0 has a bug that causes the UNIMPLEMENTED error to be written
-        # to stderr, which users will see. 1.60.1 should include a fix for the stderr
-        # regression, but it hasn't been released yet. Once 1.60.1 is released, we can
-        # depend on that version and go back to returning UNIMPLEMENTED (in this case
-        # simply not implementing the method here).
-        return proto.CheckResponse(inputs=request.news)
-
-    async def DiffConfig(  # pylint: disable=invalid-overridden-method
-        self, request, context
-    ) -> proto.DiffResponse:
-        # DiffConfig is not currently implemented.
-        # Just return DIFF_UNKNOWN, which is the default behavior.
-        #
-        # Note: We're not using `context.set_code(grpc.StatusCode.UNIMPLEMENTED)` as grpcio
-        # 1.58.0 through 1.60.0 has a bug that causes the UNIMPLEMENTED error to be written
-        # to stderr, which users will see. 1.60.1 should include a fix for the stderr
-        # regression, but it hasn't been released yet. Once 1.60.1 is released, we can
-        # depend on that version and go back to returning UNIMPLEMENTED (in this case
-        # simply not implementing the method here).
-        return proto.DiffResponse(changes=proto.DiffResponse.DIFF_UNKNOWN)
-
     async def Configure(  # pylint: disable=invalid-overridden-method
         self, request, context
     ) -> proto.ConfigureResponse:

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -44,8 +44,7 @@ setup(name='pulumi',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',
-          'grpcio==1.56.2; python_version < "3.12"',
-          'grpcio~=1.60.0; python_version >= "3.12"',
+          'grpcio~=1.60.1',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.13',

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,8 +1,7 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
 protobuf~=4.21
-grpcio==1.56.2; python_version < "3.12"
-grpcio~=1.60.0; python_version >= "3.12"
+grpcio~=1.60.1
 dill~=0.3
 six~=1.12
 semver~=2.13


### PR DESCRIPTION
grpcio 1.60.1 includes a fix for the regression that results in a traceback being written to stderr for unimplemented gRPC methods. https://github.com/grpc/grpc/releases/tag/v1.60.1

This change upgrades to 1.60.1 and reverts the workarounds we put in place in https://github.com/pulumi/pulumi/pull/15190.

Note that we have an integration test for Python dynamic providers that ensures nothing unexpected is written to stderr: https://github.com/pulumi/pulumi/blob/16a1fb31c2040785dbbfb9de43d772d8e16fffaa/tests/integration/integration_python_acceptance_test.go#L111-L117

Fixes #15365