### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pulumi/platform


### PR DESCRIPTION
In this repo we pretty much always want to request a review from the pulumi/platform team.  Add a CODEOWNERS file that makes that so to remove a manual step.

Curious if anyone can think of a reason not to do this.