### PR TITLE
Update engine test to use GRPC and fix issues

### DIFF
--- a/changelog/pending/20240208--components-go--component-providers-now-correctly-return-output-values-to-the-engine.yaml
+++ b/changelog/pending/20240208--components-go--component-providers-now-correctly-return-output-values-to-the-engine.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: components/go
+  description: Component providers now correctly return output values to the engine.

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -4875,118 +4875,129 @@ func TestConstructCallSecretsUnknowns(t *testing.T) {
 func TestConstructCallReturnDependencies(t *testing.T) {
 	t.Parallel()
 
-	loaders := []*deploytest.ProviderLoader{
-		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return &deploytest.Provider{
-				CreateF: func(urn resource.URN, inputs resource.PropertyMap, timeout float64,
-					preview bool,
-				) (resource.ID, resource.PropertyMap, resource.Status, error) {
-					return "created-id", inputs, resource.StatusOK, nil
-				},
-				ReadF: func(urn resource.URN, id resource.ID,
-					inputs, state resource.PropertyMap,
-				) (plugin.ReadResult, resource.Status, error) {
-					return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
-				},
-				ConstructF: func(monitor *deploytest.ResourceMonitor, typ, name string, parent resource.URN,
-					inputs resource.PropertyMap, info plugin.ConstructInfo, options plugin.ConstructOptions,
-				) (plugin.ConstructResult, error) {
-					urn, _, _, _, err := monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{})
-					assert.NoError(t, err)
+	test := func(t *testing.T, opt deploytest.PluginOption) {
+		loaders := []*deploytest.ProviderLoader{
+			deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+				return &deploytest.Provider{
+					CreateF: func(urn resource.URN, inputs resource.PropertyMap, timeout float64,
+						preview bool,
+					) (resource.ID, resource.PropertyMap, resource.Status, error) {
+						return "created-id", inputs, resource.StatusOK, nil
+					},
+					ReadF: func(urn resource.URN, id resource.ID,
+						inputs, state resource.PropertyMap,
+					) (plugin.ReadResult, resource.Status, error) {
+						return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
+					},
+					ConstructF: func(monitor *deploytest.ResourceMonitor, typ, name string, parent resource.URN,
+						inputs resource.PropertyMap, info plugin.ConstructInfo, options plugin.ConstructOptions,
+					) (plugin.ConstructResult, error) {
+						urn, _, _, _, err := monitor.RegisterResource(tokens.Type(typ), name, false, deploytest.ResourceOptions{})
+						assert.NoError(t, err)
 
-					urnA, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", name+"-a", true, deploytest.ResourceOptions{
-						Parent: urn,
-					})
-					assert.NoError(t, err)
+						urnA, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", name+"-a", true, deploytest.ResourceOptions{
+							Parent: urn,
+						})
+						assert.NoError(t, err)
 
-					// Return a secret and unknown output depending on some internal resource
-					deps := []resource.URN{urnA}
-					return plugin.ConstructResult{
-						URN: urn,
-						Outputs: resource.PropertyMap{
-							"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-							"bar": resource.MakeComputed(resource.NewStringProperty("")),
-						},
-						OutputDependencies: map[resource.PropertyKey][]resource.URN{
-							"foo": deps,
-							"bar": deps,
-						},
-					}, nil
-				},
-				CallF: func(monitor *deploytest.ResourceMonitor,
-					tok tokens.ModuleMember, args resource.PropertyMap,
-					info plugin.CallInfo, options plugin.CallOptions,
-				) (plugin.CallResult, error) {
-					// Assume a single output arg that this call depends on
-					arg := args["arg"]
-					deps := arg.OutputValue().Dependencies
+						// Return a secret and unknown output depending on some internal resource
+						deps := []resource.URN{urnA}
+						return plugin.ConstructResult{
+							URN: urn,
+							Outputs: resource.PropertyMap{
+								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+							},
+							OutputDependencies: map[resource.PropertyKey][]resource.URN{
+								"foo": deps,
+								"bar": deps,
+							},
+						}, nil
+					},
+					CallF: func(monitor *deploytest.ResourceMonitor,
+						tok tokens.ModuleMember, args resource.PropertyMap,
+						info plugin.CallInfo, options plugin.CallOptions,
+					) (plugin.CallResult, error) {
+						// Assume a single output arg that this call depends on
+						arg := args["arg"]
+						deps := arg.OutputValue().Dependencies
 
-					return plugin.CallResult{
-						Return: resource.PropertyMap{
-							"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-							"bar": resource.MakeComputed(resource.NewStringProperty("")),
-						},
-						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
-							"foo": deps,
-							"bar": deps,
-						},
-					}, nil
-				},
-			}, nil
-		}),
-	}
+						return plugin.CallResult{
+							Return: resource.PropertyMap{
+								"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
+								"bar": resource.MakeComputed(resource.NewStringProperty("")),
+							},
+							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
+								"foo": deps,
+								"bar": deps,
+							},
+						}, nil
+					},
+				}, nil
+			}, opt),
+		}
 
