### PR TITLE
Allow the engine to infer additional secret properties of resources from their schema when being registered

### DIFF
--- a/changelog/pending/20240208--engine--allow-the-engine-to-infer-additional-secret-properties-of-resources-from-their-schema-when-being-registered.yaml
+++ b/changelog/pending/20240208--engine--allow-the-engine-to-infer-additional-secret-properties-of-resources-from-their-schema-when-being-registered.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Allow the engine to infer additional secret properties of resources from their schema when being registered

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -881,7 +881,8 @@ func (eng *languageTestServer) RunLanguageTest(
 			Stderr: stderr,
 		},
 		Engine: engine.UpdateOptions{
-			Host: pctx.Host,
+			Host:   pctx.Host,
+			Loader: loader,
 		},
 	}
 	sm := b64secrets.NewBase64SecretsManager()

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -416,7 +416,6 @@ func newPreviewCmd() *cobra.Command {
 			if err != nil {
 				return result.FromError(err)
 			}
-
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
 					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -144,7 +144,7 @@ func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version)
 	defer l.m.Unlock()
 
 	key := packageIdentity(pkg, version)
-	if p, ok := l.getPackage(key); ok && version == nil {
+	if p, ok := l.getPackage(key); ok {
 		return p, nil
 	}
 

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 
@@ -183,6 +185,9 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 		return nil, err
 	}
 
+	if plugctx.Host != nil && opts.Loader == nil {
+		opts.Loader = schema.NewPluginLoader(plugctx.Host)
+	}
 	// Keep the plugin context open until the context is terminated, to allow for graceful provider cancellation.
 	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Terminated())
 

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -46,8 +46,11 @@ func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 	}
 	p.Run(t, nil)
 
-	// We should have started the provider 10 times, twice for each of the steps in the basic lifecycle (one preview,
+	// We should have started the provider 14 times, twice for each of the steps in the basic lifecycle (one preview,
 	// one up), but zero for the last refresh step where the provider is not needed.
+	// Twice per resource step when we load the schema for the provider.
+	// TODO: this should be 10 times because schema loading should not startup a provider
+	// more times than necessary.
 	assert.Equal(t, 14, startupCount)
 }
 

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -48,7 +48,7 @@ func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 
 	// We should have started the provider 10 times, twice for each of the steps in the basic lifecycle (one preview,
 	// one up), but zero for the last refresh step where the provider is not needed.
