### PR TITLE
Detect npm and yarn workspaces setups

### DIFF
--- a/changelog/pending/20240213--sdk-nodejs--detect-npm-and-yarn-workspaces-setups-when-installing-dependencies.yaml
+++ b/changelog/pending/20240213--sdk-nodejs--detect-npm-and-yarn-workspaces-setups-when-installing-dependencies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Detect npm and yarn workspaces setups when installing dependencies

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -95,9 +95,11 @@ ifneq ($(PULUMI_TEST_COVERAGE_PATH),)
 	if [ -e .nyc_output ]; then yarn run nyc report -r cobertura --report-dir $(PULUMI_TEST_COVERAGE_PATH); fi
 endif
 	@cd cmd/pulumi-language-nodejs && $(GO_TEST_FAST) $(shell go list ./... | grep -v /vendor/ | grep -v templates)
+	$(GO_TEST_FAST) $(shell go list ./...)
 
 test_go:: $(TEST_ALL_DEPS)
 	@cd cmd/pulumi-language-nodejs && $(GO_TEST) $(shell go list ./... | grep -v /vendor/ | grep -v templates)
+	$(GO_TEST) $(shell go list ./...)
 
 test_all:: sxs_tests unit_tests test_auto test_go
 ifneq ($(PULUMI_TEST_COVERAGE_PATH),)

--- a/sdk/nodejs/npm/testdata/nested/package.json
+++ b/sdk/nodejs/npm/testdata/nested/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "nested-project",
+    "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/nested/project/index.ts
+++ b/sdk/nodejs/npm/testdata/nested/project/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is where the pulumi program lives.

--- a/sdk/nodejs/npm/testdata/workspace/package.json
+++ b/sdk/nodejs/npm/testdata/workspace/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "a-workspace-example",
+    "description": "A project that uses npm and yarn workspaces.",
+    "private": true,
+    "workspaces": [
+        "packages/*",
+        "project/"
+    ]
+}

--- a/sdk/nodejs/npm/testdata/workspace/packages/some-package/package.json
+++ b/sdk/nodejs/npm/testdata/workspace/packages/some-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "some-package",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/workspace/project/package.json
+++ b/sdk/nodejs/npm/testdata/workspace/project/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "project",
+    "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/workspaces.go
+++ b/sdk/nodejs/npm/workspaces.go
@@ -1,3 +1,16 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package npm
 
 import (

--- a/sdk/nodejs/npm/workspaces.go
+++ b/sdk/nodejs/npm/workspaces.go
@@ -1,0 +1,93 @@
+package npm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+var ErrNotInWorkspace = errors.New("not in a workspace")
+
+// FindWorkspaceRoot determines if we are in a yarn/npm workspace setup and
+// returns the root directory of the workspace.  If the programDirectory is
+// not in a workspace, it returns ErrNotInWorkspace.
+func FindWorkspaceRoot(programDirectory string) (string, error) {
+	currentDir := filepath.Dir(programDirectory)
+	nextDir := filepath.Dir(currentDir)
+	for currentDir != nextDir { // We're at the root when the nextDir is the same as the currentDir.
+		p := filepath.Join(currentDir, "package.json")
+		_, err := os.Stat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No package.json in this directory, continue the search in the next directory up.
+				currentDir = nextDir
+				nextDir = filepath.Dir(currentDir)
+				continue
+			}
+			return "", err
+		}
+		workspaces, err := parseWorkspaces(p)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse workspaces from %s: %w", p, err)
+		}
+		for _, workspace := range workspaces {
+			// See if any of the workspace glob results is the programDirectory.
+			paths, err := filepath.Glob(filepath.Join(currentDir, workspace))
+			if err != nil {
+				return "", err
+			}
+			if paths != nil && slices.Contains(paths, programDirectory) {
+				return currentDir, nil
+			}
+		}
+		// None of the workspace globs matched the program directory, so we're
+		// in the slightly weird situation where a parent directory has a
+		// package.json with workspaces set up, but the program directory is
+		// not part of this.
+		return "", ErrNotInWorkspace
+	}
+	return "", ErrNotInWorkspace
+}
+
+// parseWorkspaces reads a package.json file and returns the list of workspaces.
+// This supports the simple format for npm and yarn:
+//
+//	{
+//	  "workspaces": ["workspace-a", "workspace-b"]
+//	}
+//
+// As well as the extended format for yarn:
+//
+//	{
+//		"workspaces": {
+//			"packages": ["packages/*"],
+//			"nohoist": ["**/react-native", "**/react-native/**"]
+//		}
+//	}
+func parseWorkspaces(p string) ([]string, error) {
+	pkgContents, err := os.ReadFile(p)
+	if err != nil {
+		return []string{}, err
+	}
+	pkg := struct {
+		Workspaces []string `json:"workspaces"`
+	}{}
+	err = json.Unmarshal(pkgContents, &pkg)
+	if err == nil {
+		return pkg.Workspaces, nil
+	}
+	// Failed to parse the simple format, try to parse extended yarn workspaces format
+	pkgExtended := struct {
+		Workspaces struct {
+			Packages []string `json:"packages"`
+		} `json:"workspaces"`
+	}{}
+	err = json.Unmarshal(pkgContents, &pkgExtended)
+	if err != nil {
+		return []string{}, err
+	}
+	return pkgExtended.Workspaces.Packages, nil
+}

