### PR TITLE
Use pnpm as package manager if we find a pnpm-lock.yaml file

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -208,9 +208,9 @@ jobs:
             echo "Deleting pulumi"
             rm -rf "$(command -v pulumi.exe)/../pulumi*"
           fi
-      - name: Install yarn
+      - name: Install yarn and pnpm
         run: |
-          npm install -g yarn
+          npm install -g yarn pnpm
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet

--- a/changelog/pending/20240216--sdk-nodejs--use-pnpm-as-package-manager-if-we-find-a-pnpm-lock-yaml-file.yaml
+++ b/changelog/pending/20240216--sdk-nodejs--use-pnpm-as-package-manager-if-we-find-a-pnpm-lock-yaml-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Use pnpm as package manager if we find a pnpm-lock.yaml file

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -54,33 +54,33 @@ func chdir(t *testing.T, dir string) {
 //nolint:paralleltest // changes working directory
 func TestNPMInstall(t *testing.T) {
 	t.Run("development", func(t *testing.T) {
-		testInstall(t, "npm", false /*production*/, "npm")
+		testInstall(t, "npm", false /*production*/)
 	})
 
 	t.Run("production", func(t *testing.T) {
-		testInstall(t, "npm", true /*production*/, "npm")
+		testInstall(t, "npm", true /*production*/)
 	})
 }
 
 //nolint:paralleltest // changes working directory
 func TestYarnInstall(t *testing.T) {
 	t.Run("development", func(t *testing.T) {
-		testInstall(t, "yarn", false /*production*/, "yarn")
+		testInstall(t, "yarn", false /*production*/)
 	})
 
 	t.Run("production", func(t *testing.T) {
-		testInstall(t, "yarn", true /*production*/, "yarn")
+		testInstall(t, "yarn", true /*production*/)
 	})
 }
 
 //nolint:paralleltest // changes working directory
 func TestPnpmInstall(t *testing.T) {
 	t.Run("development", func(t *testing.T) {
-		testInstall(t, "pnpm", false /*production*/, "pnpm")
+		testInstall(t, "pnpm", false /*production*/)
 	})
 
 	t.Run("production", func(t *testing.T) {
-		testInstall(t, "pnpm", true /*production*/, "pnpm")
+		testInstall(t, "pnpm", true /*production*/)
 	})
 }
 
@@ -190,7 +190,7 @@ func writeLockFile(t *testing.T, dir string, packageManager string) {
 	}
 }
 
