### PR TITLE
Warn about non-project mode

### DIFF
--- a/changelog/pending/20240130--backend-diy--add-a-warning-that-non-project-mode-will-be-deprecated-at-some-point.yaml
+++ b/changelog/pending/20240130--backend-diy--add-a-warning-that-non-project-mode-will-be-deprecated-at-some-point.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend/diy
+  description: Add a warning that non-project mode will be deprecated at some point.

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -302,6 +302,12 @@ func newDIYBackend(
 	var projectMode bool
 	switch meta.Version {
 	case 0:
+		if !env.DIYBackendAcknowledgeLegacyWarning.Value() {
+			msg := "Legacy non-project mode support for DIY backends are due to be deprecated this year." +
+				" Please migrate to project mode by running 'pulumi state upgrade'." +
+				" You can disable this warning by setting PULUMI_DIY_BACKEND_ACKNOWLEDGE_LEGACY_WARNING to true."
+			d.Warningf(diag.RawMessage("", msg))
+		}
 		backend.store = newLegacyReferenceStore(wbucket)
 	case 1:
 		backend.store = newProjectReferenceStore(wbucket, backend.currentProject.Load)

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -86,6 +86,9 @@ var SkipVersionCheck = env.Bool("AUTOMATION_API_SKIP_VERSION_CHECK",
 
 // Environment variables that affect the DIY backend.
 var (
+	DIYBackendAcknowledgeLegacyWarning = env.Bool("DIY_BACKEND_ACKNOWLEDGE_LEGACY_WARNING",
+		"Disables the warning about legacy non-project mode being due to deprecate.")
+
 	DIYBackendNoLegacyWarning = env.Bool("DIY_BACKEND_NO_LEGACY_WARNING",
 		"Disables the warning about legacy stack files mixed with project-scoped stack files.",
 		env.Alternative("SELF_MANAGED_STATE_NO_LEGACY_WARNING"))


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

In preparation for deprecating non-project mode at some point. This is phase 1 of encouraging users off of legacy mode.

Any time a user opens a backend in legacy mode (either old states, or new states with DIY_BACKEND_LEGACY_LAYOUT set) we'll warn that non-project mode is due to deprecate this year.

They can disable this warning by setting PULUMI_DIY_BACKEND_ACKNOWLEDGE_LEGACY_WARNING to true.

The next phase (in a few months) will turn this into an error which they'll be able to opt out of by setting PULUMI_DIY_BACKEND_ACKNOWLEDGE_LEGACY_ERROR to true.

After that it will be a hard error and all non-project related code will be removed.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