--- a/sdk/nodejs/npm/workspaces_test.go
+++ b/sdk/nodejs/npm/workspaces_test.go
@@ -1,3 +1,16 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package npm
 
 import (

--- a/sdk/nodejs/npm/workspaces_test.go
+++ b/sdk/nodejs/npm/workspaces_test.go
@@ -1,0 +1,25 @@
+package npm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindWorkspaceRoot(filepath.Join("testdata", "workspace", "project"))
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("testdata", "workspace"), root)
+}
+
+func TestFindWorkspaceRootNotInWorkspace(t *testing.T) {
+	t.Parallel()
+
+	_, err := FindWorkspaceRoot(filepath.Join("testdata", "nested", "project"))
+
+	require.ErrorIs(t, err, ErrNotInWorkspace)
+}

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -109,6 +109,8 @@
         "tests/automation/remoteWorkspace.spec.ts",
         "tests/automation/util.ts",
 
-        "tests_with_mocks/mocks.spec.ts"
+        "tests_with_mocks/mocks.spec.ts",
+
+        "npm/testdata/nested/project/index.ts"
     ]
 }

--- a/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/Pulumi.yaml
+++ b/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: npm-workspaces
+runtime: nodejs
+description: This project is not part of the npm/yarn workspaces setup in the parent directory's package.json.

--- a/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+import * as pulumi from "@pulumi/pulumi";
+
+export const project = pulumi.getProject()

--- a/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/index.ts
@@ -1,4 +1,16 @@
-// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import * as pulumi from "@pulumi/pulumi";
 
 export const project = pulumi.getProject()

--- a/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/package.json
+++ b/tests/integration/nodejs/npm-and-yarn-not-a-workspace/infra/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "infra",
+    "description": "This project is not part of the npm/yarn workspaces setup in the parent directory's package.json",
+    "main": "index.ts",
+    "version": "1.0.0",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.104.2"
+    }
+}

