### PR TITLE
Ensure ArgsDependencies are filled in

### DIFF
--- a/changelog/pending/20240216--engine--test-and-fix-the-engine-filling-in-args-dependencies-to-provider-calls.yaml
+++ b/changelog/pending/20240216--engine--test-and-fix-the-engine-filling-in-args-dependencies-to-provider-calls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Test and fix the engine filling in args dependencies to provider calls.

--- a/pkg/engine/lifecycletest/source_query_test.go
+++ b/pkg/engine/lifecycletest/source_query_test.go
@@ -116,7 +116,7 @@ func TestRunQuery_call_invoke(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		outs, _, _, err := monitor.Call("pkgA:m:typA/methodA", resource.PropertyMap{
 			"name": resource.NewStringProperty("bar"),
-		}, "", "")
+		}, nil, "", "")
 		assert.NoError(t, err)
 		assert.Equal(t, (resource.PropertyMap{
 			"message": resource.NewStringProperty("Hello, bar!"),

--- a/pkg/resource/deploy/deploytest/resourcemonitor_test.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor_test.go
@@ -22,6 +22,8 @@ func TestResourceMonitor_Call_deps(t *testing.T) {
 		// ResourceMonitorClient is unset
 		// so this will panic if an unexpected method is called.
 		CallFunc: func(req *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error) {
+			assert.ElementsMatch(t, req.ArgDependencies["k1"].Urns, []string{"urn1", "urn2"})
+
 			res, err := structpb.NewStruct(map[string]interface{}{
 				"k3": "value3",
 				"k4": "value4",
@@ -44,6 +46,9 @@ func TestResourceMonitor_Call_deps(t *testing.T) {
 			"k1": "value1",
 			"k2": "value2",
 		}),
+		map[resource.PropertyKey][]resource.URN{
+			"k1": {"urn1", "urn2"},
+		},
 		"provider", "1.0")
 	require.NoError(t, err)
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -846,6 +846,11 @@ func (rm *resmon) Call(ctx context.Context, req *pulumirpc.ResourceCallRequest) 
 		argDependencies[resource.PropertyKey(name)] = urns
 	}
 
+	// If we have output values we can add the dependencies from them to the args dependencies map we send to the provider.
+	for key, output := range args {
+		argDependencies[key] = addOutputDependencies(argDependencies[key], output)
+	}
+
 	info := plugin.CallInfo{
 		Project:        rm.constructInfo.Project,
 		Stack:          rm.constructInfo.Stack,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds argsDependencies support to the deploytest resource monitor and add some tests that the engine fills that map in with output values from args if the SDK hasn't filled it in.

We also need to do this the other way (if the SDK fills in argsDependencies but doesn't send output<T> values with those deps to args).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