-	assert.Equal(t, 10, startupCount)
+	assert.Equal(t, 14, startupCount)
 }
 
 func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -503,7 +503,7 @@ func TestBadResourceType(t *testing.T) {
 		assert.Contains(t, rpcerr.Message(), "Type 'very:bad' is not a valid type token")
 
 		// Component resources may have any format type.
-		_, _, _, _, noErr := mon.RegisterResource("a:component", "resB", false)
+		_, _, _, _, noErr := mon.RegisterResource("a:index:component", "resB", false)
 		assert.NoError(t, noErr)
 
 		_, _, _, _, noErr = mon.RegisterResource("singlename", "resC", false)

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -155,6 +157,9 @@ type UpdateOptions struct {
 
 	// the plugin host to use for this update
 	Host plugin.Host
+
+	// the schema loader to use for this update
+	Loader schema.ReferenceLoader
 
 	// The plan to use for the update, if any.
 	Plan *deploy.Plan
@@ -470,15 +475,17 @@ func newUpdateSource(ctx context.Context,
 		args = []string{plugctx.Host.ServerAddr()}
 	}
 
-	// If that succeeded, create a new source that will perform interpretation of the compiled program.
-	return deploy.NewEvalSource(plugctx, &deploy.EvalRunInfo{
+	evalInfo := &deploy.EvalRunInfo{
 		Proj:        proj,
 		Pwd:         pwd,
 		Program:     main,
 		ProjectRoot: projectRoot,
 		Args:        args,
 		Target:      target,
-	}, defaultProviderVersions, dryRun), nil
+	}
+
+	// create a new source that will perform interpretation of the compiled program.
+	return deploy.NewEvalSource(plugctx, evalInfo, defaultProviderVersions, dryRun, opts.Loader), nil
 }
 
 func update(ctx *Context, info *deploymentContext, opts *deploymentOptions,

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1433,20 +1433,20 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	}
 
 	additionalSecretOutputs := req.GetAdditionalSecretOutputs()
-	if rm.loader != nil {
-		// try to load the package reference and infer which properties are supposed to be secret.
-		var version *semver.Version
-		if parsedVersion, err := semver.Parse(req.GetVersion()); err == nil {
-			version = &parsedVersion
-		}
-		if typeToken, err := tokens.ParseTypeToken(req.Type); err == nil {
-			packageName := typeToken.Package().String()
-			if pkgReference, err := rm.loader.LoadPackageReference(packageName, version); err == nil {
-				if resourceSchema, found, err := pkgReference.Resources().Get(req.Type); err == nil && found {
-					for _, outputProperty := range resourceSchema.Properties {
-						if outputProperty.Secret {
-							additionalSecretOutputs = append(additionalSecretOutputs, outputProperty.Name)
-						}
+
+	// try to load the package reference and infer which properties are supposed to be secret.
+	var version *semver.Version
+	if parsedVersion, err := semver.Parse(req.GetVersion()); err == nil {
+		version = &parsedVersion
+	}
+
+	if typeToken, err := tokens.ParseTypeToken(req.Type); err == nil {
+		packageName := typeToken.Package().String()
+		if pkgReference, err := rm.loader.LoadPackageReference(packageName, version); err == nil {
+			if resourceSchema, found, err := pkgReference.Resources().Get(req.Type); err == nil && found {
+				for _, outputProperty := range resourceSchema.Properties {
+					if outputProperty.Secret {
+						additionalSecretOutputs = append(additionalSecretOutputs, outputProperty.Name)
 					}
 				}
 			}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -3079,6 +3079,7 @@ func TestRegisterResource(t *testing.T) {
 			cancel := make(chan bool, 1)
 			cancel <- true
 			rm := &resmon{
+				loader: emptySchemaLoader(t),
 				cancel: cancel,
 			}
 			_, err := rm.RegisterResource(context.Background(), &pulumirpc.RegisterResourceRequest{})
@@ -3094,6 +3095,7 @@ func TestRegisterResource(t *testing.T) {
 			}()
 
 			rm := &resmon{
+				loader:  emptySchemaLoader(t),
 				regChan: regChan,
 				cancel:  cancel,
 			}
@@ -3110,6 +3112,7 @@ func TestRegisterResource(t *testing.T) {
 			}()
 
 			rm := &resmon{
+				loader:  emptySchemaLoader(t),
 				regChan: regChan,
 				cancel:  cancel,
 			}
@@ -3144,7 +3147,7 @@ func TestRegisterResource(t *testing.T) {
 				State: &resource.State{},
 			}
 		}()
-		rm := &resmon{}
+		rm := &resmon{loader: emptySchemaLoader(t)}
 		req := &pulumirpc.RegisterResourceRequest{
 			Type:    "foo:bar:some-type",
 			Version: "improper-version",
@@ -3163,7 +3166,7 @@ func TestRegisterResource(t *testing.T) {
 				State: &resource.State{},
 			}
 		}()
-		rm := &resmon{}
+		rm := &resmon{loader: emptySchemaLoader(t)}
 		req := &pulumirpc.RegisterResourceRequest{
 			Type:    "pulumi:providers:some-type",
 			Version: "improper-version",
@@ -3175,7 +3178,7 @@ func TestRegisterResource(t *testing.T) {
 	})
 	t.Run("invalid alias URN", func(t *testing.T) {
 		t.Parallel()
-		rm := &resmon{}
+		rm := &resmon{loader: emptySchemaLoader(t)}
 		req := &pulumirpc.RegisterResourceRequest{
 			Type: "pulumi:providers:some-type",
 			AliasURNs: []string{
@@ -3188,6 +3191,7 @@ func TestRegisterResource(t *testing.T) {
 	t.Run("invalid dependency on property", func(t *testing.T) {
 		t.Parallel()
 		rm := &resmon{
+			loader: emptySchemaLoader(t),
 			defaultProviders: &defaultProviders{
 				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{},
 			},
@@ -3220,6 +3224,7 @@ func TestRegisterResource(t *testing.T) {
 				}
 			}()
 			rm := &resmon{
+				loader: emptySchemaLoader(t),
 				defaultProviders: &defaultProviders{
 					requests: requests,
 					config: &configSourceMock{
@@ -3254,6 +3259,7 @@ func TestRegisterResource(t *testing.T) {
 				}
 			}()
 			rm := &resmon{
+				loader: emptySchemaLoader(t),
 				defaultProviders: &defaultProviders{
 					requests: requests,
 					config: &configSourceMock{
@@ -3292,6 +3298,7 @@ func TestRegisterResource(t *testing.T) {
 				}
 			}()
 			rm := &resmon{
+				loader: emptySchemaLoader(t),
 				defaultProviders: &defaultProviders{
 					requests: requests,
 					config: &configSourceMock{
@@ -3328,6 +3335,7 @@ func TestRegisterResource(t *testing.T) {
 			}
 		}()
 		rm := &resmon{
+			loader: emptySchemaLoader(t),
 			defaultProviders: &defaultProviders{
 				requests: requests,
 				config: &configSourceMock{
@@ -3389,6 +3397,7 @@ func TestRegisterResource(t *testing.T) {
 				}
 			}()
 			rm := &resmon{
+				loader:  emptySchemaLoader(t),
 				regChan: regChan,
 				componentProviders: map[resource.URN]map[string]string{
 					"urn:pulumi:stack::project::type::foo": {
@@ -3445,6 +3454,7 @@ func TestRegisterResource(t *testing.T) {
 					}
 				}()
 				rm := &resmon{
+					loader:             emptySchemaLoader(t),
 					regChan:            regChan,
 					componentProviders: map[resource.URN]map[string]string{},
 				}
@@ -3466,6 +3476,7 @@ func TestRegisterResource(t *testing.T) {
 					}
 				}()
 				rm := &resmon{
+					loader:             emptySchemaLoader(t),
 					regChan:            regChan,
 					componentProviders: map[resource.URN]map[string]string{},
 				}

--- a/tests/integration/aliases/go/rename/step1/main.go
+++ b/tests/integration/aliases/go/rename/step1/main.go
@@ -16,6 +16,6 @@ type FooComponent struct {
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		fooComponent := &FooComponent{}
-		return ctx.RegisterComponentResource("foo:component", "foo", fooComponent)
+		return ctx.RegisterComponentResource("foo:index:component", "foo", fooComponent)
 	})
 }

--- a/tests/integration/aliases/go/rename/step2/main.go
+++ b/tests/integration/aliases/go/rename/step2/main.go
@@ -20,6 +20,6 @@ func main() {
 			Name: pulumi.String("foo"),
 		}
 		opts := pulumi.Aliases([]pulumi.Alias{*alias})
-		return ctx.RegisterComponentResource("foo:component", "newfoo", fooComponent, opts)
+		return ctx.RegisterComponentResource("foo:index:component", "newfoo", fooComponent, opts)
 	})
 }


### PR DESCRIPTION
# Description

As part of exposing schema loading to language plugins which will enable conformance tests for YAML, we are making the engine itself use schema loading. This PR implements extends the main resource monitor to infer the additional secret output properties of registered resources from their schema. Today these additional secret output property keys are being sent by the language SDKs (they are code-generated for each resource). The idea is that this will also simplify SDK-gen so that it no longer needs to emit additional secret outputs, aliases, etc.


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
