### PR TITLE
Refactor secret managers to not deal with config data directly.

### DIFF
--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -122,8 +121,8 @@ func (s *diyStack) ImportDeployment(ctx context.Context, deployment *apitype.Unt
 	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
-func (s *diyStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
-	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)
+func (s *diyStack) DefaultSecretManager() (secrets.Manager, error) {
+	return passphrase.NewPromptingPassphraseSecretsManager(false /* rotatePassphraseSecretsProvider */)
 }
 
 type diyStackSummary struct {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -209,8 +209,8 @@ func (s *cloudStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
-func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
-	return service.NewServiceSecretsManager(s.b.Client(), s.StackIdentifier(), info)
+func (s *cloudStack) DefaultSecretManager() (secrets.Manager, error) {
+	return service.NewServiceSecretsManager(s.b.Client(), s.StackIdentifier())
 }
 
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -460,7 +460,7 @@ type MockStack struct {
 		query operations.LogQuery) ([]operations.LogEntry, error)
 	ExportDeploymentF     func(ctx context.Context) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF     func(ctx context.Context, deployment *apitype.UntypedDeployment) error
-	DefaultSecretManagerF func(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManagerF func() (secrets.Manager, error)
 }
 
 var _ Stack = (*MockStack)(nil)
@@ -598,9 +598,9 @@ func (ms *MockStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 	panic("not implemented")
 }
 
-func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
+func (ms *MockStack) DefaultSecretManager() (secrets.Manager, error) {
 	if ms.DefaultSecretManagerF != nil {
-		return ms.DefaultSecretManagerF(info)
+		return ms.DefaultSecretManagerF()
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -69,7 +69,7 @@ type Stack interface {
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 
 	// DefaultSecretManager returns the default secrets manager to use for this stack.
-	DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManager() (secrets.Manager, error)
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.

--- a/pkg/cmd/pulumi/config_env_test.go
+++ b/pkg/cmd/pulumi/config_env_test.go
@@ -119,7 +119,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 						CheckYAMLEnvironmentF: checkYAMLEnvironment,
 					}
 				},
-				DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+				DefaultSecretManagerF: func() (secrets.Manager, error) {
 					return b64.NewBase64SecretsManager(), nil
 				},
 			}, nil

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -228,7 +228,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			snapshot = snap
 			return nil
 		},
-		DefaultSecretManagerF: func(_ *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func() (secrets.Manager, error) {
 			return secretsManager, nil
 		},
 	}

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -16,16 +16,28 @@ package cloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func getState(t *testing.T, url string, key string) json.RawMessage {
+	info := &workspace.ProjectStack{}
+	info.SecretsProvider = url
+	info.EncryptedKey = key
+	smTy, cloudState, err := secrets.GetConfig(info)
+	require.NoError(t, err)
+	require.Equal(t, "cloud", smTy)
+	return cloudState
+}
 
 func getAzureCaller(ctx context.Context, t *testing.T) *azidentity.DefaultAzureCredential {
 	credentials, err := azidentity.NewDefaultAzureCredential(nil)
@@ -79,10 +91,9 @@ func TestAzureKeyVaultExistingKey(t *testing.T) {
 
 	//nolint:lll // this is a base64 encoded key
 	encryptedKeyBase64 := "Ti1qQklqTnlPTWh4RFUtNmd2WmhxcTBHeUFDa0hlS1lmNERwb3dpRHhIRlFMekxyVEdvRTZ6aFV3Q2N1Q1NISmFOeXFqajd6QzY5VmNxQzF1Z0hxRExUQUtJQUhpbE00T0ZFeXU2aUdfeS1YVE9adjlPS0M5aHlYSXdJUGwyZk01Z2FRWmJhckZfQ1kyd3lWRHlXS3JQUDcwWGFQcFBZSWJnQWJuTm5KVF9ua3gyR3I0QnBTZDVabnVrd0ViM0w1NEpjOGFqc29paVZPNVZ6OURmQ0x3MXUzVDZxTHBGLXZpV1VMTlJoQnZTMjRHdzhRWGtmczRfTzZ1NTZWdmxJRWh5TUREOF9tb2YzYlpQY0V5NW1nZDVzVjJWWHhVQWdQQlYwVDFGT2p4cGxvN1VvTUdEWUd1Q1FMcmJBS0JxbEdNZmFtSFRZcDZlYXVTQ3pUd3ptYW93"
-	stackConfig := &workspace.ProjectStack{}
-	stackConfig.SecretsProvider = url
-	stackConfig.EncryptedKey = encryptedKeyBase64
-	manager, err := NewCloudSecretsManager(stackConfig, url, false)
+	cloudState := getState(t, url, encryptedKeyBase64)
+
+	manager, err := NewCloudSecretsManagerFromState(cloudState)
 	require.NoError(t, err)
 
 	enc, err := manager.Encrypter()
@@ -103,13 +114,12 @@ func TestAzureKeyVaultExistingKey(t *testing.T) {
 func TestAzureKeyVaultExistingState(t *testing.T) {
 	ctx := context.Background()
 
+	url := "azurekeyvault://pulumi-testing.vault.azure.net/keys/test-key"
 	//nolint:lll // this includes a base64 encoded key
-	cloudState := `{
-                    "url": "azurekeyvault://pulumi-testing.vault.azure.net/keys/test-key",
-                    "encryptedkey": "c3YwTUQwWjRHYlZXYWpIX3k2Z2twNDFXTlBlRERVOHJKakdTbWFVdk44NWNBWHdQTUJrNFBsRjl5SXJCaEZ5T1VjSVVCTmVkV3NOaWxCbTBOcnotYjVXOHFMRHdWbk9oQTZDMGNyX1p3ZEhiRW1acVpTX1RjazFLd0RmM1RPc3c3Q2s1UTduSXV1NERQYjdUU3ZSdzlDNU5UZ01RRXRhSWgtVGdvM3U0aXVMZV8zY3d5eHhwamIyRW8tYWEyS29XeEpSNXhUb3gxaUQ0dUFfbEszdEx0bXQxVWpod1BCZUJHcmVWd2RmclBUUk1Jcm52ZkZMaS1nQXpLT1VwLVJMQURpX1pVdU9BUFRnLWR2OGpUeGUxNV9pSkN1U25BVUstY2RRemtpRVVheGlsUVlhX2lOa0JXYm95ZUpubEM3eFhNalAwVGhQMUp4ZUI0bmxpcW9YUFFB"
-}
-`
-	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
+	encryptedKeyBase64 := "c3YwTUQwWjRHYlZXYWpIX3k2Z2twNDFXTlBlRERVOHJKakdTbWFVdk44NWNBWHdQTUJrNFBsRjl5SXJCaEZ5T1VjSVVCTmVkV3NOaWxCbTBOcnotYjVXOHFMRHdWbk9oQTZDMGNyX1p3ZEhiRW1acVpTX1RjazFLd0RmM1RPc3c3Q2s1UTduSXV1NERQYjdUU3ZSdzlDNU5UZ01RRXRhSWgtVGdvM3U0aXVMZV8zY3d5eHhwamIyRW8tYWEyS29XeEpSNXhUb3gxaUQ0dUFfbEszdEx0bXQxVWpod1BCZUJHcmVWd2RmclBUUk1Jcm52ZkZMaS1nQXpLT1VwLVJMQURpX1pVdU9BUFRnLWR2OGpUeGUxNV9pSkN1U25BVUstY2RRemtpRVVheGlsUVlhX2lOa0JXYm95ZUpubEM3eFhNalAwVGhQMUp4ZUI0bmxpcW9YUFFB"
+	cloudState := getState(t, url, encryptedKeyBase64)
+
+	manager, err := NewCloudSecretsManagerFromState(cloudState)
 	require.NoError(t, err)
 
 	enc, err := manager.Encrypter()
@@ -125,7 +135,7 @@ func TestAzureKeyVaultExistingState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "plaintext", plaintext)
 
-	assert.JSONEq(t, cloudState, string(manager.State()))
+	assert.JSONEq(t, string(cloudState), string(manager.State()))
 }
 
 //nolint:paralleltest // mutates environment variables
@@ -135,17 +145,15 @@ func TestAzureKeyEditProjectStack(t *testing.T) {
 
 	//nolint:lll // this is a base64 encoded key
 	encryptedKeyBase64 := "cTNpdy1GazRQcklya0gzWFZ6N2hFQXRaOFVfZm1heVZKQVlxQmQwMGh1V0dGNGc4OHhJUXQxVUVmdmViY0xtY01ubEx0bW5tOExEZ0F1VEFLdHgzRjF6S1NDa3EyZ3RHdFFycHk0aUJQWDRFS2lpV2tKMl9WS0lCUnB4QmhmQTJacHBvT1ZUVVZQRWU0Zm1sV1pod3Y4REd5M2p3Vnh3OFFHM2ptdXRRNnJXUzRjVEZGTXpFd3JWeFE5dlo1YTcwWFBIV3o5UFU4SjBGX0dIdlJFSFJpSmJ5c3Q0bS1fenJ6T002RTZacFp0LTVZdl9IT1d5LUo1SkxpbG5VYnFHU2lvbFNpeE9iQ2hWdGk3R28zTlM4ZkQxS2lQVnVMeUJTTDZMNmdoSGZoQXBGdnpwdUJQMWRsTlRaaHZpY0VBa2RQblpYNGJXWVAxTk5yTG5DaHpWeDlB"
-	stackConfig := &workspace.ProjectStack{}
-	stackConfig.SecretsProvider = url
-	stackConfig.EncryptedKey = encryptedKeyBase64
-	manager, err := NewCloudSecretsManager(stackConfig, url, false)
+	cloudState := getState(t, url, encryptedKeyBase64)
+	manager, err := NewCloudSecretsManagerFromState(cloudState)
 	require.NoError(t, err)
 
 	newConfig := &workspace.ProjectStack{}
-	err = EditProjectStack(newConfig, manager.State())
+	err = secrets.SetConfig(manager.Type(), manager.State(), newConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, stackConfig.EncryptedKey, newConfig.EncryptedKey)
+	assert.Equal(t, encryptedKeyBase64, newConfig.EncryptedKey)
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/15329
@@ -158,10 +166,8 @@ func TestAzureKeyVaultExistingKeyState(t *testing.T) {
 
 	//nolint:lll // this is a base64 encoded key
 	encryptedKeyBase64 := "aHROMWFlam5qX0xjVTl3WVhQdzU1alJVbWVvaFU3UENfbzk3dDU2d2FRdUJvYWR1Z0pwdHhiRDU1akRuWFFUdFVPeWNMdlFlemh1UE9IN0txV21RU3NYZDJha0xscWp5RFFTNGQtQ2lhOXRJOGgtSnd0ZHAyOWdkNEx1ejBjVmRvY3NSUlZhdnhtZkNnMTd2TG9vZ0tfbG02Wi1VYnl2Z0xraGNRVzl0T0s2c3BScjdQX2E4NzRaMV8zeTQyb3lLUWx6U1RlYnNmS0xRRDBoZENsT0VSaGlTTHRxazlzMnlKTGpEZ2Q4VUVTSnFzaG9XY2JkVFBnX2NXcWpnQVVjSTRhOEllckE2Z0Y5YXh1eW9DVndoaS1GNGJiN1NPRW5MTEVhZUtIVTZjVFFHeGFoLV9FeVlwTEZKX3dxYzNsRDZ4aU1RdVh0blQ2WG9tZXQ0V3NQMmVn"
-	stackConfig := &workspace.ProjectStack{}
-	stackConfig.SecretsProvider = url
-	stackConfig.EncryptedKey = encryptedKeyBase64
-	manager, err := NewCloudSecretsManager(stackConfig, url, false)
+	cloudState := getState(t, url, encryptedKeyBase64)
+	manager, err := NewCloudSecretsManagerFromState(cloudState)
 	require.NoError(t, err)
 
 	enc, err := manager.Encrypter()
@@ -190,13 +196,13 @@ func TestAzureKeyVaultAutoFix15329(t *testing.T) {
 	// https://github.com/pulumi/pulumi/issues/15329 result in keys like the following being written to state. We can auto-detect these because they aren't valid base64.
 	//nolint:lll // this includes a base64 encoded key
 	encryptedKey := "nLdkXrvtOYvgaVHn8FrdALMtFjgV67KoGIb6kWwz5Weo/yxAVyK7Rl0rtNxoIDnOvkvRQdCDTSrq1q8w6XZU/cvZ5FQMTMN3l1I28r7YV4HIBzDxx0G964DrfUSlxh1GhpQogcLiYor9MCGEidd5BdAqxKMHZJXUGJLCoUuuA3kWBwkeAowstpkumfXzxgxocq2BIkrfPqkfSetmLQajhBNn9dAIgxhaIaM+ubjOAFHkvYlrujE8dY7b2wNVa2ua/3tYfyIBYyg8jFRdOjxXXpXs7cZcRD3oQxa3F1DxYPl/IxuQdyHWxvmYH9SXVKn/B1z7JcOraZDTAptDgc3B0Q=="
-	cloudState := fmt.Sprintf(`{
+	cloudState := []byte(fmt.Sprintf(`{
 		"url": "azurekeyvault://pulumi-testing.vault.azure.net/keys/test-key",
 		"encryptedkey": "%s"
 }
-`, encryptedKey)
+`, encryptedKey))
 
-	manager, err := NewCloudSecretsManagerFromState([]byte(cloudState))
+	manager, err := NewCloudSecretsManagerFromState(cloudState)
 	require.NoError(t, err)
 
 	enc, err := manager.Encrypter()
@@ -214,7 +220,7 @@ func TestAzureKeyVaultAutoFix15329(t *testing.T) {
 
 	// This should now write out a _fixed_ key to state
 	stackConfig := &workspace.ProjectStack{}
-	err = EditProjectStack(stackConfig, manager.State())
+	err = secrets.SetConfig(manager.Type(), manager.State(), stackConfig)
 	require.NoError(t, err)
 
 	// This is the actual expected key we want, it's the same as the one above but with the base64 encoding fixed so it's double wrapped as we expect.

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -17,9 +17,13 @@ package secrets
 
 import (
 	"bytes"
+	b64 "encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // Manager provides the interface for providing stack encryption.
@@ -52,4 +56,116 @@ func AreCompatible(a, b Manager) bool {
 	as := a.State()
 	bs := b.State()
 	return bytes.Equal(as, bs)
+}
+
+// SetConfig sets the manager for the given type and state on the project. This holds all the compatibility code for
+// setting the legacy EncryptionSalt, Key, etc fields.
+func SetConfig(ty string, state json.RawMessage, project *workspace.ProjectStack) error {
+	if ty == "service" {
+		// To change the secrets provider to a serviceSecretsManager we would need to ensure that there are no
+		// remnants of the old secret manager To remove those remnants, we would set those values to be empty in
+		// the project stack.
+		// A passphrase secrets provider has an encryption salt, therefore, changing
+		// from passphrase to serviceSecretsManager requires the encryption salt
+		// to be removed.
+		// A cloud secrets manager has an encryption key and a secrets provider,
+		// therefore, changing from cloud to serviceSecretsManager requires the
+		// encryption key and secrets provider to be removed.
+		// Regardless of what the current secrets provider is, all of these values
+		// need to be empty otherwise `getStackSecretsManager` in crypto.go can
+		// potentially return the incorrect secret type for the stack.
+		project.EncryptionSalt = ""
+		project.SecretsProvider = ""
+		project.EncryptedKey = ""
+		return nil
+	} else if ty == "passphrase" {
+		// If there are any other secrets providers set in the config, remove them, as the passphrase
+		// provider deals only with EncryptionSalt, not EncryptedKey or SecretsProvider.
+		project.EncryptedKey = ""
+
+		// If the secrets provider is explicitly set to "passphrase" we should maintain that when setting
+		// passphrase config. But for all other cases we should clear it out and rely on just having
+		// EncryptionSalt set.
+		if project.SecretsProvider != "passphrase" {
+			project.SecretsProvider = ""
+		}
+
+		var s struct {
+			Salt string `json:"salt"`
+		}
+		err := json.Unmarshal(state, &s)
+		if err != nil {
+			return fmt.Errorf("unmarshalling passphrase state: %w", err)
+		}
+		project.EncryptionSalt = s.Salt
+		/*
+			// If our encryption salt is empty we need to set SecretsProvider to "passphrase" so we roundtrip back
+			// to the passphrase type.
+			if project.EncryptionSalt == "" {
+				project.SecretsProvider = "passphrase"
+			}
+		*/
+		return nil
+	} else if ty == "cloud" {
+		// Only a passphrase provider has an encryption salt. So changing a secrets provider from passphrase to a cloud
+		// secrets provider should ensure that we remove the encryptionsalt as it's a legacy artifact and needs to be
+		// removed
+		project.EncryptionSalt = ""
+
+		var s struct {
+			URL          string `json:"url"`
+			EncryptedKey []byte `json:"encryptedkey"`
+		}
+		err := json.Unmarshal(state, &s)
+		if err != nil {
+			return fmt.Errorf("unmarshalling cloud state: %w", err)
+		}
+		project.SecretsProvider = s.URL
+		project.EncryptedKey = b64.StdEncoding.EncodeToString(s.EncryptedKey)
+	} else {
+		// For now assume anything else doesn't have config. Longer term (i.e. when we get secret plugins) we'll need a
+		// place in the config file to store their state.
+		project.EncryptionSalt = ""
+		project.SecretsProvider = ""
+		project.EncryptedKey = ""
+	}
+
+	return nil
+}
+
+// GetConfig
+func GetConfig(project *workspace.ProjectStack) (string, json.RawMessage, error) {
+	isCloud := project.SecretsProvider != "" &&
+		project.SecretsProvider != "passphrase" &&
+		project.SecretsProvider != "default"
+
+	isPassphrase := project.EncryptionSalt != ""
+
+	if isCloud {
+		var s struct {
+			URL          string `json:"url,omitempty"`
+			EncryptedKey []byte `json:"encryptedkey,omitempty"`
+		}
+		ek, err := b64.StdEncoding.DecodeString(project.EncryptedKey)
+		if err != nil {
+			return "", nil, fmt.Errorf("decoding encrypted key: %w", err)
+		}
+		s.EncryptedKey = ek
+		s.URL = project.SecretsProvider
+
+		bytes, err := json.Marshal(s)
+		contract.Requiref(err == nil, "err", "marshalling cloud state: %v", err)
+		return "cloud", bytes, nil
+	} else if isPassphrase {
+		var s struct {
+			Salt string `json:"salt,omitempty"`
+		}
+		s.Salt = project.EncryptionSalt
+
+		bytes, err := json.Marshal(s)
+		contract.Requiref(err == nil, "err", "marshalling passphrase state: %v", err)
+		return "passphrase", bytes, nil
+	}
+
+	return "", nil, nil
 }

--- a/pkg/secrets/manager_test.go
+++ b/pkg/secrets/manager_test.go
@@ -1,0 +1,169 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secrets defines the interface common to all secret managers.
+package secrets
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		projectStack  workspace.ProjectStack
+		expectedType  string
+		expectedState string
+	}{
+		{
+			name:          "no manager",
+			projectStack:  workspace.ProjectStack{},
+			expectedType:  "",
+			expectedState: "",
+		},
+		{
+			name: "EncryptionSalt",
+			projectStack: workspace.ProjectStack{
+				EncryptionSalt: "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ==",
+			},
+			expectedType:  "passphrase",
+			expectedState: `{"salt":"v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`,
+		},
+		{
+			name: "SecretsProvider",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "awskms://mykey",
+			},
+			expectedType:  "cloud",
+			expectedState: `{"url":"awskms://mykey"}`,
+		},
+		{
+			name: "SecretsProvider+EncryptedKey",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "azurekeyvault://mykey",
+				EncryptedKey:    "Ti1qQklqTnlP", // Note not a full key, not important for this test
+			},
+			expectedType:  "cloud",
+			expectedState: `{"url":"azurekeyvault://mykey","encryptedkey":"Ti1qQklqTnlP"}`,
+		},
+		// Historically we would have picked the cloud provider here just by chance of how the if conditions for
+		// checking each field we're laid out. Ensure we continue to do so.
+		{
+			name: "SecretsProvider+EncryptionSalt",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "awskms://mykey",
+				EncryptionSalt:  "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ==",
+			},
+			expectedType:  "cloud",
+			expectedState: `{"url":"awskms://mykey"}`,
+		},
+		// Historically SecretsProvider could have been explicitly set to passphrase instead of a cloud URL.
+		// These test checks that still works.
+		{
+			name: "SecretsProvider=passphrase+EncryptionSalt",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "passphrase",
+				EncryptionSalt:  "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ==",
+			},
+			expectedType:  "passphrase",
+			expectedState: `{"salt":"v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`,
+		},
+		// Passphrase alone isn't enough to build a passphrase provider, we need the salt. So even if
+		// SecretsProvider is set to passphrase we should return that the system needs to fall back to the
+		// default provider.
+		{
+			name: "SecretsProvider=passphrase",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "passphrase",
+			},
+			expectedType:  "",
+			expectedState: ``,
+		},
+		// Historically we could explicitly set "default" as the secrets provider, this should return the empty
+		// type and no state (because we know it's not cloud, and if Salt was present we'd use passphrase even
+		// if SecretsProvider was set to "default").
+		{
+			name: "SecretsProvider=default",
+			projectStack: workspace.ProjectStack{
+				SecretsProvider: "default",
+				EncryptedKey:    "Ti1qQklqTnlP", // Note not a full key, not important for this test, this is ignored.
+			},
+			expectedType:  "",
+			expectedState: "",
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			typ, state, err := GetConfig(&tt.projectStack)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedType, typ)
+			assert.Equal(t, tt.expectedState, string(state))
+
+			// Test round tripping. Note that the new projectStack might not equal the original one e.g. in the case of
+			// both SecretsProvider and EncryptionSalt being set we would have parsed that to just SecretsProvider. But
+			// once written to ProjectStack and read back again we should get the same result.
+			var projectStack workspace.ProjectStack
+			err = SetConfig(typ, state, &projectStack)
+			require.NoError(t, err)
+
+			rtTyp, rtState, err := GetConfig(&projectStack)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedType, rtTyp)
+			assert.Equal(t, tt.expectedState, string(rtState))
+		})
+	}
+}
+
+func TestExplictPassphrase(t *testing.T) {
+	t.Parallel()
+
+	// Test that if the config explicitly had SecretProvider set to "passphrase" we maintain that when setting
+	// passphrase config.
+	projectStack := workspace.ProjectStack{
+		SecretsProvider: "passphrase",
+	}
+
+	state := `{"salt":"v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}`
+	err := SetConfig("passphrase", []byte(state), &projectStack)
+	require.NoError(t, err)
+
+	assert.Equal(t, "passphrase", projectStack.SecretsProvider)
+}
+
+/*
+func TestPassphraseWithoutSalt(t *testing.T) {
+	t.Parallel()
+
+	// Test that if we set the state to a passphrase without a salt, we explicitly set SecretsProvider.
+	// In practice we shouldn't ever hit this, but it's a good safety net.
+	projectStack := workspace.ProjectStack{
+		EncryptionSalt: "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ==",
+	}
+	state := `{}`
+	err := SetConfig("passphrase", []byte(state), &projectStack)
+	require.NoError(t, err)
+
+	assert.Equal(t, "passphrase", projectStack.SecretsProvider)
+}
+*/

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -123,24 +123,8 @@ func (sm *serviceSecretsManager) Encrypter() (config.Encrypter, error) {
 }
 
 func NewServiceSecretsManager(
-	client *client.Client, id client.StackIdentifier, info *workspace.ProjectStack,
+	client *client.Client, id client.StackIdentifier,
 ) (secrets.Manager, error) {
-	// To change the secrets provider to a serviceSecretsManager we would need to ensure that there are no
-	// remnants of the old secret manager To remove those remnants, we would set those values to be empty in
-	// the project stack.
-	// A passphrase secrets provider has an encryption salt, therefore, changing
-	// from passphrase to serviceSecretsManager requires the encryption salt
-	// to be removed.
-	// A cloud secrets manager has an encryption key and a secrets provider,
-	// therefore, changing from cloud to serviceSecretsManager requires the
-	// encryption key and secrets provider to be removed.
-	// Regardless of what the current secrets provider is, all of these values
-	// need to be empty otherwise `getStackSecretsManager` in crypto.go can
-	// potentially return the incorrect secret type for the stack.
-	info.EncryptionSalt = ""
-	info.SecretsProvider = ""
-	info.EncryptedKey = ""
-
 	state, err := json.Marshal(serviceSecretsManagerState{
 		URL:      client.URL(),
 		Owner:    id.Owner,


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Secret managers now just deal with their JSON state. All the logic of mapping between JSON state and the config files (`workspace.ProjectStack`) is kept in secrets/manager.go `SetConfig` and `GetConfig` methods.

If we add secrets to project config we'll just add the type and state fields directly.

If we add plugin support for secrets they will write raw type and state fields directly to stack config as well.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
