### PR TITLE
Pass in a header to indicate where the deployment initiated

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -173,7 +173,7 @@ type Backend interface {
 	Client() *client.Client
 
 	RunDeployment(ctx context.Context, stackRef backend.StackReference, req apitype.CreateDeploymentRequest,
-		opts display.Options) error
+		opts display.Options, deploymentInitiator string) error
 
 	// Queries the backend for resources based on the given query parameters.
 	Search(
@@ -1837,14 +1837,14 @@ func (b *cloudBackend) UpdateStackTags(ctx context.Context,
 const pulumiOperationHeader = "Pulumi operation"
 
 func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.StackReference,
-	req apitype.CreateDeploymentRequest, opts display.Options,
+	req apitype.CreateDeploymentRequest, opts display.Options, deploymentInitiator string,
 ) error {
 	stackID, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return err
 	}
 
-	resp, err := b.client.CreateDeployment(ctx, stackID, req)
+	resp, err := b.client.CreateDeployment(ctx, stackID, req, deploymentInitiator)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1127,10 +1127,14 @@ func getDeploymentPath(stack StackIdentifier, components ...string) string {
 }
 
 func (pc *Client) CreateDeployment(ctx context.Context, stack StackIdentifier,
-	req apitype.CreateDeploymentRequest,
+	req apitype.CreateDeploymentRequest, deploymentInitiator string,
 ) (*apitype.CreateDeploymentResponse, error) {
 	var resp apitype.CreateDeploymentResponse
-	err := pc.restCall(ctx, http.MethodPost, getDeploymentPath(stack), nil, req, &resp)
+	err := pc.restCallWithOptions(ctx, http.MethodPost, getDeploymentPath(stack), nil, req, &resp, httpCallOptions{
+		Header: map[string][]string{
+			"X-Pulumi-Deployment-Initiator": {deploymentInitiator},
+		},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("creating deployment failed: %w", err)
 	}

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -40,6 +40,7 @@ type MockHTTPBackend struct {
 		stackRef backend.StackReference,
 		req apitype.CreateDeploymentRequest,
 		opts display.Options,
+		deploymentInitiator string,
 	) error
 }
 
@@ -72,8 +73,9 @@ func (b *MockHTTPBackend) RunDeployment(
 	stackRef backend.StackReference,
 	req apitype.CreateDeploymentRequest,
 	opts display.Options,
+	deploymentInitiator string,
 ) error {
-	return b.FRunDeployment(ctx, stackRef, req, opts)
+	return b.FRunDeployment(ctx, stackRef, req, opts, deploymentInitiator)
 }
 
 func (b *MockHTTPBackend) Search(

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -336,7 +336,11 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 			Options:              operationOptions,
 		},
 	}
-	err = cb.RunDeployment(ctx, stackRef, req, opts)
+	// For now, these commands are only used by automation API, so we can unilaterally set the initiator
+	// to "automation-api".
+	// In the future, we may want to expose initiating deployments from the CLI, in which case we would need to
+	// pass this value in from the CLI as a flag or environment variable.
+	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/)
 	if err != nil {
 		return result.FromError(err)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12493

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
