### PR TITLE
add no_tmp_dir query parameter to file:// URLs

### DIFF
--- a/changelog/pending/20240205--backend-diy--fix-an-issue-where-state-stored-on-a-mounted-device-would-result-in-errors.yaml
+++ b/changelog/pending/20240205--backend-diy--fix-an-issue-where-state-stored-on-a-mounted-device-would-result-in-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Fix an issue where state stored on a mounted device would result in errors

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -519,7 +519,7 @@ func massageBlobPath(path string) (string, error) {
 	// See also https://github.com/pulumi/pulumi/issues/15352
 	url, err := url.Parse(path)
 	if err != nil {
-		return "", fmt.Errorf("Could not parse the provided URL: %w", err)
+		return "", fmt.Errorf("parsing the provided URL: %w", err)
 	}
 	query := url.Query()
 	if query.Get("no_tmp_dir") == "" {

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -515,8 +515,29 @@ func massageBlobPath(path string) (string, error) {
 		return path, nil
 	}
 
+	// We need to set no_tmp_dir to a value to avoid using the system temp directory.
+	// See also https://github.com/pulumi/pulumi/issues/15352
+	url, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("Could not parse the provided URL: %w", err)
+	}
+	query := url.Query()
+	if query.Get("no_tmp_dir") == "" {
+		query.Set("no_tmp_dir", "true")
+	} else if query.Get("no_tmp_dir") == "false" {
+		// If no_tmp_dir is set to false, we strip it out.  The library will default to false if
+		// the parameter is not present, but will consider any value being set as true.
+		query.Del("no_tmp_dir")
+	}
+	queryString := ""
+	if len(query) > 0 {
+		queryString = "?" + query.Encode()
+	}
+
 	// Strip off the "file://" portion so we can examine and determine what to do with the rest.
 	path = strings.TrimPrefix(path, FilePathPrefix)
+	// Strip off the query parameter, since we're computing that separately.
+	path = strings.Split(path, "?")[0]
 
 	// We need to specially handle ~.  The shell doesn't take care of this for us, and later
 	// functions we run into can't handle this either.
@@ -536,7 +557,7 @@ func massageBlobPath(path string) (string, error) {
 	}
 
 	// For file:// backend, ensure a relative path is resolved. fileblob only supports absolute paths.
-	path, err := filepath.Abs(path)
+	path, err = filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("An IO error occurred while building the absolute path: %w", err)
 	}
@@ -548,7 +569,7 @@ func massageBlobPath(path string) (string, error) {
 		path = "/" + path
 	}
 
-	return FilePathPrefix + path, nil
+	return FilePathPrefix + path + queryString, nil
 }
 
 func Login(ctx context.Context, d diag.Sink, url string, project *workspace.Project) (Backend, error) {


### PR DESCRIPTION
In gocloud.dev 0.34.0 the behaviour for file:// URLs changed, making pulumi fail when the state is supposed to be written to a mounted directory.  See also https://github.com/pulumi/pulumi/issues/15352.

Restore the old behaviour by adding a `no_tmp_dir=true` flag to the URL, unless the user provided it themselves.  We also allow users to pass `no_tmp_dir=false` in the parameters, which will opt in to the new behaviour.

This actually implements option 2 from the linked issue since it was easy enough to do, though I don't expect may users to make use of it, since I don't think a lot of people care about the contents of whatever directory the state is stored in anyway, so additional temp files there don't really matter.

Fixes https://github.com/pulumi/pulumi/issues/15352

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
