### PR TITLE
Detect pnpm workspaces

### DIFF
--- a/changelog/pending/20240227--sdk-nodejs--detect-pnpm-workspaces-when-running-pulumi-install.yaml
+++ b/changelog/pending/20240227--sdk-nodejs--detect-pnpm-workspaces-when-running-pulumi-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Detect pnpm workspaces when running pulumi install

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -901,6 +901,10 @@ func MakeTempBackend(t *testing.T) string {
 	return "file://" + filepath.ToSlash(tempDir)
 }
 
+func (pt *ProgramTester) GetTmpDir() string {
+	return pt.tmpdir
+}
+
 func (pt *ProgramTester) getBin() (string, error) {
 	return getCmdBin(&pt.bin, "pulumi", pt.opts.Bin)
 }

--- a/sdk/nodejs/npm/testdata/not-a-workspace/package.json
+++ b/sdk/nodejs/npm/testdata/not-a-workspace/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "not-a-workspace",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/pnpm-workspace/package.json
+++ b/sdk/nodejs/npm/testdata/pnpm-workspace/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspacs",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/pnpm-workspace/packages/my-component/package.json
+++ b/sdk/nodejs/npm/testdata/pnpm-workspace/packages/my-component/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-component",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/testdata/pnpm-workspace/pnpm-workspace.yaml
+++ b/sdk/nodejs/npm/testdata/pnpm-workspace/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - packages/*
+  - project

--- a/sdk/nodejs/npm/testdata/pnpm-workspace/project/package.json
+++ b/sdk/nodejs/npm/testdata/pnpm-workspace/project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "project",
+  "version": "1.0.0"
+}

--- a/sdk/nodejs/npm/workspaces_test.go
+++ b/sdk/nodejs/npm/workspaces_test.go
@@ -64,6 +64,7 @@ func TestFindWorkspaceRootFileArgument(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join("testdata", "workspace-nested"), root)
 }
+
 func TestNotAWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/nodejs/npm/workspaces_test.go
+++ b/sdk/nodejs/npm/workspaces_test.go
@@ -64,3 +64,19 @@ func TestFindWorkspaceRootFileArgument(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join("testdata", "workspace-nested"), root)
 }
+func TestNotAWorkspace(t *testing.T) {
+	t.Parallel()
+
+	_, err := FindWorkspaceRoot(filepath.Join("testdata", "not-a-workspace"))
+
+	require.ErrorIs(t, err, ErrNotInWorkspace)
+}
+
+func TestFindWorkspaceRootPNPM(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindWorkspaceRoot(filepath.Join("testdata", "pnpm-workspace", "project"))
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("testdata", "pnpm-workspace"), root)
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1511,10 +1511,13 @@ func TestNestedPackageJSON(t *testing.T) {
 	require.NoError(t, pt.TestLifeCycleInitialize(), "initialize")
 	require.NoError(t, pt.TestPreviewUpdateAndEdits(), "update")
 
-	// There is no node_modules directory in the parent directory
-	parent := filepath.Dir(dir)
-	_, err := os.Stat(filepath.Join(parent, "node_modules"))
+	// There is no node_modules directory in the test directory (parent of program dir)
+	_, err := os.Stat(filepath.Join(pt.GetTmpDir(), "node_modules"))
 	require.True(t, os.IsNotExist(err))
+
+	// node_modules was created inside the program directory
+	_, err = os.Stat(filepath.Join(pt.GetTmpDir(), "infra", "node_modules"))
+	require.NoError(t, err)
 
 	require.NoError(t, pt.TestLifeCycleDestroy(), "destroy")
 }

--- a/tests/integration/nodejs/pnpm-workspace/infra/Pulumi.yaml
+++ b/tests/integration/nodejs/pnpm-workspace/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pnpm-workspaces
+runtime: nodejs
+description: Use pnpm workspaces and import a workspace package in the pulumi program.

--- a/tests/integration/nodejs/pnpm-workspace/infra/index.ts
+++ b/tests/integration/nodejs/pnpm-workspace/infra/index.ts
@@ -1,0 +1,23 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// If this program runs successfully, then the test passes.
+// Executing this file demonstrates that we're able to successfully install
+// dependencies and run in a npm workspaces setup. 
+
+import * as myRandom from "my-random";
+
+const random = new myRandom.MyRandom("plop", {})
+
+export const id = random.randomID

--- a/tests/integration/nodejs/pnpm-workspace/infra/package.json
+++ b/tests/integration/nodejs/pnpm-workspace/infra/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "infra",
+  "main": "index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pulumi/pulumi": "latest",
+    "my-random": "1.0.0"
+  }
+}

--- a/tests/integration/nodejs/pnpm-workspace/infra/package.json
+++ b/tests/integration/nodejs/pnpm-workspace/infra/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "@pulumi/pulumi": "latest",
-    "my-random": "1.0.0"
+    "my-random": "workspace:1.0.0"
   }
 }

--- a/tests/integration/nodejs/pnpm-workspace/package.json
+++ b/tests/integration/nodejs/pnpm-workspace/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace",
+  "description": "Use pnpm workspaces and import a workspace package in the pulumi program."
+}

--- a/tests/integration/nodejs/pnpm-workspace/packages/my-random/index.ts
+++ b/tests/integration/nodejs/pnpm-workspace/packages/my-random/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export class MyRandom extends pulumi.ComponentResource {
+  public readonly randomID: pulumi.Output<string>;
+
+  constructor(name: string, opts: pulumi.ResourceOptions) {
+    super("pkg:index:MyRandom", name, {}, opts);
+    this.randomID = pulumi.output(`${name}-${Math.floor(Math.random() * 1000)}`);
+    this.registerOutputs({ randomID: this.randomID });
+  }
+}

--- a/tests/integration/nodejs/pnpm-workspace/packages/my-random/package.json
+++ b/tests/integration/nodejs/pnpm-workspace/packages/my-random/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my-random",
+  "main": "index.ts",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/nodejs/pnpm-workspace/pnpm-lock.yaml
+++ b/tests/integration/nodejs/pnpm-workspace/pnpm-lock.yaml
@@ -1,0 +1,1 @@
+lockfileVersion: '6.0'

--- a/tests/integration/nodejs/pnpm-workspace/pnpm-workspace.yaml
+++ b/tests/integration/nodejs/pnpm-workspace/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - packages/*
+  - infra


### PR DESCRIPTION
Detect pnpm workspaces and run `pulumi install` from the workspace root. Note that this change does not address issues with function serialisation in pnpm workspaces.

Fixes https://github.com/pulumi/pulumi/issues/15512