### PR TITLE
Fix TestDestroySetsEncryptionsalt test and resulting bug

### DIFF
--- a/changelog/pending/20240214--cli--fix-pulumi-destroy-to-fill-in-stack-config-with-the-secret-config-from-state-not-fresh-secret-config.yaml
+++ b/changelog/pending/20240214--cli--fix-pulumi-destroy-to-fill-in-stack-config-with-the-secret-config-from-state-not-fresh-secret-config.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `pulumi destroy` to fill in stack config with the secret config from state, not fresh secret config.

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -1147,8 +1147,10 @@ func looksLikeSecret(k config.Key, v string) bool {
 		(info.Entropy >= (entropyThreshold/2) && entropyPerChar >= entropyPerCharThreshold)
 }
 
-func getAndSaveSecretsManager(stack backend.Stack, workspaceStack *workspace.ProjectStack) (secrets.Manager, error) {
-	sm, needsSave, err := getStackSecretsManager(stack, workspaceStack)
+func getAndSaveSecretsManager(
+	stack backend.Stack, workspaceStack *workspace.ProjectStack, fallbackManager secrets.Manager,
+) (secrets.Manager, error) {
+	sm, needsSave, err := getStackSecretsManager(stack, workspaceStack, fallbackManager)
 	if err != nil {
 		return nil, fmt.Errorf("get stack secrets manager: %w", err)
 	}
@@ -1286,7 +1288,7 @@ func getStackConfigurationWithFallback(
 		}
 	}
 
-	sm, err := getAndSaveSecretsManager(stack, workspaceStack)
+	sm, err := getAndSaveSecretsManager(stack, workspaceStack, fallbackSecretsManager)
 	if err != nil {
 		if fallbackSecretsManager != nil {
 			sm = fallbackSecretsManager

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -996,7 +996,7 @@ func promptForConfig(
 		return nil, fmt.Errorf("loading stack config: %w", err)
 	}
 
-	sm, needsSave, err := getStackSecretsManager(stack, ps)
+	sm, needsSave, err := getStackSecretsManager(stack, ps, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -155,7 +155,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(ctx context.Context,
 	}
 
 	// Get the newly created secrets manager for the stack
-	newSecretsManager, needsSave, err := getStackSecretsManager(currentStack, reloadedProjectStack)
+	newSecretsManager, needsSave, err := getStackSecretsManager(currentStack, reloadedProjectStack, nil)
 	if err != nil {
 		return err
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

While working on some other secret manager changes I found that `TestDestroySetsEncryptedkey` wasn't actually fully testing what we thought it was.

Firstly it was a bad name, we're checking for `encryptionsalt` being set not `encryptedkey`. But more importantly it wasn't checking that the salt stayed the same. 

Turned out `destroy` was loading the stack config, seeing no `encryptionsalt` and so new'ing up a brand new passphrase secret manager and state and then saving that to the stack config.

This is now fixed that the test asserts that the salt is exactly what's expected and I've fixed up the engine code to do this correctly.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
