### PR TITLE
Schema loader made to respect PULUMI_DEBUG_PROVIDERS

### DIFF
--- a/changelog/pending/20240228--pkg--schema-newpluginloader-now-respects-pulumi_debug_providers-which-enables-pulumi-yaml-programs-to-work-correctly-with-this-feature.yaml
+++ b/changelog/pending/20240228--pkg--schema-newpluginloader-now-respects-pulumi_debug_providers-which-enables-pulumi-yaml-programs-to-work-correctly-with-this-feature.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: pkg
+  description: Make schema.NewPluginLoader respect PULUMI_DEBUG_PROVIDERS, which enables Pulumi YAML programs to work correctly with this feature

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -214,6 +214,26 @@ func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (P
 }
 
 func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]byte, *semver.Version, error) {
+	attachPort, err := plugin.GetProviderAttachPort(tokens.Package(pkg))
+	if err != nil {
+		return nil, nil, err
+	}
+	// If PULUMI_DEBUG_PROVIDERS requested an attach port, skip caching and workspace
+	// interaction and load the schema directly from the given port.
+	if attachPort != nil {
+		schemaBytes, provider, err := l.loadPluginSchemaBytes(pkg, version)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error loading schema from plugin: %w", err)
+		}
+
+		if version == nil {
+			info, err := provider.GetPluginInfo()
+			contract.IgnoreError(err) // nonfatal error
+			version = info.Version
+		}
+		return schemaBytes, version, nil
+	}
+
 	pluginInfo, err := l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, version)
 	if err != nil {
 		// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -16,7 +16,9 @@
 package schema
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/url"
 	"os"
@@ -26,13 +28,20 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/hcl/v2"
-
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 func readSchemaFile(file string) (pkgSpec PackageSpec) {
@@ -1543,4 +1552,76 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 			require.Equal(t, tc.fn, fn)
 		})
 	}
+}
+
+//nolint:paralleltest // using t.Setenv which is incompatible with t.Parallel
+func TestLoaderRespectsDebugProviders(t *testing.T) {
+	host := debugProvidersHelperHost(t)
+	loader := NewPluginLoader(host)
+	cancel := make(chan bool)
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterResourceProviderServer(srv, &debugProvidersHelperServer{})
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, host.SignalCancellation())
+		cancel <- true
+		require.NoError(t, <-handle.Done)
+		require.NoError(t, host.Close())
+	})
+
+	// Instruct to attach to the imaginary provider.
+	t.Setenv("PULUMI_DEBUG_PROVIDERS", fmt.Sprintf("imaginary:%d", handle.Port))
+
+	// Load from the in-process provider.
+	pref, err := loader.LoadPackageReference("imaginary", nil)
+	require.NoError(t, err)
+	require.Equal(t, "imaginary", pref.Name())
+}
+
+type debugProvidersHelperServer struct {
+	pulumirpc.UnimplementedResourceProviderServer
+}
+
+func (*debugProvidersHelperServer) GetSchema(
+	ctx context.Context, req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	schema := PackageSpec{
+		Name:    "imaginary",
+		Version: "0.0.1",
+	}
+	bytes, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	return &pulumirpc.GetSchemaResponse{Schema: string(bytes)}, nil
+}
+
+func (*debugProvidersHelperServer) GetPluginInfo(
+	context.Context, *emptypb.Empty,
+) (*pulumirpc.PluginInfo, error) {
+	return &pulumirpc.PluginInfo{Version: "0.0.1"}, nil
+}
+
+func (*debugProvidersHelperServer) Attach(
+	context.Context, *pulumirpc.PluginAttach,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// This is the host that pulumi-yaml is using. Somehow the test does not work with utils.NewHost,
+// perhaps that does not support PULUMI_DEBUG_PROVIDERS yet.
+func debugProvidersHelperHost(t *testing.T) plugin.Host {
+	cwd := t.TempDir()
+	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
+		Color: cmdutil.GetGlobalColorization(),
+	})
+	pluginCtx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+	require.NoError(t, err)
+	return pluginCtx.Host
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

With this change pulumi-yaml can pick up local provider and attach to it from PULUMI_DEBUG_PROVIDERS for the purposes of schema resolution, which enables using non-existent test-only providers. Before the change it would fail hard trying to download it. 


## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
