### PR TITLE
Update tests to run on Go 1.21 and 1.22

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -115,7 +115,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
-    "go": "1.20.x",
+    "go": "1.21.x",
     "nodejs": "18.x",
     "python": "3.8.x",
 }
@@ -123,7 +123,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
-    "go": "1.21.x",
+    "go": "1.22.x",
     "nodejs": "21.x",
     "python": "3.12.x",
 }


### PR DESCRIPTION
Go 1.22 has been released https://tip.golang.org/doc/go1.22.