### PR TITLE
only publish dev releases when the SDK has changes

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -135,7 +135,7 @@ jobs:
   nodejs-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release, matrix]
     runs-on: ubuntu-latest
-#    if: ${{ needs.sdk-check-release.outputs.nodejs-release }} #TODO: enable this after testing
+    if: ${{ needs.sdk-check-release.outputs.nodejs-release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
   python-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release]
     runs-on: ubuntu-latest
-#    if: ${{ needs.sdk-check-release.outputs.python-release }} # TODO: enable this after testing
+    if: ${{ needs.sdk-check-release.outputs.python-release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
For testing purposes we released a new dev SDK on every merge. However this is unnecessary once dev releases are working, and just clogs up the release page/uses extra storage space for the package hosts.

Only publish new dev releases when something actually changed in the SDK, otherwise we can skip publishing.