### PR TITLE
Decouple persist and display events

### DIFF
--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -265,7 +265,14 @@ func (r *treeRenderer) frame(locked, done bool) {
 
 		treeTableHeight = termHeight - systemMessagesHeight - statusMessageHeight - 1
 		r.maxTreeTableOffset = len(treeTableRows) - treeTableHeight + 1
+		if r.maxTreeTableOffset < 0 {
+			r.maxTreeTableOffset = 0
+		}
 		scrollable := r.maxTreeTableOffset != 0
+
+		if r.treeTableOffset > r.maxTreeTableOffset {
+			r.treeTableOffset = r.maxTreeTableOffset
+		}
 
 		if autoscroll {
 			r.treeTableOffset = r.maxTreeTableOffset
@@ -275,7 +282,11 @@ func (r *treeRenderer) frame(locked, done bool) {
 			// Ensure that the treeTableHeight is at least 1 to avoid going out of bounds.
 			treeTableHeight = 1
 		}
-		treeTableRows = treeTableRows[r.treeTableOffset : r.treeTableOffset+treeTableHeight-1]
+		if r.treeTableOffset+treeTableHeight-1 < len(treeTableRows) {
+			treeTableRows = treeTableRows[r.treeTableOffset : r.treeTableOffset+treeTableHeight-1]
+		} else if r.treeTableOffset < len(treeTableRows) {
+			treeTableRows = treeTableRows[r.treeTableOffset:]
+		}
 
 		totalHeight = treeTableHeight + systemMessagesHeight + statusMessageHeight + 1
 

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -182,6 +182,7 @@ func TestTreeRenderCallsFrameOnTick(t *testing.T) {
 			// the treeRenderer has never rendered, so the systemMessages array
 			// should be empty at this point
 			assert.Emptyf(t, treeRenderer.systemMessages, "Not expecting system messages to be populated until render time.")
+			assert.Equalf(t, "", buf.String(), "Nothing should have been written to the terminal yet")
 		}()
 	}
 
@@ -218,4 +219,9 @@ func TestTreeRenderCallsFrameOnTick(t *testing.T) {
 	// array of system messages
 	assert.Equalf(t, 1000, len(treeRenderer.systemMessages),
 		"Expecting 1000 system messages to now be in  the tree renderer")
+	// Check that at least one system messages was written to the terminal
+	terminalText := buf.String()
+	assert.Contains(t, terminalText, "pulumi:pulumi:Stack")
+	assert.Contains(t, terminalText, "System Messages")
+	assert.Contains(t, terminalText, strings.Repeat("a", 1000))
 }

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -50,6 +50,8 @@ func TestTreeFrameSize(t *testing.T) {
 			treeRenderer := newInteractiveRenderer(term, "this-is-a-fake-permalink", Options{
 				Color: colors.Always,
 			}).(*treeRenderer)
+			display := &ProgressDisplay{}
+			treeRenderer.initializeDisplay(display)
 
 			// Fill the renderer with too many rows of strings to fit in the terminal.
 			for i := 0; i < 1000; i++ {
@@ -75,6 +77,8 @@ func TestTreeKeyboardHandling(t *testing.T) {
 	treeRenderer := newInteractiveRenderer(term, "this-is-a-fake-permalink", Options{
 		Color: colors.Always,
 	}).(*treeRenderer)
+	display := &ProgressDisplay{}
+	treeRenderer.initializeDisplay(display)
 
 	// Fill the renderer with too many rows of strings to fit in the terminal.
 	for i := 0; i < 1000; i++ {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -115,10 +115,12 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// We take the channel of engine events and pass them to separate components that will display
 	// them to the console or persist them on the Pulumi Service. Both should terminate as soon as
 	// they see a CancelEvent, and when finished, close the "done" channel.
-	displayEvents := make(chan engine.Event) // Note: unbuffered, but we assume it won't matter in practice.
+	const eventChannelBufferSize = 100 // Use the same buffer size for both channels to reduce the chance of
+	// one channel stalling the other
+	displayEvents := make(chan engine.Event, eventChannelBufferSize)
 	displayEventsDone := make(chan bool)
 
-	persistEvents := make(chan engine.Event, 100)
+	persistEvents := make(chan engine.Event, eventChannelBufferSize)
 	persistEventsDone := make(chan bool)
 
 	// We close our own done channel when both of the dependent components have finished.

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -115,8 +115,9 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// We take the channel of engine events and pass them to separate components that will display
 	// them to the console or persist them on the Pulumi Service. Both should terminate as soon as
 	// they see a CancelEvent, and when finished, close the "done" channel.
-	const eventChannelBufferSize = 100 // Use the same buffer size for both channels to reduce the chance of
+	// Use the same buffer size for both channels to reduce the chance of
 	// one channel stalling the other
+	const eventChannelBufferSize = 100 
 	displayEvents := make(chan engine.Event, eventChannelBufferSize)
 	displayEventsDone := make(chan bool)
 

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -115,13 +115,10 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// We take the channel of engine events and pass them to separate components that will display
 	// them to the console or persist them on the Pulumi Service. Both should terminate as soon as
 	// they see a CancelEvent, and when finished, close the "done" channel.
-	// Use the same buffer size for both channels to reduce the chance of
-	// one channel stalling the other
-	const eventChannelBufferSize = 100 
-	displayEvents := make(chan engine.Event, eventChannelBufferSize)
+	displayEvents := make(chan engine.Event) // Note: unbuffered, but we assume it won't matter in practice.
 	displayEventsDone := make(chan bool)
 
-	persistEvents := make(chan engine.Event, eventChannelBufferSize)
+	persistEvents := make(chan engine.Event, 100)
 	persistEventsDone := make(chan bool)
 
 	// We close our own done channel when both of the dependent components have finished.


### PR DESCRIPTION
# Description

This removes a scenario where events could not be persisted to the cloud because they were waiting on the same event being displayed

~This uses the same buffer size for both the display and persist channels~ [Removed  to make PR a single change]

The primary change, however, is to stop rendering the tree every time a row is updated, instead, theis renders when the display actually happens in the the `frame` call. The renderer instead simply marks itself as dirty in the `rowUpdated`, `tick`, `systemMessage` and `done` methods and relies on the frame being redrawn on a 60Hz timer (the `done` method calls `frame` explicitly). This makes the rowUpdated call exceedingly cheap (it simply marks the treeRenderer as dirty) which allows the ProgressDisplay instance to service the display events faster, which prevents it from blocking the persist events.

This requires a minor refactor to ensure that the display object is available in the frame method

Because the treeRenderer is calling back into the ProgressDisplay object in a goroutine, the ProgressDisplay object needs to be thread safe, so a read-write mutex is added to protect the `eventUrnToResourceRow` map. The unused `urnToID` map was removed in passing.

## Impact

There are scenarios where the total time taken for an operation was dominated by servicing the events.

This reduces the time for a complex (~2000 resources) `pulumi preview` from 1m45s to 45s

For a `pulumi up` with `-v=11` on a the same stack, where all the register resource spans were completing in 1h6m and the postEngineEventBatch events were taking 3h45m, this PR removes the time impact of reporting the events (greatly inflated by the high verbosity setting) and the operation takes the anticipated 1h6m

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
