### PR TITLE
push post-release changelog and go.mod updates straight to master

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -152,5 +152,4 @@ jobs:
   #     version: ${{ needs.info.outputs.version }}
   #     release-notes: ${{ needs.info.outputs.release-notes }}
   #     version-set: ${{ needs.matrix.outputs.version-set }}
-  #     queue-merge: false
   #   secrets: inherit

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -37,6 +37,5 @@ jobs:
       ref: ${{ github.event.release.tag_name }}
       version: ${{ needs.info.outputs.version }}
       release-notes: ${{ github.event.release.body }}
-      queue-merge: true
       run-dispatch-commands: true
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -60,7 +60,7 @@ jobs:
           )
           make tidy
           git add -A
-          git commit -m "chore: post-release go.mod and changelog updates"
+          git commit -m "chore: post-release go.mod and changelog updates for v${PULUMI_VERSION}"
 
           # Rebase on the latest upstream commit.  We want to make sure to only clear
           # the changelog at the latest tag (which we check out originally), but rebase

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,11 +24,6 @@ on:
         required: true
         description: "Release notes to publish"
         type: string
-      queue-merge:
-        required: false
-        default: false
-        description: "Whether to queue the release for immediate merge"
-        type: boolean
 
 jobs:
   version-bump:
@@ -38,6 +33,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.19.0' # decoupled from version sets, only used by changelog tool
@@ -45,21 +42,16 @@ jobs:
         env:
           PULUMI_VERSION: ${{ inputs.version }}
           RELEASE_NOTES: ${{ inputs.release-notes }}
-          QUEUE_MERGE: ${{ inputs.queue-merge }}
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
           set -euo pipefail
-          git switch --create "automation/release-v${PULUMI_VERSION}"
 
           echo -en "# Changelog\n\n${RELEASE_NOTES}\n\n$(tail -n+3 CHANGELOG.md)" > ./CHANGELOG.md
 
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          rm ./changelog/pending/*.yaml || true
-          git add -A
-
-          git commit -m "chore: changelog for v${PULUMI_VERSION}"
+          rm -f ./changelog/pending/*.yaml
 
           # Update go module dependencies
           (
@@ -68,15 +60,16 @@ jobs:
           )
           make tidy
           git add -A
-          git commit -m "chore: post-release go.mod updates"
+          git commit -m "chore: post-release go.mod and changelog updates"
+
+          # Rebase on the latest upstream commit.  We want to make sure to only clear
+          # the changelog at the latest tag (which we check out originally), but rebase
+          # here in case a commit has been merged to master.  This is to minimize the
+          # chance of races.
+          git pull
+          git rebase origin/master
 
           # Publish pkg module on another tag.
           git tag "pkg/v${PULUMI_VERSION}"
           git push origin "pkg/v${PULUMI_VERSION}"
-          git push -u origin HEAD
-
-          PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}" --body "")
-
-          if [ "${QUEUE_MERGE}" = "true" ]; then
-            gh pr merge --auto --squash "${PR}"
-          fi
+          git push -u origin HEAD:master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,6 @@ on:
         required: true
         description: "Release notes to publish"
         type: string
-      queue-merge:
-        required: false
-        default: false
-        description: "Whether to queue the release for immediate merge"
-        type: boolean
       run-dispatch-commands:
         required: false
         default: false
@@ -139,7 +134,6 @@ jobs:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
       release-notes: ${{ inputs.release-notes }}
-      queue-merge: ${{ inputs.queue-merge }}
     secrets: inherit
 
   dispatch:

--- a/changelog/pending/20240226--pkg--tag-new-pkg-versions-on-a-commit-on-the-main-branch.yaml
+++ b/changelog/pending/20240226--pkg--tag-new-pkg-versions-on-a-commit-on-the-main-branch.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Tag new pkg versions on a commit on the main branch


### PR DESCRIPTION
Post release, we need to update the changelog (clear out all the pending entries), and update the go.mod in pkg, and also tag the latest version of that.  Currently we create a new PR for that. However since we are using squash merges, and need to do the tagging while creating the PR, we're tagging a commit that doesn't end up on the main branch.  This means the Go tooling doesn't work properly with pkg.  See also https://github.com/pulumi/pulumi/issues/15458.

There is nothing really we are doing with that PR other than merging it (in fact queue-merge is set to true, so it should be queued and merged automatically, but that doesn't seem to work).

Because of that, we can just tag the release, and push it straight to the main branch instead.  This removes one human step from the release process and makes the Go tooling work correctly.

The only potential downsides of this change are:
- a small race condition, if a commit gets merged just before we do the rebase we might end up failing that and the release workflow fails.  This is very unlikely, since the release process should be relatively quick.
- we need to adjust the branch protection rules for pulumi-bot so it's able to push to the main branch directly.  This should not be a problem, since it's an automated tool, so all of its potential activity has been reviewed by humans beforehand.

Curious especially if @justinvp has any thoughts on this, since he's mostly taking care of the release process.

Fixes https://github.com/pulumi/pulumi/issues/15458