### PR TITLE
Ensure project plugins are absolute paths

### DIFF
--- a/changelog/pending/20240220--engine--fix-root-and-program-paths-to-always-be-absolute.yaml
+++ b/changelog/pending/20240220--engine--fix-root-and-program-paths-to-always-be-absolute.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix root and program paths to always be absolute.

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -549,8 +549,9 @@ func TestRunLangPlugin(t *testing.T) {
 								assert.Equal(t, "expected-address", info.MonitorAddress)
 								assert.Equal(t, "expected-stack", info.Stack)
 								assert.Equal(t, "expected-project", info.Project)
-								assert.Equal(t, "expected-pwd", info.Pwd)
-								assert.Equal(t, "expected-program", p.EntryPoint())
+								assert.Equal(t, "/expected-pwd", info.Pwd)
+								assert.Equal(t, "/expected-pwd", info.Info.ProgramDirectory())
+								assert.Equal(t, "expected-program", info.Info.EntryPoint())
 								assert.Equal(t, []string{"expected", "args"}, info.Args)
 								assert.Equal(t, "secret-value", info.Config[config.MustMakeKey("test", "secret")])
 								assert.Equal(t, "regular-value", info.Config[config.MustMakeKey("test", "regular")])
@@ -574,7 +575,7 @@ func TestRunLangPlugin(t *testing.T) {
 					Name:    "expected-project",
 					Runtime: workspace.NewProjectRuntimeInfo("stuff", map[string]interface{}{}),
 				},
-				Pwd:     "expected-pwd",
+				Pwd:     "/expected-pwd",
 				Program: "expected-program",
 				Args:    []string{"expected", "args"},
 				Target: &Target{

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -38,18 +38,15 @@ type ProgramInfo struct {
 }
 
 func NewProgramInfo(rootDirectory, programDirectory, entryPoint string, options map[string]any) ProgramInfo {
-	isValidPath := func(path string) bool {
-		return filepath.IsLocal(path) || filepath.IsAbs(path)
-	}
 	isFileName := func(path string) bool {
 		return filepath.Base(path) == path
 	}
 
-	if !isValidPath(rootDirectory) {
+	if !filepath.IsAbs(rootDirectory) {
 		panic(fmt.Sprintf("rootDirectory '%s' is not a valid path when creating ProgramInfo", rootDirectory))
 	}
 
-	if !isValidPath(programDirectory) {
+	if !filepath.IsAbs(programDirectory) {
 		panic(fmt.Sprintf("programDirectory '%s' is not a valid path when creating ProgramInfo", programDirectory))
 	}
 

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -405,3 +405,24 @@ func TestPreviewImportFile(t *testing.T) {
 	_, has := actual["nameTable"]
 	assert.False(t, has, "nameTable should not be present in import file")
 }
+
+// Small integration test for relative plugin paths. It's hard to do this test via the standard ProgramTest because that
+// framework does it's own manipulation of plugin paths. Regression test for
+// https://github.com/pulumi/pulumi/issues/15467.
+func TestRelativePluginPath(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+
+	// We can't use ImportDirectory here because we need to run this in the right directory such that the relative paths
+	// work.
+	var err error
+	e.CWD, err = filepath.Abs("testdata/relative_plugin_node")
+	require.NoError(t, err)
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", "test")
+	e.RunCommand("pulumi", "install")
+	e.RunCommand("pulumi", "preview")
+}

--- a/tests/testdata/relative_plugin_node/.gitignore
+++ b/tests/testdata/relative_plugin_node/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/node_modules/
+package-lock.json
+Pulumi.test.yaml

--- a/tests/testdata/relative_plugin_node/Pulumi.yaml
+++ b/tests/testdata/relative_plugin_node/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: import_node
+runtime: nodejs
+description: A minimal NodeJS program to test relative provider plugin paths.
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../testprovider

--- a/tests/testdata/relative_plugin_node/component.ts
+++ b/tests/testdata/relative_plugin_node/component.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface ComponentArgs {
+    echo: pulumi.Input<any>;
+}
+
+export class Component extends pulumi.ComponentResource {
+    public readonly echo!: pulumi.Output<any>;
+    public readonly childId!: pulumi.Output<pulumi.ID>;
+
+    constructor(name: string, args: ComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        const inputs: any = {};
+        inputs["echo"] = args.echo;
+        inputs["childId"] = undefined /*out*/;
+        inputs["secret"] = undefined /*out*/;
+
+        super("testcomponent:index:Component", name, inputs, opts, true);
+    }
+}
+

--- a/tests/testdata/relative_plugin_node/index.ts
+++ b/tests/testdata/relative_plugin_node/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import { Random } from "./random";
+
+const componentA = new Random("a", 10);

--- a/tests/testdata/relative_plugin_node/package.json
+++ b/tests/testdata/relative_plugin_node/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "relative_plugin_node",
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^16"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.19.0"
+  }
+}

--- a/tests/testdata/relative_plugin_node/random.ts
+++ b/tests/testdata/relative_plugin_node/random.ts
@@ -1,0 +1,13 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export class Random extends pulumi.Resource {
+    result!: pulumi.Output<string | undefined>;
+  
+    constructor(name: string, length: number, opts?: pulumi.ResourceOptions) {
+      const inputs: any = {};
+      inputs["length"] = length;
+      super("testprovider:index:Random", name, true, inputs, opts);
+    }
+  }

--- a/tests/testdata/relative_plugin_node/tsconfig.json
+++ b/tests/testdata/relative_plugin_node/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "random.ts"
+    ]
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15467.

This tightens the restriction on paths passed to `NewProgramInfo`. Previously it allowed relative paths like "./providers/my_provider". That is now an error. This is correct behaviour. The fields of this structure are passed via protobuf and the descriptions for them in the proto spec are that they should always be absolute paths.

Where we build plugin paths we ensure that if they're relative we resolve them to what they are relative to. That is generally _not_ the current working directory so `filepath.Abs` doesn't do the right thing here.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
