### PR TITLE
Error on deeply nested types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ get_schemas: \
 			schema-aws!4.37.1           \
 			schema-aws!5.4.0            \
 			schema-aws!5.16.2           \
-			schema-azure-native!1.28.0  \
 			schema-azure-native!1.29.0  \
 			schema-azure-native!1.56.0  \
 			schema-azure!4.18.0         \

--- a/changelog/pending/20240227--sdkgen-go--fix-a-panic-when-types-are-nested-three-levels-deep-in-collections.yaml
+++ b/changelog/pending/20240227--sdkgen-go--fix-a-panic-when-types-are-nested-three-levels-deep-in-collections.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix a panic when types are nested three levels deep in collections.

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -390,6 +390,33 @@ func TestInvalidTypes(t *testing.T) {
 	}
 }
 
+// Regression test for https://github.com/pulumi/pulumi/issues/15478.
+func TestOverlyNestedTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		expected string
+	}{
+		{"nested-type-1.json", "#/types/nestedTypes:index:NestedType/properties/arrs: type Array<Array<Array<string>>> is nested too deeply"},
+		{"nested-type-2.json", "#/types/nestedTypes:index:NestedType/properties/maps: type Map<Map<Map<string>>> is nested too deeply"},
+		{"nested-type-3.json", "#/resources/nestedTypes:index:Resource/properties/arrs: type Array<Array<Array<string>>> is nested too deeply"},
+		{"nested-type-4.json", "#/resources/nestedTypes:index:Resource/properties/maps: type Map<Map<Map<string>>> is nested too deeply"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+
+			pkgSpec := readSchemaFile(filepath.Join("schema", tt.filename))
+
+			_, err := ImportSpec(pkgSpec, nil)
+			assert.ErrorContains(t, err, tt.expected)
+		})
+	}
+}
+
 func TestEnums(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/package.json
@@ -5,7 +5,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/azure-native": "^1.28.0",
+        "@pulumi/azure-native": "^1.29.0",
         "@pulumi/pulumi": "^3.7.0"
     },
     "devDependencies": {

--- a/pkg/codegen/testing/test/testdata/hyphen-url/schema.json
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/schema.json
@@ -6,18 +6,18 @@
       "isComponent": true,
       "inputProperties": {
         "resourceGroup": {
-          "$ref": "/azure-native/v1.28.0/schema.json#/resources/azure-native:resources:ResourceGroup",
+          "$ref": "/azure-native/v1.29.0/schema.json#/resources/azure-native:resources:ResourceGroup",
           "description": "The resource group that hosts the component resource"
         }
       },
       "requiredInputs": ["resourceGroup"],
       "properties": {
         "registry": {
-          "$ref": "/azure-native/v1.28.0/schema.json#/resources/azure-native:containerregistry:Registry",
+          "$ref": "/azure-native/v1.29.0/schema.json#/resources/azure-native:containerregistry:Registry",
           "description": "The Registry"
         },
         "replication": {
-          "$ref": "/azure-native/v1.28.0/schema.json#/resources/azure-native:containerregistry:Replication",
+          "$ref": "/azure-native/v1.29.0/schema.json#/resources/azure-native:containerregistry:Replication",
           "description": "The replication policy"
         },
         "acrLoginServerOut": {
@@ -31,7 +31,7 @@
   "language": {
     "csharp": {
       "packageReferences": {
-        "Pulumi.AzureNative": "1.28.*"
+        "Pulumi.AzureNative": "1.29.*"
       }
     },
     "go": {
@@ -42,7 +42,7 @@
     "nodejs": {
       "dependencies": {
         "@pulumi/pulumi": "^3.7.0",
-        "@pulumi/azure-native": "^1.28.0"
+        "@pulumi/azure-native": "^1.29.0"
       },
       "devDependencies": {
         "typescript": "^3.7.0"

--- a/pkg/codegen/testing/test/testdata/schema/nested-type-1.json
+++ b/pkg/codegen/testing/test/testdata/schema/nested-type-1.json
@@ -1,0 +1,40 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+          "arrs"
+      ]
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/nested-type-2.json
+++ b/pkg/codegen/testing/test/testdata/schema/nested-type-2.json
@@ -1,0 +1,37 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/nested-type-3.json
+++ b/pkg/codegen/testing/test/testdata/schema/nested-type-3.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/nested-type-4.json
+++ b/pkg/codegen/testing/test/testdata/schema/nested-type-4.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -57,7 +57,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"aws", "4.37.1"},
 		SchemaProvider{"aws", "5.16.2"},
 		SchemaProvider{"azure", "4.18.0"},
-		SchemaProvider{"azure-native", "1.28.0"},
 		SchemaProvider{"azure-native", "1.29.0"},
 		SchemaProvider{"random", "4.2.0"},
 		SchemaProvider{"random", "4.3.1"},


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Go codegen can't handle types that are nested three layers deep (e.g. array[array[array[string]]]), so error on binding if we encounter any types of that shape.

Fixes https://github.com/pulumi/pulumi/issues/15478.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
