### PR TITLE
Upgrade to grpc-js 1.10.1 and remove calls to deprecated server.start

### DIFF
--- a/changelog/pending/20240223--sdk-nodejs--upgrade-to-atgrpc-grpc-js-1-10-1.yaml
+++ b/changelog/pending/20240223--sdk-nodejs--upgrade-to-atgrpc-grpc-js-1-10-1.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Upgrade to @grpc/grpc-js 1.10.1

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -227,7 +227,6 @@ Event: ${line}\n${e.toString()}`);
                     }
                 });
             });
-            server.start();
             onExit = (hasError: boolean) => {
                 languageServer.onPulumiExit(hasError);
                 server.forceShutdown();
@@ -359,7 +358,6 @@ Event: ${line}\n${e.toString()}`);
                     }
                 });
             });
-            server.start();
             onExit = (hasError: boolean) => {
                 languageServer.onPulumiExit(hasError);
                 server.forceShutdown();

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -406,7 +406,6 @@ export async function main(args: string[]) {
             }
         });
     });
-    server.start();
 
     // Emit the address so the monitor can read it to connect.  The gRPC server will keep the message loop alive.
     // We explicitly convert the number to a string so that Node doesn't colorize the output.

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -9,7 +9,7 @@
         "directory": "sdk/nodejs"
     },
     "dependencies": {
-        "@grpc/grpc-js": "^1.9.14",
+        "@grpc/grpc-js": "^1.10.1",
         "@logdna/tail-file": "^2.0.6",
         "@opentelemetry/api": "^1.2.0",
         "@opentelemetry/exporter-zipkin": "^1.6.0",

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -679,7 +679,6 @@ export async function main(provider: Provider, args: string[]) {
             }
         });
     });
-    server.start();
 
     // Emit the address so the monitor can read it to connect.  The gRPC server will keep the message loop alive.
     // We explicitly convert the number to a string so that Node doesn't colorize the output.

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1999,8 +1999,6 @@ async function createMockEngineAsync(
         });
     });
 
-    server.start();
-
     cleanup(async () => server.forceShutdown());
 
     return { server: server, addr: `127.0.0.1:${port}` };

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -285,10 +285,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@grpc/grpc-js@^1.9.14":
-  version "1.9.14"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.14.tgz#236378822876cbf7903f9d61a0330410e8dcc5a1"
-  integrity sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==
+"@grpc/grpc-js@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.1.tgz#be450560c990c08274bc19d514e181ea205ccaa8"
+  integrity sha512-55ONqFytZExfOIjF1RjXPcVmT/jJqFzbbDqxK9jmRV4nxiYWtL9hENSW1Jfx0SdZfrvoqd44YJ/GJTqfRrawSQ==
   dependencies:
     "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15499

This should be safe, as we are effectively already running 1.10.1. This makes this the new minimum so we can remove the `server.start` calls (the server is started in `server.bindAsync`) that cause deprecation warnings to be printed in Automation API or when using dynamic providers with nodejs.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
