### PR TITLE
Error on deeply nested types

### DIFF
--- a/changelog/pending/20240227--sdkgen-go--fix-a-panic-when-types-are-nested-three-levels-deep-in-collections.yaml
+++ b/changelog/pending/20240227--sdkgen-go--fix-a-panic-when-types-are-nested-three-levels-deep-in-collections.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fix a panic when types are nested three levels deep in collections.

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1049,6 +1049,37 @@ func bindDefaultValue(path string, value interface{}, spec *DefaultSpec, typ Typ
 	return dv, diags
 }
 
+func isOverlyNested(path string, typ Type) hcl.Diagnostics {
+	isCollection := func(typ Type) Type {
+		switch typ := typ.(type) {
+		case *ArrayType:
+			return typ.ElementType
+		case *MapType:
+			return typ.ElementType
+		}
+		return nil
+	}
+
+	// If isCollection returns non-nil three, the type is overly nested.
+	inner := isCollection(typ)
+	if inner == nil {
+		return nil
+	}
+	innerInner := isCollection(inner)
+	if innerInner == nil {
+		return nil
+	}
+	innerInnerInner := isCollection(innerInner)
+	if innerInnerInner == nil {
+		return nil
+	}
+	// We can handle a three layer deep collection IFF the innermost type is any.
+	if innerInnerInner == AnyType {
+		return nil
+	}
+	return hcl.Diagnostics{errorf(path, "type %v is nested too deeply", typ)}
+}
+
 // bindProperties binds the map of property specs and list of required properties into a sorted list of properties and
 // a lookup table.
 func (t *types) bindProperties(path string, properties map[string]PropertySpec, requiredPath string, required []string,
@@ -1075,6 +1106,11 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 		if err != nil {
 			return nil, nil, diags, fmt.Errorf("error binding type for property %q: %w", name, err)
 		}
+
+		// After binding the type of a property we need to check if it's overly nested, we can only handle two layers of
+		// nesting so array[array[string]] is ok but array[array[array[string]]] is not.
+		diags = diags.Extend(isOverlyNested(propertyPath, typ))
+		// Note we can keep binding after this but it will be an error diagnostic and so stop any later codegen.
 
 		cv, cvDiags := bindConstValue(propertyPath+"/const", "constant", spec.Const, typ)
 		diags = diags.Extend(cvDiags)

--- a/pkg/codegen/testing/test/testdata/schema/bad-nested-type-1.json
+++ b/pkg/codegen/testing/test/testdata/schema/bad-nested-type-1.json
@@ -1,0 +1,40 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+          "arrs"
+      ]
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/bad-nested-type-2.json
+++ b/pkg/codegen/testing/test/testdata/schema/bad-nested-type-2.json
@@ -1,0 +1,37 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/bad-nested-type-3.json
+++ b/pkg/codegen/testing/test/testdata/schema/bad-nested-type-3.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/bad-nested-type-4.json
+++ b/pkg/codegen/testing/test/testdata/schema/bad-nested-type-4.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/good-nested-type-1.json
+++ b/pkg/codegen/testing/test/testdata/schema/good-nested-type-1.json
@@ -1,0 +1,40 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "pulumi.json#/Any"
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+          "arrs"
+      ]
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/good-nested-type-2.json
+++ b/pkg/codegen/testing/test/testdata/schema/good-nested-type-2.json
@@ -1,0 +1,37 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "types": {
+    "nestedTypes:index:NestedType": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "pulumi.json#/Any"
+              }
+            }
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "nested": {
+          "$ref": "#/types/nestedTypes:index:NestedType"
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/good-nested-type-3.json
+++ b/pkg/codegen/testing/test/testdata/schema/good-nested-type-3.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "arrs": { 
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "pulumi.json#/Any"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}

--- a/pkg/codegen/testing/test/testdata/schema/good-nested-type-4.json
+++ b/pkg/codegen/testing/test/testdata/schema/good-nested-type-4.json
@@ -1,0 +1,27 @@
+{
+  "name": "nestedTypes",
+  "version": "1.0.0",
+  "resources": {
+    "nestedTypes:index:Resource": {
+      "properties": {
+        "maps": { 
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "pulumi.json#/Any"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "language": {
+    "go": {
+      "importBasePath": "nested-types/nestedTypes"
+    }
+  }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Go codegen can't handle types that are nested three layers deep (e.g. array[array[array[string]]]), so error on binding if we encounter any types of that shape.

Go codegen can handle a three layer nested type if the inner element is any (there are types like `pulumi.MapArrayArray`). There are schemas that already make use of this.

Fixes https://github.com/pulumi/pulumi/issues/15478.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
