### PR TITLE
Add vim shortcuts and Home and End Keys to terminal

### DIFF
--- a/changelog/pending/20240209--pkg--adds-simple-vim-keyboard-shortcuts-to-the-live-tree-view-j-k-g-g-ctrl-f-ctrl-b-and-also-wires-up-home-and-end-keys.yaml
+++ b/changelog/pending/20240209--pkg--adds-simple-vim-keyboard-shortcuts-to-the-live-tree-view-j-k-g-g-ctrl-f-ctrl-b-and-also-wires-up-home-and-end-keys.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg
+  description: Adds simple vim keyboard shortcuts to the live tree view (j,k,g,G,Ctrl+F,Ctrl+B) and also wires up Home and End keys

--- a/pkg/backend/display/internal/terminal/term.go
+++ b/pkg/backend/display/internal/terminal/term.go
@@ -259,6 +259,8 @@ const (
 	KeyCtrlC    = "ctrl+c"
 	KeyCtrlO    = "ctrl+o"
 	KeyDown     = "down"
+	KeyEnd      = "end"
+	KeyHome     = "home"
 	KeyPageDown = "page-down"
 	KeyPageUp   = "page-up"
 	KeyUp       = "up"
@@ -288,8 +290,12 @@ func (t *terminal) ReadKey() (string, error) {
 	switch d.kind {
 	case ansiKey:
 		switch d.final {
+		case 2: // Ctrl+B --- Vim key for page up (page back)
+			return KeyPageUp, nil
 		case 3: // ETX
 			return KeyCtrlC, nil
+		case 6: // Ctrl+F ---- Vim key for page down (page forward)
+			return KeyPageDown, nil
 		case 15: // SI
 			return KeyCtrlO, nil
 		}
@@ -304,9 +310,25 @@ func (t *terminal) ReadKey() (string, error) {
 		case 'B':
 			// CUD - Cursor Down: CSI (Pn) B
 			return KeyDown, nil
+		case 'F':
+			// Some terminals use CSI F for End, other use CSI 4 ~
+			// Historically this is the SCO mapping for a vt220
+			return KeyEnd, nil
+		case 'H':
+			// Some terminals use CSI H for home, other use CSI 1 ~
+			// in VT100 terms this is CUP (Pl; Pc) H
+			return KeyHome, nil
 		case '~':
 			// DECFNK - Function Key: CSI Ps1 (; Ps2) ~
 			switch string(d.params) {
+			case "1":
+				// Some terminals use CSI H for home, other use CSI 1 ~
+				// which is probably a reinterpretation of the DEC Find key
+				return KeyHome, nil
+			case "4":
+				// Some terminals use CSI F for End, other use CSI 4 ~
+				// which is probably a reinterpretation of the DEC Select key
+				return KeyEnd, nil
 			case "5":
 				// Page Up: CSI 5 ~
 				return KeyPageUp, nil

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -385,12 +385,12 @@ func (r *treeRenderer) handleEvents() {
 						r.showStatusMessage(colors.Red+"could not open browser"+colors.Reset, 5*time.Second)
 					}
 				}
-			case terminal.KeyUp:
+			case terminal.KeyUp, "k":
 				if r.treeTableOffset > 0 {
 					r.treeTableOffset--
 				}
 				r.markDirty()
-			case terminal.KeyDown:
+			case terminal.KeyDown, "j":
 				if r.treeTableOffset < r.maxTreeTableOffset {
 					r.treeTableOffset++
 				}
@@ -412,6 +412,16 @@ func (r *treeRenderer) handleEvents() {
 				if r.maxTreeTableOffset-r.treeTableOffset > termHeight {
 					r.treeTableOffset += termHeight
 				} else {
+					r.treeTableOffset = r.maxTreeTableOffset
+				}
+				r.markDirty()
+			case terminal.KeyHome, "g":
+				if r.treeTableOffset > 0 {
+					r.treeTableOffset = 0
+				}
+				r.markDirty()
+			case terminal.KeyEnd, "G":
+				if r.treeTableOffset < r.maxTreeTableOffset {
 					r.treeTableOffset = r.maxTreeTableOffset
 				}
 				r.markDirty()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Updates the terminal support for the tree view in Pulumi CLI

This adds the vim shortcuts :
`j` &ndash; down
`k` &ndash; up
`Ctrl+F` &ndash; page down 
`Ctrl+B` &ndash; page up
`g` &ndash; home
`G` &ndash; end

Also adds Home and End key support

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
