### PR TITLE
Program dependencies aren't necessarily semantic versions

### DIFF
--- a/changelog/pending/20240208--engine--engine-no-longer-assumes-program-dependencies-are-specified-as-semantic-versions.yaml
+++ b/changelog/pending/20240208--engine--engine-no-longer-assumes-program-dependencies-are-specified-as-semantic-versions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Engine no longer assumes program dependencies are specified as semantic versions.

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -811,7 +811,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		return makeTestResponse(fmt.Sprintf("get program dependencies: %v", err)), nil
 	}
 	expectedDependencies := []plugin.DependencyInfo{
-		{Name: "pulumi", Version: semver.MustParse("1.0.1")},
+		{Name: "pulumi", Version: "1.0.1"},
 	}
 	for _, provider := range test.providers {
 		pkg := string(provider.Pkg())
@@ -821,7 +821,7 @@ func (eng *languageTestServer) RunLanguageTest(
 		}
 		expectedDependencies = append(expectedDependencies, plugin.DependencyInfo{
 			Name:    pkg,
-			Version: version,
+			Version: version.String(),
 		})
 	}
 	for _, expectedDependency := range expectedDependencies {
@@ -831,12 +831,12 @@ func (eng *languageTestServer) RunLanguageTest(
 		// found is the version we've found for this dependency, if any. We fuzzy match by name and then check version
 		// so this is just to give better error messages. For our main dependencies we should have a different version
 		// for every package, so the fuzzy check by name then exact check by version should be unique.
-		var found *semver.Version
+		var found *string
 		for _, actual := range dependencies {
 			actual := actual
 			if strings.Contains(strings.ToLower(actual.Name), strings.ToLower(expectedDependency.Name)) {
 				found = &actual.Version
-				if expectedDependency.Version.Equals(actual.Version) {
+				if expectedDependency.Version == actual.Version {
 					break
 				}
 			}
@@ -844,9 +844,9 @@ func (eng *languageTestServer) RunLanguageTest(
 
 		if found == nil {
 			return makeTestResponse(fmt.Sprintf("missing expected dependency %s", expectedDependency.Name)), nil
-		} else if !expectedDependency.Version.Equals(*found) {
+		} else if expectedDependency.Version != *found {
 			return makeTestResponse(fmt.Sprintf("dependency %s has unexpected version %s, expected %s",
-				expectedDependency.Name, found, expectedDependency.Version)), nil
+				expectedDependency.Name, *found, expectedDependency.Version)), nil
 		}
 	}
 

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -170,7 +170,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 					for i, dep := range deps {
 						result.Dependencies[i] = programDependencyAbout{
 							Name:    dep.Name,
-							Version: dep.Version.String(),
+							Version: dep.Version,
 						}
 					}
 				}

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -151,9 +151,14 @@ type LanguageRuntime interface {
 	Pack(packageDirectory string, version semver.Version, destinationDirectory string) (string, error)
 }
 
+// DependencyInfo contains information about a dependency reported by a language runtime.
+// These are the languages dependencies, they are not necessarily Pulumi packages.
 type DependencyInfo struct {
-	Name    string
-	Version semver.Version
+	// The name of the dependency.
+	Name string
+	// The version of the dependency. Unlike most versions in the system this is not guaranteed to be a semantic
+	// version.
+	Version string
 }
 
 type AboutInfo struct {

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -376,16 +376,9 @@ func (h *langhost) GetProgramDependencies(info ProgramInfo, transitiveDependenci
 
 	results := slice.Prealloc[DependencyInfo](len(resp.GetDependencies()))
 	for _, dep := range resp.GetDependencies() {
-		var version semver.Version
-		if v := dep.Version; v != "" {
-			version, err = semver.ParseTolerant(v)
-			if err != nil {
-				return nil, errors.Wrapf(err, "illegal semver returned by language host: %s@%s", dep.Name, v)
-			}
-		}
 		results = append(results, DependencyInfo{
 			Name:    dep.Name,
-			Version: version,
+			Version: dep.Version,
 		})
 	}
 


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This weakens the contract of GetProgramDependencies that the versions returned are just "strings". The format of those strings is defined by the language plugin. This is especially useful for python which uses PEP440 not semantic versions for it's pip dependencies.

There wasn't anywhere in the system that took a strong dependency on these being semvers.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
