### PR TITLE
enable thelper linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - misspell
     - nolintlint
     - nakedret
+    - thelper
     - unconvert
     - unused
     - paralleltest
@@ -66,6 +67,15 @@ linters-settings:
       alias: testingrpc
     - pkg: github.com/deckarep/golang-set/v2
       alias: mapset
+  thelper:
+    test:
+      first: false
+    benchmark:
+      first: false
+    tb:
+      first: false
+    fuzz:
+      first: false
 
 issues:
   exclude-rules:

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -70,6 +70,8 @@ func loadEvents(path string) (events []engine.Event, err error) {
 }
 
 func testDiffEvents(t *testing.T, path string, accept bool, truncateOutput bool) {
+	t.Helper()
+
 	events, err := loadEvents(path)
 	require.NoError(t, err)
 

--- a/pkg/backend/display/internal/terminal/term_test.go
+++ b/pkg/backend/display/internal/terminal/term_test.go
@@ -18,6 +18,8 @@ type ansiCase struct {
 }
 
 func (c ansiCase) run(t *testing.T) {
+	t.Helper()
+
 	t.Run(c.in, func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -37,6 +37,8 @@ import (
 )
 
 func testProgressEvents(t *testing.T, path string, accept, interactive bool, width, height int, raw bool) {
+	t.Helper()
+
 	events, err := loadEvents(path)
 	require.NoError(t, err)
 

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -366,6 +366,8 @@ func TestDIYBackendRejectsStackInitOptions_legacy(t *testing.T) {
 //
 // Returns the directory that was marked.
 func markLegacyStore(t *testing.T, dir string) string {
+	t.Helper()
+
 	metaPath := filepath.Join(dir, pulumiMetaPath)
 	require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0o755))
 	require.NoError(t, os.WriteFile(metaPath, []byte(`version: 0`), 0o600))

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -822,6 +822,8 @@ func TestProjectFolderStructure(t *testing.T) {
 }
 
 func chdir(t *testing.T, dir string) {
+	t.Helper()
+
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(dir)) // Set directory

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -53,6 +53,8 @@ func (m *MockStackPersister) LastSnap() *deploy.Snapshot {
 }
 
 func MockSetup(t *testing.T, baseSnap *deploy.Snapshot) (*SnapshotManager, *MockStackPersister) {
+	t.Helper()
+
 	err := baseSnap.VerifyIntegrity()
 	if !assert.NoError(t, err) {
 		t.FailNow()

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func chdir(t *testing.T, dir string) {
+	t.Helper()
+
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 	assert.NoError(t, os.Chdir(dir)) // Set directory
@@ -248,6 +250,8 @@ func promptMock(name string, stackName string) promptForValueFunc {
 }
 
 func loadProject(t *testing.T, dir string) *workspace.Project {
+	t.Helper()
+
 	path, err := workspace.DetectProjectPathFrom(dir)
 	assert.NoError(t, err)
 	proj, err := workspace.LoadProject(path)
@@ -256,6 +260,8 @@ func loadProject(t *testing.T, dir string) *workspace.Project {
 }
 
 func currentUser(t *testing.T) string {
+	t.Helper()
+
 	ctx := context.Background()
 	b, err := currentBackend(ctx, nil, display.Options{})
 	assert.NoError(t, err)
@@ -265,12 +271,16 @@ func currentUser(t *testing.T) string {
 }
 
 func loadStackName(t *testing.T) string {
+	t.Helper()
+
 	w, err := workspace.New()
 	require.NoError(t, err)
 	return w.Settings().Stack
 }
 
 func removeStack(t *testing.T, dir, name string) {
+	t.Helper()
+
 	project := loadProject(t, dir)
 	ctx := context.Background()
 	b, err := currentBackend(ctx, project, display.Options{})
@@ -284,6 +294,8 @@ func removeStack(t *testing.T, dir, name string) {
 }
 
 func skipIfShortOrNoPulumiAccessToken(t *testing.T) {
+	t.Helper()
+
 	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
 	if !ok {
 		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -37,6 +37,8 @@ import (
 
 // mockBackendInstance sets the backendInstance for the test and cleans it up after.
 func mockBackendInstance(t *testing.T, b backend.Backend) {
+	t.Helper()
+
 	t.Cleanup(func() {
 		backendInstance = nil
 	})

--- a/pkg/cmd/pulumi/policy_new_acceptance_test.go
+++ b/pkg/cmd/pulumi/policy_new_acceptance_test.go
@@ -42,6 +42,8 @@ func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
 }
 
 func assertNotFoundError(t *testing.T, err error) {
+	t.Helper()
+
 	msg := err.Error()
 	if strings.Contains(msg, "not found") || strings.Contains(msg, "no such file or directory") {
 		return

--- a/pkg/cmd/pulumi/preview_test.go
+++ b/pkg/cmd/pulumi/preview_test.go
@@ -49,6 +49,8 @@ type stateOptions struct {
 func makeStateMetadata(
 	t *testing.T, name string, typ tokens.Type, custom bool, opts stateOptions,
 ) engine.StepEventStateMetadata {
+	t.Helper()
+
 	var provider string
 	if opts.Provider != nil {
 		provider = opts.Provider.String()
@@ -85,6 +87,8 @@ func makeMetadata(op display.StepOp, state engine.StepEventStateMetadata) engine
 
 // Adds a default provider for the given type if appropriate (i.e. the type token is pkg:mod:typ).
 func addDefaultProvider(t *testing.T, typ tokens.Type, events chan<- engine.Event) string {
+	t.Helper()
+
 	pkg := typ.Package()
 	if pkg != "" {
 		state := makeStateMetadata(t, "default_1_2_3", providers.MakeProviderType(pkg), true, stateOptions{

--- a/pkg/codegen/dotnet/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test.go
@@ -27,6 +27,7 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 			Extension:  "cs",
 			OutputFile: "Program.cs",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, "")
 			},
 			GenProgram: GenerateProgram,

--- a/pkg/codegen/dotnet/gen_program_test/batchyaml/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batchyaml/gen_program_test.go
@@ -24,6 +24,7 @@ func TestGenerateProgram(t *testing.T) {
 			Extension:  "cs",
 			OutputFile: "Program.cs",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				codegenDotnet.Check(t, path, dependencies, "")
 			},
 			GenProgram: codegenDotnet.GenerateProgram,

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -30,6 +30,8 @@ func TestGeneratePackage(t *testing.T) {
 var buildMutex sync.Mutex
 
 func typeCheckGeneratedPackage(t *testing.T, pwd string) {
+	t.Helper()
+
 	versionPath := filepath.Join(pwd, "version.txt")
 	if _, err := os.Stat(versionPath); os.IsNotExist(err) {
 		err := os.WriteFile(versionPath, []byte("0.0.0\n"), 0o600)
@@ -46,6 +48,8 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string) {
 }
 
 func testGeneratedPackage(t *testing.T, pwd string) {
+	t.Helper()
+
 	test.RunCommand(t, "dotnet build", pwd, "dotnet", "test")
 }
 

--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKPath string) {
+	t.Helper()
+
 	var err error
 	dir := filepath.Dir(path)
 
@@ -70,6 +72,8 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKP
 }
 
 func TypeCheck(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKPath string) {
+	t.Helper()
+
 	var err error
 	dir := filepath.Dir(path)
 
@@ -87,6 +91,8 @@ type dep struct {
 }
 
 func (pkg dep) install(t *testing.T, ex, dir string) {
+	t.Helper()
+
 	args := []string{ex, "add", "package", pkg.Name}
 	if pkg.Version != "" {
 		args = append(args, "--version", pkg.Version)
@@ -126,12 +132,15 @@ func dotnetDependencies(deps codegen.StringSet) []dep {
 }
 
 func GenerateProgramBatchTest(t *testing.T, testCases []test.ProgramTest) {
+	t.Helper()
+
 	test.TestProgramCodegen(t,
 		test.ProgramCodegenOptions{
 			Language:   "dotnet",
 			Extension:  "cs",
 			OutputFile: "Program.cs",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, "")
 			},
 			GenProgram: GenerateProgram,

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -389,6 +389,8 @@ func testGenerateExpression(
 	scope *model.Scope,
 	gen func(w io.Writer, g *generator, e model.Expression),
 ) {
+	t.Helper()
+
 	t.Run(hcl2Expr, func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -47,6 +47,7 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 			Extension:  "go",
 			OutputFile: "main.go",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, "../../../../../../../sdk")
 			},
 			GenProgram: func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
@@ -460,6 +461,8 @@ func TestSecondLastIndex(t *testing.T) {
 }
 
 func newTestGenerator(t *testing.T, testFile string) *generator {
+	t.Helper()
+
 	path := filepath.Join(testdataPath, testFile)
 	contents, err := os.ReadFile(path)
 	require.NoErrorf(t, err, "could not read %v: %v", path, err)
@@ -502,6 +505,8 @@ func parseAndBindProgram(t *testing.T,
 	name string,
 	options ...pcl.BindOption,
 ) (*pcl.Program, hcl.Diagnostics, error) {
+	t.Helper()
+
 	parser := syntax.NewParser()
 	err := parser.ParseFile(strings.NewReader(text), name)
 	if err != nil {

--- a/pkg/codegen/go/gen_program_test/batchyaml/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batchyaml/gen_program_test.go
@@ -26,6 +26,7 @@ func TestGenerateProgram(t *testing.T) {
 			Extension:  "go",
 			OutputFile: "main.go",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				codegenGo.Check(t, path, dependencies, "../../../../../../../../sdk")
 			},
 			GenProgram: func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -131,6 +131,8 @@ func inferModuleName(codeDir string) string {
 }
 
 func typeCheckGeneratedPackage(t *testing.T, codeDir string) {
+	t.Helper()
+
 	sdk, err := filepath.Abs(filepath.Join("..", "..", "..", "sdk"))
 	require.NoError(t, err)
 
@@ -154,6 +156,8 @@ func typeCheckGeneratedPackage(t *testing.T, codeDir string) {
 }
 
 func testGeneratedPackage(t *testing.T, codeDir string) {
+	t.Helper()
+
 	goExe, err := executable.FindExecutable("go")
 	require.NoError(t, err)
 
@@ -435,6 +439,7 @@ func TestTokenToResource(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.token+"=>"+tt.expected, func(t *testing.T) {
+			t.Helper()
 			t.Parallel()
 
 			actual := tt.pkg.tokenToResource(tt.token)
@@ -444,6 +449,8 @@ func TestTokenToResource(t *testing.T) {
 }
 
 func importSpec(t *testing.T, spec schema.PackageSpec) *schema.Package {
+	t.Helper()
+
 	importedPkg, err := schema.ImportSpec(spec, map[string]schema.Language{})
 	assert.NoError(t, err)
 	return importedPkg

--- a/pkg/codegen/go/test.go
+++ b/pkg/codegen/go/test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func Check(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath string) {
+	t.Helper()
+
 	dir := filepath.Dir(path)
 	ex, err := executable.FindExecutable("go")
 	require.NoError(t, err)
@@ -50,6 +52,8 @@ func Check(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath stri
 }
 
 func TypeCheck(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath string) {
+	t.Helper()
+
 	dir := filepath.Dir(path)
 	ex, err := executable.FindExecutable("go")
 	require.NoError(t, err)
@@ -67,12 +71,15 @@ func TypeCheck(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath 
 }
 
 func GenerateProgramBatchTest(t *testing.T, testCases []test.ProgramTest) {
+	t.Helper()
+
 	test.TestProgramCodegen(t,
 		test.ProgramCodegenOptions{
 			Language:   "go",
 			Extension:  "go",
 			OutputFile: "main.go",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, "../../../../../../../sdk")
 			},
 			GenProgram: func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {

--- a/pkg/codegen/hcl2/model/binder_expression_test.go
+++ b/pkg/codegen/hcl2/model/binder_expression_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func assertConvertibleFrom(t *testing.T, to, from Type) {
+	t.Helper()
+
 	assert.NotEqual(t, NoConversion, to.ConversionFrom(from))
 }
 

--- a/pkg/codegen/hcl2/model/pretty/display_test.go
+++ b/pkg/codegen/hcl2/model/pretty/display_test.go
@@ -26,6 +26,8 @@ type test struct {
 }
 
 func testFormatter(t *testing.T, tests []test) {
+	t.Helper()
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run("", func(t *testing.T) {

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func testTraverse(t *testing.T, receiver Traversable, traverser hcl.Traverser, expected Traversable, expectDiags bool) {
+	t.Helper()
+
 	actual, diags := receiver.Traverse(traverser)
 	assert.Equal(t, expected, actual)
 	if expectDiags {
@@ -567,6 +569,8 @@ func TestInputType(t *testing.T) {
 }
 
 func assertUnified(t *testing.T, expectedSafe, expectedUnsafe Type, types ...Type) {
+	t.Helper()
+
 	actualSafe, actualUnsafe := UnifyTypes(types...)
 	assert.Equal(t, expectedSafe, actualSafe)
 	assert.Equal(t, expectedUnsafe, actualUnsafe)

--- a/pkg/codegen/hcl2/syntax/comments_test.go
+++ b/pkg/codegen/hcl2/syntax/comments_test.go
@@ -26,6 +26,8 @@ func commentString(trivia []Trivia) string {
 }
 
 func validateTokenLeadingTrivia(t *testing.T, token Token) {
+	t.Helper()
+
 	// There is nowhere to attach leading trivia to template control sequences.
 	if token.Raw.Type == hclsyntax.TokenTemplateControl {
 		assert.Len(t, token.LeadingTrivia, 0)
@@ -39,6 +41,8 @@ func validateTokenLeadingTrivia(t *testing.T, token Token) {
 }
 
 func validateTokenTrailingTrivia(t *testing.T, token Token) {
+	t.Helper()
+
 	trailingText := commentString(token.TrailingTrivia)
 	if trailingText != "" && !assert.Equal(t, string(token.Raw.Bytes), trailingText) {
 		t.Logf("trailing trivia mismatch for token @ %v", token.Range())
@@ -46,11 +50,15 @@ func validateTokenTrailingTrivia(t *testing.T, token Token) {
 }
 
 func validateTokenTrivia(t *testing.T, token Token) {
+	t.Helper()
+
 	validateTokenLeadingTrivia(t, token)
 	validateTokenTrailingTrivia(t, token)
 }
 
 func validateTrivia(t *testing.T, tokens ...interface{}) {
+	t.Helper()
+
 	for _, te := range tokens {
 		switch te := te.(type) {
 		case Token:
@@ -83,6 +91,8 @@ func validateTrivia(t *testing.T, tokens ...interface{}) {
 func validateTemplateStringTrivia(t *testing.T, template *hclsyntax.TemplateExpr, n *hclsyntax.LiteralValueExpr,
 	tokens *LiteralValueTokens,
 ) {
+	t.Helper()
+
 	index := -1
 	for i := range template.Parts {
 		if template.Parts[i] == n {

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -29,6 +29,7 @@ func TestGenerateProgramVersionSelection(t *testing.T) {
 			Extension:  "ts",
 			OutputFile: "index.ts",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, true)
 			},
 			GenProgram: GenerateProgram,

--- a/pkg/codegen/nodejs/gen_program_test/batchyaml/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batchyaml/gen_program_test.go
@@ -24,6 +24,7 @@ func TestGenerateProgram(t *testing.T) {
 			Extension:  "ts",
 			OutputFile: "index.ts",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				codegenNode.Check(t, path, dependencies, true)
 			},
 			GenProgram: codegenNode.GenerateProgram,

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -41,11 +41,14 @@ func TestGeneratePackageThree(t *testing.T) {
 }
 
 func testGeneratePackageBatch(t *testing.T, testCases []*test.SDKTest) {
+	t.Helper()
+
 	test.TestSDKCodegen(t, &test.SDKCodegenOptions{
 		Language:   "nodejs",
 		GenPackage: GeneratePackage,
 		Checks: map[string]test.CodegenCheck{
 			"nodejs/compile": func(t *testing.T, pwd string) {
+				t.Helper()
 				typeCheckGeneratedPackage(t, pwd, true)
 			},
 			"nodejs/test": testGeneratedPackage,
@@ -56,6 +59,8 @@ func testGeneratePackageBatch(t *testing.T, testCases []*test.SDKTest) {
 
 // Runs unit tests against the generated code.
 func testGeneratedPackage(t *testing.T, pwd string) {
+	t.Helper()
+
 	// Some tests have do not have mocha as a dependency.
 	hasMocha := false
 	for _, c := range getYarnCommands(t, pwd) {
@@ -95,6 +100,8 @@ func testGeneratedPackage(t *testing.T, pwd string) {
 
 // Get the commands runnable with yarn run
 func getYarnCommands(t *testing.T, pwd string) []string {
+	t.Helper()
+
 	cmd := exec.Command("yarn", "run", "--json")
 	cmd.Dir = pwd
 	out, err := cmd.Output()

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func Check(t *testing.T, path string, dependencies codegen.StringSet, linkLocal bool) {
+	t.Helper()
+
 	dir := filepath.Dir(path)
 
 	removeFile := func(name string) {
@@ -57,12 +59,16 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, linkLocal 
 }
 
 func TypeCheck(t *testing.T, path string, _ codegen.StringSet, linkLocal bool) {
+	t.Helper()
+
 	dir := filepath.Dir(path)
 
 	typeCheckGeneratedPackage(t, dir, linkLocal)
 }
 
 func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
+	t.Helper()
+
 	// NOTE: previous attempt used npm. It may be more popular and
 	// better target than yarn, however our build uses yarn in
 	// other places at the moment, and yarn does not run into the
@@ -82,6 +88,8 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
 
 // Returns the nodejs equivalent to the hcl2 package names provided.
 func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
+	t.Helper()
+
 	result := make(map[string]string, len(deps))
 	for _, d := range deps.SortedValues() {
 		pkgName := "@pulumi/" + d
@@ -110,12 +118,15 @@ func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
 }
 
 func GenerateProgramBatchTest(t *testing.T, testCases []test.ProgramTest) {
+	t.Helper()
+
 	test.TestProgramCodegen(t,
 		test.ProgramCodegenOptions{
 			Language:   "nodejs",
 			Extension:  "ts",
 			OutputFile: "index.ts",
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				t.Helper()
 				Check(t, path, dependencies, true)
 			},
 			GenProgram: GenerateProgram,

--- a/pkg/codegen/pcl/utilities_test.go
+++ b/pkg/codegen/pcl/utilities_test.go
@@ -15,6 +15,8 @@ func ParseAndBindProgram(t *testing.T,
 	name string,
 	options ...pcl.BindOption,
 ) (*pcl.Program, hcl.Diagnostics, error) {
+	t.Helper()
+
 	parser := syntax.NewParser()
 	err := parser.ParseFile(strings.NewReader(text), name)
 	if err != nil {

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -80,6 +80,7 @@ func TestGeneratePackage(t *testing.T) {
 	// environment lazily
 	needsEnv := func(testFn test.CodegenCheck) test.CodegenCheck {
 		return func(t *testing.T, codedir string) {
+			t.Helper()
 			func() {
 				virtualEnvLock.Lock()
 				defer virtualEnvLock.Unlock()
@@ -181,6 +182,8 @@ func buildVirtualEnv(ctx context.Context) error {
 }
 
 func pyTestCheck(t *testing.T, codeDir string) {
+	t.Helper()
+
 	extraDir := filepath.Join(filepath.Dir(codeDir), "python-extras")
 	if _, err := os.Stat(extraDir); os.IsNotExist(err) {
 		// We won't run any tests since no extra tests were included.

--- a/pkg/codegen/python/test.go
+++ b/pkg/codegen/python/test.go
@@ -14,11 +14,15 @@ import (
 )
 
 func Check(t *testing.T, path string, _ codegen.StringSet) {
+	t.Helper()
+
 	pyCompileCheck(t, filepath.Dir(path))
 }
 
 // Checks generated code for syntax errors with `python -m compile`.
 func pyCompileCheck(t *testing.T, codeDir string) {
+	t.Helper()
+
 	pythonFiles := []string{}
 	err := filepath.Walk(codeDir, func(path string, info filesystem.FileInfo, err error) error {
 		require.NoError(t, err) // an error in the walk
@@ -44,6 +48,8 @@ func pyCompileCheck(t *testing.T, codeDir string) {
 }
 
 func GenerateProgramBatchTest(t *testing.T, testCases []test.ProgramTest) {
+	t.Helper()
+
 	test.TestProgramCodegen(t,
 		test.ProgramCodegenOptions{
 			Language:   "python",

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -17,6 +17,8 @@ import (
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")
 
 func parseAndBindProgram(t *testing.T, text, name string, options ...pcl.BindOption) (*pcl.Program, hcl.Diagnostics) {
+	t.Helper()
+
 	parser := syntax.NewParser()
 	err := parser.ParseFile(strings.NewReader(text), name)
 	if err != nil {

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -34,6 +34,7 @@ var testdataPath = filepath.Join("..", "testing", "test", "testdata")
 
 var nodeAssertions = testutil.DefaultNodeAssertions().Union(testutil.NodeAssertions{
 	KindShortcode: func(t *testing.T, sourceExpected, sourceActual []byte, expected, actual ast.Node) bool {
+		t.Helper()
 		shortcodeExpected, shortcodeActual := expected.(*Shortcode), actual.(*Shortcode)
 		return testutil.AssertEqualBytes(t, shortcodeExpected.Name, shortcodeActual.Name)
 	},
@@ -172,6 +173,8 @@ func TestParseAndRenderDocs(t *testing.T) {
 }
 
 func pkgInfo(t *testing.T, filename string) (string, *semver.Version) {
+	t.Helper()
+
 	filename = strings.TrimSuffix(filename, ".json")
 	idx := 0
 	for {

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {
+	b.Helper()
+
 	cwd, err := os.Getwd()
 	require.NoError(b, err)
 	sink := diagtest.LogSink(b)

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -102,6 +102,8 @@ func TestRoundtripEnum(t *testing.T) {
 	t.Parallel()
 
 	assertEnum := func(t *testing.T, pkg *Package) {
+		t.Helper()
+
 		typ, ok := pkg.GetType("enum:index:Color")
 		assert.True(t, ok)
 		enum, ok := typ.(*EnumType)
@@ -137,6 +139,8 @@ func TestRoundtripPlainProperties(t *testing.T) {
 	t.Parallel()
 
 	assertPlainnessFromType := func(t *testing.T, pkg *Package) {
+		t.Helper()
+
 		exampleType, ok := pkg.GetType("plain-properties:index:ExampleType")
 		assert.True(t, ok)
 		exampleObjectType, ok := exampleType.(*ObjectType)
@@ -163,6 +167,8 @@ func TestRoundtripPlainProperties(t *testing.T) {
 	}
 
 	assertPlainnessFromResource := func(t *testing.T, pkg *Package) {
+		t.Helper()
+
 		exampleResource, ok := pkg.GetResource("plain-properties:index:ExampleResource")
 		assert.True(t, ok)
 

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -147,6 +147,8 @@ func (cm *codegenManifest) save(dir string) error {
 
 // ValidateFileEquality compares maps of files for equality.
 func ValidateFileEquality(t *testing.T, actual, expected map[string][]byte) bool {
+	t.Helper()
+
 	ok := true
 	for name, file := range expected {
 		_, inActual := actual[name]
@@ -173,6 +175,8 @@ func ValidateFileEquality(t *testing.T, actual, expected map[string][]byte) bool
 // file set, so we can continue enjoying golden tests without manually
 // modifying the expected output.
 func RewriteFilesWhenPulumiAccept(t *testing.T, dir, lang string, actual map[string][]byte) bool {
+	t.Helper()
+
 	if os.Getenv("PULUMI_ACCEPT") == "" {
 		return false
 	}
@@ -212,6 +216,8 @@ func RewriteFilesWhenPulumiAccept(t *testing.T, dir, lang string, actual map[str
 // unit test files. These files are copied from `$dir/$lang-extras`
 // folder if present.
 func CopyExtraFiles(t *testing.T, dir, lang string) {
+	t.Helper()
+
 	codeDir := filepath.Join(dir, lang)
 	extrasDir := filepath.Join(dir, lang+"-extras")
 	gotExtras, err := PathExists(extrasDir)
@@ -264,6 +270,8 @@ func writeFileEnsuringDir(path string, bytes []byte) error {
 // CheckAllFilesGenerated ensures that the set of expected and actual files generated
 // are exactly equivalent.
 func CheckAllFilesGenerated(t *testing.T, actual, expected map[string][]byte) {
+	t.Helper()
+
 	seen := map[string]bool{}
 	for x := range expected {
 		seen[x] = true
@@ -287,6 +295,8 @@ func ValidateFileTransformer(
 	expectedOutputFile string,
 	transformer func(reader io.Reader, writer io.Writer) error,
 ) {
+	t.Helper()
+
 	reader, err := os.Open(inputFile)
 	if err != nil {
 		t.Error(err)
@@ -325,6 +335,8 @@ func ValidateFileTransformer(
 }
 
 func RunCommand(t *testing.T, name string, cwd string, exec string, args ...string) {
+	t.Helper()
+
 	RunCommandWithOptions(t, &integration.ProgramTestOptions{}, name, cwd, exec, args...)
 }
 
@@ -333,6 +345,8 @@ func RunCommandWithOptions(
 	opts *integration.ProgramTestOptions,
 	name string, cwd string, exec string, args ...string,
 ) {
+	t.Helper()
+
 	exec, err := executable.FindExecutable(exec)
 	if err != nil {
 		t.Error(err)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -711,6 +711,8 @@ func collectExtraPulumiPackages(program *pcl.Program, extraPulumiPackages codege
 // CheckVersion checks for an expected package version
 // Todo: support checking multiple package expected versions
 func CheckVersion(t *testing.T, dir, depFilePath string, expectedVersionMap map[string]PkgVersionInfo) {
+	t.Helper()
+
 	depFile, err := os.Open(depFilePath)
 	require.NoError(t, err)
 	defer depFile.Close()
@@ -757,6 +759,8 @@ func CheckVersion(t *testing.T, dir, depFilePath string, expectedVersionMap map[
 }
 
 func GenProjectCleanUp(t *testing.T, dir, depFilePath, outfilePath string) {
+	t.Helper()
+
 	os.Remove(depFilePath)
 	os.Remove(outfilePath)
 	os.Remove(dir + "/.gitignore")

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -67,7 +67,9 @@ type testContext struct {
 	firedEvents []Event
 }
 
-func makeTestContext(t testing.TB, cancelCtx *cancel.Context) *testContext {
+func makeTestContext(tb testing.TB, cancelCtx *cancel.Context) *testContext {
+	tb.Helper()
+
 	events := make(chan Event)
 	journal := NewJournal()
 
@@ -94,9 +96,11 @@ func makeTestContext(t testing.TB, cancelCtx *cancel.Context) *testContext {
 	return ctx
 }
 
-func (ctx *testContext) makeEventEmitter(t testing.TB) eventEmitter {
+func (ctx *testContext) makeEventEmitter(tb testing.TB) eventEmitter {
+	tb.Helper()
+
 	emitter, err := makeQueryEventEmitter(ctx.events)
-	assert.NoError(t, err)
+	assert.NoError(tb, err)
 	return emitter
 }
 
@@ -106,9 +110,11 @@ func (ctx *testContext) Close() error {
 	return nil
 }
 
-func makePluginHost(t testing.TB, program deploytest.ProgramFunc) plugin.Host {
-	sink := diagtest.LogSink(t)
-	statusSink := diagtest.LogSink(t)
+func makePluginHost(tb testing.TB, program deploytest.ProgramFunc) plugin.Host {
+	tb.Helper()
+
+	sink := diagtest.LogSink(tb)
+	statusSink := diagtest.LogSink(tb)
 	lang := deploytest.NewLanguageRuntime(program)
 	return deploytest.NewPluginHost(sink, statusSink, lang)
 }

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -144,6 +144,8 @@ func makeSpecAliasWithNoParent(name, typ, project, stack string, parent bool) *p
 }
 
 func registerResources(t *testing.T, monitor *deploytest.ResourceMonitor, resources []Resource) error {
+	t.Helper()
+
 	for _, r := range resources {
 		r := r
 		_, _, _, err := monitor.RegisterResource(r.t, r.name, true, deploytest.ResourceOptions{

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -23,6 +23,8 @@ var complexTestDependencyGraphNames = []string{"A", "B", "C", "D", "E", "F", "G"
 func generateComplexTestDependencyGraph(
 	t *testing.T, p *TestPlan,
 ) ([]resource.URN, *deploy.Snapshot, deploytest.LanguageRuntimeFactory) {
+	t.Helper()
+
 	resType := tokens.Type("pkgA:m:typA")
 
 	names := complexTestDependencyGraphNames

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1404,6 +1404,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 				Kind:              workspace.ResourcePlugin,
 			}},
 			validate: func(t *testing.T, r *resource.State) {
+				t.Helper()
 				if providers.IsProviderType(r.Type) && !providers.IsDefaultProvider(r.URN) {
 					assert.Equal(t, r.Inputs["version"].StringValue(), "1.1.0")
 					assert.Equal(t, r.Inputs["pluginDownloadURL"].StringValue(), "example.com/default")
@@ -1420,6 +1421,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 				Kind:    workspace.ResourcePlugin,
 			}},
 			validate: func(t *testing.T, r *resource.State) {
+				t.Helper()
 				if providers.IsProviderType(r.Type) && !providers.IsDefaultProvider(r.URN) {
 					_, hasVersion := r.Inputs["version"]
 					assert.False(t, hasVersion)
@@ -1449,6 +1451,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, r *resource.State) {
+				t.Helper()
 				if providers.IsProviderType(r.Type) && !providers.IsDefaultProvider(r.URN) {
 					assert.Equal(t, r.Inputs["version"].StringValue(), "1.1.0")
 				}

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -71,6 +71,8 @@ type StepSummary struct {
 }
 
 func AssertSameSteps(t *testing.T, expected []StepSummary, actual []deploy.Step) bool {
+	t.Helper()
+
 	assert.Equal(t, len(expected), len(actual))
 	for _, exp := range expected {
 		act := actual[0]
@@ -84,6 +86,8 @@ func AssertSameSteps(t *testing.T, expected []StepSummary, actual []deploy.Step)
 }
 
 func ExpectDiagMessage(t *testing.T, messagePattern string) ValidateFunc {
+	t.Helper()
+
 	validate := func(
 		project workspace.Project, target deploy.Target,
 		entries JournalEntries, events []Event,
@@ -110,6 +114,8 @@ func ExpectDiagMessage(t *testing.T, messagePattern string) ValidateFunc {
 }
 
 func pickURN(t *testing.T, urns []resource.URN, names []string, target string) resource.URN {
+	t.Helper()
+
 	assert.Equal(t, len(urns), len(names))
 	assert.Contains(t, names, target)
 
@@ -1614,6 +1620,8 @@ type DiffFunc = func(urn resource.URN, id resource.ID,
 	oldInputs, oldOutputs, newInputs resource.PropertyMap, ignoreChanges []string) (plugin.DiffResult, error)
 
 func replaceOnChangesTest(t *testing.T, name string, diffFunc DiffFunc) {
+	t.Helper()
+
 	t.Run(name, func(t *testing.T) {
 		t.Parallel()
 
@@ -2508,6 +2516,8 @@ type updateContext struct {
 }
 
 func startUpdate(t *testing.T, hostF deploytest.PluginHostFactory) (*updateContext, error) {
+	t.Helper()
+
 	ctx := &updateContext{
 		resmon:       make(chan *deploytest.ResourceMonitor),
 		programErr:   make(chan error),

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -306,6 +306,8 @@ func TestRefreshDeleteDependencies(t *testing.T) {
 
 // Looks up the provider ID in newResources and sets "Provider" to reference that in every resource in oldResources.
 func setProviderRef(t *testing.T, oldResources, newResources []*resource.State, provURN resource.URN) {
+	t.Helper()
+
 	for _, r := range newResources {
 		if r.URN == provURN {
 			provRef, err := providers.NewReference(r.URN, r.ID)
@@ -319,6 +321,8 @@ func setProviderRef(t *testing.T, oldResources, newResources []*resource.State, 
 }
 
 func validateRefreshDeleteCombination(t *testing.T, names []string, targets []string) {
+	t.Helper()
+
 	p := &TestPlan{}
 
 	const resType = "pkgA:m:typA"
@@ -483,6 +487,8 @@ func TestRefreshBasics(t *testing.T) {
 }
 
 func validateRefreshBasicsCombination(t *testing.T, names []string, targets []string) {
+	t.Helper()
+
 	p := &TestPlan{}
 
 	const resType = "pkgA:m:typA"

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -76,6 +76,8 @@ func destroySpecificTargets(
 	t *testing.T, targets []string, targetDependents bool,
 	validate func(urns []resource.URN, deleted map[resource.URN]bool),
 ) {
+	t.Helper()
+
 	//             A
 	//    _________|_________
 	//    B        C        D
@@ -187,6 +189,8 @@ func TestUpdateTarget(t *testing.T) {
 }
 
 func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDependents bool, expectedUpdates int) {
+	t.Helper()
+
 	//             A
 	//    _________|_________
 	//    B        C        D
@@ -305,6 +309,8 @@ func contains(list []string, entry string) bool {
 }
 
 func updateInvalidTarget(t *testing.T) {
+	t.Helper()
+
 	p := &TestPlan{}
 
 	_, old, programF := generateComplexTestDependencyGraph(t, p)
@@ -738,6 +744,8 @@ func generateParentedTestDependencyGraph(t *testing.T, p *TestPlan) (
 
 	[]resource.URN, *deploy.Snapshot, deploytest.LanguageRuntimeFactory,
 ) {
+	t.Helper()
+
 	resTypeComponent := tokens.Type("pkgA:index:Component")
 	resTypeResource := tokens.Type("pkgA:index:Resource")
 
@@ -870,6 +878,8 @@ func destroySpecificTargetsWithChildren(
 	t *testing.T, targets []string, targetDependents bool,
 	validate func(urns []resource.URN, deleted map[resource.URN]bool),
 ) {
+	t.Helper()
+
 	p := &TestPlan{}
 
 	urns, old, programF := generateParentedTestDependencyGraph(t, p)

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -61,6 +61,8 @@ var names = NameTable{
 }
 
 func renderExpr(t *testing.T, x model.Expression) resource.PropertyValue {
+	t.Helper()
+
 	switch x := x.(type) {
 	case *model.LiteralValueExpression:
 		return renderLiteralValue(t, x)
@@ -81,6 +83,8 @@ func renderExpr(t *testing.T, x model.Expression) resource.PropertyValue {
 }
 
 func renderLiteralValue(t *testing.T, x *model.LiteralValueExpression) resource.PropertyValue {
+	t.Helper()
+
 	switch x.Value.Type() {
 	case cty.Bool:
 		return resource.NewBoolProperty(x.Value.True())
@@ -96,6 +100,8 @@ func renderLiteralValue(t *testing.T, x *model.LiteralValueExpression) resource.
 }
 
 func renderTemplate(t *testing.T, x *model.TemplateExpression) resource.PropertyValue {
+	t.Helper()
+
 	if len(x.Parts) == 1 {
 		return renderLiteralValue(t, x.Parts[0].(*model.LiteralValueExpression))
 	}
@@ -107,6 +113,8 @@ func renderTemplate(t *testing.T, x *model.TemplateExpression) resource.Property
 }
 
 func renderObjectCons(t *testing.T, x *model.ObjectConsExpression) resource.PropertyValue {
+	t.Helper()
+
 	obj := resource.PropertyMap{}
 	for _, item := range x.Items {
 		kv := renderExpr(t, item.Key)
@@ -119,6 +127,8 @@ func renderObjectCons(t *testing.T, x *model.ObjectConsExpression) resource.Prop
 }
 
 func renderScopeTraversal(t *testing.T, x *model.ScopeTraversalExpression) resource.PropertyValue {
+	t.Helper()
+
 	if !assert.Len(t, x.Traversal, 1) {
 		return resource.NewNullProperty()
 	}
@@ -135,6 +145,8 @@ func renderScopeTraversal(t *testing.T, x *model.ScopeTraversalExpression) resou
 }
 
 func renderTupleCons(t *testing.T, x *model.TupleConsExpression) resource.PropertyValue {
+	t.Helper()
+
 	arr := make([]resource.PropertyValue, len(x.Expressions))
 	for i, x := range x.Expressions {
 		arr[i] = renderExpr(t, x)
@@ -143,6 +155,8 @@ func renderTupleCons(t *testing.T, x *model.TupleConsExpression) resource.Proper
 }
 
 func renderFunctionCall(t *testing.T, x *model.FunctionCallExpression) resource.PropertyValue {
+	t.Helper()
+
 	switch x.Name {
 	case "fileArchive":
 		if !assert.Len(t, x.Args, 1) {
@@ -174,6 +188,8 @@ func renderFunctionCall(t *testing.T, x *model.FunctionCallExpression) resource.
 }
 
 func renderResource(t *testing.T, r *pcl.Resource) *resource.State {
+	t.Helper()
+
 	inputs := resource.PropertyMap{}
 	for _, attr := range r.Inputs {
 		inputs[resource.PropertyKey(attr.Name)] = renderExpr(t, attr.Value)

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func getPulumiResources(t *testing.T, path string) *Resource {
+	t.Helper()
+
 	ctx := context.Background()
 	var checkpoint apitype.CheckpointV3
 	byts, err := os.ReadFile(path)

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -168,6 +168,8 @@ type providerLoader struct {
 }
 
 func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
+	t.Helper()
+
 	return &testPluginHost{
 		t: t,
 		provider: func(pkg tokens.Package, ver *semver.Version) (plugin.Provider, error) {
@@ -198,6 +200,8 @@ func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
 func newLoader(t *testing.T, pkg, version string,
 	load func(tokens.Package, semver.Version) (plugin.Provider, error),
 ) *providerLoader {
+	t.Helper()
+
 	var ver semver.Version
 	if version != "" {
 		v, err := semver.ParseTolerant(version)
@@ -214,6 +218,8 @@ func newLoader(t *testing.T, pkg, version string,
 }
 
 func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.PropertyMap) error) *providerLoader {
+	t.Helper()
+
 	if config == nil {
 		config = func(resource.PropertyMap) error {
 			return nil

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -85,9 +85,11 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 	}
 }
 
-func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin.Context, error) {
-	sink := diagtest.LogSink(t)
-	statusSink := diagtest.LogSink(t)
+func newTestPluginContext(tb testing.TB, program deploytest.ProgramFunc) (*plugin.Context, error) {
+	tb.Helper()
+
+	sink := diagtest.LogSink(tb)
+	statusSink := diagtest.LogSink(tb)
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
 	return plugin.NewContext(sink, statusSink, host, nil, "", nil, false, nil)

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -364,6 +364,7 @@ func TestDeleteProtected(t *testing.T) {
 		{
 			"root-protected",
 			func(t *testing.T, pA, a, b, c *resource.State, snap *deploy.Snapshot) {
+				t.Helper()
 				a.Protect = true
 				protectedCount := 0
 				err := DeleteResource(snap, a, func(s *resource.State) error {
@@ -379,6 +380,7 @@ func TestDeleteProtected(t *testing.T) {
 		{
 			"root-and-branch",
 			func(t *testing.T, pA, a, b, c *resource.State, snap *deploy.Snapshot) {
+				t.Helper()
 				a.Protect = true
 				b.Protect = true
 				c.Protect = true
@@ -398,6 +400,7 @@ func TestDeleteProtected(t *testing.T) {
 		{
 			"branch",
 			func(t *testing.T, pA, a, b, c *resource.State, snap *deploy.Snapshot) {
+				t.Helper()
 				b.Protect = true
 				c.Protect = true
 				protectedCount := 0
@@ -414,6 +417,7 @@ func TestDeleteProtected(t *testing.T) {
 		{
 			"no-permission-root",
 			func(t *testing.T, pA, a, b, c *resource.State, snap *deploy.Snapshot) {
+				t.Helper()
 				c.Protect = true
 				err := DeleteResource(snap, c, nil, false).(ResourceProtectedError)
 				assert.Equal(t, ResourceProtectedError{
@@ -424,6 +428,7 @@ func TestDeleteProtected(t *testing.T) {
 		{
 			"no-permission-branch",
 			func(t *testing.T, pA, a, b, c *resource.State, snap *deploy.Snapshot) {
+				t.Helper()
 				c.Protect = true
 				err := DeleteResource(snap, b, nil, true).(ResourceProtectedError)
 				assert.Equal(t, ResourceProtectedError{

--- a/pkg/resource/graph/dependency_graph_rapid_test.go
+++ b/pkg/resource/graph/dependency_graph_rapid_test.go
@@ -389,6 +389,8 @@ func showStates(sts []*resource.State) string {
 }
 
 func graphCheck(t *testing.T, check func(*rapid.T, []*resource.State)) {
+	t.Helper()
+
 	rss := resourceStateSliceGenerator()
 	rapid.Check(t, func(t *rapid.T) {
 		universe := rss.Draw(t, "universe")

--- a/pkg/secrets/cloud/aws_test.go
+++ b/pkg/secrets/cloud/aws_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func getAwsCaller(t *testing.T) (context.Context, aws.Config, *sts.GetCallerIdentityOutput) {
+	t.Helper()
+
 	ctx := context.Background()
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -48,6 +50,8 @@ func getAwsCaller(t *testing.T) (context.Context, aws.Config, *sts.GetCallerIden
 }
 
 func createKey(ctx context.Context, t *testing.T, cfg aws.Config) *kms.CreateKeyOutput {
+	t.Helper()
+
 	kmsClient := kms.NewFromConfig(cfg)
 	keyName := "test-key-" + randomName(t)
 	key, err := kmsClient.CreateKey(ctx, &kms.CreateKeyInput{Description: &keyName})

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func getAzureCaller(ctx context.Context, t *testing.T) *azidentity.DefaultAzureCredential {
+	t.Helper()
 	credentials, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		t.Logf("Skipping, could not load azure config: %s", err)
@@ -37,6 +38,7 @@ func getAzureCaller(ctx context.Context, t *testing.T) *azidentity.DefaultAzureC
 }
 
 func createAzureKey(ctx context.Context, t *testing.T, credentials *azidentity.DefaultAzureCredential) string {
+	t.Helper()
 	url := "pulumi-testing.vault.azure.net"
 	keysClient, err := azkeys.NewClient("https://"+url, credentials, nil)
 	require.NoError(t, err)

--- a/pkg/secrets/cloud/gcp_test.go
+++ b/pkg/secrets/cloud/gcp_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func createGCPKey(ctx context.Context, t *testing.T) string {
+	t.Helper()
 	keyName := "test-key-" + randomName(t)
 
 	parent := "projects/pulumi-development/locations/global/keyRings/pulumi-testing"

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -32,6 +32,8 @@ import (
 // the main testing function, takes a kms url and tries to make a new secret manager out of it and encrypt and
 // decrypt data, this is used by the aws_test and azure_test files.
 func testURL(ctx context.Context, t *testing.T, url string) {
+	t.Helper()
+
 	info := &workspace.ProjectStack{}
 	info.SecretsProvider = url
 
@@ -53,6 +55,8 @@ func testURL(ctx context.Context, t *testing.T, url string) {
 }
 
 func randomName(t *testing.T) string {
+	t.Helper()
+
 	name := ""
 	letters := "abcdefghijklmnopqrstuvwxyz"
 	for i := 0; i < 32; i++ {

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -29,6 +29,8 @@ import (
 // RunCommand executes the specified command and additional arguments, wrapping any output in the
 // specialized test output streams that list the location the test is running in.
 func RunCommand(t *testing.T, name string, args []string, wd string, opts *ProgramTestOptions) error {
+	t.Helper()
+
 	path := args[0]
 	command := strings.Join(args, " ")
 	t.Logf("**** Invoke '%v' in '%v'", command, wd)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -704,6 +704,8 @@ func GetLogs(
 	stackInfo RuntimeValidationStackInfo,
 	query operations.LogQuery,
 ) *[]operations.LogEntry {
+	t.Helper()
+
 	snap, err := stack.DeserializeDeploymentV3(
 		context.Background(),
 		*stackInfo.Deployment,
@@ -730,6 +732,8 @@ func GetLogs(
 }
 
 func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
+	t.Helper()
+
 	// If we're just listing tests, simply print this test's directory.
 	if listDirs {
 		fmt.Printf("%s\n", opts.Dir)
@@ -839,6 +843,8 @@ func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
 //
 // All commands must return success return codes for the test to succeed, unless ExpectFailure is true.
 func ProgramTest(t *testing.T, opts *ProgramTestOptions) {
+	t.Helper()
+
 	prepareProgram(t, opts)
 	pt := newProgramTester(t, opts)
 	err := pt.TestLifeCycleInitAndDestroy()
@@ -849,6 +855,8 @@ func ProgramTest(t *testing.T, opts *ProgramTestOptions) {
 
 // ProgramTestManualLifeCycle returns a ProgramTester than must be manually controlled in terms of its lifecycle
 func ProgramTestManualLifeCycle(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
+	t.Helper()
+
 	prepareProgram(t, opts)
 	pt := newProgramTester(t, opts)
 	return pt
@@ -872,6 +880,8 @@ type ProgramTester struct {
 }
 
 func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
+	t.Helper()
+
 	stackName := opts.GetStackName()
 	maxStepTries := 1
 	if opts.RetryFailedSteps {
@@ -887,6 +897,8 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 
 // MakeTempBackend creates a temporary backend directory which will clean up on test exit.
 func MakeTempBackend(t *testing.T) string {
+	t.Helper()
+
 	tempDir := t.TempDir()
 	return "file://" + filepath.ToSlash(tempDir)
 }

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -181,6 +181,8 @@ func AssertHTTPResultWithRetry(
 	maxWait time.Duration,
 	check func(string) bool,
 ) bool {
+	t.Helper()
+
 	hostname, ok := output.(string)
 	if !assert.True(t, ok, fmt.Sprintf("expected `%s` output", output)) {
 		return false

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2001,6 +2001,8 @@ func TestSupportsStackOutputs(t *testing.T) {
 	}
 
 	assertOutputs := func(t *testing.T, outputs OutputMap) {
+		t.Helper()
+
 		assert.Equal(t, 4, len(outputs), "expected four outputs")
 		assert.Equal(t, "foo", outputs["exp_static"].Value)
 		assert.False(t, outputs["exp_static"].Secret)

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -38,6 +38,8 @@ const (
 func testRemoteStackGitSourceErrors(t *testing.T, fn func(ctx context.Context, stackName string, repo GitRepo,
 	opts ...RemoteWorkspaceOption) (RemoteStack, error),
 ) {
+	t.Helper()
+
 	ctx := context.Background()
 
 	const stack = "owner/project/stack"
@@ -138,6 +140,8 @@ func testRemoteStackGitSource(
 	fn func(ctx context.Context, stackName string, repo GitRepo, opts ...RemoteWorkspaceOption) (RemoteStack, error),
 	useCommitHash bool,
 ) {
+	t.Helper()
+
 	// This test requires the service with access to Pulumi Deployments.
 	// Set PULUMI_ACCESS_TOKEN to an access token with access to Pulumi Deployments
 	// and set PULUMI_TEST_DEPLOYMENTS_API to any value to enable the test.

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -41,6 +41,8 @@ const (
 
 // TODO[pulumi/pulumi#8647]
 func skipWindows(t *testing.T) {
+	t.Helper()
+
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipped on Windows: TODO handle Windows local paths in URIs")
 	}
@@ -551,6 +553,8 @@ func TestInvalidPathArchive(t *testing.T) {
 }
 
 func validateTestDirArchive(t *testing.T, arch *rarchive.Archive, expected int) {
+	t.Helper()
+
 	r, err := arch.Open()
 	assert.NoError(t, err)
 	defer func() {
@@ -622,6 +626,8 @@ perferendis doloribus asperiores repellat…
 }
 
 func assertAssetTextEquals(t *testing.T, asset *rasset.Asset, expect string) {
+	t.Helper()
+
 	blob, err := asset.Read()
 	assert.NoError(t, err)
 	assert.NotNil(t, blob)
@@ -629,6 +635,8 @@ func assertAssetTextEquals(t *testing.T, asset *rasset.Asset, expect string) {
 }
 
 func assertAssetBlobEquals(t *testing.T, blob *rasset.Blob, expect string) {
+	t.Helper()
+
 	var text bytes.Buffer
 	n, err := io.Copy(&text, blob)
 	assert.NoError(t, err)

--- a/sdk/go/common/resource/config/repr_test.go
+++ b/sdk/go/common/resource/config/repr_test.go
@@ -33,6 +33,8 @@ import (
 
 // mapPaths returns the set of all possible paths in c.
 func mapPaths(t *testing.T, c Map) []Key {
+	t.Helper()
+
 	//nolint:prealloc
 	var paths []Key
 	for k, v := range c {

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -590,17 +590,17 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 }
 
 // newTestContext builds a *Context for use in tests.
-func newTestContext(t testing.TB) *Context {
-	t.Helper()
+func newTestContext(tb testing.TB) *Context {
+	tb.Helper()
 
 	cwd, err := os.Getwd()
-	require.NoError(t, err, "get working directory")
+	require.NoError(tb, err, "get working directory")
 
-	sink := diagtest.LogSink(t)
+	sink := diagtest.LogSink(tb)
 	ctx, err := NewContext(
 		sink, sink,
 		nil /* host */, nil /* source */, cwd, nil /* options */, false, nil /* span */)
-	require.NoError(t, err, "build context")
+	require.NoError(tb, err, "build context")
 
 	return ctx
 }

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -1642,6 +1642,8 @@ func pbList(elems ...*structpb.Value) *structpb.Value {
 }
 
 func assertValidProtobufValue(t *testing.T, value *structpb.Value) {
+	t.Helper()
+
 	err := walkValueSelfWithDescendants(value, "", func(path string, v *structpb.Value) error {
 		return nil
 	})

--- a/sdk/go/common/resource/properties_diff_test.go
+++ b/sdk/go/common/resource/properties_diff_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func assertDeepEqualsIffEmptyDiff(t *testing.T, val1, val2 PropertyValue) {
+	t.Helper()
+
 	diff := val1.Diff(val2)
 	equals := val1.DeepEquals(val2)
 	assert.Equal(t, diff == nil, equals, "DeepEquals <--> empty diff")

--- a/sdk/go/common/testing/diagtest/sink.go
+++ b/sdk/go/common/testing/diagtest/sink.go
@@ -28,10 +28,12 @@ import (
 //
 // Messages are prefixed with [stdout] or [stderr]
 // to indicate which stream they were written to.
-func LogSink(t testing.TB) diag.Sink {
+func LogSink(tb testing.TB) diag.Sink {
+	tb.Helper()
+
 	return diag.DefaultSink(
-		iotest.LogWriterPrefixed(t, "[stdout] "),
-		iotest.LogWriterPrefixed(t, "[stderr] "),
+		iotest.LogWriterPrefixed(tb, "[stdout] "),
+		iotest.LogWriterPrefixed(tb, "[stderr] "),
 		diag.FormatOptions{
 			// Don't colorize test output.
 			Color: colors.Never,

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -75,6 +75,8 @@ func WriteYarnRCForTest(root string) error {
 
 // NewGoEnvironment returns a new Environment object, located in a GOPATH temp directory.
 func NewGoEnvironment(t *testing.T) *Environment {
+	t.Helper()
+
 	testRoot, err := tools.CreateTemporaryGoFolder("test-env")
 	if err != nil {
 		t.Errorf("error creating test directory %s", err)
@@ -90,6 +92,8 @@ func NewGoEnvironment(t *testing.T) *Environment {
 
 // NewEnvironment returns a new Environment object, located in a temp directory.
 func NewEnvironment(t *testing.T) *Environment {
+	t.Helper()
+
 	root, err := os.MkdirTemp("", "test-env")
 	assert.NoError(t, err, "creating temp directory")
 	assert.NoError(t, WriteYarnRCForTest(root), "writing .yarnrc file")

--- a/sdk/go/common/testing/iotest/log_writer.go
+++ b/sdk/go/common/testing/iotest/log_writer.go
@@ -53,15 +53,19 @@ var _ io.Writer = (*logWriter)(nil)
 //
 // The returned writer is safe for concurrent use
 // from multiple parallel tests.
-func LogWriter(t testing.TB) io.Writer {
-	return LogWriterPrefixed(t, "")
+func LogWriter(tb testing.TB) io.Writer {
+	tb.Helper()
+
+	return LogWriterPrefixed(tb, "")
 }
 
 // LogWriterPrefixed is a variant of LogWriter
 // that prepends the given prefix to each line.
-func LogWriterPrefixed(t testing.TB, prefix string) io.Writer {
-	w := logWriter{t: t, prefix: prefix}
-	t.Cleanup(w.flush)
+func LogWriterPrefixed(tb testing.TB, prefix string) io.Writer {
+	tb.Helper()
+
+	w := logWriter{t: tb, prefix: prefix}
+	tb.Cleanup(w.flush)
 	return &w
 }
 

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -118,6 +118,8 @@ func TestIgnoreNestedGitignore(t *testing.T) {
 }
 
 func doArchiveTest(t *testing.T, path string, files ...fileContents) {
+	t.Helper()
+
 	doTest := func(prefixPathInsideTar, path string) {
 		tarball, err := archiveContents(t, prefixPathInsideTar, path, files...)
 		assert.NoError(t, err)
@@ -135,6 +137,8 @@ func doArchiveTest(t *testing.T, path string, files ...fileContents) {
 }
 
 func archiveContents(t *testing.T, prefixPathInsideTar, path string, files ...fileContents) ([]byte, error) {
+	t.Helper()
+
 	dir := t.TempDir()
 
 	for _, file := range files {
@@ -158,6 +162,8 @@ func archiveContents(t *testing.T, prefixPathInsideTar, path string, files ...fi
 }
 
 func checkFiles(t *testing.T, prefixPathInsideTar, path string, expected []fileContents, r *tar.Reader) {
+	t.Helper()
+
 	var expectedFiles []string
 	var actualFiles []string
 

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -403,6 +403,8 @@ func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
 }
 
 func lookPathOrSkip(t *testing.T, name string) string {
+	t.Helper()
+
 	path, err := exec.LookPath(name)
 	if err != nil {
 		t.Skipf("Skipping test: %q not found: %v", name, err)

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -403,6 +403,8 @@ func TestParseAuthURL(t *testing.T) {
 
 	//nolint: gosec
 	generateSSHKey := func(t *testing.T, passphrase string) string {
+		t.Helper()
+
 		r := rand.New(rand.NewSource(0))
 		key, err := rsa.GenerateKey(r, 256)
 		require.NoError(t, err)

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -29,6 +29,8 @@ import (
 // not. This can lead to asserts especially on macos where TmpDir will have returned /var/folders/XX, but
 // after sym link resolution that is /private/var/folders/XX.
 func mkTempDir(t *testing.T) string {
+	t.Helper()
+
 	tmpDir := t.TempDir()
 	result, err := filepath.EvalSymlinks(tmpDir)
 	assert.NoError(t, err)
@@ -62,6 +64,8 @@ func TestDetectProjectAndPath(t *testing.T) {
 func TestProjectStackPath(t *testing.T) {
 	expectedPath := func(expectedPath string) func(t *testing.T, projectDir, path string, err error) {
 		return func(t *testing.T, projectDir, path string, err error) {
+			t.Helper()
+
 			assert.NoError(t, err)
 			assert.Equal(t, filepath.Join(projectDir, expectedPath), path)
 		}
@@ -87,6 +91,7 @@ func TestProjectStackPath(t *testing.T) {
 		"WithBoth",
 		"name: some_project\ndescription: Some project\nruntime: nodejs\nconfig: stacksA\nstackConfigDir: stacksB\n",
 		func(t *testing.T, projectDir, path string, err error) {
+			t.Helper()
 			errorMsg := "Should not use both config and stackConfigDir to define the stack directory. " +
 				"Use only stackConfigDir instead."
 			assert.EqualError(t, err, errorMsg)

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -61,6 +61,7 @@ func createTGZ(files map[string][]byte) ([]byte, error) {
 }
 
 func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
+	t.Helper()
 	if files == nil {
 		files = map[string][]byte{}
 	}
@@ -78,6 +79,8 @@ func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
 }
 
 func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, PluginSpec) {
+	t.Helper()
+
 	tarball := prepareTestPluginTGZ(t, files)
 
 	dir := t.TempDir()
@@ -94,6 +97,8 @@ func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadClose
 }
 
 func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginInfo {
+	t.Helper()
+
 	info, err := os.Stat(filepath.Join(dir, plugin.Dir()))
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
@@ -126,6 +131,8 @@ func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginIn
 }
 
 func testDeletePlugin(t *testing.T, plugin PluginInfo) {
+	t.Helper()
+
 	paths := []string{
 		plugin.Path,
 		plugin.Path + ".partial",
@@ -150,6 +157,8 @@ func testDeletePlugin(t *testing.T, plugin PluginInfo) {
 }
 
 func testPluginInstall(t *testing.T, expectedDir string, files map[string][]byte) {
+	t.Helper()
+
 	// Skip during short test runs since this test involves downloading dependencies.
 	if testing.Short() {
 		t.Skip("Skipped in short test run")

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -213,6 +213,8 @@ func TestProjectLoadJSON(t *testing.T) {
 }
 
 func deleteFile(t *testing.T, file *os.File) {
+	t.Helper()
+
 	if file != nil {
 		err := os.Remove(file.Name())
 		assert.NoError(t, err, "Error while deleting file")
@@ -220,6 +222,8 @@ func deleteFile(t *testing.T, file *os.File) {
 }
 
 func loadProjectFromText(t *testing.T, content string) (*Project, error) {
+	t.Helper()
+
 	tmp, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
@@ -230,6 +234,8 @@ func loadProjectFromText(t *testing.T, content string) (*Project, error) {
 }
 
 func loadProjectStackFromText(t *testing.T, project *Project, content string) (*ProjectStack, error) {
+	t.Helper()
+
 	tmp, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
@@ -240,6 +246,8 @@ func loadProjectStackFromText(t *testing.T, project *Project, content string) (*
 }
 
 func loadProjectStackFromJSONText(t *testing.T, project *Project, content string) (*ProjectStack, error) {
+	t.Helper()
+
 	tmp, err := os.CreateTemp("", "*.json")
 	assert.NoError(t, err)
 	path := tmp.Name()
@@ -358,6 +366,8 @@ config:
 }
 
 func getConfigValue(t *testing.T, stackConfig config.Map, key string) string {
+	t.Helper()
+
 	parsedKey, err := config.ParseKey(key)
 	assert.NoErrorf(t, err, "There should be no error parsing the config key '%v'", key)
 	configValue, foundValue := stackConfig[parsedKey]
@@ -368,6 +378,8 @@ func getConfigValue(t *testing.T, stackConfig config.Map, key string) string {
 }
 
 func getConfigValueUnmarshalled(t *testing.T, stackConfig config.Map, key string) interface{} {
+	t.Helper()
+
 	parsedKey, err := config.ParseKey(key)
 	assert.NoErrorf(t, err, "There should be no error parsing the config key '%v'", key)
 	configValue, foundValue := stackConfig[parsedKey]

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -401,6 +401,8 @@ func TestPluginsAndDependencies_subdir(t *testing.T) {
 }
 
 func testPluginsAndDependencies(t *testing.T, progDir string) {
+	t.Helper()
+
 	host := newLanguageHost("0.0.0.0:0", progDir, "")
 	ctx := context.Background()
 

--- a/sdk/go/pulumi/alias_test.go
+++ b/sdk/go/pulumi/alias_test.go
@@ -47,6 +47,7 @@ var aliasTestCases = []struct {
 	{
 		"parent",
 		func(t *testing.T) Alias {
+			t.Helper()
 			return Alias{
 				Type:   String("kubernetes:storage.k8s.io/v1beta1:CSIDriver"),
 				Parent: newResource(t, URN("AParent::AParent"), ID("theParent")),
@@ -82,6 +83,8 @@ func TestAliasResolution(t *testing.T) {
 }
 
 func newResource(t *testing.T, urn URN, id ID) Resource {
+	t.Helper()
+
 	ctx, err := NewContext(context.Background(), RunInfo{})
 	assert.NoError(t, err)
 	return newSimpleCustomResource(ctx, urn, id)

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -115,6 +115,8 @@ func NewLoggingTestResource(
 	input StringInput,
 	opts ...ResourceOption,
 ) (*LoggingTestResource, error) {
+	t.Helper()
+
 	resource := &LoggingTestResource{}
 	err := ctx.RegisterComponentResource("test:go:NewLoggingTestResource", name, resource, opts...)
 	if err != nil {
@@ -266,6 +268,8 @@ type Prov struct {
 
 // Invoke the creation
 func (pr *Prov) i(ctx *Context, t *testing.T) ProviderResource {
+	t.Helper()
+
 	if pr == nil {
 		return nil
 	}
@@ -285,6 +289,8 @@ type Res struct {
 
 // Invoke the creation
 func (rs *Res) i(ctx *Context, t *testing.T) Resource {
+	t.Helper()
+
 	if rs == nil {
 		return nil
 	}

--- a/sdk/go/pulumi/printf_test.go
+++ b/sdk/go/pulumi/printf_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func testPrintf(t *testing.T, ins ...interface{}) {
+	t.Helper()
+
 	const f = "%v %v %v"
 	expected := fmt.Sprintf(f, "foo", 42, true)
 

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -559,6 +559,8 @@ func init() {
 }
 
 func assertOutputEqual(t *testing.T, value interface{}, known bool, secret bool, deps urnSet, output interface{}) {
+	t.Helper()
+
 	actualValue, actualKnown, actualSecret, actualDeps, err := await(output.(Output))
 	assert.NoError(t, err)
 	assert.Equal(t, value, actualValue)
@@ -597,6 +599,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewStringProperty("hello"),
 			args:  &StringArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, "hello", actual)
 			},
 		},
@@ -605,6 +608,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNullProperty(),
 			args:  &StringArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, "", actual)
 			},
 		},
@@ -628,6 +632,8 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
+
 				assert.Equal(t, "hello", actual)
 			},
 		},
@@ -656,6 +662,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewStringProperty("hello"),
 			args:  &StringPtrArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, stringPtr("hello"), actual)
 			},
 		},
@@ -670,6 +677,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNullProperty(),
 			args:  &StringPtrArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Nil(t, actual)
 			},
 		},
@@ -680,6 +688,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewStringProperty("hello"),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, String("hello"), actual)
 			},
 		},
@@ -688,6 +697,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.MakeSecret(resource.NewStringProperty("hello")),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, "hello", true, true, urnSet{}, actual)
 			},
 		},
@@ -700,6 +710,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, "hello", true, true, urnSet{}, actual)
 			},
 		},
@@ -708,6 +719,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewOutputProperty(resource.Output{}),
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, nil, false, false, urnSet{}, actual)
 			},
 		},
@@ -718,6 +730,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, nil, false, true, urnSet{}, actual)
 			},
 		},
@@ -727,6 +740,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps:  urnSet{"fakeURN": struct{}{}},
 			args:  &StringInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, "hello", true, false, urnSet{"fakeURN": struct{}{}}, actual)
 			},
 		},
@@ -737,6 +751,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewStringProperty("hello"),
 			args:  &StringPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, String("hello"), actual)
 			},
 		},
@@ -745,6 +760,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNullProperty(),
 			args:  &StringPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Nil(t, actual)
 			},
 		},
@@ -755,6 +771,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewBoolProperty(true),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, Bool(true), actual)
 			},
 		},
@@ -763,6 +780,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.MakeSecret(resource.NewBoolProperty(true)),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, true, true, true, urnSet{}, actual)
 			},
 		},
@@ -775,6 +793,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, true, true, true, urnSet{}, actual)
 			},
 		},
@@ -783,6 +802,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewOutputProperty(resource.Output{}),
 			args:  &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, nil, false, false, urnSet{}, actual)
 			},
 		},
@@ -793,6 +813,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &BoolInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, nil, false, true, urnSet{}, actual)
 			},
 		},
@@ -803,6 +824,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewBoolProperty(true),
 			args:  &BoolPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, Bool(true), actual)
 			},
 		},
@@ -811,6 +833,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNullProperty(),
 			args:  &BoolPtrInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Nil(t, actual)
 			},
 		},
@@ -821,6 +844,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNumberProperty(42),
 			args:  &IntArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, 42, actual)
 			},
 		},
@@ -837,6 +861,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewBoolProperty(true),
 			args:  &BoolEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, BoolEnum(true), actual)
 			},
 		},
@@ -846,6 +871,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNumberProperty(42),
 			args:  &IntEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, IntEnum(42), actual)
 			},
 		},
@@ -855,6 +881,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewNumberProperty(42),
 			args:  &FloatEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, FloatEnum(42), actual)
 			},
 		},
@@ -864,6 +891,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewStringProperty("hello"),
 			args:  &StringEnumInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, StringEnum("hello"), actual)
 			},
 		},
@@ -877,6 +905,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, []string{"hello", "world"}, actual)
 			},
 		},
@@ -890,6 +919,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringArrayInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, StringArray{
 					String("hello"),
 					String("world"),
@@ -908,6 +938,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringArrayInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(StringArray)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -925,6 +956,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &StringMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, map[string]string{
 					"foo": "hello",
 					"bar": "world",
@@ -941,6 +973,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringMapInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, StringMap{
 					"foo": String("hello"),
 					"bar": String("world"),
@@ -959,6 +992,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &StringMapInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -980,6 +1014,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN": struct{}{}},
 			args: &StringMapInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1001,6 +1036,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN1": struct{}{}},
 			args: &StringMapInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(StringMap)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1021,6 +1057,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, Nested{Foo: "hi", Bar: 7}, actual)
 			},
 		},
@@ -1063,6 +1100,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedPtrArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &Nested{Foo: "pointer", Bar: 2}, actual)
 			},
 		},
@@ -1082,6 +1120,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &NestedArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, []Nested{
 					{Foo: "1", Bar: 1},
 					{Foo: "2", Bar: 2},
@@ -1104,6 +1143,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, map[string]Nested{
 					"a": {Foo: "3", Bar: 3},
 					"b": {Foo: "4", Bar: 4},
@@ -1120,6 +1160,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedOutputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, Nested{
 					Foo: "hello",
 					Bar: 42,
@@ -1136,6 +1177,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedPtrOutputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, &Nested{
 					Foo: "world",
 					Bar: 100,
@@ -1158,6 +1200,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &NestedArrayOutputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, []Nested{
 					{Foo: "a", Bar: 1},
 					{Foo: "b", Bar: 2},
@@ -1180,6 +1223,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &NestedMapOutputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, map[string]Nested{
 					"a": {Foo: "c", Bar: 3},
 					"b": {Foo: "d", Bar: 4},
@@ -1196,6 +1240,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, []StringInput{
 					String("foo"),
 					String("bar"),
@@ -1210,6 +1255,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1225,6 +1271,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1243,6 +1290,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, []StringInput{
 					String("foo"),
 					String("bar"),
@@ -1261,6 +1309,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1277,6 +1326,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN": struct{}{}},
 			args: &PlainArrayArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.([]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1294,6 +1344,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			})),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, map[string]StringInput{
 					"foo": String("bar"),
 					"baz": String("qux"),
@@ -1308,6 +1359,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1323,6 +1375,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1341,6 +1394,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, map[string]StringInput{
 					"foo": String("bar"),
 					"baz": String("qux"),
@@ -1359,6 +1413,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1375,6 +1430,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN": struct{}{}},
 			args: &PlainMapArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(map[string]StringInput)
 				assert.True(t, ok)
 				assert.Len(t, v, 2)
@@ -1389,6 +1445,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewObjectProperty(resource.PropertyMap{}),
 			args:  &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyInputArgs{}, actual)
 			},
 		},
@@ -1399,6 +1456,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyInputArgs{
 					Something: String("anything"),
 				}, actual)
@@ -1411,6 +1469,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyInputArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{}, v.Something)
@@ -1423,6 +1482,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyInputArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, nil, false, false, urnSet{}, v.Something)
@@ -1438,6 +1498,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyInputArgs{
 					Something: String("anything"),
 				}, actual)
@@ -1454,6 +1515,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyInputArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{}, v.Something)
@@ -1472,6 +1534,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN": struct{}{}},
 			args: &PlainOptionalNestedInputtyInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyInputArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{"fakeURN": struct{}{}}, v.Something)
@@ -1484,6 +1547,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewObjectProperty(resource.PropertyMap{}),
 			args:  &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyArgs{}, actual)
 			},
 		},
@@ -1494,6 +1558,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyArgs{
 					Something: String("anything"),
 				}, actual)
@@ -1506,6 +1571,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{}, v.Something)
@@ -1518,6 +1584,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, nil, false, false, urnSet{}, v.Something)
@@ -1533,6 +1600,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, &NestedInputtyArgs{
 					Something: String("anything"),
 				}, actual)
@@ -1549,6 +1617,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{}, v.Something)
@@ -1567,6 +1636,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			deps: urnSet{"fakeURN": struct{}{}},
 			args: &PlainOptionalNestedInputtyArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				v, ok := actual.(*NestedInputtyArgs)
 				assert.True(t, ok)
 				assertOutputEqual(t, "anything", true, true, urnSet{"fakeURN": struct{}{}}, v.Something)
@@ -1579,6 +1649,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewStringAsset("hello"), actual)
 			},
 		},
@@ -1589,6 +1660,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewStringAsset("hello"), actual)
 			},
 		},
@@ -1599,6 +1671,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewFileArchive("path"), actual)
 			},
 		},
@@ -1609,6 +1682,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewArchiveProperty(&rarchive.Archive{Path: "path"}),
 			args:  &ArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewFileArchive("path"), actual)
 			},
 		},
@@ -1619,6 +1693,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewStringAsset("hello"), actual)
 			},
 		},
@@ -1629,6 +1704,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewAssetProperty(&rasset.Asset{Text: "hello"}),
 			args:  &AssetOrArchiveInputArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assert.Equal(t, NewStringAsset("hello"), actual)
 			},
 		},
@@ -1651,6 +1727,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			}),
 			args: &LaunchTemplateArgs{},
 			assert: func(t *testing.T, actual interface{}) {
+				t.Helper()
 				assertOutputEqual(t, &LaunchTemplateOptions{
 					TagSpecifications: []LaunchTemplateTagSpecification{
 						{
@@ -1667,6 +1744,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Helper()
 			t.Parallel()
 
 			ctx, err := NewContext(context.Background(), RunInfo{})
@@ -1749,6 +1827,7 @@ func TestConstruct_resourceOptionsSnapshot(t *testing.T) {
 	//
 	// Fails the test if any operation fails.
 	snapshotFromRequest := func(t *testing.T, req *pulumirpc.ConstructRequest) *ResourceOptions {
+		t.Helper()
 		// Keep test cases simple:
 		req.Stack = "mystack"
 		req.Project = "myproject"

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -526,6 +526,7 @@ func TestResourceOptionMergingTransformations(t *testing.T) {
 }
 
 func assertTransformations(t *testing.T, t1 []ResourceTransformation, t2 []ResourceTransformation) {
+	t.Helper()
 	assert.Equal(t, len(t1), len(t2))
 	for i := range t1 {
 		p1 := reflect.ValueOf(t1[i]).Pointer()
@@ -1215,6 +1216,7 @@ func assertHasDeps(
 	res Resource,
 	expectedDeps ...Resource,
 ) {
+	t.Helper()
 	name := res.getName()
 	resDeps := depTracker.dependencies(urn(t, ctx, res))
 
@@ -1239,6 +1241,8 @@ func outputDependingOnResource(res Resource, isKnown bool) IntOutput {
 }
 
 func newTestRes(t *testing.T, ctx *Context, name string, opts ...ResourceOption) Resource {
+	t.Helper()
+
 	var res testRes
 	err := ctx.RegisterResource(fmt.Sprintf("test:resource:%stype", name), name, nil, &res, opts...)
 	assert.NoError(t, err)
@@ -1246,6 +1250,8 @@ func newTestRes(t *testing.T, ctx *Context, name string, opts ...ResourceOption)
 }
 
 func urn(t *testing.T, ctx *Context, res Resource) URN {
+	t.Helper()
+
 	urn, _, _, err := res.URN().awaitURN(ctx.ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/sdk/go/pulumi/types_contravariance_test.go
+++ b/sdk/go/pulumi/types_contravariance_test.go
@@ -26,6 +26,8 @@ import (
 
 // asAnySlice converts []T to []interface{} by reflection, simulating covariance.
 func asAnySlice(t *testing.T, values interface{}) []interface{} {
+	t.Helper()
+
 	v := reflect.ValueOf(values)
 	// use reflect.valueOf to iterate over items of values
 	require.Equalf(t, v.Kind(), reflect.Slice, "expected a slice, got %v", v.Type())

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -34,6 +34,8 @@ func await(out Output) (interface{}, bool, bool, []Resource, error) {
 }
 
 func assertApplied(t *testing.T, out Output) {
+	t.Helper()
+
 	_, known, _, _, err := await(out)
 	assert.True(t, known)
 	assert.NoError(t, err)
@@ -718,6 +720,8 @@ func TestDeps(t *testing.T) {
 }
 
 func testMixedWaitGroups(t *testing.T, combine func(o1, o2 Output) Output) {
+	t.Helper()
+
 	var wg1, wg2 workGroup
 
 	o1 := internal.NewOutput(&wg1, anyOutputType)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -65,6 +65,8 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 }
 
 func runEngine(t *testing.T) string {
+	t.Helper()
+
 	// Run a gRPC server that implements the Pulumi engine RPC interface. But all we do is forward logs on to T.
 	engine := &hostEngine{t: t}
 	stop := make(chan bool)
@@ -84,6 +86,8 @@ func runEngine(t *testing.T) string {
 }
 
 func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
+	t.Helper()
+
 	// We can't just go run the pulumi-test-language package because of
 	// https://github.com/golang/go/issues/39172, so we build it to a temp file then run that.
 	binary := t.TempDir() + "/pulumi-test-language"

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -67,6 +67,8 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 }
 
 func runEngine(t *testing.T) string {
+	t.Helper()
+
 	// Run a gRPC server that implements the Pulumi engine RPC interface. But all we do is forward logs on to T.
 	engine := &hostEngine{t: t}
 	stop := make(chan bool)
@@ -86,6 +88,8 @@ func runEngine(t *testing.T) string {
 }
 
 func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
+	t.Helper()
+
 	// We can't just go run the pulumi-test-language package because of
 	// https://github.com/golang/go/issues/39172, so we build it to a temp file then run that.
 	binary := t.TempDir() + "/pulumi-test-language"

--- a/tests/examples/examples_acceptance_test.go
+++ b/tests/examples/examples_acceptance_test.go
@@ -38,6 +38,8 @@ func TestAccMinimal_withLocalState(t *testing.T) {
 				"secret": "this is my secret message",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Simple runtime validation that just ensures the checkpoint was written and read.
 				assert.NotNil(t, stackInfo.Deployment)
 			},
@@ -71,6 +73,8 @@ func TestAccFormattable_withLocalState(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "formattable"),
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
 				stdout := formattableStdout.String()
 				assert.False(t, strings.Contains(stdout, "MISSING"))
@@ -84,6 +88,8 @@ func TestAccFormattable_withLocalState(t *testing.T) {
 }
 
 func getCwd(t *testing.T) string {
+	t.Helper()
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.FailNow()

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -40,6 +40,7 @@ func TestAccMinimal(t *testing.T) {
 				"secret": "this is my secret message",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
 				// Simple runtime validation that just ensures the checkpoint was written and read.
 				assert.NotNil(t, stackInfo.Deployment)
 			},
@@ -91,6 +92,8 @@ func TestAccDynamicProviderMultipleTurns(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "dynamic-provider/multiple-turns"),
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				for _, res := range stackInfo.Deployment.Resources {
 					if !providers.IsProviderType(res.Type) && res.Parent == "" {
 						assert.Equal(t, stackInfo.RootResource.URN, res.URN,
@@ -109,6 +112,8 @@ func TestAccDynamicProviderMultipleTurns_withLocalState(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "dynamic-provider/multiple-turns"),
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				for _, res := range stackInfo.Deployment.Resources {
 					if !providers.IsProviderType(res.Type) && res.Parent == "" {
 						assert.Equal(t, stackInfo.RootResource.URN, res.URN,
@@ -152,6 +157,8 @@ func TestAccDynamicProviderSecrets(t *testing.T) {
 				"password": "s3cret",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Ensure the __provider input (and corresponding output) was marked secret
 				dynRes := stackInfo.Deployment.Resources[2]
 				for _, providerVal := range []interface{}{dynRes.Inputs["__provider"], dynRes.Outputs["__provider"]} {
@@ -210,6 +217,8 @@ func TestAccFormattable(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "formattable"),
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
 				stdout := formattableStdout.String()
 				assert.False(t, strings.Contains(stdout, "MISSING"))
@@ -234,6 +243,8 @@ func TestAccSecrets(t *testing.T) {
 			},
 			Quick: true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				assert.NotNil(t, stackInfo.Deployment.SecretsProviders, "Deployment should have a secrets provider")
 
 				isEncrypted := func(v interface{}) bool {

--- a/tests/integration/double_pending_delete/double_pending_delete_test.go
+++ b/tests/integration/double_pending_delete/double_pending_delete_test.go
@@ -26,6 +26,8 @@ func TestDoublePendingDelete(t *testing.T) {
 				Additive:      true,
 				ExpectFailure: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					assert.NotNil(t, stackInfo.Deployment)
 
 					// Four resources in this deployment: the root resource, A, B, and A (pending delete)
@@ -53,6 +55,8 @@ func TestDoublePendingDelete(t *testing.T) {
 				Additive:      true,
 				ExpectFailure: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// There is still two pending delete resources in this snapshot.
 					assert.NotNil(t, stackInfo.Deployment)
 
@@ -83,6 +87,8 @@ func TestDoublePendingDelete(t *testing.T) {
 				Dir:      "step4",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// We should have cleared out all of the pending deletes now.
 					assert.NotNil(t, stackInfo.Deployment)
 

--- a/tests/integration/integration_acceptance_test.go
+++ b/tests/integration/integration_acceptance_test.go
@@ -146,6 +146,8 @@ func TestJSONOutputWithStreamingPreview(t *testing.T) {
 		JSONOutput:   true,
 		Env:          []string{"PULUMI_ENABLE_STREAMING_JSON_PREVIEW=1"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stdout.String()
 
 			// Check that the previewSummary is *not* present.

--- a/tests/integration/integration_go_acceptance_test.go
+++ b/tests/integration/integration_go_acceptance_test.go
@@ -138,6 +138,8 @@ func TestNestedConstructGo(t *testing.T) {
 func optsForConstructGo(
 	t *testing.T, dir string, expectedResourceCount int, localProviders []integration.LocalDependency, env ...string,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Env: env,
 		Dir: filepath.Join(dir, "go"),
@@ -150,6 +152,8 @@ func optsForConstructGo(
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -74,6 +74,7 @@ func TestNoEmitExitStatus(t *testing.T) {
 		Quick:         true,
 		SkipRefresh:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			// ensure exit status is not emitted by the program
 			assert.NotContains(t, stderr.String(), "exit status")
 		},
@@ -93,6 +94,7 @@ func TestPanickingProgram(t *testing.T) {
 		Quick:         true,
 		SkipRefresh:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			assert.Contains(t, stderr.String(), "panic: great sadness\n")
 		},
 	})
@@ -125,6 +127,7 @@ func TestPanickingComponentConfigure(t *testing.T) {
 		SkipRefresh:   true,
 		NoParallel:    true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			assert.Contains(t, stderr.String(), "panic: great sadness\n")
 		},
 	})
@@ -146,6 +149,7 @@ func TestNoLogError(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			errorCount := strings.Count(stderr.String()+stdout.String(), "  error: ")
 
 			// ensure `  error: ` is only being shown once by the program
@@ -172,6 +176,8 @@ func TestGoRunEnvFlag(t *testing.T) {
 		Quick:         true,
 		SkipRefresh:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// ensure exit status IS emitted by the program as it indicates `go run` was used
 			assert.Contains(t, stderr.String(), "exit status")
 		},
@@ -260,6 +266,8 @@ func TestConfigMissingGo(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			text1 := "Missing required configuration variable 'config_missing_go:notFound'"
 			text2 := "\tplease set a value using the command `pulumi config set --secret config_missing_go:notFound <value>`"
@@ -429,6 +437,8 @@ func TestConfigSecretsWarnGo(t *testing.T) {
 			{Key: "names3[1]", Value: "secret2", Path: true, Secret: true},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			//nolint:lll
 			expectedWarnings := []string{
@@ -600,6 +610,8 @@ func TestConstructSlowGo(t *testing.T) {
 		Quick:          true,
 		NoParallel:     true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]
@@ -661,6 +673,8 @@ func TestConstructPlainGo(t *testing.T) {
 func optsForConstructPlainGo(
 	t *testing.T, expectedResourceCount int, localProviders []integration.LocalDependency, env ...string,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Env: env,
 		Dir: filepath.Join("construct_component_plain", "go"),
@@ -670,6 +684,8 @@ func optsForConstructPlainGo(
 		LocalProviders: localProviders,
 		Quick:          true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
 		},
@@ -719,6 +735,8 @@ func TestConstructMethodsGo(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
 
 					// TODO[pulumi/pulumi#12471]: Only the Go SDK has been fixed such that rehydrated
@@ -794,6 +812,7 @@ func TestConstructProviderGo(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.Equal(t, "hello world", stackInfo.Outputs["message"])
 				},
 			})
@@ -817,6 +836,8 @@ func TestGetResourceGo(t *testing.T) {
 			"bar": "this super secret is encrypted",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stack.Outputs)
 			assert.Equal(t, float64(2), stack.Outputs["getPetLength"])
 
@@ -942,6 +963,7 @@ func TestProjectMainGo(t *testing.T) {
 		Dir:          "project_main/go",
 		Dependencies: []string{"github.com/pulumi/pulumi/sdk/v3"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			// Simple runtime validation that just ensures the checkpoint was written and read.
 			assert.NotNil(t, stackInfo.Deployment)
 		},

--- a/tests/integration/integration_nodejs_acceptance_test.go
+++ b/tests/integration/integration_nodejs_acceptance_test.go
@@ -111,6 +111,8 @@ func TestConstructNode(t *testing.T) {
 func optsForConstructNode(
 	t *testing.T, expectedResourceCount int, localProviders []integration.LocalDependency,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Dir:            filepath.Join("construct_component", "nodejs"),
 		Dependencies:   []string{"@pulumi/pulumi"},
@@ -122,6 +124,8 @@ func optsForConstructNode(
 		// verify that additional flags don't cause the component provider hang
 		UpdateCommandlineFlags: []string{"--logflow", "--logtostderr"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -83,6 +83,8 @@ func TestEngineEvents(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// Ensure that we have a non-empty list of events.
 			assert.NotEmpty(t, stackInfo.Events)
 
@@ -107,6 +109,7 @@ func TestProjectMainNodejs(t *testing.T) {
 		Dir:          "project_main/nodejs",
 		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			// Simple runtime validation that just ensures the checkpoint was written and read.
 			assert.NotNil(t, stackInfo.Deployment)
 		},
@@ -214,6 +217,8 @@ func TestStackOutputsNodeJS(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// Ensure the checkpoint contains a single resource, the Stack, with two outputs.
 			fmt.Printf("Deployment: %v", stackInfo.Deployment)
 			assert.NotNil(t, stackInfo.Deployment)
@@ -264,6 +269,8 @@ func TestStackOutputsDisplayed(t *testing.T) {
 		Verbose:      true,
 		Stdout:       stdout,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stdout.String()
 
 			// ensure we get the outputs info both for the normal update, and for the no-change update.
@@ -286,6 +293,8 @@ func TestStackOutputsSuppressed(t *testing.T) {
 		Stdout:                 stdout,
 		UpdateCommandlineFlags: []string{"--suppress-outputs"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stdout.String()
 			assert.NotContains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n")
 			assert.NotContains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n")
@@ -302,6 +311,8 @@ func TestStackParenting(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// Ensure the checkpoint contains resources parented correctly.  This should look like this:
 			//
 			//     A      F
@@ -367,6 +378,8 @@ func TestStackDependencyGraph(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			latest := stackInfo.Deployment
 			assert.True(t, len(latest.Resources) >= 2)
@@ -432,6 +445,8 @@ func TestConfigMissingJS(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			text1 := "Missing required configuration variable 'config_missing_js:notFound'"
 			text2 := "\tplease set a value using the command `pulumi config set --secret config_missing_js:notFound <value>`"
@@ -519,6 +534,8 @@ func TestConfigSecretsWarnNodeJS(t *testing.T) {
 			{Key: "names2[1]", Value: "secret2", Path: true, Secret: true},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			//nolint:lll
 			expectedWarnings := []string{
@@ -604,6 +621,8 @@ func TestExplicitProvider(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			latest := stackInfo.Deployment
 
@@ -680,6 +699,8 @@ func TestResourceWithSecretSerializationNodejs(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// The program exports three resources:
 			//   1. One named `withSecret` who's prefix property should be secret, specified via `pulumi.secret()`.
 			//   2. One named `withSecretAdditional` who's prefix property should be a secret, specified via
@@ -733,6 +754,8 @@ func TestStackReferenceSecretsNodejs(t *testing.T) {
 				Additive:        true,
 				ExpectNoChanges: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					_, isString := stackInfo.Outputs["refNormal"].(string)
 					assert.Truef(t, isString, "referenced non-secret output was not a string")
 
@@ -761,6 +784,8 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 
 	workingTestOptions := testOptions.With(integration.ProgramTestOptions{
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			t.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
 			secretsProvider := stackInfo.Deployment.SecretsProviders
 			assert.NotNil(t, secretsProvider)
@@ -779,6 +804,8 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 
 	brokenTestOptions := testOptions.With(integration.ProgramTestOptions{
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			secretsProvider := stackInfo.Deployment.SecretsProviders
 			assert.NotNil(t, secretsProvider)
 			assert.Equal(t, secretsProvider.Type, "passphrase")
@@ -824,6 +851,8 @@ func TestCloudSecretProvider(t *testing.T) {
 			"mysecret": "THISISASECRET",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			secretsProvider := stackInfo.Deployment.SecretsProviders
 			assert.NotNil(t, secretsProvider)
 			assert.Equal(t, secretsProvider.Type, "cloud")
@@ -890,6 +919,8 @@ func TestEnumOutputNode(t *testing.T) {
 		Dir:          filepath.Join("enums", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stack.Outputs)
 			assert.Equal(t, "Burgundy", stack.Outputs["myTreeType"])
 			assert.Equal(t, "Pulumi Planters Inc.foo", stack.Outputs["myTreeFarmChanged"])
@@ -916,6 +947,8 @@ func TestConstructSlowNode(t *testing.T) {
 		Quick:          true,
 		NoParallel:     true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]
@@ -969,12 +1002,15 @@ func TestConstructPlainNode(t *testing.T) {
 func optsForConstructPlainNode(
 	t *testing.T, expectedResourceCount int, localProviders []integration.LocalDependency,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Dir:            filepath.Join("construct_component_plain", "nodejs"),
 		Dependencies:   []string{"@pulumi/pulumi"},
 		LocalProviders: localProviders,
 		Quick:          true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			assert.NotNil(t, stackInfo.Deployment)
 			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
 		},
@@ -1021,6 +1057,7 @@ func TestConstructMethodsNode(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
 				},
 			})
@@ -1081,6 +1118,7 @@ func TestConstructProviderNode(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.Equal(t, "hello world", stackInfo.Outputs["message"])
 				},
 			})
@@ -1095,6 +1133,8 @@ func TestGetResourceNode(t *testing.T) {
 		Dependencies:             []string{"@pulumi/pulumi"},
 		AllowEmptyPreviewChanges: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stack.Outputs)
 			assert.Equal(t, "foo", stack.Outputs["foo"])
 
@@ -1139,6 +1179,8 @@ func TestConstructNodeErrorApply(t *testing.T) {
 		Stderr:        stderr,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stderr.String()
 			assert.Contains(t, output, expectedError)
 		},
@@ -1170,6 +1212,8 @@ func TestNodejsStackTruncate(t *testing.T) {
 				ExpectFailure: true,
 				// We need to validate that the failure has a truncated stack trace
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// Ensure that we have a non-empty list of events.
 					assert.NotEmpty(t, stackInfo.Events)
 
@@ -1282,6 +1326,8 @@ func TestESMTSNestedSrc(t *testing.T) {
 			"test": "hello world",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Len(t, stack.Outputs, 1)
 			test, ok := stack.Outputs["test"]
 			assert.True(t, ok)
@@ -1297,6 +1343,8 @@ func TestESMTSDefaultExport(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Len(t, stack.Outputs, 1)
 			helloWorld, ok := stack.Outputs["helloWorld"]
 			assert.True(t, ok)
@@ -1425,6 +1473,8 @@ func TestUnsafeSnapshotManagerRetainsResourcesOnError(t *testing.T) {
 			// The program throws an exception and 1 resource fails to be created.
 			ExpectFailure: true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Ensure the checkpoint contains the 1003 other resources that were created
 				// - stack
 				// - provider
@@ -1450,6 +1500,8 @@ func TestUnsafeSnapshotManagerRetainsResourcesOnError(t *testing.T) {
 			// The program throws an exception and 1 resource fails to be created.
 			ExpectFailure: true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				// Ensure the checkpoint contains the 1003 other resources that were created
 				// - stack
 				// - provider
@@ -1499,6 +1551,8 @@ func TestCustomResourceTypeNameDynamicNode(t *testing.T) {
 		Dir:          filepath.Join("dynamic", "nodejs-resource-type-name"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			urnOut := stack.Outputs["urn"].(string)
 			urn := resource.URN(urnOut)
 			typ := urn.Type().String()
@@ -1516,6 +1570,8 @@ func TestErrorCreateDynamicNode(t *testing.T) {
 		Dependencies:  []string{"@pulumi/pulumi"},
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			foundError := false
 			for _, event := range stack.Events {
 				if event.ResOpFailedEvent != nil {
@@ -1543,6 +1599,8 @@ func TestRegression12301Node(t *testing.T) {
 			return os.Rename(jsonPath, newPath)
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Len(t, stack.Outputs, 1)
 			assert.Contains(t, stack.Outputs, "bar")
 			assert.Equal(t, 3.0, stack.Outputs["bar"].(float64))
@@ -1561,6 +1619,8 @@ func TestPulumiConfig(t *testing.T) {
 			"pulumi-nodejs:id": "testing123",
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Len(t, stack.Outputs, 1)
 			assert.Contains(t, stack.Outputs, "rid")
 			assert.Equal(t, "testing123", stack.Outputs["rid"].(string))
@@ -1588,6 +1648,8 @@ func TestUndefinedStackOutputNode(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "undefined-stack-output"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Equal(t, nil, stack.Outputs["nil"])
 			assert.Equal(t, []interface{}{0.0, nil, nil}, stack.Outputs["list"])
 			assert.Equal(t, map[string]interface{}{

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -85,12 +85,15 @@ func TestDynamicPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			randomVal = stack.Outputs["random_val"].(string)
 		},
 		EditDirs: []integration.EditDir{{
 			Dir:      filepath.Join("dynamic", "python", "step1"),
 			Additive: true,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				assert.Equal(t, randomVal, stack.Outputs["random_val"].(string))
 
 				// Regression testing the workaround for https://github.com/pulumi/pulumi/issues/8265
@@ -170,6 +173,8 @@ func TestConstructPython(t *testing.T) {
 func optsForConstructPython(
 	t *testing.T, expectedResourceCount int, localProviders []integration.LocalDependency, env ...string,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Env: env,
 		Dir: filepath.Join("construct_component", "python"),
@@ -183,6 +188,8 @@ func optsForConstructPython(
 		Quick:               true,
 		UseSharedVirtualEnv: boolPointer(false),
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]
@@ -248,6 +255,8 @@ func TestAutomaticVenvCreation(t *testing.T) {
 	// handling by the pulumi CLI itself.
 
 	check := func(t *testing.T, venvPathTemplate string, dir string) {
+		t.Helper()
+
 		e := ptesting.NewEnvironment(t)
 		defer func() {
 			if !t.Failed() {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -54,6 +54,7 @@ func TestMissingMainDoesNotEmitStackTrace(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			// ensure `  error: ` is only being shown once by the program
 			assert.NotContains(t, stdout.String()+stderr.String(), "Traceback")
 		},
@@ -83,6 +84,8 @@ func TestStackOutputsPython(t *testing.T) {
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// Ensure the checkpoint contains a single resource, the Stack, with two outputs.
 			fmt.Printf("Deployment: %v", stackInfo.Deployment)
 			assert.NotNil(t, stackInfo.Deployment)
@@ -143,6 +146,8 @@ func TestConfigMissingPython(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			text1 := "Missing required configuration variable 'config_missing_py:notFound'"
 			text2 := "\tplease set a value using the command `pulumi config set --secret config_missing_py:notFound <value>`"
@@ -228,6 +233,8 @@ func TestConfigSecretsWarnPython(t *testing.T) {
 			{Key: "names2[1]", Value: "secret2", Path: true, Secret: true},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotEmpty(t, stackInfo.Events)
 			//nolint:lll
 			expectedWarnings := []string{
@@ -351,6 +358,8 @@ func TestResourceWithSecretSerializationPython(t *testing.T) {
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// The program exports three resources:
 			//   1. One named `withSecret` who's prefix property should be secret, specified via `pulumi.secret()`.
 			//   2. One named `withSecretAdditional` who's prefix property should be a secret, specified via
@@ -410,6 +419,8 @@ func TestPython3NotInstalled(t *testing.T) {
 		ExpectFailure: true,
 		Stderr:        stderr,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stderr.String()
 			assert.Contains(t, output, expectedError)
 		},
@@ -426,6 +437,8 @@ func TestCustomResourceTypeNameDynamicPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			urnOut := stack.Outputs["urn"].(string)
 			urn := resource.URN(urnOut)
 			typ := urn.Type().String()
@@ -467,6 +480,8 @@ func TestEnumOutputsPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stack.Outputs)
 
 			assert.Equal(t, "Burgundy", stack.Outputs["myTreeType"])
@@ -488,6 +503,8 @@ func TestPythonPylint(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			randomURN := stack.Outputs["random_urn"].(string)
 			assert.NotEmpty(t, randomURN)
 
@@ -571,6 +588,8 @@ func TestPythonStackTruncate(t *testing.T) {
 				ExpectFailure: true,
 				// We need to validate that the failure has a truncated stack trace
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// Ensure that we have a non-empty list of events.
 					assert.NotEmpty(t, stackInfo.Events)
 
@@ -630,6 +649,8 @@ func TestConstructSlowPython(t *testing.T) {
 		Quick:          true,
 		NoParallel:     true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
 				stackRes := stackInfo.Deployment.Resources[0]
@@ -691,6 +712,8 @@ func TestConstructPlainPython(t *testing.T) {
 func optsForConstructPlainPython(t *testing.T, expectedResourceCount int, localProviders []integration.LocalDependency,
 	env ...string,
 ) *integration.ProgramTestOptions {
+	t.Helper()
+
 	return &integration.ProgramTestOptions{
 		Env: env,
 		Dir: filepath.Join("construct_component_plain", "python"),
@@ -700,6 +723,7 @@ func optsForConstructPlainPython(t *testing.T, expectedResourceCount int, localP
 		LocalProviders: localProviders,
 		Quick:          true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			assert.NotNil(t, stackInfo.Deployment)
 			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
 		},
@@ -748,6 +772,7 @@ func TestConstructMethodsPython(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
 				},
 			})
@@ -782,6 +807,8 @@ func TestConstructComponentWithIdOutputPython(t *testing.T) {
 		LocalProviders: []integration.LocalDependency{localProvider},
 		Quick:          true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			component := findResource("testcomponent:index:Component", stackInfo.Deployment.Resources)
 			require.NotNil(t, component, "component should be present in the deployment")
 			require.NotNil(t, component.Outputs, "component should have outputs")
@@ -855,6 +882,7 @@ func TestConstructProviderPython(t *testing.T) {
 				LocalProviders: []integration.LocalDependency{localProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.Equal(t, "hello world", stackInfo.Outputs["message"])
 				},
 			})
@@ -886,6 +914,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			AllowEmptyPreviewChanges: true,
 			Quick:                    true,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				sawMagicStringMessage := false
 				for _, evt := range stack.Events {
 					if evt.DiagnosticEvent != nil {
@@ -909,6 +939,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			AllowEmptyPreviewChanges: true,
 			Quick:                    true,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				sawMagicString := false
 				sawFoo := false
 				sawBar := false
@@ -943,6 +975,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			AllowEmptyPreviewChanges: true,
 			Quick:                    true,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				sawUrn := false
 				for _, evt := range stack.Events {
 					if evt.DiagnosticEvent != nil {
@@ -966,6 +1000,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			AllowEmptyPreviewChanges: true,
 			Quick:                    true,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				sawMagicStringMessage := false
 				for _, evt := range stack.Events {
 					if evt.DiagnosticEvent != nil {
@@ -993,6 +1029,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			Quick:                    true,
 			Stderr:                   stderr,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				output := stderr.String()
 				assert.Contains(t, output, expectedError)
 			},
@@ -1013,6 +1051,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			Quick:                    true,
 			Stderr:                   stderr,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				output := stderr.String()
 				assert.Contains(t, output, expectedError)
 				sawFoo := false
@@ -1052,6 +1092,8 @@ func TestPythonAwaitOutputs(t *testing.T) {
 			Quick:                    true,
 			Stderr:                   stderr,
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+
 				output := stderr.String()
 				assert.Contains(t, output, expectedError)
 				sawFoo := false
@@ -1180,6 +1222,8 @@ func TestDuplicateOutputPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			expected := []interface{}{float64(1), float64(2)}
 			assert.Equal(t, expected, stack.Outputs["export1"])
 			assert.Equal(t, expected, stack.Outputs["export2"])
@@ -1209,6 +1253,8 @@ func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
 		},
 		Stdout: stdout,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Contains(
 				t, stdout.String(),
 				"RuntimeError: We have detected a circular dependency involving a resource of type "+

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -617,6 +617,8 @@ func TestJSONOutput(t *testing.T) {
 		Verbose:      true,
 		JSONOutput:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			output := stdout.String()
 
 			// Check that the previewSummary is present.
@@ -634,6 +636,8 @@ func TestProviderDownloadURL(t *testing.T) {
 	t.Parallel()
 
 	validate := func(t *testing.T, stdout []byte) {
+		t.Helper()
+
 		deployment := &apitype.UntypedDeployment{}
 		err := json.Unmarshal(stdout, deployment)
 		assert.NoError(t, err)
@@ -815,6 +819,8 @@ description: A Pulumi program testing passphrase config.
 // Language-specific tests should call this function with the
 // appropriate parameters.
 func testConstructProviderPropagation(t *testing.T, lang string, deps []string) {
+	t.Helper()
+
 	const (
 		testDir      = "construct_component_provider_propagation"
 		componentDir = "testcomponent-go"
@@ -833,6 +839,8 @@ func testConstructProviderPropagation(t *testing.T, lang string, deps []string) 
 		Quick:      true,
 		NoParallel: true, // already called by tests
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			gotProviders := make(map[string]string) // resource name => provider name
 
 			for _, res := range stackInfo.Deployment.Resources {
@@ -857,6 +865,8 @@ func testConstructProviderPropagation(t *testing.T, lang string, deps []string) 
 
 // Test to validate that various resource options are propagated for MLCs.
 func testConstructResourceOptions(t *testing.T, dir string, deps []string) {
+	t.Helper()
+
 	const (
 		testDir      = "construct_component_resource_options"
 		componentDir = "testcomponent-go"
@@ -864,6 +874,8 @@ func testConstructResourceOptions(t *testing.T, dir string, deps []string) {
 	runComponentSetup(t, testDir)
 
 	validate := func(t *testing.T, resources []apitype.ResourceV3) {
+		t.Helper()
+
 		urns := make(map[string]resource.URN) // name => URN
 		for _, res := range resources {
 			urns[res.URN.Name()] = res.URN
@@ -914,6 +926,7 @@ func testConstructResourceOptions(t *testing.T, dir string, deps []string) {
 		DestroyExcludeProtected: true, // test contains protected resources
 		SkipStackRemoval:        true, // protected resources prevent stack removal
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			validate(t, stackInfo.Deployment.Resources)
 		},
 	})
@@ -992,6 +1005,7 @@ func TestParentRename_issue13179(t *testing.T) {
 		SkipRefresh: true,
 		Quick:       true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			for _, res := range stackInfo.Deployment.Resources {
 				if res.URN.Name() == "parent" {
 					parentURN = res.URN

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -78,6 +78,8 @@ func (t assertPerfBenchmark) ReportCommand(stats integration.TestCommandStats) {
 }
 
 func testComponentSlowLocalProvider(t *testing.T) integration.LocalDependency {
+	t.Helper()
+
 	return integration.LocalDependency{
 		Package: "testcomponent",
 		Path:    filepath.Join("construct_component_slow", "testcomponent"),
@@ -85,6 +87,8 @@ func testComponentSlowLocalProvider(t *testing.T) integration.LocalDependency {
 }
 
 func testComponentProviderSchema(t *testing.T, path string) {
+	t.Helper()
+
 	runComponentSetup(t, "component_provider_schema")
 
 	tests := []struct {
@@ -153,6 +157,8 @@ func testComponentProviderSchema(t *testing.T, path string) {
 
 // Test remote component inputs properly handle unknowns.
 func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_unknown"
 	runComponentSetup(t, testDir)
 
@@ -192,6 +198,8 @@ func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
 
 // Test methods properly handle unknowns.
 func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_methods_unknown"
 	runComponentSetup(t, testDir)
 	tests := []struct {
@@ -230,6 +238,8 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 }
 
 func runComponentSetup(t *testing.T, testDir string) {
+	t.Helper()
+
 	ptesting.YarnInstallMutex.Lock()
 	defer ptesting.YarnInstallMutex.Unlock()
 
@@ -258,7 +268,9 @@ func runComponentSetup(t *testing.T, testDir string) {
 	require.False(t, t.Failed(), "component setup failed")
 }
 
-func synchronouslyDo(t testing.TB, lockfile string, timeout time.Duration, fn func()) {
+func synchronouslyDo(tb testing.TB, lockfile string, timeout time.Duration, fn func()) {
+	tb.Helper()
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -275,7 +287,7 @@ func synchronouslyDo(t testing.TB, lockfile string, timeout time.Duration, fn fu
 			}
 
 			defer func() {
-				assert.NoError(t, mutex.Unlock())
+				assert.NoError(tb, mutex.Unlock())
 			}()
 			break
 		}
@@ -290,7 +302,7 @@ func synchronouslyDo(t testing.TB, lockfile string, timeout time.Duration, fn fu
 
 	select {
 	case <-ctx.Done():
-		t.Fatalf("timed out waiting for lock on %s", lockfile)
+		tb.Fatalf("timed out waiting for lock on %s", lockfile)
 	case <-lockWait:
 		// waited for fn, success.
 	}
@@ -338,6 +350,8 @@ func (t *nonfatalT) Fatalf(msg string, args ...interface{}) {
 
 // Test methods that create resources.
 func testConstructMethodsResources(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_methods_resources"
 	runComponentSetup(t, testDir)
 
@@ -366,6 +380,8 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 				LocalProviders: localProviders,
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 6, len(stackInfo.Deployment.Resources))
 					var hasExpectedResource bool
@@ -388,6 +404,8 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 
 // Test failures returned from methods are observed.
 func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_methods_errors"
 	runComponentSetup(t, testDir)
 
@@ -421,6 +439,8 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 				Stderr:         stderr,
 				ExpectFailure:  true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					output := stderr.String()
 					assert.Contains(t, output, expectedError)
 				},
@@ -431,6 +451,8 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 
 // Tests methods work when there is an explicit provider for another provider set on the component.
 func testConstructMethodsProvider(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_methods_provider"
 	runComponentSetup(t, testDir)
 
@@ -462,6 +484,8 @@ func testConstructMethodsProvider(t *testing.T, lang string, dependencies ...str
 				LocalProviders: []integration.LocalDependency{localProvider, testProvider},
 				Quick:          true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message1"])
 					assert.Equal(t, "Hi There, Bob!", stackInfo.Outputs["message2"])
 				},
@@ -471,6 +495,8 @@ func testConstructMethodsProvider(t *testing.T, lang string, dependencies ...str
 }
 
 func testConstructOutputValues(t *testing.T, lang string, dependencies ...string) {
+	t.Helper()
+
 	const testDir = "construct_component_output_values"
 	runComponentSetup(t, testDir)
 
@@ -507,6 +533,8 @@ var previewSummaryRegex = regexp.MustCompile(
 	`{\s+"steps": \[[\s\S]+],\s+"duration": \d+,\s+"changeSummary": {[\s\S]+}\s+}`)
 
 func assertOutputContainsEvent(t *testing.T, evt apitype.EngineEvent, output string) {
+	t.Helper()
+
 	evtJSON := bytes.Buffer{}
 	encoder := json.NewEncoder(&evtJSON)
 	encoder.SetEscapeHTML(false)
@@ -518,6 +546,8 @@ func assertOutputContainsEvent(t *testing.T, evt apitype.EngineEvent, output str
 // printfTestValidation is used by the TestPrintfXYZ test cases in the language-specific test
 // files. It validates that there are a precise count of expected stdout/stderr lines in the test output.
 func printfTestValidation(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+	t.Helper()
+
 	var foundStdout int
 	var foundStderr int
 	for _, ev := range stack.Events {
@@ -534,6 +564,8 @@ func printfTestValidation(t *testing.T, stack integration.RuntimeValidationStack
 }
 
 func testConstructProviderExplicit(t *testing.T, lang string, dependencies []string) {
+	t.Helper()
+
 	const testDir = "construct_component_provider_explicit"
 	runComponentSetup(t, testDir)
 
@@ -547,6 +579,8 @@ func testConstructProviderExplicit(t *testing.T, lang string, dependencies []str
 		Quick:          true,
 		NoParallel:     true, // already called by tests
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Equal(t, "hello world", stackInfo.Outputs["message"])
 			assert.Equal(t, "hello world", stackInfo.Outputs["nestedMessage"])
 		},
@@ -567,6 +601,8 @@ func testConstructComponentConfigureProviderCommonOptions() integration.ProgramT
 		Quick:                    false, // intentional, need to test preview here
 		AllowEmptyPreviewChanges: true,  // Pulumi will warn that provider has unknowns in its config
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			assert.Contains(t, stackInfo.Outputs, "keyAlgo")
 			assert.Equal(t, "ECDSA", stackInfo.Outputs["keyAlgo"])
 			assert.Contains(t, stackInfo.Outputs, "keyAlgo2")

--- a/tests/integration/partial_state/partial_state_test.go
+++ b/tests/integration/partial_state/partial_state_test.go
@@ -26,6 +26,8 @@ func TestPartialState(t *testing.T) {
 		Quick:         true,
 		ExpectFailure: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// The first update tries to create a resource with state 4. This fails partially.
 			assert.NotNil(t, stackInfo.Deployment)
 			assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -46,6 +48,8 @@ func TestPartialState(t *testing.T) {
 				Dir:      "step2",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// The next update deletes the resource. We should successfully delete it.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 1, len(stackInfo.Deployment.Resources))
@@ -57,6 +61,8 @@ func TestPartialState(t *testing.T) {
 				Dir:      "step3",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// Step 3 creates a resource with state 5, which succeeds.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -76,6 +82,8 @@ func TestPartialState(t *testing.T) {
 				Additive:      true,
 				ExpectFailure: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// Step 4 updates the resource to have state 4, which fails partially.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))

--- a/tests/integration/protect_resources/protect_test.go
+++ b/tests/integration/protect_resources/protect_test.go
@@ -22,6 +22,8 @@ func TestProtectedResources(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
+
 			// A single synthetic stack and a single "eternal" resource.
 			assert.NotNil(t, stackInfo.Deployment)
 			assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -38,6 +40,8 @@ func TestProtectedResources(t *testing.T) {
 				Dir:      "step2",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// An update to "eternal"; should still be there.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -56,6 +60,8 @@ func TestProtectedResources(t *testing.T) {
 				// This step will fail because the resource is protected.
 				ExpectFailure: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// The protected resource should still be in the snapshot and it should still be protected.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -72,6 +78,8 @@ func TestProtectedResources(t *testing.T) {
 				Dir:      "step4",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// "eternal" should now be unprotected.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
@@ -88,6 +96,8 @@ func TestProtectedResources(t *testing.T) {
 				Dir:      "step5",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					// Finally, "eternal" should be deleted.
 					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 1, len(stackInfo.Deployment.Resources))

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func validateResources(t *testing.T, resources []apitype.ResourceV3, expectedNames ...string) {
+	t.Helper()
+
 	// Build the lookup table of expected resource names.
 	expectedNamesTable := make(map[string]struct{})
 	for _, n := range expectedNames {
@@ -54,6 +56,7 @@ func TestSteps(t *testing.T) {
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			t.Helper()
 			assert.NotNil(t, stackInfo.Deployment)
 			validateResources(t, stackInfo.Deployment.Resources, "a", "b", "c", "d")
 		},
@@ -62,6 +65,7 @@ func TestSteps(t *testing.T) {
 				Dir:      "step2",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.NotNil(t, stackInfo.Deployment)
 					validateResources(t, stackInfo.Deployment.Resources, "a", "b", "c", "e")
 				},
@@ -70,6 +74,7 @@ func TestSteps(t *testing.T) {
 				Dir:      "step3",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.NotNil(t, stackInfo.Deployment)
 					validateResources(t, stackInfo.Deployment.Resources, "a", "c", "e")
 				},
@@ -78,6 +83,7 @@ func TestSteps(t *testing.T) {
 				Dir:      "step4",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.NotNil(t, stackInfo.Deployment)
 					validateResources(t, stackInfo.Deployment.Resources, "a", "c", "e")
 				},
@@ -86,6 +92,7 @@ func TestSteps(t *testing.T) {
 				Dir:      "step5",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.NotNil(t, stackInfo.Deployment)
 					validateResources(t, stackInfo.Deployment.Resources, "a", "c", "e")
 				},
@@ -94,6 +101,7 @@ func TestSteps(t *testing.T) {
 				Dir:      "step6",
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
 					assert.NotNil(t, stackInfo.Deployment)
 					validateResources(t, stackInfo.Deployment.Resources)
 				},

--- a/tests/integration/transformations/transformations_test.go
+++ b/tests/integration/transformations/transformations_test.go
@@ -17,6 +17,8 @@ var Dirs = []string{
 }
 
 func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+	t.Helper()
+
 	randomResName := "testprovider:index:Random"
 	foundRes1 := false
 	foundRes2Child := false

--- a/tests/integration/types/types_test.go
+++ b/tests/integration/types/types_test.go
@@ -25,6 +25,8 @@ func TestPythonTypes(t *testing.T) {
 					filepath.Join("..", "..", "..", "sdk", "python", "env", "src"),
 				},
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					for _, res := range []string{"", "2", "3", "4"} {
 						assert.Equal(t, "hello", stack.Outputs[fmt.Sprintf("res%s_first_value", res)])
 						assert.Equal(t, 42.0, stack.Outputs[fmt.Sprintf("res%s_second_value", res)])

--- a/tests/integration/valid-property-names/steps_test.go
+++ b/tests/integration/valid-property-names/steps_test.go
@@ -54,6 +54,8 @@ func TestPropertyNameDiffs(t *testing.T) {
 				},
 				Quick: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					t.Helper()
+
 					require.NotNil(t, stackInfo.Deployment)
 					res, err := getResource(stackInfo, "a")
 					assert.NoError(t, err)
@@ -65,6 +67,8 @@ func TestPropertyNameDiffs(t *testing.T) {
 						Dir:      "step2",
 						Additive: true,
 						ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+							t.Helper()
+
 							require.NotNil(t, stackInfo.Deployment)
 							_, err := getResource(stackInfo, "a")
 							assert.NoError(t, err)

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -620,6 +620,8 @@ func TestLocalStateLocking(t *testing.T) {
 // stackFileFormatAsserters returns a function to assert that the current file
 // format is for gzip and plain formats respectively.
 func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, projectName, stackName string) (func(), func()) {
+	t.Helper()
+
 	stacksDir := filepath.Join(".pulumi", "stacks", projectName)
 	pathStack := filepath.Join(stacksDir, stackName+".json")
 	pathStackGzip := pathStack + ".gz"
@@ -738,6 +740,8 @@ func filterOutAttrsFiles(files []os.DirEntry) []os.DirEntry {
 }
 
 func assertBackupStackFile(t *testing.T, stackName string, file os.DirEntry, before int64, after int64) {
+	t.Helper()
+
 	assert.False(t, file.IsDir())
 	fi, err := file.Info()
 	assert.NoError(t, err)


### PR DESCRIPTION
Enable the thelper linter and add t.Helper() functions to the beginning of each test helper function.  This makes the test output a bit more easy to consume.

I ran into missing `t.Helper()` functions a couple of times while debugging tests, and I figured it might be worth just adding them everywhere, which will be especially helpful if there's any flakes in these helper functions.  

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`