-func testInstall(t *testing.T, expectedBin string, production bool, packageManager string) {
+func testInstall(t *testing.T, packageManager string, production bool) {
 	// To test this functionality without actually hitting NPM,
 	// we'll spin up a local HTTP server that implements a subset
 	// of the NPM registry API.
@@ -242,7 +242,7 @@ func testInstall(t *testing.T, expectedBin string, production bool, packageManag
 	out := iotest.LogWriter(t)
 	bin, err := Install(context.Background(), pkgdir, production, out, out)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedBin, bin)
+	assert.Equal(t, packageManager, bin)
 }
 
 // fakeNPMRegistry starts up an HTTP server that implements a subset of the NPM registry API

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -67,7 +68,8 @@ func (node *npmManager) Pack(ctx context.Context, dir string, stderr io.Writer) 
 	// Next, we try to read the name of the file from stdout.
 	// packfile is the name of the file containing the tarball,
 	// as produced by `npm pack`.
-	packfile := strings.TrimSpace(stdout.String())
+	packFilename := strings.TrimSpace(stdout.String())
+	packfile := filepath.Join(dir, packFilename)
 	defer os.Remove(packfile)
 
 	packTarball, err := os.ReadFile(packfile)

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -80,7 +80,8 @@ func (pnpm *pnpmManager) Pack(ctx context.Context, dir string, stderr io.Writer)
 	// Next, we try to read the name of the file from stdout.
 	// packfile is the name of the file containing the tarball,
 	// as produced by `pnpm pack`.
-	packfile := strings.TrimSpace(stdout.String())
+	packFilename := strings.TrimSpace(stdout.String())
+	packfile := filepath.Join(dir, packFilename)
 	defer os.Remove(packfile)
 
 	packTarball, err := os.ReadFile(packfile)

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -54,7 +54,7 @@ func (pnpm *pnpmManager) Install(ctx context.Context, dir string, production boo
 }
 
 func (pnpm *pnpmManager) installCmd(ctx context.Context, production bool) *exec.Cmd {
-	args := []string{"install"}
+	args := []string{"install", "--use-stderr"}
 
 	if production {
 		args = append(args, "--production")
@@ -66,7 +66,7 @@ func (pnpm *pnpmManager) installCmd(ctx context.Context, production bool) *exec.
 
 func (pnpm *pnpmManager) Pack(ctx context.Context, dir string, stderr io.Writer) ([]byte, error) {
 	//nolint:gosec // False positive on tained command execution. We aren't accepting input from the user here.
-	command := exec.CommandContext(ctx, pnpm.executable, "pack")
+	command := exec.CommandContext(ctx, pnpm.executable, "pack", "--use-stderr")
 	command.Dir = dir
 
 	// We have to read the name of the file from stdout.

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -1,0 +1,102 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package npm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// pnpm is an alternative package manager for Node.js.
+type pnpmManager struct {
+	executable string
+}
+
+// Assert that pnpm is an instance of PackageManager.
+var _ PackageManager = &pnpmManager{}
+
+func newPnpm() (*pnpmManager, error) {
+	pnpmPath, err := exec.LookPath("pnpm")
+	instance := &pnpmManager{
+		executable: pnpmPath,
+	}
+	return instance, err
+}
+
+func (pnpm *pnpmManager) Name() string {
+	return "pnpm"
+}
+
+func (pnpm *pnpmManager) Install(ctx context.Context, dir string, production bool, stdout, stderr io.Writer) error {
+	command := pnpm.installCmd(ctx, production)
+	command.Dir = dir
+	command.Stdout = stdout
+	command.Stderr = stderr
+	return command.Run()
+}
+
+func (pnpm *pnpmManager) installCmd(ctx context.Context, production bool) *exec.Cmd {
+	args := []string{"install"}
+
+	if production {
+		args = append(args, "--production")
+	}
+
+	//nolint:gosec // False positive on tained command execution. We aren't accepting input from the user here.
+	return exec.CommandContext(ctx, pnpm.executable, args...)
+}
+
+func (pnpm *pnpmManager) Pack(ctx context.Context, dir string, stderr io.Writer) ([]byte, error) {
+	//nolint:gosec // False positive on tained command execution. We aren't accepting input from the user here.
+	command := exec.CommandContext(ctx, pnpm.executable, "pack")
+	command.Dir = dir
+
+	// We have to read the name of the file from stdout.
+	var stdout bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = stderr
+	err := command.Run()
+	if err != nil {
+		return nil, err
+	}
+	// Next, we try to read the name of the file from stdout.
+	// packfile is the name of the file containing the tarball,
+	// as produced by `pnpm pack`.
+	packfile := strings.TrimSpace(stdout.String())
+	defer os.Remove(packfile)
+
+	packTarball, err := os.ReadFile(packfile)
+	if err != nil {
+		newErr := fmt.Errorf("'pnpm pack' completed successfully but the package .tgz file was not generated: %w", err)
+		return nil, newErr
+	}
+
+	return packTarball, nil
+}
+
+// checkPnpmLock checks if there's a file named pnpm-lock.yaml in pwd.
+// This function is used to indicate whether to prefer pnpm over
+// other package managers.
+func checkPnpmLock(pwd string) bool {
+	pnpmFile := filepath.Join(pwd, "pnpm-lock.yaml")
+	_, err := os.Stat(pnpmFile)
+	return err == nil
+}

--- a/sdk/nodejs/npm/testdata/workspace-extended/package.json
+++ b/sdk/nodejs/npm/testdata/workspace-extended/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "a-workspace-example",
+    "description": "A project that uses yarn workspaces using the extended configuration in package.json",
+    "private": true,
+    "workspaces": {
+        "packages": [
+            "packages/*",
+            "project/"
+        ]
+    }
+}

--- a/sdk/nodejs/npm/testdata/workspace-extended/packages/some-package/package.json
+++ b/sdk/nodejs/npm/testdata/workspace-extended/packages/some-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "some-package",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/workspace-extended/project/package.json
+++ b/sdk/nodejs/npm/testdata/workspace-extended/project/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "project",
+    "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/workspaces_test.go
+++ b/sdk/nodejs/npm/workspaces_test.go
@@ -36,3 +36,12 @@ func TestFindWorkspaceRootNotInWorkspace(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrNotInWorkspace)
 }
+
+func TestFindWorkspaceRootYarnExtended(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindWorkspaceRoot(filepath.Join("testdata", "workspace-extended", "project"))
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("testdata", "workspace-extended"), root)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Initial support pnpm. Note that this does not support pnpm workspaces yet.

This also does not handle passing the package manager through from `pulumi new`. Once a user manually runs pnpm, creating a pnpm-lock.yaml, we'll detect that and pnpm.

Fixes https://github.com/pulumi/pulumi/issues/15455

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
