### PR TITLE
Fix enum rendering issue

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1063,6 +1063,8 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 					enums[lang] = langEnumValues
 				}
 
+				fmt.Printf("enums: %v \n", enums)
+
 				typs = append(typs, docNestedType{
 					Name:       wbr(name),
 					AnchorID:   strings.ToLower(name),

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1063,8 +1063,6 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 					enums[lang] = langEnumValues
 				}
 
-				fmt.Printf("enums: %v \n", enums)
-
 				typs = append(typs, docNestedType{
 					Name:       wbr(name),
 					AnchorID:   strings.ToLower(name),

--- a/pkg/codegen/docs/templates/enums.tmpl
+++ b/pkg/codegen/docs/templates/enums.tmpl
@@ -3,7 +3,7 @@
 {{- range $lang, $enums := . }}
 
 <div>
-<pulumi-choosable type="language" values="{{ print $lang }}">
+<pulumi-choosable type="language" values="{{- if eq $lang "nodejs" -}}{{ print "javascript,typescript" }}{{- else -}}{{ print $lang }}{{- end -}}">
 <dl class="tabular">
 {{- range . -}}
     <dt>{{- htmlSafe .DisplayName -}}</dt>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -483,7 +483,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -541,7 +541,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -1131,7 +1131,7 @@ Container<wbr>Brightness<pulumi-choosable type="language" values="python,go" cla
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Zero<wbr>Point<wbr>One</dt>
     <dd>0.1</dd><dt>One</dt>
     <dd>1</dd></dl>
@@ -1186,7 +1186,7 @@ Container<wbr>Color<pulumi-choosable type="language" values="python,go" class="i
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Red</dt>
     <dd>red</dd><dt>Blue</dt>
     <dd>blue</dd><dt>Yellow</dt>
@@ -1244,7 +1244,7 @@ Container<wbr>Size<pulumi-choosable type="language" values="python,go" class="in
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Four<wbr>Inch</dt>
     <dd>4</dd><dt>Six<wbr>Inch</dt>
     <dd>6</dd><dt>Eight<wbr>Inch</dt>
@@ -1299,7 +1299,7 @@ Diameter<pulumi-choosable type="language" values="python,go" class="inline">, Di
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Sixinch</dt>
     <dd>6</dd><dt>Twelveinch</dt>
     <dd>12</dd></dl>
@@ -1351,7 +1351,7 @@ Farm<pulumi-choosable type="language" values="python,go" class="inline">, Farm<w
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Pulumi_Planters_Inc_</dt>
     <dd>Pulumi Planters Inc.</dd><dt>Plants_R_Us</dt>
     <dd>Plants'R'Us</dd></dl>
@@ -1406,7 +1406,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -1464,7 +1464,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -483,7 +483,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -541,7 +541,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -1131,7 +1131,7 @@ Container<wbr>Brightness<pulumi-choosable type="language" values="python,go" cla
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Zero<wbr>Point<wbr>One</dt>
     <dd>0.1</dd><dt>One</dt>
     <dd>1</dd></dl>
@@ -1186,7 +1186,7 @@ Container<wbr>Color<pulumi-choosable type="language" values="python,go" class="i
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Red</dt>
     <dd>red</dd><dt>Blue</dt>
     <dd>blue</dd><dt>Yellow</dt>
@@ -1244,7 +1244,7 @@ Container<wbr>Size<pulumi-choosable type="language" values="python,go" class="in
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Four<wbr>Inch</dt>
     <dd>4</dd><dt>Six<wbr>Inch</dt>
     <dd>6</dd><dt>Eight<wbr>Inch</dt>
@@ -1299,7 +1299,7 @@ Diameter<pulumi-choosable type="language" values="python,go" class="inline">, Di
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Sixinch</dt>
     <dd>6</dd><dt>Twelveinch</dt>
     <dd>12</dd></dl>
@@ -1351,7 +1351,7 @@ Farm<pulumi-choosable type="language" values="python,go" class="inline">, Farm<w
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Pulumi_Planters_Inc_</dt>
     <dd>Pulumi Planters Inc.</dd><dt>Plants_R_Us</dt>
     <dd>Plants'R'Us</dd></dl>
@@ -1406,7 +1406,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -1464,7 +1464,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -480,7 +480,7 @@ My<wbr>Enum<pulumi-choosable type="language" values="python,go" class="inline">,
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Pi</dt>
     <dd>3.1415</dd><dt>Small</dt>
     <dd>1e-07</dd></dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -565,7 +565,7 @@ Enum<wbr>Overlay<pulumi-choosable type="language" values="python,go" class="inli
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Some<wbr>Enum<wbr>Value</dt>
     <dd>SOME_ENUM_VALUE</dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -1071,7 +1071,7 @@ Enum<wbr>Thing<pulumi-choosable type="language" values="python,go" class="inline
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Four</dt>
     <dd>4</dd><dt>Six</dt>
     <dd>6</dd><dt>Eight</dt>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -480,7 +480,7 @@ Color<pulumi-choosable type="language" values="python,go" class="inline">, Color
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Blue</dt>
     <dd>blue</dd><dt>Red</dt>
     <dd>red</dd></dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -483,7 +483,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -541,7 +541,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -1131,7 +1131,7 @@ Container<wbr>Brightness<pulumi-choosable type="language" values="python,go" cla
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Zero<wbr>Point<wbr>One</dt>
     <dd>0.1</dd><dt>One</dt>
     <dd>1</dd></dl>
@@ -1186,7 +1186,7 @@ Container<wbr>Color<pulumi-choosable type="language" values="python,go" class="i
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Red</dt>
     <dd>red</dd><dt>Blue</dt>
     <dd>blue</dd><dt>Yellow</dt>
@@ -1244,7 +1244,7 @@ Container<wbr>Size<pulumi-choosable type="language" values="python,go" class="in
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Four<wbr>Inch</dt>
     <dd>4</dd><dt>Six<wbr>Inch</dt>
     <dd>6</dd><dt>Eight<wbr>Inch</dt>
@@ -1299,7 +1299,7 @@ Diameter<pulumi-choosable type="language" values="python,go" class="inline">, Di
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Sixinch</dt>
     <dd>6</dd><dt>Twelveinch</dt>
     <dd>12</dd></dl>
@@ -1351,7 +1351,7 @@ Farm<pulumi-choosable type="language" values="python,go" class="inline">, Farm<w
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Pulumi_Planters_Inc_</dt>
     <dd>Pulumi Planters Inc.</dd><dt>Plants_R_Us</dt>
     <dd>Plants'R'Us</dd></dl>
@@ -1406,7 +1406,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>
@@ -1464,7 +1464,7 @@ Tree<wbr>Size<pulumi-choosable type="language" values="python,go" class="inline"
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Small</dt>
     <dd>small</dd><dt>Medium</dt>
     <dd>medium</dd><dt>Large</dt>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -565,7 +565,7 @@ Enum<wbr>Overlay<pulumi-choosable type="language" values="python,go" class="inli
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Some<wbr>Enum<wbr>Value</dt>
     <dd>SOME_ENUM_VALUE</dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -1274,7 +1274,7 @@ Output<wbr>Only<wbr>Enum<wbr>Type<pulumi-choosable type="language" values="pytho
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Foo</dt>
     <dd>foo</dd><dt>Bar</dt>
     <dd>bar</dd></dl>
@@ -1417,7 +1417,7 @@ Rubber<wbr>Tree<wbr>Variety<pulumi-choosable type="language" values="python,go" 
 </div>
 
 <div>
-<pulumi-choosable type="language" values="nodejs">
+<pulumi-choosable type="language" values="javascript,typescript">
 <dl class="tabular"><dt>Burgundy</dt>
     <dd>BurgundyA burgundy rubber tree.</dd><dt>Ruby</dt>
     <dd>RubyA ruby rubber tree.</dd><dt>Tineke</dt>


### PR DESCRIPTION
Fixes: https://github.com/pulumi/registry/issues/3724
Fixes: https://github.com/pulumi/registry/issues/2966

This PR is to resolve the enum rendering issue. The enums were not being rendered on the page at all due to a misconfigured language choosable (i.e. `<pulumi-choosable>`) that wraps the enum section.  I found out this had to do with the lang property being set as `nodejs` when instead the choosable expects `javascript` or `typescript` as the valid values. I then followed the pattern of what we seem to be doing for the other pulumi-choosables which have this issue, which is to  have an if statement that sets it to `javascript,typescript` if `nodejs` is given.

This is how the rendering looks now. I have not adjusted any layouts of the template or anything along those lines, only fixed the choosable. I am wondering if this is actually what was intended for these, as we have a display name in the left column that is ~useless IMO and the right column has the value. I am assuming this was done to match the formatting of the other nested types that are displayed since these enums are treated as such. Though I don't think it is optimal for what we are trying to present given that we do not have descriptions for any of the individual enum values and what they represent.

Should we consider doing something like having a separate enum section that is more purpose built for the data we can display where we just have the enum type in the left column, followed by the valid enum values in the right column. For example:

| Instance Type | a1.2xlarge, a1.4xlarge , a1.large.... |


Should we consider moving to something like this or continue following the current pattern we have? Thoughts welcome!

Also, we can consider shipping this as it is as it is still an improvement over what we have now and file a follow up issue to re-assess the way this is presented.

This is the current render that this PR fix will produce:

<img width="795" alt="Screen Shot 2024-02-09 at 8 35 21 AM" src="https://github.com/pulumi/pulumi/assets/16751381/352462b7-720c-4495-bdfe-f62cfdd946c0">


 