### PR TITLE
[program-gen] Emit Output-returning JSON serialization methods without rewriting applies

### DIFF
--- a/changelog/pending/20240204--programgen-dotnet-nodejs-python--emit-output-returning-json-serialization-methods-without-rewriting-applies-for-top-level-function-expression.yaml
+++ b/changelog/pending/20240204--programgen-dotnet-nodejs-python--emit-output-returning-json-serialization-methods-without-rewriting-applies-for-top-level-function-expression.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,nodejs,python
+  description: Emit Output-returning JSON serialization methods without rewriting applies for top-level function expression

--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -31,7 +31,7 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKP
 		require.NoError(t, err)
 	}
 	err = integration.RunCommand(t, "create dotnet project",
-		[]string{ex, "new", "console"}, dir, &integration.ProgramTestOptions{})
+		[]string{ex, "new", "console", "-f", "net6.0"}, dir, &integration.ProgramTestOptions{})
 	require.NoError(t, err, "Failed to create C# project")
 
 	// Remove Program.cs again generated from "dotnet new console"
@@ -46,6 +46,7 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKP
 		for _, pkg := range pkgs {
 			pkg.install(t, ex, dir)
 		}
+		dep{"Pulumi", test.PulumiDotnetSDKVersion}.install(t, ex, dir)
 	} else {
 		// We would like this regardless of other dependencies, but dotnet
 		// packages do not play well with package references.
@@ -55,7 +56,7 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKP
 				dir, &integration.ProgramTestOptions{})
 			require.NoError(t, err, "Failed to dotnet sdk package reference")
 		} else {
-			dep{"Pulumi", ""}.install(t, ex, dir)
+			dep{"Pulumi", test.PulumiDotnetSDKVersion}.install(t, ex, dir)
 		}
 	}
 

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -34,6 +34,7 @@ type NameInfo interface {
 type applyRewriter struct {
 	nameInfo      NameInfo
 	applyPromises bool
+	skipToJSON    bool
 
 	activeContext applyRewriteContext
 	exprStack     []model.Expression
@@ -154,6 +155,11 @@ func (r *applyRewriter) inspectsEventualValues(x model.Expression) bool {
 	case *model.ForExpression:
 		return r.hasEventualElements(x.Collection)
 	case *model.FunctionCallExpression:
+		// special case toJSON function because we map it to pulumi.jsonStringify which accepts anything
+		// such that it doesn't have to rewrite its subexpressions to apply but can be used directly
+		if r.skipToJSON && x.Name == "toJSON" {
+			return false
+		}
 		_, isEventual := r.isEventualType(x.Signature.ReturnType)
 		if isEventual {
 			return true
@@ -193,6 +199,12 @@ func (r *applyRewriter) observesEventualValues(x model.Expression) bool {
 		_, collectionIsEventual := r.isEventualType(x.Collection.Type())
 		return collectionIsEventual
 	case *model.FunctionCallExpression:
+		// special case toJSON function because we map it to pulumi.jsonStringify which accepts anything
+		// such that it doesn't have to rewrite its subexpressions to apply but can be used directly
+		if r.skipToJSON && x.Name == "toJSON" {
+			return false
+		}
+
 		for i, arg := range x.Args {
 			if !r.isPromptArg(x.Signature.Parameters[i].Type, arg) {
 				return true
@@ -648,9 +660,19 @@ func (ctx *inspectContext) PostVisit(expr model.Expression) (model.Expression, h
 // This form is amenable to code generation for targets that require that outputs are resolved before their values are
 // accessible (e.g. Pulumi's JS/TS libraries).
 func RewriteApplies(expr model.Expression, nameInfo NameInfo, applyPromises bool) (model.Expression, hcl.Diagnostics) {
+	return RewriteAppliesWithSkipToJSON(expr, nameInfo, applyPromises, false)
+}
+
+func RewriteAppliesWithSkipToJSON(
+	expr model.Expression,
+	nameInfo NameInfo,
+	applyPromises bool,
+	skipToJSON bool,
+) (model.Expression, hcl.Diagnostics) {
 	applyRewriter := &applyRewriter{
 		nameInfo:      nameInfo,
 		applyPromises: applyPromises,
+		skipToJSON:    skipToJSON,
 	}
 	applyRewriter.activeContext = &inspectContext{
 		applyRewriter: applyRewriter,

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -374,3 +374,6 @@ const (
 	RandomSchema      SchemaVersion = "4.11.2"
 	EksSchema         SchemaVersion = "0.37.1"
 )
+
+// PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
+const PulumiDotnetSDKVersion = "3.59.0"

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
@@ -146,12 +146,12 @@ export = async () => {
     });
     return {
         clusterName: eksCluster.name,
-        kubeconfig: pulumi.all([eksCluster.endpoint, eksCluster.certificateAuthority, eksCluster.name]).apply(([endpoint, certificateAuthority, name]) => JSON.stringify({
+        kubeconfig: pulumi.jsonStringify({
             apiVersion: "v1",
             clusters: [{
                 cluster: {
-                    server: endpoint,
-                    "certificate-authority-data": certificateAuthority.data,
+                    server: eksCluster.endpoint,
+                    "certificate-authority-data": eksCluster.certificateAuthority.apply(certificateAuthority => certificateAuthority.data),
                 },
                 name: "kubernetes",
             }],
@@ -173,10 +173,10 @@ export = async () => {
                     args: [
                         "token",
                         "-i",
-                        name,
+                        eksCluster.name,
                     ],
                 },
             }],
-        })),
+        }),
     };
 }

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/python/aws-eks.py
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/python/aws-eks.py
@@ -130,12 +130,12 @@ node_group = aws.eks.NodeGroup("nodeGroup",
         min_size=1,
     ))
 pulumi.export("clusterName", eks_cluster.name)
-pulumi.export("kubeconfig", pulumi.Output.all(eks_cluster.endpoint, eks_cluster.certificate_authority, eks_cluster.name).apply(lambda endpoint, certificate_authority, name: json.dumps({
+pulumi.export("kubeconfig", pulumi.Output.json_dumps({
     "apiVersion": "v1",
     "clusters": [{
         "cluster": {
-            "server": endpoint,
-            "certificate-authority-data": certificate_authority.data,
+            "server": eks_cluster.endpoint,
+            "certificate-authority-data": eks_cluster.certificate_authority.data,
         },
         "name": "kubernetes",
     }],
@@ -157,8 +157,8 @@ pulumi.export("kubeconfig", pulumi.Output.all(eks_cluster.endpoint, eks_cluster.
             "args": [
                 "token",
                 "-i",
-                name,
+                eks_cluster.name,
             ],
         },
     }],
-})))
+}))

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/dotnet/aws-s3-folder.cs
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/dotnet/aws-s3-folder.cs
@@ -35,7 +35,7 @@ return await Deployment.RunAsync(() =>
     var bucketPolicy = new Aws.S3.BucketPolicy("bucketPolicy", new()
     {
         Bucket = siteBucket.Id,
-        Policy = siteBucket.Id.Apply(id => JsonSerializer.Serialize(new Dictionary<string, object?>
+        Policy = Output.JsonSerialize(Output.Create(new Dictionary<string, object?>
         {
             ["Version"] = "2012-10-17",
             ["Statement"] = new[]
@@ -50,7 +50,7 @@ return await Deployment.RunAsync(() =>
                     },
                     ["Resource"] = new[]
                     {
-                        $"arn:aws:s3:::{id}/*",
+                        siteBucket.Id.Apply(id => $"arn:aws:s3:::{id}/*"),
                     },
                 },
             },

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
@@ -21,15 +21,15 @@ for (const range of fs.readdirSync(siteDir).map((v, k) => ({key: k, value: v})))
 // Set the access policy for the bucket so all objects are readable
 const bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
     bucket: siteBucket.id,
-    policy: siteBucket.id.apply(id => JSON.stringify({
+    policy: pulumi.jsonStringify({
         Version: "2012-10-17",
         Statement: [{
             Effect: "Allow",
             Principal: "*",
             Action: ["s3:GetObject"],
-            Resource: [`arn:aws:s3:::${id}/*`],
+            Resource: [pulumi.interpolate`arn:aws:s3:::${siteBucket.id}/*`],
         }],
-    })),
+    }),
 });
 export const bucketName = siteBucket.bucket;
 export const websiteUrl = siteBucket.websiteEndpoint;

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/python/aws-s3-folder.py
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/python/aws-s3-folder.py
@@ -20,14 +20,14 @@ for range in [{"key": k, "value": v} for [k, v] in enumerate(os.listdir(site_dir
 # Set the access policy for the bucket so all objects are readable
 bucket_policy = aws.s3.BucketPolicy("bucketPolicy",
     bucket=site_bucket.id,
-    policy=site_bucket.id.apply(lambda id: json.dumps({
+    policy=pulumi.Output.json_dumps({
         "Version": "2012-10-17",
         "Statement": [{
             "Effect": "Allow",
             "Principal": "*",
             "Action": ["s3:GetObject"],
-            "Resource": [f"arn:aws:s3:::{id}/*"],
+            "Resource": [site_bucket.id.apply(lambda id: f"arn:aws:s3:::{id}/*")],
         }],
-    })))
+    }))
 pulumi.export("bucketName", site_bucket.bucket)
 pulumi.export("websiteUrl", site_bucket.website_endpoint)

--- a/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python/python-regress-14037.py
+++ b/pkg/codegen/testing/test/testdata/python-regress-14037-pp/python/python-regress-14037.py
@@ -15,7 +15,7 @@ db_users = []
 for range in [{"key": k, "value": v} for [k, v] in enumerate(data)]:
     db_users.append(aws.secretsmanager.SecretVersion(f"dbUsers-{range['key']}",
         secret_id="mySecret",
-        secret_string=user[range["value"]].result.apply(lambda result: json.dumps({
+        secret_string=pulumi.Output.json_dumps({
             "username": range["value"],
-            "password": result,
-        }))))
+            "password": user[range["value"]].result,
+        })))


### PR DESCRIPTION
### Description

A while ago we started implementing [specialized JSON serialization methods](https://github.com/pulumi/pulumi/issues/12519) for Pulumi programs which can accept nested outputs without having to rewrite and combine applies. 
 - `Output.SerializeJson` in .NET
 - `pulumi.jsonStringify` in nodejs
 - `pulumi.Output.json_dumps` in Python

This PR extends program-gen for TypeScript, C# and Python to start emitting these JSON serialization functions (when necessary). The PR special-cases the `toJSON` PCL function when rewriting applies so that nested outputs aren't rewritted.

Example PCL program and generated results:

> Also check out the downstream codegen tests to see improved generated examples

```
resource vpc "aws:ec2:Vpc" {
	cidrBlock = "10.100.0.0/16"
	instanceTenancy = "default"
}

resource policy "aws:iam/policy:Policy" {
	description = "test"
	policy = toJSON({
		"Version" = "2012-10-17"
		"Interpolated" = "arn:${vpc.arn}:value"
		"Value" = vpc.id
	})
}
```


### Generated TypeScript Before
```typescript
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";

const vpc = new aws.ec2.Vpc("vpc", {
    cidrBlock: "10.100.0.0/16",
    instanceTenancy: "default",
});
const policy = new aws.iam.Policy("policy", {
    description: "test",
    policy: pulumi.all([vpc.arn, vpc.id]).apply(([arn, id]) => JSON.stringify({
        Version: "2012-10-17",
        Interpolated: `arn:${arn}:value`,
        Value: id,
    })),
});
```

### Generated TypeScript After
```typescript
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";

const vpc = new aws.ec2.Vpc("vpc", {
    cidrBlock: "10.100.0.0/16",
    instanceTenancy: "default",
});
const policy = new aws.iam.Policy("policy", {
    description: "test",
    policy: pulumi.jsonStringify({
        Version: "2012-10-17",
        Interpolated: pulumi.interpolate`arn:${vpc.arn}:value`,
        Value: vpc.id,
    }),
});
```
### Generated Python Before
```python
import pulumi
import json
import pulumi_aws as aws

vpc = aws.ec2.Vpc("vpc",
    cidr_block="10.100.0.0/16",
    instance_tenancy="default")
policy = aws.iam.Policy("policy",
    description="test",
    policy=pulumi.Output.all(vpc.arn, vpc.id).apply(lambda arn, id: json.dumps({
        "Version": "2012-10-17",
        "Interpolated": f"arn:{arn}:value",
        "Value": id,
    })))
```

### Generated Python After
```python
import pulumi
import json
import pulumi_aws as aws

vpc = aws.ec2.Vpc("vpc",
    cidr_block="10.100.0.0/16",
    instance_tenancy="default")
policy = aws.iam.Policy("policy",
    description="test",
    policy=pulumi.Output.json_dumps({
        "Version": "2012-10-17",
        "Interpolated": vpc.arn.apply(lambda arn: f"arn:{arn}:value"),
        "Value": vpc.id,
    }))
```

### Generated C# Before
```csharp
using System.Collections.Generic;
using System.Linq;
using System.Text.Json;
using Pulumi;
using Aws = Pulumi.Aws;

return await Deployment.RunAsync(() => 
{
    var vpc = new Aws.Ec2.Vpc("vpc", new()
    {
        CidrBlock = "10.100.0.0/16",
        InstanceTenancy = "default",
    });

    var policy = new Aws.Iam.Policy("policy", new()
    {
        Description = "test",
        PolicyDocument = Output.Tuple(vpc.Arn, vpc.Id).Apply(values =>
        {
            var arn = values.Item1;
            var id = values.Item2;
            return JsonSerializer.Serialize(new Dictionary<string, object?>
            {
                ["Version"] = "2012-10-17",
                ["Interpolated"] = $"arn:{arn}:value",
                ["Value"] = id,
            });
        }),
    });

});
```

### Generated C# After
```csharp
using System.Collections.Generic;
using System.Linq;
using System.Text.Json;
using Pulumi;
using Aws = Pulumi.Aws;

return await Deployment.RunAsync(() => 
{
    var vpc = new Aws.Ec2.Vpc("vpc", new()
    {
        CidrBlock = "10.100.0.0/16",
        InstanceTenancy = "default",
    });

    var policy = new Aws.Iam.Policy("policy", new()
    {
        Description = "test",
        PolicyDocument = Output.JsonSerialize(Output.Create(new Dictionary<string, object?>
        {
            ["Version"] = "2012-10-17",
            ["Interpolated"] = vpc.Arn.Apply(arn => $"arn:{arn}:value"),
            ["Value"] = vpc.Id,
        })),
    });

});
```

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
