### PR TITLE
correct latest-dev-version file

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -72,7 +72,7 @@ jobs:
 
   update-dev-version:
     name: update-dev-version
-    needs: [dev-release]
+    needs: [dev-release, info]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -93,11 +93,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
-          version="${{ steps.ghd.outputs.describe }}"
-          # the git describe output includes a 'v' prefix, but we
-          # don't expect that in the latest-dev-version file.  Strip
-          # it here.
-          version="${version#v}"
+          short_sha="${{ steps.ghd.outputs.short-sha }}"
+          version="${{ needs.info.outputs.version }}"
+          version="${version#v}-alpha.${short_sha}"
           pulumictl dispatch -c pulumi-cli-dev-version -r pulumi/docs dev_version="$version"
 
   ci-ok:


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/15299 we changed the versioning scheme of dev releases slightly, as npm and python have slightly different requirements.  However this also means that names of CLI dev releases changed, and thus downloads failed.

Fix that by updating the latest-dev-version file to the new versioning scheme.

Fixes https://github.com/pulumi/pulumi/issues/15443

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
