### PR TITLE
[sdkgen/python] Require Python >=3.8

### DIFF
--- a/changelog/pending/20240203--sdkgen-python--update-the-default-minimum-required-version-of-python-to-3-8-or-greater-for-generated-provider-sdks.yaml
+++ b/changelog/pending/20240203--sdkgen-python--update-the-default-minimum-required-version-of-python-to-3-8-or-greater-for-generated-provider-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/python
+  description: Update the default minimum required version of Python to 3.8 or greater for generated provider SDKs.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -55,10 +55,10 @@ type typeDetails struct {
 type imports codegen.StringSet
 
 // defaultMinPythonVersion is what we use as the minimum version field in generated
-// package metadata if the schema does not provide a vaule. This version corresponds
+// package metadata if the schema does not provide a value. This version corresponds
 // to the minimum supported version as listed in the reference documentation:
-// https://www.pulumi.com/docs/reference/pkg/python/pulumi/
-const defaultMinPythonVersion = ">=3.7"
+// https://www.pulumi.com/docs/languages-sdks/python/
+const defaultMinPythonVersion = ">=3.8"
 
 func (imports imports) addType(mod *modContext, t *schema.ObjectType, input bool) {
 	imports.addTypeIf(mod, t, input, nil /*predicate*/)
@@ -3211,7 +3211,6 @@ func calculateDeps(requires map[string]string) ([][2]string, error) {
 	deps := []string{
 		"semver>=2.8.1",
 		"parver>=0.2.1",
-		"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"",
 	}
 	for dep := range requires {
 		deps = append(deps, dep)

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -289,10 +289,9 @@ func TestCalculateDeps(t *testing.T) {
 		// Test 1: Give no explicit deps.
 		inputDeps: map[string]string{},
 		expected: [][2]string{
-			// We expect four alphabetized deps,
+			// We expect three alphabetized deps,
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
-			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ""},
 			{"semver>=2.8.1"},
@@ -305,7 +304,6 @@ func TestCalculateDeps(t *testing.T) {
 		},
 		expected: [][2]string{
 			{"foobar", "7.10.8"},
-			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ">=3.0.0,<4.0.0"},
 			{"semver>=2.8.1"},
@@ -319,7 +317,6 @@ func TestCalculateDeps(t *testing.T) {
 		expected: [][2]string{
 			// We expect three alphabetized deps,
 			// with semver and parver formatted differently from Pulumi.
-			{"importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", ""},
 			{"parver>=0.2.1", ""},
 			{"pulumi", ">=3.0.0,<3.50.0"},
 			{"semver>=2.8.1"},

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -13,11 +14,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -72,7 +68,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/assets-and-archives/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/assets-and-archives/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/assets-and-archives/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_azure_native',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       description="A native Pulumi package for creating and managing Azure resources.",
       long_description=readme(),
@@ -38,7 +38,6 @@ setup(name='pulumi_azure_native',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_foo_bar',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_foo_bar',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-kubernetes>=3.0.0,<4.0.0',

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-google-native>=0.20.0,<1.0.0',

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.37.1,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_registrygeoreplication',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_registrygeoreplication',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-azure-native>=1.0.0,<2.0.0',

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_repro',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_repro',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/methods-return-plain-resource/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_metaprovider',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_metaprovider',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='foo_bar',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='foo_bar',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_myedgeorder',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_myedgeorder',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_foobar',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_foobar',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_xyz',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_xyz',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-aws>=4.0.0,<5.0.0',

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_configstation',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_configstation',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_providerType',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_providerType',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_mongodbatlas',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_mongodbatlas',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_my8110',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_my8110',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-12546/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12546/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-12980/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-12980/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_myPkg',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       description="Test imports across different module names",
       long_description=readme(),
@@ -32,7 +32,6 @@ setup(name='pulumi_myPkg',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-14539/python/pyproject.toml
+++ b/pkg/codegen/testing/test/testdata/regress-py-14539/python/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
   name = "pulumi_gcp"
-  dependencies = ["importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", "parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
-  requires-python = ">=3.7"
+  requires-python = ">=3.8"
   version = "0.0.0"
 
 [build-system]

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_aws',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_aws',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='custom_py_package',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='custom_py_package',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/python/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["importlib-metadata>=6.0.0,<7.0.0; python_version < \"3.8\"", "parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
-  requires-python = ">=3.7"
+  requires-python = ">=3.8"
   version = "0.0.1"
   [project.license]
     text = "MIT"

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/unions-inline/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/unions-inline/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/unions-inline/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/unions-inline/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/unions-inside-arrays/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/pkg/codegen/testing/test/testdata/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/pkg/codegen/testing/test/testdata/urn-id-properties/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/urn-id-properties/python/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_urnid',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       description="Test urn and id in valid locations",
       long_description=readme(),
@@ -32,7 +32,6 @@ setup(name='pulumi_urnid',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/sdks/simple-1.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/sdks/simple-1.0.0/pulumi_simple/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import inspect
 import json
@@ -17,11 +18,6 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
 
 
 def get_env(*args):
@@ -76,7 +72,7 @@ def _get_semver_version():
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
-    pep440_version_string = metadata.version(root_package)
+    pep440_version_string = importlib.metadata.version(root_package)
     pep440_version = PEP440Version.parse(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None

--- a/sdk/python/cmd/pulumi-language-python/testdata/sdks/simple-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/sdks/simple-1.0.0/setup.py
@@ -19,7 +19,7 @@ def readme():
 
 
 setup(name='pulumi_simple',
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -31,7 +31,6 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'importlib-metadata>=6.0.0,<7.0.0; python_version < "3.8"',
           'parver>=0.2.1',
           'pulumi',
           'semver>=2.8.1'


### PR DESCRIPTION
Python 3.7 is unsupported and has been end-of-life since 6/27/2023. See https://devguide.python.org/versions/

The core `pulumi` Python SDK package is being updated to indicate that Python 3.8 or greater is required (see #15365).

This change updates the default minimum required Python version for generated provider SDKs to Python 3.8 or greater as well.

Fixes #15367