-	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, state, deps, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
-			Remote: true,
+		programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, state, deps, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
+				Remote: true,
+			})
+			assert.NoError(t, err)
+
+			// The urn of the internal resource the component created
+			urn := resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typA::resA-a")
+
+			// Assert that the outputs are received as just plain values because SDKs don't yet support output
+			// values returned from RegisterResource.
+			assert.Equal(t, resource.PropertyMap{
+				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+			}, state)
+			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+				"foo": {urn},
+				"bar": {urn},
+			}, deps)
+
+			result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
+				// Send this as an output value using the dependencies returned.
+				"arg": resource.NewOutputProperty(resource.Output{
+					Element:      state["foo"].SecretValue().Element,
+					Known:        true,
+					Secret:       true,
+					Dependencies: []resource.URN{urn},
+				}),
+			}, "", "")
+			assert.NoError(t, err)
+
+			// Assert that the outputs are received as just plain values because SDKs don't yet support output
+			// values returned from Call.
+			assert.Equal(t, resource.PropertyMap{
+				"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
+				"bar": resource.MakeComputed(resource.NewStringProperty("")),
+			}, result)
+			assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+				"foo": {urn},
+				"bar": {urn},
+			}, deps)
+
+			return nil
 		})
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+		p := &TestPlan{
+			Options: TestUpdateOptions{HostF: hostF},
+		}
+
+		project := p.GetProject()
+		_, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, true, p.BackendClient, nil)
 		assert.NoError(t, err)
-
-		// The urn of the internal resource the component created
-		urn := resource.URN("urn:pulumi:test::test::pkgA:m:typA$pkgA:m:typA::resA-a")
-
-		// Assert that the outputs are received as just plain values because SDKs don't yet support output
-		// values returned from RegisterResource.
-		assert.Equal(t, resource.PropertyMap{
-			"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-			"bar": resource.MakeComputed(resource.NewStringProperty("")),
-		}, state)
-		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
-			"foo": {urn},
-			"bar": {urn},
-		}, deps)
-
-		result, deps, _, err := monitor.Call("pkgA:m:typA", resource.PropertyMap{
-			// Send this as an output value using the dependencies returned.
-			"arg": resource.NewOutputProperty(resource.Output{
-				Element:      state["foo"].SecretValue().Element,
-				Known:        true,
-				Secret:       true,
-				Dependencies: []resource.URN{urn},
-			}),
-		}, "", "")
-		assert.NoError(t, err)
-
-		// Assert that the outputs are received as just plain values because SDKs don't yet support output
-		// values returned from Call.
-		assert.Equal(t, resource.PropertyMap{
-			"foo": resource.MakeSecret(resource.NewStringProperty("foo")),
-			"bar": resource.MakeComputed(resource.NewStringProperty("")),
-		}, result)
-		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
-			"foo": {urn},
-			"bar": {urn},
-		}, deps)
-
-		return nil
-	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-
-	p := &TestPlan{
-		Options: TestUpdateOptions{HostF: hostF},
 	}
 
-	project := p.GetProject()
-	_, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
-	assert.NoError(t, err)
+	t.Run("WithGrpc", func(t *testing.T) {
+		t.Parallel()
+		test(t, deploytest.WithGrpc)
+	})
+	t.Run("WithoutGrpc", func(t *testing.T) {
+		t.Parallel()
+		test(t, deploytest.WithoutGrpc)
+	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

So it turned out that the server code for providers was set up to never return output values. I don't think any actual providers  used this code but it meant the tests running in GRPC mode started to fail.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