--- a/tests/integration/nodejs/npm-and-yarn-not-a-workspace/package.json
+++ b/tests/integration/nodejs/npm-and-yarn-not-a-workspace/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "npm-and-yarn-workspaces",
+    "description": "A project that uses npm and yarn workspaces, but the nested pulumi project `infra` is NOT a workspace",
+    "private": true,
+    "workspaces": [
+        "doesnt-exist/*"
+    ],
+    "dependencies": {
+        "@pulumi/pulumi": "^3.104.2",
+        "@pulumi/aws": "^6.0.0"
+    }
+}

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/infra/Pulumi.yaml
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: npm-workspaces
+runtime: nodejs
+description: Use npm workspaces and import a workspace package in the pulumi program.

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/infra/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/infra/index.ts
@@ -1,4 +1,16 @@
-// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 // If this program runs successfully, then the test passes.
 // Executing this file demonstrates that we're able to successfully install

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/infra/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/infra/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+//
+// If this program runs successfully, then the test passes.
+// Executing this file demonstrates that we're able to successfully install
+// dependencies and run in a npm workspaces setup. 
+
+import * as myRandom from "my-random";
+
+const random = new myRandom.MyRandom("plop", {})
+
+export const id = random.randomID

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/infra/package.json
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/infra/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "infra",
+    "main": "index.ts",
+    "version": "1.0.0",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.104.2",
+        "my-random": "1.0.0"
+    }
+}

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/package.json
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "npm-and-yarn-workspaces",
+    "description": "A project that uses npm and yarn workspaces. `pulumi install` should successfully install dependencies.",
+    "private": true,
+    "workspaces": [
+        "packages/*",
+        "infra/"
+    ]
+}

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/index.ts
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import * as pulumi from "@pulumi/pulumi";
 
 export class MyRandom extends pulumi.ComponentResource {

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/index.ts
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export class MyRandom extends pulumi.ComponentResource {
+  public readonly randomID: pulumi.Output<string>;
+
+  constructor(name: string, opts: pulumi.ResourceOptions) {
+    super("pkg:index:MyRandom", name, {}, opts);
+    this.randomID = pulumi.output(`${name}-${Math.floor(Math.random() * 1000)}`);
+    this.registerOutputs({ randomID: this.randomID });
+  }
+}

--- a/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/package.json
+++ b/tests/integration/nodejs/npm-and-yarn-workspaces/packages/my-random/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my-random",
+  "main": "index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.104.2"
+  }
+}

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/infra/Pulumi.yaml
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: yarn-workspaces-nohoist
+runtime: nodejs
+description: A project that uses yarn workspaces with the nohoist option. `pulumi install` should successfully install dependencies.

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/infra/index.ts
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/infra/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+//
+// If this program runs successfully, then the test passes.
+// Executing this file demonstrates that we're able to successfully install
+// dependencies and run in a yarn workspaces setup. 
+
+import * as myRandom from "my-random";
+
+const random = new myRandom.MyRandom("plop", {})
+
+export const id = random.randomID

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/infra/package.json
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/infra/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "infra",
+    "main": "index.ts",
+    "version": "1.0.0",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.104.2",
+        "my-random": "1.0.0"
+    }
+}

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/package.json
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "yarn-workspaces-nohoist",
+    "description": "A project that uses yarn workspaces with the nohoist option. `pulumi install` should successfully install dependencies.",
+    "private": true,
+    "workspaces": {
+        "packages": [
+            "packages/*",
+            "infra/"
+        ],
+        "nohoist": [
+            "semver"
+        ]
+    }
+}

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/index.ts
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/index.ts
@@ -1,3 +1,16 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import * as pulumi from "@pulumi/pulumi";
 
 export class MyRandom extends pulumi.ComponentResource {

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/index.ts
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export class MyRandom extends pulumi.ComponentResource {
+  public readonly randomID: pulumi.Output<string>;
+
+  constructor(name: string, opts: pulumi.ResourceOptions) {
+    super("pkg:index:MyRandom", name, {}, opts);
+    this.randomID = pulumi.output(`${name}-${Math.floor(Math.random() * 1000)}`);
+    this.registerOutputs({ randomID: this.randomID });
+  }
+}

--- a/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/package.json
+++ b/tests/integration/nodejs/yarn-workspaces-nohoist/packages/my-random/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my-random",
+  "main": "index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.104.2"
+  }
+}


### PR DESCRIPTION
# Description

Make `pulumi install` detect npm and yarn workspaces setups and successfully install dependencies.

Fixes #15435 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

