### PR TITLE
Exit no-op `pulumi state edit`

### DIFF
--- a/changelog/pending/20240226--cli-state--pulumi-state-edit-exit-immediatly-when-no-change-was-made.yaml
+++ b/changelog/pending/20240226--cli-state--pulumi-state-edit-exit-immediatly-when-no-change-was-made.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/state
-  description: "`pulumi state edit`: exit immediatly when no change was made"
+  description: Exit immediately from state edit when no change was made

--- a/changelog/pending/20240226--cli-state--pulumi-state-edit-exit-immediatly-when-no-change-was-made.yaml
+++ b/changelog/pending/20240226--cli-state--pulumi-state-edit-exit-immediatly-when-no-change-was-made.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: "`pulumi state edit`: exit immediatly when no change was made"


### PR DESCRIPTION
The current behavior of `pulumi state edit` when the edited file is unchanged is to prompt the user to `accept`, `edit`, `reset` or `cancel`. Since the file is unchanged, `accept` and `cancel` do the same thing. `edit` (again) is the same as `reset` which is the same as running the command from scratch.

The feature would be much easier to use if a no-op edit simply exited. If the user wants to edit again, they can just run `!!` to repeat the command.

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
