### PR TITLE
[program-gen] Fix stack overflow when binding invoke that resolves to promise

### DIFF
--- a/changelog/pending/20240217--programgen--fix-infinite-recursion-when-binding-invoke-signature-into-promises-without-accounting-for-recursive-type-references.yaml
+++ b/changelog/pending/20240217--programgen--fix-infinite-recursion-when-binding-invoke-signature-into-promises-without-accounting-for-recursive-type-references.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Fix infinite recursion when binding invoke signature into promises without accounting for recursive type references

--- a/pkg/codegen/pcl/functions_test.go
+++ b/pkg/codegen/pcl/functions_test.go
@@ -54,3 +54,19 @@ func TestSingleOrNoneBindsCorrectlyWhenFirstArgumentIsList(t *testing.T) {
 	elementType := pcl.UnwrapOption(variableType)
 	assert.True(t, model.IsConstType(elementType), "element type must the type of one element in the list")
 }
+
+func TestBindingInvokeThatReturnsRecursiveType(t *testing.T) {
+	t.Parallel()
+	source := `value = invoke("recursive:index:getRecursiveType", { name = "foo" })`
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	contract.Ignore(diags)
+	assert.NotNil(t, program, "The program doesn't bind")
+	assert.Nil(t, err, "There is no bind error")
+	assert.Equal(t, len(program.Nodes), 1, "there is one node")
+	localVariable, ok := program.Nodes[0].(*pcl.LocalVariable)
+	assert.True(t, ok, "first node is a local variable variable")
+	assert.Equal(t, localVariable.Name(), "value")
+	variableType := localVariable.Type()
+	_, isPromise := variableType.(*model.PromiseType)
+	assert.True(t, isPromise, "the type is a promise")
+}

--- a/pkg/codegen/testing/test/testdata/recursive-1.0.0.json
+++ b/pkg/codegen/testing/test/testdata/recursive-1.0.0.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "recursive",
+  "version": "1.0.0",
+  "//": [
+    "The recursive:index:getRecursiveType function returns an object of which one field is a recursive type"
+  ],
+  "functions": {
+    "recursive:index:getRecursiveType": {
+      "inputs": {
+        "properties": {
+          "name": {
+            "description": "The name of the recursive type",
+            "type": "string"
+          }
+        }
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+           "recursiveType": {
+             "$ref": "#/types/recursive:index:RecursiveType"
+           }
+        }
+      }
+    }
+  },
+  "types": {
+    "recursive:index:RecursiveType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the recursive type",
+          "type": "string"
+        },
+        "recursiveType": {
+          "description": "The recursive type",
+          "$ref": "#/types/recursive:index:RecursiveType"
+        }
+      }
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -92,5 +92,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"localref", "1.0.0"},
 		SchemaProvider{"enum", "1.0.0"},
 		SchemaProvider{"plain-properties", "1.0.0"},
+		SchemaProvider{"recursive", "1.0.0"},
 	)
 }


### PR DESCRIPTION
# Description


Fixes #15434 because using `ContainsPromises` doesn't account for recursive object references where as `ContainsEventuals` does. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
