### PR TITLE
[program-gen] Emit missing trivia for resources and local variables

### DIFF
--- a/changelog/pending/20240211--programgen-dotnet-go-nodejs-python--emit-missing-trivia-for-resources-and-local-variables.yaml
+++ b/changelog/pending/20240211--programgen-dotnet-go-nodejs-python--emit-missing-trivia-for-resources-and-local-variables.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Emit missing trivia for resources and local variables

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1503,6 +1503,7 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 }
 
 func (g *generator) genLocalVariable(w io.Writer, localVariable *pcl.LocalVariable) {
+	g.genTrivia(w, localVariable.Definition.Tokens.Name)
 	variableName := makeValidIdentifier(localVariable.Name())
 	value := localVariable.Definition.Value
 	functionSchema, isInvokeCall := g.isFunctionInvoke(localVariable)

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1254,7 +1254,7 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 }
 
 func (g *generator) genLocalVariable(w io.Writer, v *pcl.LocalVariable) {
-	// TODO(pdg): trivia
+	g.genTrivia(w, v.Definition.Tokens.Name)
 	g.Fgenf(w, "%sconst %s = %.3v;\n", g.Indent, v.Name(), g.lowerExpression(v.Definition.Value, v.Type()))
 }
 

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -1133,7 +1133,7 @@ func (g *generator) genLocalVariable(w io.Writer, v *pcl.LocalVariable) {
 	value, temps := g.lowerExpression(v.Definition.Value, v.Type())
 	g.genTemps(w, temps)
 
-	// TODO(pdg): trivia
+	g.genTrivia(w, v.Definition.Tokens.Name)
 	g.Fgenf(w, "%s%s = %.v\n", g.Indent, PyName(v.Name()), value)
 }
 

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/go/aws-eks.go
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/go/aws-eks.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		// VPC
 		eksVpc, err := ec2.NewVpc(ctx, "eksVpc", &ec2.VpcArgs{
 			CidrBlock:          pulumi.String("10.100.0.0/16"),
 			InstanceTenancy:    pulumi.String("default"),

--- a/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/nodejs/aws-fargate-output-versioned.ts
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/nodejs/aws-fargate-output-versioned.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+// Read the default VPC and public subnets, which we will use.
 const vpc = aws.ec2.getVpcOutput({
     "default": true,
 });

--- a/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/python/aws-fargate-output-versioned.py
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-output-versioned-pp/python/aws-fargate-output-versioned.py
@@ -2,6 +2,7 @@ import pulumi
 import json
 import pulumi_aws as aws
 
+# Read the default VPC and public subnets, which we will use.
 vpc = aws.ec2.get_vpc_output(default=True)
 subnets = aws.ec2.get_subnet_ids_output(vpc_id=vpc.id)
 # Create a security group that permits HTTP ingress and unrestricted egress.

--- a/pkg/codegen/testing/test/testdata/aws-fargate-pp/dotnet/aws-fargate.cs
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-pp/dotnet/aws-fargate.cs
@@ -6,6 +6,7 @@ using Aws = Pulumi.Aws;
 
 return await Deployment.RunAsync(() => 
 {
+    // Read the default VPC and public subnets, which we will use.
     var vpc = Aws.Ec2.GetVpc.Invoke(new()
     {
         Default = true,

--- a/pkg/codegen/testing/test/testdata/aws-fargate-pp/nodejs/aws-fargate.ts
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-pp/nodejs/aws-fargate.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+// Read the default VPC and public subnets, which we will use.
 const vpc = aws.ec2.getVpc({
     "default": true,
 });

--- a/pkg/codegen/testing/test/testdata/aws-fargate-pp/python/aws-fargate.py
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-pp/python/aws-fargate.py
@@ -2,6 +2,7 @@ import pulumi
 import json
 import pulumi_aws as aws
 
+# Read the default VPC and public subnets, which we will use.
 vpc = aws.ec2.get_vpc(default=True)
 subnets = aws.ec2.get_subnet_ids(vpc_id=vpc.id)
 # Create a security group that permits HTTP ingress and unrestricted egress.

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
@@ -36,6 +36,7 @@ func main() {
 			return err
 		}
 		json0 := string(tmpJSON0)
+		// Create a policy with multiple Condition keys
 		policy, err := iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
 			Path:        pulumi.String("/"),
 			Description: pulumi.String("My test policy"),

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a bucket and expose a website index document
 		siteBucket, err := s3.NewBucket(ctx, "siteBucket", &s3.BucketArgs{
 			Website: &s3.BucketWebsiteArgs{
 				IndexDocument: pulumi.String("index.html"),
@@ -21,6 +22,7 @@ func main() {
 			return err
 		}
 		siteDir := "www"
+		// For each file in the directory, create an S3 object stored in `siteBucket`
 		files0, err := os.ReadDir(siteDir)
 		if err != nil {
 			return err
@@ -42,6 +44,7 @@ func main() {
 			}
 			files = append(files, __res)
 		}
+		// Set the access policy for the bucket so all objects are readable
 		_, err = s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(),
 			Policy: siteBucket.ID().ApplyT(func(id string) (pulumi.String, error) {

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/dotnet/aws-webserver.cs
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/dotnet/aws-webserver.cs
@@ -23,6 +23,7 @@ return await Deployment.RunAsync(() =>
         },
     });
 
+    // Get the ID for the latest Amazon Linux AMI.
     var ami = Aws.GetAmi.Invoke(new()
     {
         Filters = new[]

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
@@ -8,6 +8,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a new security group for port 80.
 		securityGroup, err := ec2.NewSecurityGroup(ctx, "securityGroup", &ec2.SecurityGroupArgs{
 			Ingress: ec2.SecurityGroupIngressArray{
 				&ec2.SecurityGroupIngressArgs{
@@ -23,6 +24,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// Get the ID for the latest Amazon Linux AMI.
 		ami, err := aws.GetAmi(ctx, &aws.GetAmiArgs{
 			Filters: []aws.GetAmiFilter{
 				{
@@ -40,6 +42,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// Create a simple web server using the startup script for the instance.
 		server, err := ec2.NewInstance(ctx, "server", &ec2.InstanceArgs{
 			Tags: pulumi.StringMap{
 				"Name": pulumi.String("web-server-www"),

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/nodejs/aws-webserver.ts
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/nodejs/aws-webserver.ts
@@ -8,6 +8,7 @@ const securityGroup = new aws.ec2.SecurityGroup("securityGroup", {ingress: [{
     toPort: 0,
     cidrBlocks: ["0.0.0.0/0"],
 }]});
+// Get the ID for the latest Amazon Linux AMI.
 const ami = aws.getAmi({
     filters: [{
         name: "name",

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/python/aws-webserver.py
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/python/aws-webserver.py
@@ -8,6 +8,7 @@ security_group = aws.ec2.SecurityGroup("securityGroup", ingress=[aws.ec2.Securit
     to_port=0,
     cidr_blocks=["0.0.0.0/0"],
 )])
+# Get the ID for the latest Amazon Linux AMI.
 ami = aws.get_ami(filters=[aws.GetAmiFilterArgs(
         name="name",
         values=["amzn-ami-hvm-*-x86_64-ebs"],

--- a/pkg/codegen/testing/test/testdata/components-pp/go/exampleComponent.go
+++ b/pkg/codegen/testing/test/testdata/components-pp/go/exampleComponent.go
@@ -63,6 +63,7 @@ func NewExampleComponent(
 	if err != nil {
 		return nil, err
 	}
+	// Example of iterating a list of objects
 	var serverPasswords []*random.RandomPassword
 	for index := 0; index < len(args.Servers); index++ {
 		key0 := index
@@ -77,6 +78,7 @@ func NewExampleComponent(
 		}
 		serverPasswords = append(serverPasswords, __res)
 	}
+	// Example of iterating a map of objects
 	var zonePasswords []*random.RandomPassword
 	for key0, val0 := range args.DeploymentZones {
 		__res, err := random.NewRandomPassword(ctx, fmt.Sprintf("%s-zonePasswords-%v", name, key0), &random.RandomPasswordArgs{

--- a/pkg/codegen/testing/test/testdata/functions-pp/dotnet/functions.cs
+++ b/pkg/codegen/testing/test/testdata/functions-pp/dotnet/functions.cs
@@ -41,6 +41,7 @@ return await Deployment.RunAsync(() =>
         "2",
     });
 
+    // tests that we initialize "var, err" with ":=" first, then "=" subsequently (Go specific)
     var zone = Aws.GetAvailabilityZones.Invoke();
 
     var zone2 = Aws.GetAvailabilityZones.Invoke();

--- a/pkg/codegen/testing/test/testdata/functions-pp/go/functions.go
+++ b/pkg/codegen/testing/test/testdata/functions-pp/go/functions.go
@@ -47,6 +47,7 @@ func main() {
 			decoded,
 			"2",
 		}, "-")
+		// tests that we initialize "var, err" with ":=" first, then "=" subsequently (Go specific)
 		_, err := aws.GetAvailabilityZones(ctx, nil, nil)
 		if err != nil {
 			return err
@@ -77,6 +78,7 @@ func main() {
 			return cwd
 		}(os.Getwd())
 		fileMimeType := mime.TypeByExtension(path.Ext("./base64.txt"))
+		// using the filebase64 function
 		_, err = s3.NewBucketObject(ctx, "first", &s3.BucketObjectArgs{
 			Bucket:      bucket.ID(),
 			Source:      pulumi.NewStringAsset(filebase64OrPanic("./base64.txt")),
@@ -90,6 +92,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// using the filebase64sha256 function
 		_, err = s3.NewBucketObject(ctx, "second", &s3.BucketObjectArgs{
 			Bucket: bucket.ID(),
 			Source: pulumi.NewStringAsset(filebase64sha256OrPanic("./base64.txt")),
@@ -97,6 +100,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// using the sha1 function
 		_, err = s3.NewBucketObject(ctx, "third", &s3.BucketObjectArgs{
 			Bucket: bucket.ID(),
 			Source: pulumi.NewStringAsset(sha1Hash("content")),

--- a/pkg/codegen/testing/test/testdata/functions-pp/nodejs/functions.ts
+++ b/pkg/codegen/testing/test/testdata/functions-pp/nodejs/functions.ts
@@ -19,6 +19,7 @@ const joined = [
     decoded,
     "2",
 ].join("-");
+// tests that we initialize "var, err" with ":=" first, then "=" subsequently (Go specific)
 const zone = aws.getAvailabilityZones({});
 const zone2 = aws.getAvailabilityZones({});
 const bucket = new aws.s3.Bucket("bucket", {});

--- a/pkg/codegen/testing/test/testdata/functions-pp/python/functions.py
+++ b/pkg/codegen/testing/test/testdata/functions-pp/python/functions.py
@@ -17,6 +17,7 @@ joined = "-".join([
     decoded,
     "2",
 ])
+# tests that we initialize "var, err" with ":=" first, then "=" subsequently (Go specific)
 zone = aws.get_availability_zones()
 zone2 = aws.get_availability_zones()
 bucket = aws.s3.Bucket("bucket")

--- a/pkg/codegen/testing/test/testdata/invalid-go-sprintf-pp/go/invalid-go-sprintf.go
+++ b/pkg/codegen/testing/test/testdata/invalid-go-sprintf-pp/go/invalid-go-sprintf.go
@@ -8,6 +8,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		// example
 		_, err := appsv1.NewDeployment(ctx, "argocd_serverDeployment", &appsv1.DeploymentArgs{
 			ApiVersion: pulumi.String("apps/v1"),
 			Kind:       pulumi.String("Deployment"),

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
@@ -67,6 +67,7 @@ return await Deployment.RunAsync(() =>
         },
     });
 
+    // Test that we can assign from a constant without type errors
     var kind = bar.Kind;
 
 });

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -57,6 +57,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// Test that we can assign from a constant without type errors
 		_ := bar.Kind
 		return nil
 	})

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
@@ -43,4 +43,5 @@ const bar = new kubernetes.core.v1.Pod("bar", {
         ],
     },
 });
+// Test that we can assign from a constant without type errors
 const kind = bar.kind;

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
@@ -42,4 +42,5 @@ bar = kubernetes.core.v1.Pod("bar",
             ),
         ],
     ))
+# Test that we can assign from a constant without type errors
 kind = bar.kind

--- a/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/dotnet/output-funcs-aws.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/dotnet/output-funcs-aws.cs
@@ -39,6 +39,9 @@ return await Deployment.RunAsync(() =>
         ToPort = 443,
     });
 
+    // A contrived example to test that helper nested records ( `filters`
+    // below) generate correctly when using output-versioned function
+    // invoke forms.
     var amis = Aws.Ec2.GetAmiIds.Invoke(new()
     {
         Owners = new[]

--- a/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/go/output-funcs-aws.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/go/output-funcs-aws.go
@@ -45,6 +45,9 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// A contrived example to test that helper nested records ( `filters`
+		// below) generate correctly when using output-versioned function
+		// invoke forms.
 		_ = ec2.GetAmiIdsOutput(ctx, ec2.GetAmiIdsOutputArgs{
 			Owners: pulumi.StringArray{
 				bar.ID(),

--- a/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/nodejs/output-funcs-aws.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/nodejs/output-funcs-aws.ts
@@ -23,6 +23,9 @@ const privateS3NetworkAclRule = new aws.ec2.NetworkAclRule("privateS3NetworkAclR
     fromPort: 443,
     toPort: 443,
 });
+// A contrived example to test that helper nested records ( `filters`
+// below) generate correctly when using output-versioned function
+// invoke forms.
 const amis = aws.ec2.getAmiIdsOutput({
     owners: [bar.id],
     filters: [{

--- a/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/python/output-funcs-aws.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/python/output-funcs-aws.py
@@ -18,6 +18,9 @@ private_s3_network_acl_rule = aws.ec2.NetworkAclRule("privateS3NetworkAclRule",
     cidr_block=private_s3_prefix_list.cidr_blocks[0],
     from_port=443,
     to_port=443)
+# A contrived example to test that helper nested records ( `filters`
+# below) generate correctly when using output-versioned function
+# invoke forms.
 amis = aws.ec2.get_ami_ids_output(owners=[bar.id],
     filters=[aws.ec2.GetAmiIdsFilterArgs(
         name=bar.id,


### PR DESCRIPTION
# Description

For C#, Python and TypeScript: emit missing comments for local variable declaration
For Go: emit missing comments for local variables and resources


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
