### PR TITLE
Use `SYSTEM_PULLREQUEST_SOURCECOMMITID` for AZ pipeline on GH PR

### DIFF
--- a/changelog/pending/20240226--ci--use-system_pullrequest_sourcecommitid-for-az-pipeline-on-gh-pr.yaml
+++ b/changelog/pending/20240226--ci--use-system_pullrequest_sourcecommitid-for-az-pipeline-on-gh-pr.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: ci
+  description: Use SYSTEM_PULLREQUEST_SOURCECOMMITID for AZ pipeline on GH PR

--- a/sdk/go/common/util/ciutil/az_pipelines.go
+++ b/sdk/go/common/util/ciutil/az_pipelines.go
@@ -44,7 +44,10 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	// Azure Pipelines can be connected to external repos.
 	// If the repo provider is GitHub, then we need to use
 	// `SYSTEM_PULLREQUEST_PULLREQUESTNUMBER` instead of
-	// `SYSTEM_PULLREQUEST_PULLREQUESTID`. For other Git repos,
+	// `SYSTEM_PULLREQUEST_PULLREQUESTID` and
+	// `SYSTEM_PULLREQUEST_SOURCECOMMITID` instead of
+	// `BUILD_SOURCEVERSION`.
+	// For other Git repos,
 	// `SYSTEM_PULLREQUEST_PULLREQUESTID` may be the only variable
 	// that is set if the build is running for a PR build.
 	//
@@ -54,6 +57,7 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	case "GitHub":
 		// GitHub is a git repo hosted on GitHub.
 		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+		v.SHA = os.Getenv("SYSTEM_PULLREQUEST_SOURCECOMMITID")
 	default:
 		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Use `SYSTEM_PULLREQUEST_SOURCECOMMITID` when AZ pipelines checks against a Github PR. Fix made based on investigation from @blampe in #15072 

Fixes #15072

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
