### PR TITLE
fix diff check for releasing dev SDKs

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -119,13 +119,13 @@ jobs:
       - name: Check for changes
         id: check-changes
         run: |
-          if git diff --exit-code master...HEAD sdk/nodejs; then
+          if ! git diff --exit-code master...HEAD sdk/nodejs; then
             echo "nodejs-release=true" >>"${GITHUB_OUTPUT}"
           else
             echo "nodejs-release=false" >>"${GITHUB_OUTPUT}"
           fi
 
-          if git diff --exit-code master...HEAD sdk/python; then
+          if ! git diff --exit-code master...HEAD sdk/python; then
             echo "python-release=true" >>"${GITHUB_OUTPUT}"
           else
             echo "python-release=false" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
Currently we release a new dev SDK when nothing changed because the condition here is set incorrectly.  We want to create a new release when the exit code is non-zero, so we need to check for `if ! git diff`.