### PR TITLE
Use camelCase for schema names

### DIFF
--- a/pkg/codegen/testing/test/testdata/plain-and-default-go-generics-only/go/foo/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default-go-generics-only/go/foo/moduleResource.go
@@ -16,7 +16,7 @@ import (
 type ModuleResource struct {
 	pulumi.CustomResourceState
 
-	Optional_bool pulumix.Output[*bool] `pulumi:"optional_bool"`
+	OptionalBool pulumix.Output[*bool] `pulumi:"optionalBool"`
 }
 
 // NewModuleResource registers a new resource with the given unique name, arguments, and options.
@@ -26,54 +26,54 @@ func NewModuleResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Optional_bool == nil {
-		args.Optional_bool = pulumix.Ptr(true)
+	if args.OptionalBool == nil {
+		args.OptionalBool = pulumix.Ptr(true)
 	}
-	args.Optional_const = pulumix.Ptr("val")
-	if args.Optional_enum == nil {
-		args.Optional_enum = pulumix.Ptr(EnumThing(8))
+	args.OptionalConst = pulumix.Ptr("val")
+	if args.OptionalEnum == nil {
+		args.OptionalEnum = pulumix.Ptr(EnumThing(8))
 	}
-	if args.Optional_number == nil {
-		args.Optional_number = pulumix.Ptr(42.0)
+	if args.OptionalNumber == nil {
+		args.OptionalNumber = pulumix.Ptr(42.0)
 	}
-	if args.Optional_string == nil {
-		args.Optional_string = pulumix.Ptr("buzzer")
+	if args.OptionalString == nil {
+		args.OptionalString = pulumix.Ptr("buzzer")
 	}
-	if args.Plain_optional_bool == nil {
-		plain_optional_bool_ := true
-		args.Plain_optional_bool = &plain_optional_bool_
+	if args.PlainOptionalBool == nil {
+		plainOptionalBool_ := true
+		args.PlainOptionalBool = &plainOptionalBool_
 	}
-	plain_optional_const_ := "val"
-	args.Plain_optional_const = &plain_optional_const_
-	if args.Plain_optional_number == nil {
-		plain_optional_number_ := 42.0
-		args.Plain_optional_number = &plain_optional_number_
+	plainOptionalConst_ := "val"
+	args.PlainOptionalConst = &plainOptionalConst_
+	if args.PlainOptionalNumber == nil {
+		plainOptionalNumber_ := 42.0
+		args.PlainOptionalNumber = &plainOptionalNumber_
 	}
-	if args.Plain_optional_string == nil {
-		plain_optional_string_ := "buzzer"
-		args.Plain_optional_string = &plain_optional_string_
+	if args.PlainOptionalString == nil {
+		plainOptionalString_ := "buzzer"
+		args.PlainOptionalString = &plainOptionalString_
 	}
-	if internal.IsZero(args.Plain_required_bool) {
-		args.Plain_required_bool = true
+	if internal.IsZero(args.PlainRequiredBool) {
+		args.PlainRequiredBool = true
 	}
-	args.Plain_required_const = "val"
-	if internal.IsZero(args.Plain_required_number) {
-		args.Plain_required_number = 42.0
+	args.PlainRequiredConst = "val"
+	if internal.IsZero(args.PlainRequiredNumber) {
+		args.PlainRequiredNumber = 42.0
 	}
-	if internal.IsZero(args.Plain_required_string) {
-		args.Plain_required_string = "buzzer"
+	if internal.IsZero(args.PlainRequiredString) {
+		args.PlainRequiredString = "buzzer"
 	}
-	if args.Required_bool == nil {
-		args.Required_bool = pulumix.Val(true)
+	if args.RequiredBool == nil {
+		args.RequiredBool = pulumix.Val(true)
 	}
-	if args.Required_enum == nil {
-		args.Required_enum = pulumix.Val(EnumThing(4))
+	if args.RequiredEnum == nil {
+		args.RequiredEnum = pulumix.Val(EnumThing(4))
 	}
-	if args.Required_number == nil {
-		args.Required_number = pulumix.Val(42.0)
+	if args.RequiredNumber == nil {
+		args.RequiredNumber = pulumix.Val(42.0)
 	}
-	if args.Required_string == nil {
-		args.Required_string = pulumix.Val("buzzer")
+	if args.RequiredString == nil {
+		args.RequiredString = pulumix.Val("buzzer")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource ModuleResource
@@ -108,44 +108,44 @@ func (ModuleResourceState) ElementType() reflect.Type {
 }
 
 type moduleResourceArgs struct {
-	Optional_bool         *bool      `pulumi:"optional_bool"`
-	Optional_const        *string    `pulumi:"optional_const"`
-	Optional_enum         *EnumThing `pulumi:"optional_enum"`
-	Optional_number       *float64   `pulumi:"optional_number"`
-	Optional_string       *string    `pulumi:"optional_string"`
-	Plain_optional_bool   *bool      `pulumi:"plain_optional_bool"`
-	Plain_optional_const  *string    `pulumi:"plain_optional_const"`
-	Plain_optional_number *float64   `pulumi:"plain_optional_number"`
-	Plain_optional_string *string    `pulumi:"plain_optional_string"`
-	Plain_required_bool   bool       `pulumi:"plain_required_bool"`
-	Plain_required_const  string     `pulumi:"plain_required_const"`
-	Plain_required_number float64    `pulumi:"plain_required_number"`
-	Plain_required_string string     `pulumi:"plain_required_string"`
-	Required_bool         bool       `pulumi:"required_bool"`
-	Required_enum         EnumThing  `pulumi:"required_enum"`
-	Required_number       float64    `pulumi:"required_number"`
-	Required_string       string     `pulumi:"required_string"`
+	OptionalBool        *bool      `pulumi:"optionalBool"`
+	OptionalConst       *string    `pulumi:"optionalConst"`
+	OptionalEnum        *EnumThing `pulumi:"optionalEnum"`
+	OptionalNumber      *float64   `pulumi:"optionalNumber"`
+	OptionalString      *string    `pulumi:"optionalString"`
+	PlainOptionalBool   *bool      `pulumi:"plainOptionalBool"`
+	PlainOptionalConst  *string    `pulumi:"plainOptionalConst"`
+	PlainOptionalNumber *float64   `pulumi:"plainOptionalNumber"`
+	PlainOptionalString *string    `pulumi:"plainOptionalString"`
+	PlainRequiredBool   bool       `pulumi:"plainRequiredBool"`
+	PlainRequiredConst  string     `pulumi:"plainRequiredConst"`
+	PlainRequiredNumber float64    `pulumi:"plainRequiredNumber"`
+	PlainRequiredString string     `pulumi:"plainRequiredString"`
+	RequiredBool        bool       `pulumi:"requiredBool"`
+	RequiredEnum        EnumThing  `pulumi:"requiredEnum"`
+	RequiredNumber      float64    `pulumi:"requiredNumber"`
+	RequiredString      string     `pulumi:"requiredString"`
 }
 
 // The set of arguments for constructing a ModuleResource resource.
 type ModuleResourceArgs struct {
-	Optional_bool         pulumix.Input[*bool]
-	Optional_const        pulumix.Input[*string]
-	Optional_enum         pulumix.Input[*EnumThing]
-	Optional_number       pulumix.Input[*float64]
-	Optional_string       pulumix.Input[*string]
-	Plain_optional_bool   *bool
-	Plain_optional_const  *string
-	Plain_optional_number *float64
-	Plain_optional_string *string
-	Plain_required_bool   bool
-	Plain_required_const  string
-	Plain_required_number float64
-	Plain_required_string string
-	Required_bool         pulumix.Input[bool]
-	Required_enum         pulumix.Input[EnumThing]
-	Required_number       pulumix.Input[float64]
-	Required_string       pulumix.Input[string]
+	OptionalBool        pulumix.Input[*bool]
+	OptionalConst       pulumix.Input[*string]
+	OptionalEnum        pulumix.Input[*EnumThing]
+	OptionalNumber      pulumix.Input[*float64]
+	OptionalString      pulumix.Input[*string]
+	PlainOptionalBool   *bool
+	PlainOptionalConst  *string
+	PlainOptionalNumber *float64
+	PlainOptionalString *string
+	PlainRequiredBool   bool
+	PlainRequiredConst  string
+	PlainRequiredNumber float64
+	PlainRequiredString string
+	RequiredBool        pulumix.Input[bool]
+	RequiredEnum        pulumix.Input[EnumThing]
+	RequiredNumber      pulumix.Input[float64]
+	RequiredString      pulumix.Input[string]
 }
 
 func (ModuleResourceArgs) ElementType() reflect.Type {
@@ -172,8 +172,8 @@ func (o ModuleResourceOutput) ToOutput(ctx context.Context) pulumix.Output[Modul
 	}
 }
 
-func (o ModuleResourceOutput) Optional_bool() pulumix.Output[*bool] {
-	value := pulumix.Apply[ModuleResource](o, func(v ModuleResource) pulumix.Output[*bool] { return v.Optional_bool })
+func (o ModuleResourceOutput) OptionalBool() pulumix.Output[*bool] {
+	value := pulumix.Apply[ModuleResource](o, func(v ModuleResource) pulumix.Output[*bool] { return v.OptionalBool })
 	return pulumix.Flatten[*bool, pulumix.Output[*bool]](value)
 }
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default-go-generics-only/schema.json
+++ b/pkg/codegen/testing/test/testdata/plain-and-default-go-generics-only/schema.json
@@ -4,100 +4,100 @@
   "resources": {
     "foobar::ModuleResource": {
       "properties": {
-        "optional_bool": {
+        "optionalBool": {
           "type": "boolean"
         }
       },
       "inputProperties": {
-        "plain_optional_const": {
+        "plainOptionalConst": {
           "type": "string",
           "const": "val",
           "default": "another",
           "plain": true
         },
-        "plain_optional_string": {
+        "plainOptionalString": {
           "type": "string",
           "default": "buzzer",
           "plain": true
         },
-        "plain_optional_bool": {
+        "plainOptionalBool": {
           "type": "boolean",
           "default": true,
           "plain": true
         },
-        "plain_optional_number": {
+        "plainOptionalNumber": {
           "type": "number",
           "default": 42,
           "plain": true
         },
-        "plain_required_string": {
+        "plainRequiredString": {
           "type": "string",
           "default": "buzzer",
           "plain": true
         },
-        "plain_required_bool": {
+        "plainRequiredBool": {
           "type": "boolean",
           "default": true,
           "plain": true
         },
-        "plain_required_number": {
+        "plainRequiredNumber": {
           "type": "number",
           "default": 42,
           "plain": true
         },
-        "optional_const": {
+        "optionalConst": {
           "type": "string",
           "const": "val",
           "default": "another"
         },
-        "optional_string": {
+        "optionalString": {
           "type": "string",
           "default": "buzzer"
         },
-        "optional_bool": {
+        "optionalBool": {
           "type": "boolean",
           "default": true
         },
-        "optional_number": {
+        "optionalNumber": {
           "type": "number",
           "default": 42
         },
-        "optional_enum": {
+        "optionalEnum": {
           "$ref": "#/types/foobar::EnumThing",
           "default": 8
         },
-        "plain_required_const": {
+        "plainRequiredConst": {
           "type": "string",
           "const": "val",
           "default": "another",
           "plain": true
         },
-        "required_string": {
+        "requiredString": {
           "type": "string",
           "default": "buzzer"
         },
-        "required_bool": {
+        "requiredBool": {
           "type": "boolean",
           "default": true
         },
-        "required_number": {
+        "requiredNumber": {
           "type": "number",
           "default": 42
         },
-        "required_enum": {
+        "requiredEnum": {
           "$ref": "#/types/foobar::EnumThing",
           "default": 4
         }
       },
       "requiredInputs": [
-        "plain_required_string",
-        "plain_required_bool",
-        "plain_required_number",
-        "plain_required_const",
-        "required_string",
-        "required_bool",
-        "required_number",
-        "required_enum"
+        "plainRequiredString",
+        "plainRequiredBool",
+        "plainRequiredNumber",
+        "plainRequiredConst",
+        "requiredString",
+        "requiredBool",
+        "requiredNumber",
+        "requiredEnum"
       ],
       "type": "object"
     }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -234,112 +234,112 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <pulumi-choosable type="language" values="csharp">
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
-        <span id="plain_required_bool_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
+        <span id="plainrequiredbool_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredbool_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_number_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
+        <span id="plainrequirednumber_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequirednumber_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_string_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
+        <span id="plainrequiredstring_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredstring_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_bool_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
+        <span id="requiredbool_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredbool_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_enum_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
+        <span id="requiredenum_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredenum_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_number_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
+        <span id="requirednumber_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednumber_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_string_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
+        <span id="requiredstring_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredstring_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_bool_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
+        <span id="optionalbool_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalbool_csharp" style="color: inherit; text-decoration: inherit;">Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_enum_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
+        <span id="optionalenum_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalenum_csharp" style="color: inherit; text-decoration: inherit;">Optional<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_number_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
+        <span id="optionalnumber_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalnumber_csharp" style="color: inherit; text-decoration: inherit;">Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_string_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
+        <span id="optionalstring_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalstring_csharp" style="color: inherit; text-decoration: inherit;">Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_bool_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
+        <span id="plainoptionalbool_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalbool_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_number_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
+        <span id="plainoptionalnumber_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalnumber_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_string_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
+        <span id="plainoptionalstring_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalstring_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -352,112 +352,112 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <pulumi-choosable type="language" values="go">
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
-        <span id="plain_required_bool_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
+        <span id="plainrequiredbool_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredbool_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_number_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
+        <span id="plainrequirednumber_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequirednumber_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_string_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
+        <span id="plainrequiredstring_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredstring_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_bool_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
+        <span id="requiredbool_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredbool_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_enum_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
+        <span id="requiredenum_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredenum_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_number_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
+        <span id="requirednumber_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednumber_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_string_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
+        <span id="requiredstring_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredstring_go" style="color: inherit; text-decoration: inherit;">Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_bool_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
+        <span id="optionalbool_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalbool_go" style="color: inherit; text-decoration: inherit;">Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_enum_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
+        <span id="optionalenum_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalenum_go" style="color: inherit; text-decoration: inherit;">Optional<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_number_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
+        <span id="optionalnumber_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalnumber_go" style="color: inherit; text-decoration: inherit;">Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_string_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
+        <span id="optionalstring_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalstring_go" style="color: inherit; text-decoration: inherit;">Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_bool_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
+        <span id="plainoptionalbool_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalbool_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_number_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
+        <span id="plainoptionalnumber_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalnumber_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_string_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
+        <span id="plainoptionalstring_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalstring_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -470,112 +470,112 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <pulumi-choosable type="language" values="java">
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
-        <span id="plain_required_bool_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
+        <span id="plainrequiredbool_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredbool_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_number_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
+        <span id="plainrequirednumber_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequirednumber_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Double</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_string_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
+        <span id="plainrequiredstring_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredstring_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_bool_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_java" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
+        <span id="requiredbool_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredbool_java" style="color: inherit; text-decoration: inherit;">required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_enum_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_java" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
+        <span id="requiredenum_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredenum_java" style="color: inherit; text-decoration: inherit;">required<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_number_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_java" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
+        <span id="requirednumber_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednumber_java" style="color: inherit; text-decoration: inherit;">required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Double</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_string_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_java" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
+        <span id="requiredstring_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredstring_java" style="color: inherit; text-decoration: inherit;">required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_bool_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
+        <span id="optionalbool_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalbool_java" style="color: inherit; text-decoration: inherit;">optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_enum_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
+        <span id="optionalenum_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalenum_java" style="color: inherit; text-decoration: inherit;">optional<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_number_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
+        <span id="optionalnumber_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalnumber_java" style="color: inherit; text-decoration: inherit;">optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Double</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_string_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
+        <span id="optionalstring_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalstring_java" style="color: inherit; text-decoration: inherit;">optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_bool_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
+        <span id="plainoptionalbool_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalbool_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_number_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
+        <span id="plainoptionalnumber_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalnumber_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Double</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_string_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_java" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
+        <span id="plainoptionalstring_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalstring_java" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
@@ -588,112 +588,112 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <pulumi-choosable type="language" values="javascript,typescript">
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
-        <span id="plain_required_bool_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
+        <span id="plainrequiredbool_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredbool_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_number_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
+        <span id="plainrequirednumber_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequirednumber_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_string_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
+        <span id="plainrequiredstring_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredstring_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_bool_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
+        <span id="requiredbool_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredbool_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_enum_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
+        <span id="requiredenum_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredenum_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_number_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
+        <span id="requirednumber_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednumber_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_string_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
+        <span id="requiredstring_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredstring_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_bool_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
+        <span id="optionalbool_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalbool_nodejs" style="color: inherit; text-decoration: inherit;">optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_enum_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
+        <span id="optionalenum_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalenum_nodejs" style="color: inherit; text-decoration: inherit;">optional<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_number_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
+        <span id="optionalnumber_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalnumber_nodejs" style="color: inherit; text-decoration: inherit;">optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_string_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
+        <span id="optionalstring_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalstring_nodejs" style="color: inherit; text-decoration: inherit;">optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_bool_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
+        <span id="plainoptionalbool_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalbool_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_number_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
+        <span id="plainoptionalnumber_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalnumber_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_string_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
+        <span id="plainoptionalstring_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalstring_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -824,112 +824,112 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <pulumi-choosable type="language" values="yaml">
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
-        <span id="plain_required_bool_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
+        <span id="plainrequiredbool_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredbool_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_number_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
+        <span id="plainrequirednumber_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequirednumber_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Number</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="plain_required_string_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
+        <span id="plainrequiredstring_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainrequiredstring_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_bool_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_yaml" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
+        <span id="requiredbool_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredbool_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_enum_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_yaml" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
+        <span id="requiredenum_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredenum_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">4 | 6 | 8</a></span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_number_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_yaml" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
+        <span id="requirednumber_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednumber_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Number</span>
     </dt>
     <dd></dd><dt class="property-required"
             title="Required">
-        <span id="required_string_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_yaml" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
+        <span id="requiredstring_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredstring_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_bool_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_yaml" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
+        <span id="optionalbool_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalbool_yaml" style="color: inherit; text-decoration: inherit;">optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_enum_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_yaml" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
+        <span id="optionalenum_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalenum_yaml" style="color: inherit; text-decoration: inherit;">optional<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">4 | 6 | 8</a></span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_number_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_yaml" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
+        <span id="optionalnumber_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalnumber_yaml" style="color: inherit; text-decoration: inherit;">optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Number</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="optional_string_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_yaml" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
+        <span id="optionalstring_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optionalstring_yaml" style="color: inherit; text-decoration: inherit;">optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_bool_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
+        <span id="plainoptionalbool_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalbool_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Boolean</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_number_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
+        <span id="plainoptionalnumber_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalnumber_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>Number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Number</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
-        <span id="plain_optional_string_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_yaml" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
+        <span id="plainoptionalstring_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainoptionalstring_yaml" style="color: inherit; text-decoration: inherit;">plain<wbr>Optional<wbr>String</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
@@ -12,8 +12,8 @@ namespace Pulumi.FooBar
     [FooBarResourceType("foobar::ModuleResource")]
     public partial class ModuleResource : global::Pulumi.CustomResource
     {
-        [Output("optional_bool")]
-        public Output<bool?> Optional_bool { get; private set; } = null!;
+        [Output("optionalBool")]
+        public Output<bool?> OptionalBool { get; private set; } = null!;
 
 
         /// <summary>
@@ -36,9 +36,9 @@ namespace Pulumi.FooBar
         private static ModuleResourceArgs MakeArgs(ModuleResourceArgs args)
         {
             args ??= new ModuleResourceArgs();
-            args.Optional_const = "val";
-            args.Plain_optional_const = "val";
-            args.Plain_required_const = "val";
+            args.OptionalConst = "val";
+            args.PlainOptionalConst = "val";
+            args.PlainRequiredConst = "val";
             return args;
         }
 
@@ -69,76 +69,76 @@ namespace Pulumi.FooBar
 
     public sealed class ModuleResourceArgs : global::Pulumi.ResourceArgs
     {
-        [Input("optional_bool")]
-        public Input<bool>? Optional_bool { get; set; }
+        [Input("optionalBool")]
+        public Input<bool>? OptionalBool { get; set; }
 
-        [Input("optional_const")]
-        public Input<string>? Optional_const { get; set; }
+        [Input("optionalConst")]
+        public Input<string>? OptionalConst { get; set; }
 
-        [Input("optional_enum")]
-        public Input<Pulumi.FooBar.EnumThing>? Optional_enum { get; set; }
+        [Input("optionalEnum")]
+        public Input<Pulumi.FooBar.EnumThing>? OptionalEnum { get; set; }
 
-        [Input("optional_number")]
-        public Input<double>? Optional_number { get; set; }
+        [Input("optionalNumber")]
+        public Input<double>? OptionalNumber { get; set; }
 
-        [Input("optional_string")]
-        public Input<string>? Optional_string { get; set; }
+        [Input("optionalString")]
+        public Input<string>? OptionalString { get; set; }
 
-        [Input("plain_optional_bool")]
-        public bool? Plain_optional_bool { get; set; }
+        [Input("plainOptionalBool")]
+        public bool? PlainOptionalBool { get; set; }
 
-        [Input("plain_optional_const")]
-        public string? Plain_optional_const { get; set; }
+        [Input("plainOptionalConst")]
+        public string? PlainOptionalConst { get; set; }
 
-        [Input("plain_optional_number")]
-        public double? Plain_optional_number { get; set; }
+        [Input("plainOptionalNumber")]
+        public double? PlainOptionalNumber { get; set; }
 
-        [Input("plain_optional_string")]
-        public string? Plain_optional_string { get; set; }
+        [Input("plainOptionalString")]
+        public string? PlainOptionalString { get; set; }
 
-        [Input("plain_required_bool", required: true)]
-        public bool Plain_required_bool { get; set; }
+        [Input("plainRequiredBool", required: true)]
+        public bool PlainRequiredBool { get; set; }
 
-        [Input("plain_required_const", required: true)]
-        public string Plain_required_const { get; set; } = null!;
+        [Input("plainRequiredConst", required: true)]
+        public string PlainRequiredConst { get; set; } = null!;
 
-        [Input("plain_required_number", required: true)]
-        public double Plain_required_number { get; set; }
+        [Input("plainRequiredNumber", required: true)]
+        public double PlainRequiredNumber { get; set; }
 
-        [Input("plain_required_string", required: true)]
-        public string Plain_required_string { get; set; } = null!;
+        [Input("plainRequiredString", required: true)]
+        public string PlainRequiredString { get; set; } = null!;
 
-        [Input("required_bool", required: true)]
-        public Input<bool> Required_bool { get; set; } = null!;
+        [Input("requiredBool", required: true)]
+        public Input<bool> RequiredBool { get; set; } = null!;
 
-        [Input("required_enum", required: true)]
-        public Input<Pulumi.FooBar.EnumThing> Required_enum { get; set; } = null!;
+        [Input("requiredEnum", required: true)]
+        public Input<Pulumi.FooBar.EnumThing> RequiredEnum { get; set; } = null!;
 
-        [Input("required_number", required: true)]
-        public Input<double> Required_number { get; set; } = null!;
+        [Input("requiredNumber", required: true)]
+        public Input<double> RequiredNumber { get; set; } = null!;
 
-        [Input("required_string", required: true)]
-        public Input<string> Required_string { get; set; } = null!;
+        [Input("requiredString", required: true)]
+        public Input<string> RequiredString { get; set; } = null!;
 
         public ModuleResourceArgs()
         {
-            Optional_bool = true;
-            Optional_const = "another";
-            Optional_enum = Pulumi.FooBar.EnumThing.Eight;
-            Optional_number = 42;
-            Optional_string = "buzzer";
-            Plain_optional_bool = true;
-            Plain_optional_const = "another";
-            Plain_optional_number = 42;
-            Plain_optional_string = "buzzer";
-            Plain_required_bool = true;
-            Plain_required_const = "another";
-            Plain_required_number = 42;
-            Plain_required_string = "buzzer";
-            Required_bool = true;
-            Required_enum = Pulumi.FooBar.EnumThing.Four;
-            Required_number = 42;
-            Required_string = "buzzer";
+            OptionalBool = true;
+            OptionalConst = "another";
+            OptionalEnum = Pulumi.FooBar.EnumThing.Eight;
+            OptionalNumber = 42;
+            OptionalString = "buzzer";
+            PlainOptionalBool = true;
+            PlainOptionalConst = "another";
+            PlainOptionalNumber = 42;
+            PlainOptionalString = "buzzer";
+            PlainRequiredBool = true;
+            PlainRequiredConst = "another";
+            PlainRequiredNumber = 42;
+            PlainRequiredString = "buzzer";
+            RequiredBool = true;
+            RequiredEnum = Pulumi.FooBar.EnumThing.Four;
+            RequiredNumber = 42;
+            RequiredString = "buzzer";
         }
         public static new ModuleResourceArgs Empty => new ModuleResourceArgs();
     }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go-extras/tests/codegen_test.go
@@ -17,14 +17,13 @@ package codegentest
 import (
 	"context"
 	"fmt"
+	"plain-and-default/foo"
 	"testing"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
-
-	"plain-and-default/foo"
 )
 
 type mocks int
@@ -41,20 +40,20 @@ func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
 func TestDefaults(t *testing.T) {
 	pulumiTest(t, "explicit false", func(ctx *pulumi.Context) error {
 		output, err := foo.NewModuleResource(ctx, "test", &foo.ModuleResourceArgs{
-			Optional_bool: pulumi.Bool(false),
+			OptionalBool: pulumi.Bool(false),
 		})
 		assert.NoError(t, err)
-		assert.Equalf(t, *waitOut(t, output.Optional_bool).(*bool), false,
+		assert.Equalf(t, *waitOut(t, output.OptionalBool).(*bool), false,
 			"Value has been set to false, make sure it doesn't change.")
 		return nil
 	})
 
 	pulumiTest(t, "explicit true", func(ctx *pulumi.Context) error {
 		output, err := foo.NewModuleResource(ctx, "test", &foo.ModuleResourceArgs{
-			Optional_bool: pulumi.Bool(true),
+			OptionalBool: pulumi.Bool(true),
 		})
 		assert.NoError(t, err)
-		assert.Equalf(t, *waitOut(t, output.Optional_bool).(*bool), true,
+		assert.Equalf(t, *waitOut(t, output.OptionalBool).(*bool), true,
 			"Value has been set to true, make sure it doesn't change.")
 		return nil
 	})
@@ -62,7 +61,7 @@ func TestDefaults(t *testing.T) {
 	pulumiTest(t, "default value", func(ctx *pulumi.Context) error {
 		output, err := foo.NewModuleResource(ctx, "test", &foo.ModuleResourceArgs{})
 		assert.NoError(t, err)
-		assert.Equalf(t, *waitOut(t, output.Optional_bool).(*bool), true,
+		assert.Equalf(t, *waitOut(t, output.OptionalBool).(*bool), true,
 			"Default value is true, and the value has not been specified")
 		return nil
 	})

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
@@ -16,7 +16,7 @@ import (
 type ModuleResource struct {
 	pulumi.CustomResourceState
 
-	Optional_bool pulumi.BoolPtrOutput `pulumi:"optional_bool"`
+	OptionalBool pulumi.BoolPtrOutput `pulumi:"optionalBool"`
 }
 
 // NewModuleResource registers a new resource with the given unique name, arguments, and options.
@@ -26,54 +26,54 @@ func NewModuleResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Optional_bool == nil {
-		args.Optional_bool = pulumi.BoolPtr(true)
+	if args.OptionalBool == nil {
+		args.OptionalBool = pulumi.BoolPtr(true)
 	}
-	args.Optional_const = pulumi.StringPtr("val")
-	if args.Optional_enum == nil {
-		args.Optional_enum = EnumThing(8)
+	args.OptionalConst = pulumi.StringPtr("val")
+	if args.OptionalEnum == nil {
+		args.OptionalEnum = EnumThing(8)
 	}
-	if args.Optional_number == nil {
-		args.Optional_number = pulumi.Float64Ptr(42.0)
+	if args.OptionalNumber == nil {
+		args.OptionalNumber = pulumi.Float64Ptr(42.0)
 	}
-	if args.Optional_string == nil {
-		args.Optional_string = pulumi.StringPtr("buzzer")
+	if args.OptionalString == nil {
+		args.OptionalString = pulumi.StringPtr("buzzer")
 	}
-	if args.Plain_optional_bool == nil {
-		plain_optional_bool_ := true
-		args.Plain_optional_bool = &plain_optional_bool_
+	if args.PlainOptionalBool == nil {
+		plainOptionalBool_ := true
+		args.PlainOptionalBool = &plainOptionalBool_
 	}
-	plain_optional_const_ := "val"
-	args.Plain_optional_const = &plain_optional_const_
-	if args.Plain_optional_number == nil {
-		plain_optional_number_ := 42.0
-		args.Plain_optional_number = &plain_optional_number_
+	plainOptionalConst_ := "val"
+	args.PlainOptionalConst = &plainOptionalConst_
+	if args.PlainOptionalNumber == nil {
+		plainOptionalNumber_ := 42.0
+		args.PlainOptionalNumber = &plainOptionalNumber_
 	}
-	if args.Plain_optional_string == nil {
-		plain_optional_string_ := "buzzer"
-		args.Plain_optional_string = &plain_optional_string_
+	if args.PlainOptionalString == nil {
+		plainOptionalString_ := "buzzer"
+		args.PlainOptionalString = &plainOptionalString_
 	}
-	if internal.IsZero(args.Plain_required_bool) {
-		args.Plain_required_bool = true
+	if internal.IsZero(args.PlainRequiredBool) {
+		args.PlainRequiredBool = true
 	}
-	args.Plain_required_const = "val"
-	if internal.IsZero(args.Plain_required_number) {
-		args.Plain_required_number = 42.0
+	args.PlainRequiredConst = "val"
+	if internal.IsZero(args.PlainRequiredNumber) {
+		args.PlainRequiredNumber = 42.0
 	}
-	if internal.IsZero(args.Plain_required_string) {
-		args.Plain_required_string = "buzzer"
+	if internal.IsZero(args.PlainRequiredString) {
+		args.PlainRequiredString = "buzzer"
 	}
-	if args.Required_bool == nil {
-		args.Required_bool = pulumi.Bool(true)
+	if args.RequiredBool == nil {
+		args.RequiredBool = pulumi.Bool(true)
 	}
-	if args.Required_enum == nil {
-		args.Required_enum = EnumThing(4)
+	if args.RequiredEnum == nil {
+		args.RequiredEnum = EnumThing(4)
 	}
-	if args.Required_number == nil {
-		args.Required_number = pulumi.Float64(42.0)
+	if args.RequiredNumber == nil {
+		args.RequiredNumber = pulumi.Float64(42.0)
 	}
-	if args.Required_string == nil {
-		args.Required_string = pulumi.String("buzzer")
+	if args.RequiredString == nil {
+		args.RequiredString = pulumi.String("buzzer")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource ModuleResource
@@ -108,44 +108,44 @@ func (ModuleResourceState) ElementType() reflect.Type {
 }
 
 type moduleResourceArgs struct {
-	Optional_bool         *bool      `pulumi:"optional_bool"`
-	Optional_const        *string    `pulumi:"optional_const"`
-	Optional_enum         *EnumThing `pulumi:"optional_enum"`
-	Optional_number       *float64   `pulumi:"optional_number"`
-	Optional_string       *string    `pulumi:"optional_string"`
-	Plain_optional_bool   *bool      `pulumi:"plain_optional_bool"`
-	Plain_optional_const  *string    `pulumi:"plain_optional_const"`
-	Plain_optional_number *float64   `pulumi:"plain_optional_number"`
-	Plain_optional_string *string    `pulumi:"plain_optional_string"`
-	Plain_required_bool   bool       `pulumi:"plain_required_bool"`
-	Plain_required_const  string     `pulumi:"plain_required_const"`
-	Plain_required_number float64    `pulumi:"plain_required_number"`
-	Plain_required_string string     `pulumi:"plain_required_string"`
-	Required_bool         bool       `pulumi:"required_bool"`
-	Required_enum         EnumThing  `pulumi:"required_enum"`
-	Required_number       float64    `pulumi:"required_number"`
-	Required_string       string     `pulumi:"required_string"`
+	OptionalBool        *bool      `pulumi:"optionalBool"`
+	OptionalConst       *string    `pulumi:"optionalConst"`
+	OptionalEnum        *EnumThing `pulumi:"optionalEnum"`
+	OptionalNumber      *float64   `pulumi:"optionalNumber"`
+	OptionalString      *string    `pulumi:"optionalString"`
+	PlainOptionalBool   *bool      `pulumi:"plainOptionalBool"`
+	PlainOptionalConst  *string    `pulumi:"plainOptionalConst"`
+	PlainOptionalNumber *float64   `pulumi:"plainOptionalNumber"`
+	PlainOptionalString *string    `pulumi:"plainOptionalString"`
+	PlainRequiredBool   bool       `pulumi:"plainRequiredBool"`
+	PlainRequiredConst  string     `pulumi:"plainRequiredConst"`
+	PlainRequiredNumber float64    `pulumi:"plainRequiredNumber"`
+	PlainRequiredString string     `pulumi:"plainRequiredString"`
+	RequiredBool        bool       `pulumi:"requiredBool"`
+	RequiredEnum        EnumThing  `pulumi:"requiredEnum"`
+	RequiredNumber      float64    `pulumi:"requiredNumber"`
+	RequiredString      string     `pulumi:"requiredString"`
 }
 
 // The set of arguments for constructing a ModuleResource resource.
 type ModuleResourceArgs struct {
-	Optional_bool         pulumi.BoolPtrInput
-	Optional_const        pulumi.StringPtrInput
-	Optional_enum         EnumThingPtrInput
-	Optional_number       pulumi.Float64PtrInput
-	Optional_string       pulumi.StringPtrInput
-	Plain_optional_bool   *bool
-	Plain_optional_const  *string
-	Plain_optional_number *float64
-	Plain_optional_string *string
-	Plain_required_bool   bool
-	Plain_required_const  string
-	Plain_required_number float64
-	Plain_required_string string
-	Required_bool         pulumi.BoolInput
-	Required_enum         EnumThingInput
-	Required_number       pulumi.Float64Input
-	Required_string       pulumi.StringInput
+	OptionalBool        pulumi.BoolPtrInput
+	OptionalConst       pulumi.StringPtrInput
+	OptionalEnum        EnumThingPtrInput
+	OptionalNumber      pulumi.Float64PtrInput
+	OptionalString      pulumi.StringPtrInput
+	PlainOptionalBool   *bool
+	PlainOptionalConst  *string
+	PlainOptionalNumber *float64
+	PlainOptionalString *string
+	PlainRequiredBool   bool
+	PlainRequiredConst  string
+	PlainRequiredNumber float64
+	PlainRequiredString string
+	RequiredBool        pulumi.BoolInput
+	RequiredEnum        EnumThingInput
+	RequiredNumber      pulumi.Float64Input
+	RequiredString      pulumi.StringInput
 }
 
 func (ModuleResourceArgs) ElementType() reflect.Type {
@@ -197,8 +197,8 @@ func (o ModuleResourceOutput) ToOutput(ctx context.Context) pulumix.Output[*Modu
 	}
 }
 
-func (o ModuleResourceOutput) Optional_bool() pulumi.BoolPtrOutput {
-	return o.ApplyT(func(v *ModuleResource) pulumi.BoolPtrOutput { return v.Optional_bool }).(pulumi.BoolPtrOutput)
+func (o ModuleResourceOutput) OptionalBool() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *ModuleResource) pulumi.BoolPtrOutput { return v.OptionalBool }).(pulumi.BoolPtrOutput)
 }
 
 func init() {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/x/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/x/moduleResource.go
@@ -16,7 +16,7 @@ import (
 type ModuleResource struct {
 	pulumi.CustomResourceState
 
-	Optional_bool pulumix.Output[*bool] `pulumi:"optional_bool"`
+	OptionalBool pulumix.Output[*bool] `pulumi:"optionalBool"`
 }
 
 // NewModuleResource registers a new resource with the given unique name, arguments, and options.
@@ -26,54 +26,54 @@ func NewModuleResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Optional_bool == nil {
-		args.Optional_bool = pulumix.Ptr(true)
+	if args.OptionalBool == nil {
+		args.OptionalBool = pulumix.Ptr(true)
 	}
-	args.Optional_const = pulumix.Ptr("val")
-	if args.Optional_enum == nil {
-		args.Optional_enum = pulumix.Ptr(EnumThing(8))
+	args.OptionalConst = pulumix.Ptr("val")
+	if args.OptionalEnum == nil {
+		args.OptionalEnum = pulumix.Ptr(EnumThing(8))
 	}
-	if args.Optional_number == nil {
-		args.Optional_number = pulumix.Ptr(42.0)
+	if args.OptionalNumber == nil {
+		args.OptionalNumber = pulumix.Ptr(42.0)
 	}
-	if args.Optional_string == nil {
-		args.Optional_string = pulumix.Ptr("buzzer")
+	if args.OptionalString == nil {
+		args.OptionalString = pulumix.Ptr("buzzer")
 	}
-	if args.Plain_optional_bool == nil {
-		plain_optional_bool_ := true
-		args.Plain_optional_bool = &plain_optional_bool_
+	if args.PlainOptionalBool == nil {
+		plainOptionalBool_ := true
+		args.PlainOptionalBool = &plainOptionalBool_
 	}
-	plain_optional_const_ := "val"
-	args.Plain_optional_const = &plain_optional_const_
-	if args.Plain_optional_number == nil {
-		plain_optional_number_ := 42.0
-		args.Plain_optional_number = &plain_optional_number_
+	plainOptionalConst_ := "val"
+	args.PlainOptionalConst = &plainOptionalConst_
+	if args.PlainOptionalNumber == nil {
+		plainOptionalNumber_ := 42.0
+		args.PlainOptionalNumber = &plainOptionalNumber_
 	}
-	if args.Plain_optional_string == nil {
-		plain_optional_string_ := "buzzer"
-		args.Plain_optional_string = &plain_optional_string_
+	if args.PlainOptionalString == nil {
+		plainOptionalString_ := "buzzer"
+		args.PlainOptionalString = &plainOptionalString_
 	}
-	if internal.IsZero(args.Plain_required_bool) {
-		args.Plain_required_bool = true
+	if internal.IsZero(args.PlainRequiredBool) {
+		args.PlainRequiredBool = true
 	}
-	args.Plain_required_const = "val"
-	if internal.IsZero(args.Plain_required_number) {
-		args.Plain_required_number = 42.0
+	args.PlainRequiredConst = "val"
+	if internal.IsZero(args.PlainRequiredNumber) {
+		args.PlainRequiredNumber = 42.0
 	}
-	if internal.IsZero(args.Plain_required_string) {
-		args.Plain_required_string = "buzzer"
+	if internal.IsZero(args.PlainRequiredString) {
+		args.PlainRequiredString = "buzzer"
 	}
-	if args.Required_bool == nil {
-		args.Required_bool = pulumix.Val(true)
+	if args.RequiredBool == nil {
+		args.RequiredBool = pulumix.Val(true)
 	}
-	if args.Required_enum == nil {
-		args.Required_enum = pulumix.Val(EnumThing(4))
+	if args.RequiredEnum == nil {
+		args.RequiredEnum = pulumix.Val(EnumThing(4))
 	}
-	if args.Required_number == nil {
-		args.Required_number = pulumix.Val(42.0)
+	if args.RequiredNumber == nil {
+		args.RequiredNumber = pulumix.Val(42.0)
 	}
-	if args.Required_string == nil {
-		args.Required_string = pulumix.Val("buzzer")
+	if args.RequiredString == nil {
+		args.RequiredString = pulumix.Val("buzzer")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource ModuleResource
@@ -108,44 +108,44 @@ func (ModuleResourceState) ElementType() reflect.Type {
 }
 
 type moduleResourceArgs struct {
-	Optional_bool         *bool      `pulumi:"optional_bool"`
-	Optional_const        *string    `pulumi:"optional_const"`
-	Optional_enum         *EnumThing `pulumi:"optional_enum"`
-	Optional_number       *float64   `pulumi:"optional_number"`
-	Optional_string       *string    `pulumi:"optional_string"`
-	Plain_optional_bool   *bool      `pulumi:"plain_optional_bool"`
-	Plain_optional_const  *string    `pulumi:"plain_optional_const"`
-	Plain_optional_number *float64   `pulumi:"plain_optional_number"`
-	Plain_optional_string *string    `pulumi:"plain_optional_string"`
-	Plain_required_bool   bool       `pulumi:"plain_required_bool"`
-	Plain_required_const  string     `pulumi:"plain_required_const"`
-	Plain_required_number float64    `pulumi:"plain_required_number"`
-	Plain_required_string string     `pulumi:"plain_required_string"`
-	Required_bool         bool       `pulumi:"required_bool"`
-	Required_enum         EnumThing  `pulumi:"required_enum"`
-	Required_number       float64    `pulumi:"required_number"`
-	Required_string       string     `pulumi:"required_string"`
+	OptionalBool        *bool      `pulumi:"optionalBool"`
+	OptionalConst       *string    `pulumi:"optionalConst"`
+	OptionalEnum        *EnumThing `pulumi:"optionalEnum"`
+	OptionalNumber      *float64   `pulumi:"optionalNumber"`
+	OptionalString      *string    `pulumi:"optionalString"`
+	PlainOptionalBool   *bool      `pulumi:"plainOptionalBool"`
+	PlainOptionalConst  *string    `pulumi:"plainOptionalConst"`
+	PlainOptionalNumber *float64   `pulumi:"plainOptionalNumber"`
+	PlainOptionalString *string    `pulumi:"plainOptionalString"`
+	PlainRequiredBool   bool       `pulumi:"plainRequiredBool"`
+	PlainRequiredConst  string     `pulumi:"plainRequiredConst"`
+	PlainRequiredNumber float64    `pulumi:"plainRequiredNumber"`
+	PlainRequiredString string     `pulumi:"plainRequiredString"`
+	RequiredBool        bool       `pulumi:"requiredBool"`
+	RequiredEnum        EnumThing  `pulumi:"requiredEnum"`
+	RequiredNumber      float64    `pulumi:"requiredNumber"`
+	RequiredString      string     `pulumi:"requiredString"`
 }
 
 // The set of arguments for constructing a ModuleResource resource.
 type ModuleResourceArgs struct {
-	Optional_bool         pulumix.Input[*bool]
-	Optional_const        pulumix.Input[*string]
-	Optional_enum         pulumix.Input[*EnumThing]
-	Optional_number       pulumix.Input[*float64]
-	Optional_string       pulumix.Input[*string]
-	Plain_optional_bool   *bool
-	Plain_optional_const  *string
-	Plain_optional_number *float64
-	Plain_optional_string *string
-	Plain_required_bool   bool
-	Plain_required_const  string
-	Plain_required_number float64
-	Plain_required_string string
-	Required_bool         pulumix.Input[bool]
-	Required_enum         pulumix.Input[EnumThing]
-	Required_number       pulumix.Input[float64]
-	Required_string       pulumix.Input[string]
+	OptionalBool        pulumix.Input[*bool]
+	OptionalConst       pulumix.Input[*string]
+	OptionalEnum        pulumix.Input[*EnumThing]
+	OptionalNumber      pulumix.Input[*float64]
+	OptionalString      pulumix.Input[*string]
+	PlainOptionalBool   *bool
+	PlainOptionalConst  *string
+	PlainOptionalNumber *float64
+	PlainOptionalString *string
+	PlainRequiredBool   bool
+	PlainRequiredConst  string
+	PlainRequiredNumber float64
+	PlainRequiredString string
+	RequiredBool        pulumix.Input[bool]
+	RequiredEnum        pulumix.Input[EnumThing]
+	RequiredNumber      pulumix.Input[float64]
+	RequiredString      pulumix.Input[string]
 }
 
 func (ModuleResourceArgs) ElementType() reflect.Type {
@@ -172,8 +172,8 @@ func (o ModuleResourceOutput) ToOutput(ctx context.Context) pulumix.Output[Modul
 	}
 }
 
-func (o ModuleResourceOutput) Optional_bool() pulumix.Output[*bool] {
-	value := pulumix.Apply[ModuleResource](o, func(v ModuleResource) pulumix.Output[*bool] { return v.Optional_bool })
+func (o ModuleResourceOutput) OptionalBool() pulumix.Output[*bool] {
+	value := pulumix.Apply[ModuleResource](o, func(v ModuleResource) pulumix.Output[*bool] { return v.OptionalBool })
 	return pulumix.Flatten[*bool, pulumix.Output[*bool]](value)
 }
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/moduleResource.ts
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/moduleResource.ts
@@ -34,7 +34,7 @@ export class ModuleResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === ModuleResource.__pulumiType;
     }
 
-    public readonly optional_bool!: pulumi.Output<boolean | undefined>;
+    public readonly optionalBool!: pulumi.Output<boolean | undefined>;
 
     /**
      * Create a ModuleResource resource with the given unique name, arguments, and options.
@@ -47,49 +47,49 @@ export class ModuleResource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.plain_required_bool === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'plain_required_bool'");
+            if ((!args || args.plainRequiredBool === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'plainRequiredBool'");
             }
-            if ((!args || args.plain_required_const === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'plain_required_const'");
+            if ((!args || args.plainRequiredConst === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'plainRequiredConst'");
             }
-            if ((!args || args.plain_required_number === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'plain_required_number'");
+            if ((!args || args.plainRequiredNumber === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'plainRequiredNumber'");
             }
-            if ((!args || args.plain_required_string === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'plain_required_string'");
+            if ((!args || args.plainRequiredString === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'plainRequiredString'");
             }
-            if ((!args || args.required_bool === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'required_bool'");
+            if ((!args || args.requiredBool === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredBool'");
             }
-            if ((!args || args.required_enum === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'required_enum'");
+            if ((!args || args.requiredEnum === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredEnum'");
             }
-            if ((!args || args.required_number === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'required_number'");
+            if ((!args || args.requiredNumber === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredNumber'");
             }
-            if ((!args || args.required_string === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'required_string'");
+            if ((!args || args.requiredString === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredString'");
             }
-            resourceInputs["optional_bool"] = (args ? args.optional_bool : undefined) ?? true;
-            resourceInputs["optional_const"] = "val";
-            resourceInputs["optional_enum"] = (args ? args.optional_enum : undefined) ?? 8;
-            resourceInputs["optional_number"] = (args ? args.optional_number : undefined) ?? 42;
-            resourceInputs["optional_string"] = (args ? args.optional_string : undefined) ?? "buzzer";
-            resourceInputs["plain_optional_bool"] = (args ? args.plain_optional_bool : undefined) ?? true;
-            resourceInputs["plain_optional_const"] = "val";
-            resourceInputs["plain_optional_number"] = (args ? args.plain_optional_number : undefined) ?? 42;
-            resourceInputs["plain_optional_string"] = (args ? args.plain_optional_string : undefined) ?? "buzzer";
-            resourceInputs["plain_required_bool"] = (args ? args.plain_required_bool : undefined) ?? true;
-            resourceInputs["plain_required_const"] = "val";
-            resourceInputs["plain_required_number"] = (args ? args.plain_required_number : undefined) ?? 42;
-            resourceInputs["plain_required_string"] = (args ? args.plain_required_string : undefined) ?? "buzzer";
-            resourceInputs["required_bool"] = (args ? args.required_bool : undefined) ?? true;
-            resourceInputs["required_enum"] = (args ? args.required_enum : undefined) ?? 4;
-            resourceInputs["required_number"] = (args ? args.required_number : undefined) ?? 42;
-            resourceInputs["required_string"] = (args ? args.required_string : undefined) ?? "buzzer";
+            resourceInputs["optionalBool"] = (args ? args.optionalBool : undefined) ?? true;
+            resourceInputs["optionalConst"] = "val";
+            resourceInputs["optionalEnum"] = (args ? args.optionalEnum : undefined) ?? 8;
+            resourceInputs["optionalNumber"] = (args ? args.optionalNumber : undefined) ?? 42;
+            resourceInputs["optionalString"] = (args ? args.optionalString : undefined) ?? "buzzer";
+            resourceInputs["plainOptionalBool"] = (args ? args.plainOptionalBool : undefined) ?? true;
+            resourceInputs["plainOptionalConst"] = "val";
+            resourceInputs["plainOptionalNumber"] = (args ? args.plainOptionalNumber : undefined) ?? 42;
+            resourceInputs["plainOptionalString"] = (args ? args.plainOptionalString : undefined) ?? "buzzer";
+            resourceInputs["plainRequiredBool"] = (args ? args.plainRequiredBool : undefined) ?? true;
+            resourceInputs["plainRequiredConst"] = "val";
+            resourceInputs["plainRequiredNumber"] = (args ? args.plainRequiredNumber : undefined) ?? 42;
+            resourceInputs["plainRequiredString"] = (args ? args.plainRequiredString : undefined) ?? "buzzer";
+            resourceInputs["requiredBool"] = (args ? args.requiredBool : undefined) ?? true;
+            resourceInputs["requiredEnum"] = (args ? args.requiredEnum : undefined) ?? 4;
+            resourceInputs["requiredNumber"] = (args ? args.requiredNumber : undefined) ?? 42;
+            resourceInputs["requiredString"] = (args ? args.requiredString : undefined) ?? "buzzer";
         } else {
-            resourceInputs["optional_bool"] = undefined /*out*/;
+            resourceInputs["optionalBool"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(ModuleResource.__pulumiType, name, resourceInputs, opts);
@@ -100,21 +100,21 @@ export class ModuleResource extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleResource resource.
  */
 export interface ModuleResourceArgs {
-    optional_bool?: pulumi.Input<boolean>;
-    optional_const?: pulumi.Input<"val">;
-    optional_enum?: pulumi.Input<enums.EnumThing>;
-    optional_number?: pulumi.Input<number>;
-    optional_string?: pulumi.Input<string>;
-    plain_optional_bool?: boolean;
-    plain_optional_const?: "val";
-    plain_optional_number?: number;
-    plain_optional_string?: string;
-    plain_required_bool: boolean;
-    plain_required_const: "val";
-    plain_required_number: number;
-    plain_required_string: string;
-    required_bool: pulumi.Input<boolean>;
-    required_enum: pulumi.Input<enums.EnumThing>;
-    required_number: pulumi.Input<number>;
-    required_string: pulumi.Input<string>;
+    optionalBool?: pulumi.Input<boolean>;
+    optionalConst?: pulumi.Input<"val">;
+    optionalEnum?: pulumi.Input<enums.EnumThing>;
+    optionalNumber?: pulumi.Input<number>;
+    optionalString?: pulumi.Input<string>;
+    plainOptionalBool?: boolean;
+    plainOptionalConst?: "val";
+    plainOptionalNumber?: number;
+    plainOptionalString?: string;
+    plainRequiredBool: boolean;
+    plainRequiredConst: "val";
+    plainRequiredNumber: number;
+    plainRequiredString: string;
+    requiredBool: pulumi.Input<boolean>;
+    requiredEnum: pulumi.Input<enums.EnumThing>;
+    requiredNumber: pulumi.Input<number>;
+    requiredString: pulumi.Input<string>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -97,7 +97,7 @@ class ModuleResourceArgs:
             pulumi.set(__self__, "plain_optional_string", plain_optional_string)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainRequiredBool")
     def plain_required_bool(self) -> bool:
         return pulumi.get(self, "plain_required_bool")
 
@@ -106,7 +106,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_required_bool", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainRequiredConst")
     def plain_required_const(self) -> str:
         return pulumi.get(self, "plain_required_const")
 
@@ -115,7 +115,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_required_const", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainRequiredNumber")
     def plain_required_number(self) -> float:
         return pulumi.get(self, "plain_required_number")
 
@@ -124,7 +124,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_required_number", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainRequiredString")
     def plain_required_string(self) -> str:
         return pulumi.get(self, "plain_required_string")
 
@@ -133,7 +133,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_required_string", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="requiredBool")
     def required_bool(self) -> pulumi.Input[bool]:
         return pulumi.get(self, "required_bool")
 
@@ -142,7 +142,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "required_bool", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="requiredEnum")
     def required_enum(self) -> pulumi.Input['EnumThing']:
         return pulumi.get(self, "required_enum")
 
@@ -151,7 +151,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "required_enum", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="requiredNumber")
     def required_number(self) -> pulumi.Input[float]:
         return pulumi.get(self, "required_number")
 
@@ -160,7 +160,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "required_number", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="requiredString")
     def required_string(self) -> pulumi.Input[str]:
         return pulumi.get(self, "required_string")
 
@@ -169,7 +169,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "required_string", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalBool")
     def optional_bool(self) -> Optional[pulumi.Input[bool]]:
         return pulumi.get(self, "optional_bool")
 
@@ -178,7 +178,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "optional_bool", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalConst")
     def optional_const(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "optional_const")
 
@@ -187,7 +187,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "optional_const", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalEnum")
     def optional_enum(self) -> Optional[pulumi.Input['EnumThing']]:
         return pulumi.get(self, "optional_enum")
 
@@ -196,7 +196,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "optional_enum", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalNumber")
     def optional_number(self) -> Optional[pulumi.Input[float]]:
         return pulumi.get(self, "optional_number")
 
@@ -205,7 +205,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "optional_number", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalString")
     def optional_string(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "optional_string")
 
@@ -214,7 +214,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "optional_string", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainOptionalBool")
     def plain_optional_bool(self) -> Optional[bool]:
         return pulumi.get(self, "plain_optional_bool")
 
@@ -223,7 +223,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_optional_bool", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainOptionalConst")
     def plain_optional_const(self) -> Optional[str]:
         return pulumi.get(self, "plain_optional_const")
 
@@ -232,7 +232,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_optional_const", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainOptionalNumber")
     def plain_optional_number(self) -> Optional[float]:
         return pulumi.get(self, "plain_optional_number")
 
@@ -241,7 +241,7 @@ class ModuleResourceArgs:
         pulumi.set(self, "plain_optional_number", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="plainOptionalString")
     def plain_optional_string(self) -> Optional[str]:
         return pulumi.get(self, "plain_optional_string")
 
@@ -420,7 +420,7 @@ class ModuleResource(pulumi.CustomResource):
         return ModuleResource(resource_name, opts=opts, __props__=__props__)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="optionalBool")
     def optional_bool(self) -> pulumi.Output[Optional[bool]]:
         return pulumi.get(self, "optional_bool")
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/schema.json
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/schema.json
@@ -4,100 +4,100 @@
   "resources": {
     "foobar::ModuleResource": {
       "properties": {
-        "optional_bool": {
+        "optionalBool": {
           "type": "boolean"
         }
       },
       "inputProperties": {
-        "plain_optional_const": {
+        "plainOptionalConst": {
           "type": "string",
           "const": "val",
           "default": "another",
           "plain": true
         },
-        "plain_optional_string": {
+        "plainOptionalString": {
           "type": "string",
           "default": "buzzer",
           "plain": true
         },
-        "plain_optional_bool": {
+        "plainOptionalBool": {
           "type": "boolean",
           "default": true,
           "plain": true
         },
-        "plain_optional_number": {
+        "plainOptionalNumber": {
           "type": "number",
           "default": 42,
           "plain": true
         },
-        "plain_required_string": {
+        "plainRequiredString": {
           "type": "string",
           "default": "buzzer",
           "plain": true
         },
-        "plain_required_bool": {
+        "plainRequiredBool": {
           "type": "boolean",
           "default": true,
           "plain": true
         },
-        "plain_required_number": {
+        "plainRequiredNumber": {
           "type": "number",
           "default": 42,
           "plain": true
         },
-        "optional_const": {
+        "optionalConst": {
           "type": "string",
           "const": "val",
           "default": "another"
         },
-        "optional_string": {
+        "optionalString": {
           "type": "string",
           "default": "buzzer"
         },
-        "optional_bool": {
+        "optionalBool": {
           "type": "boolean",
           "default": true
         },
-        "optional_number": {
+        "optionalNumber": {
           "type": "number",
           "default": 42
         },
-        "optional_enum": {
+        "optionalEnum": {
           "$ref": "#/types/foobar::EnumThing",
           "default": 8
         },
-        "plain_required_const": {
+        "plainRequiredConst": {
           "type": "string",
           "const": "val",
           "default": "another",
           "plain": true
         },
-        "required_string": {
+        "requiredString": {
           "type": "string",
           "default": "buzzer"
         },
-        "required_bool": {
+        "requiredBool": {
           "type": "boolean",
           "default": true
         },
-        "required_number": {
+        "requiredNumber": {
           "type": "number",
           "default": 42
         },
-        "required_enum": {
+        "requiredEnum": {
           "$ref": "#/types/foobar::EnumThing",
           "default": 4
         }
       },
       "requiredInputs": [
-        "plain_required_string",
-        "plain_required_bool",
-        "plain_required_number",
-        "plain_required_const",
-        "required_string",
-        "required_bool",
-        "required_number",
-        "required_enum"
+        "plainRequiredString",
+        "plainRequiredBool",
+        "plainRequiredNumber",
+        "plainRequiredConst",
+        "requiredString",
+        "requiredBool",
+        "requiredNumber",
+        "requiredEnum"
       ],
       "type": "object"
     }

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/python/pulumi_foo/_inputs.py
@@ -22,7 +22,7 @@ class ProviderCertmanagerArgs:
         pulumi.set(__self__, "mtls_key_pem", mtls_key_pem)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="mtlsCertPem")
     def mtls_cert_pem(self) -> pulumi.Input[str]:
         return pulumi.get(self, "mtls_cert_pem")
 
@@ -31,7 +31,7 @@ class ProviderCertmanagerArgs:
         pulumi.set(self, "mtls_cert_pem", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="mtlsKeyPem")
     def mtls_key_pem(self) -> pulumi.Input[str]:
         return pulumi.get(self, "mtls_key_pem")
 

--- a/pkg/codegen/testing/test/testdata/regress-py-14012/schema.json
+++ b/pkg/codegen/testing/test/testdata/regress-py-14012/schema.json
@@ -11,16 +11,16 @@
     "types": {
         "foo:index:ProviderCertmanager": {
             "properties": {
-                "mtls_cert_pem": {
+                "mtlsCertPem": {
                     "type": "string"
                 },
-                "mtls_key_pem": {
+                "mtlsKeyPem": {
                     "type": "string"
                 }
             },
             "required": [
-                "mtls_cert_pem",
-                "mtls_key_pem"
+                "mtlsCertPem",
+                "mtlsKeyPem"
             ],
             "type": "object"
         }

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

A few of the test schema's were using snake_case names. Codegen doesn't actually deal well with that so was giving some odd snapshot results, this just fixes up the tests to use camelCase instead to get more standard codegen results out.
