### PR TITLE
use randomStackName in config_test.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,8 @@ linters-settings:
       alias: testingrpc
     - pkg: github.com/deckarep/golang-set/v2
       alias: mapset
+    - pkg: github.com/pulumi/pulumi/sdk/v3/go/common/testing
+      alias: ptesting
 
 issues:
   exclude-rules:

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
@@ -149,7 +149,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
-	stackName := pulumi_testing.RandomStackName()
+	stackName := ptesting.RandomStackName()
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -15,8 +15,6 @@ package httpstate
 
 import (
 	"context"
-	cryptorand "crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
@@ -26,8 +24,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,13 +135,6 @@ func TestDefaultOrganizationPriority(t *testing.T) {
 	}
 }
 
-func randomStackName() string {
-	b := make([]byte, 4)
-	_, err := cryptorand.Read(b)
-	contract.AssertNoErrorf(err, "failed to generate random stack name")
-	return "test" + hex.EncodeToString(b)
-}
-
 //nolint:paralleltest // mutates global state
 func TestDisableIntegrityChecking(t *testing.T) {
 	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
@@ -158,7 +149,7 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
-	stackName := randomStackName()
+	stackName := pulumi_testing.RandomStackName()
 	ref, err := b.ParseStackReference(stackName)
 	require.NoError(t, err)
 

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	pul_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -47,7 +47,7 @@ func TestReadingGitRepo(t *testing.T) {
 	// it will change the expected behavior.
 	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
 
-	e := pul_testing.NewEnvironment(t)
+	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("git", "init", "-b", "master")
@@ -189,7 +189,7 @@ func TestReadingGitLabMetadata(t *testing.T) {
 	// it will change the expected behavior.
 	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
 
-	e := pul_testing.NewEnvironment(t)
+	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
 	e.RunCommand("git", "init", "-b", "master")

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -47,7 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tools"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -1077,8 +1077,8 @@ func (pt *ProgramTester) runPulumiCommand(name string, args []string, wd string,
 
 func (pt *ProgramTester) runYarnCommand(name string, args []string, wd string) error {
 	// Yarn will time out if multiple processes are trying to install packages at the same time.
-	pulumi_testing.YarnInstallMutex.Lock()
-	defer pulumi_testing.YarnInstallMutex.Unlock()
+	ptesting.YarnInstallMutex.Lock()
+	defer ptesting.YarnInstallMutex.Unlock()
 	pt.t.Log("acquired yarn install lock")
 	defer pt.t.Log("released yarn install lock")
 
@@ -2111,7 +2111,7 @@ func (pt *ProgramTester) prepareProjectDir(projectDir string) error {
 
 // prepareNodeJSProject runs setup necessary to get a Node.js project ready for `pulumi` commands.
 func (pt *ProgramTester) prepareNodeJSProject(projinfo *engine.Projinfo) error {
-	if err := pulumi_testing.WriteYarnRCForTest(projinfo.Root); err != nil {
+	if err := ptesting.WriteYarnRCForTest(projinfo.Root); err != nil {
 		return err
 	}
 

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -37,7 +37,7 @@ func TestConcurrentUpdateError(t *testing.T) {
 	n := 50
 	ctx := context.Background()
 	pName := "conflict_error"
-	sName := randomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	// initialize

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 	"github.com/stretchr/testify/assert"
@@ -104,7 +104,7 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 	t.Skip("disabled, see https://github.com/pulumi/pulumi/issues/5312")
 	ctx := context.Background()
 	pName := "inline_conflict_error"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	// initialize
@@ -161,7 +161,7 @@ func TestCompilationErrorGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -194,7 +194,7 @@ func TestSelectStack404Error(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, "testproj", sName)
 
 	// initialize
@@ -215,7 +215,7 @@ func TestCreateStack409Error(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, "testproj", sName)
 
 	// initialize first stack
@@ -249,7 +249,7 @@ func TestCompilationErrorDotnet(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -282,7 +282,7 @@ func TestCompilationErrorTypescript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -326,7 +326,7 @@ func TestRuntimeErrorGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -359,7 +359,7 @@ func TestRuntimeErrorInlineGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -393,7 +393,7 @@ func TestRuntimeErrorPython(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -453,7 +453,7 @@ func TestRuntimeErrorJavascript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -495,7 +495,7 @@ func TestRuntimeErrorTypescript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -537,7 +537,7 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 	"github.com/stretchr/testify/assert"
@@ -103,7 +104,7 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 	t.Skip("disabled, see https://github.com/pulumi/pulumi/issues/5312")
 	ctx := context.Background()
 	pName := "inline_conflict_error"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	// initialize
@@ -160,7 +161,7 @@ func TestCompilationErrorGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -193,7 +194,7 @@ func TestSelectStack404Error(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, "testproj", sName)
 
 	// initialize
@@ -214,7 +215,7 @@ func TestCreateStack409Error(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, "testproj", sName)
 
 	// initialize first stack
@@ -248,7 +249,7 @@ func TestCompilationErrorDotnet(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -281,7 +282,7 @@ func TestCompilationErrorTypescript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, compilationErrProj, sName)
 
 	// initialize
@@ -325,7 +326,7 @@ func TestRuntimeErrorGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -358,7 +359,7 @@ func TestRuntimeErrorInlineGo(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -392,7 +393,7 @@ func TestRuntimeErrorPython(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -452,7 +453,7 @@ func TestRuntimeErrorJavascript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -494,7 +495,7 @@ func TestRuntimeErrorTypescript(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize
@@ -536,7 +537,7 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, runtimeErrProj, sName)
 
 	// initialize

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	resourceConfig "github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -84,7 +84,7 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	mkstack := func(passphrase string) Stack {
@@ -167,7 +167,7 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestRemoveWithForce(t *testing.T) {
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -247,7 +247,7 @@ func TestRemoveWithForce(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestNewStackLocalSource(t *testing.T) {
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -360,7 +360,7 @@ func TestNewStackLocalSource(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestUpsertStackLocalSource(t *testing.T) {
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -469,7 +469,7 @@ func TestNewStackRemoteSource(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -563,7 +563,7 @@ func TestUpsertStackRemoteSource(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -657,7 +657,7 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -766,7 +766,7 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -874,7 +874,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -964,7 +964,7 @@ func TestUpsertStackInlineSourceParallel(t *testing.T) {
 		ctx := context.Background()
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
-			sName := pulumi_testing.RandomStackName()
+			sName := ptesting.RandomStackName()
 			stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 			cfg := ConfigMap{
 				"bar": ConfigValue{
@@ -1060,7 +1060,7 @@ func TestNestedStackFails(t *testing.T) {
 	t.Parallel()
 
 	testCtx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	parentstackName := FullyQualifiedStackName(pulumiOrg, "parent", sName)
 	nestedstackName := FullyQualifiedStackName(pulumiOrg, "nested", sName)
 
@@ -1122,7 +1122,7 @@ func TestErrorProgressStreams(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "inline_error_progress_streams"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	logLevel := uint(4)
@@ -1182,7 +1182,7 @@ func TestProgressStreams(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "inline_progress_streams"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1253,7 +1253,7 @@ func TestImportExportStack(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1327,7 +1327,7 @@ func TestConfigFlagLike(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1362,7 +1362,7 @@ func TestConfigWithOptions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1541,7 +1541,7 @@ func TestConfigAllWithOptions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1713,7 +1713,7 @@ func TestEnvFunctions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, ptesting.RandomStackName())
 
 	pDir := filepath.Join(".", "test", pName)
 	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
@@ -1777,7 +1777,7 @@ func TestTagFunctions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, ptesting.RandomStackName())
 
 	pDir := filepath.Join(".", "test", "testproj")
 	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
@@ -1826,7 +1826,7 @@ func TestTagFunctions(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestStructuredOutput(t *testing.T) {
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1949,7 +1949,7 @@ func TestSupportsStackOutputs(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -2165,7 +2165,7 @@ func TestProjectSettingsRespected(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	pName := "correct_project"
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	badProjectName := "project_was_overwritten"
@@ -2190,7 +2190,7 @@ func TestSaveStackSettings(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	opts := []LocalWorkspaceOption{
@@ -2259,7 +2259,7 @@ func TestConfigSecretWarnings(t *testing.T) {
 	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
 	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"plainstr1":    ConfigValue{Value: "1"},
@@ -2689,7 +2689,7 @@ func TestWhoAmIDetailed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, ptesting.RandomStackName())
 
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -17,8 +17,6 @@ package auto
 import (
 	"bytes"
 	"context"
-	cryptorand "crypto/rand"
-	"encoding/hex"
 	"io"
 	"os"
 	"os/exec"
@@ -44,8 +42,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	resourceConfig "github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
@@ -86,7 +84,7 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	mkstack := func(passphrase string) Stack {
@@ -169,7 +167,7 @@ func TestWorkspaceSecretsProvider(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestRemoveWithForce(t *testing.T) {
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -249,7 +247,7 @@ func TestRemoveWithForce(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestNewStackLocalSource(t *testing.T) {
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -362,7 +360,7 @@ func TestNewStackLocalSource(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestUpsertStackLocalSource(t *testing.T) {
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -466,19 +464,12 @@ func TestUpsertStackLocalSource(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
-func randomStackName() string {
-	b := make([]byte, 4)
-	_, err := cryptorand.Read(b)
-	contract.AssertNoErrorf(err, "failed to generate random stack name")
-	return "test" + hex.EncodeToString(b)
-}
-
 func TestNewStackRemoteSource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -572,7 +563,7 @@ func TestUpsertStackRemoteSource(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -666,7 +657,7 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -775,7 +766,7 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -883,7 +874,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -973,7 +964,7 @@ func TestUpsertStackInlineSourceParallel(t *testing.T) {
 		ctx := context.Background()
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
-			sName := randomStackName()
+			sName := pulumi_testing.RandomStackName()
 			stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 			cfg := ConfigMap{
 				"bar": ConfigValue{
@@ -1069,7 +1060,7 @@ func TestNestedStackFails(t *testing.T) {
 	t.Parallel()
 
 	testCtx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	parentstackName := FullyQualifiedStackName(pulumiOrg, "parent", sName)
 	nestedstackName := FullyQualifiedStackName(pulumiOrg, "nested", sName)
 
@@ -1131,7 +1122,7 @@ func TestErrorProgressStreams(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "inline_error_progress_streams"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	logLevel := uint(4)
@@ -1191,7 +1182,7 @@ func TestProgressStreams(t *testing.T) {
 
 	ctx := context.Background()
 	pName := "inline_progress_streams"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1262,7 +1253,7 @@ func TestImportExportStack(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1336,7 +1327,7 @@ func TestConfigFlagLike(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1371,7 +1362,7 @@ func TestConfigWithOptions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1550,7 +1541,7 @@ func TestConfigAllWithOptions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")
@@ -1722,7 +1713,7 @@ func TestEnvFunctions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, randomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
 
 	pDir := filepath.Join(".", "test", pName)
 	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
@@ -1786,7 +1777,7 @@ func TestTagFunctions(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, randomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
 
 	pDir := filepath.Join(".", "test", "testproj")
 	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
@@ -1835,7 +1826,7 @@ func TestTagFunctions(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestStructuredOutput(t *testing.T) {
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -1958,7 +1949,7 @@ func TestSupportsStackOutputs(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"bar": ConfigValue{
@@ -2174,7 +2165,7 @@ func TestProjectSettingsRespected(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	pName := "correct_project"
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	badProjectName := "project_was_overwritten"
@@ -2199,7 +2190,7 @@ func TestSaveStackSettings(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	opts := []LocalWorkspaceOption{
@@ -2268,7 +2259,7 @@ func TestConfigSecretWarnings(t *testing.T) {
 	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
 	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	cfg := ConfigMap{
 		"plainstr1":    ConfigValue{Value: "1"},
@@ -2698,7 +2689,7 @@ func TestWhoAmIDetailed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	stackName := FullyQualifiedStackName(pulumiOrg, pName, randomStackName())
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, pulumi_testing.RandomStackName())
 
 	// initialize
 	pDir := filepath.Join(".", "test", "testproj")

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremotepreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 )
 
 const (
@@ -151,7 +151,7 @@ func testRemoteStackGitSource(
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	repo := GitRepo{
 		URL:         remoteTestRepo,

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremotepreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 )
 
 const (
@@ -150,7 +151,7 @@ func testRemoteStackGitSource(
 
 	ctx := context.Background()
 	pName := "go_remote_proj"
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	repo := GitRepo{
 		URL:         remoteTestRepo,

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestUpdatePlans(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := pulumi_testing.RandomStackName()
+	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	opts := []LocalWorkspaceOption{

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestUpdatePlans(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sName := randomStackName()
+	sName := pulumi_testing.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
 	opts := []LocalWorkspaceOption{

--- a/sdk/go/common/testing/util.go
+++ b/sdk/go/common/testing/util.go
@@ -1,0 +1,15 @@
+package testing
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func RandomStackName() string {
+	b := make([]byte, 4)
+	_, err := rand.Read(b)
+	contract.AssertNoErrorf(err, "failed to generate random stack name")
+	return "test" + hex.EncodeToString(b)
+}

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -31,7 +31,7 @@ import (
 	"strconv"
 	"testing"
 
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,8 +245,8 @@ func testInstall(t *testing.T, packageManager string, production bool) {
 
 	// Install dependencies, passing nil for stdout and stderr, which connects
 	// them to the file descriptor for the null device (os.DevNull).
-	pulumi_testing.YarnInstallMutex.Lock()
-	defer pulumi_testing.YarnInstallMutex.Unlock()
+	ptesting.YarnInstallMutex.Lock()
+	defer ptesting.YarnInstallMutex.Unlock()
 	out := iotest.LogWriter(t)
 	bin, err := Install(context.Background(), pkgdir, production, out, out)
 	assert.NoError(t, err)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -45,7 +45,8 @@ func TestConfigCommands(t *testing.T) {
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
-		e.RunCommand("pulumi", "stack", "init", "test")
+		stackName := ptesting.RandomStackName()
+		e.RunCommand("pulumi", "stack", "init", stackName)
 
 		// check config is empty
 		stdout, _ := e.RunCommand("pulumi", "config")
@@ -74,12 +75,12 @@ func TestConfigCommands(t *testing.T) {
 		// check that the nested config does not exist because we didn't use path
 		_, stderr := e.RunCommandExpectError("pulumi", "config", "get", "outer")
 		assert.Equal(t,
-			"error: configuration key 'outer' not found for stack 'test'",
+			"error: configuration key 'outer' not found for stack '"+stackName+"'",
 			strings.Trim(stderr, "\r\n"))
 
 		_, stderr = e.RunCommandExpectError("pulumi", "config", "get", "myList")
 		assert.Equal(t,
-			"error: configuration key 'myList' not found for stack 'test'",
+			"error: configuration key 'myList' not found for stack '"+stackName+"'",
 			strings.Trim(stderr, "\r\n"))
 
 		// set the nested config using --path
@@ -141,7 +142,8 @@ func TestConfigCommands(t *testing.T) {
 
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
-		e.RunCommand("pulumi", "stack", "init", "test")
+		stackName := ptesting.RandomStackName()
+		e.RunCommand("pulumi", "stack", "init", stackName)
 
 		// check config is empty
 		stdout, _ := e.RunCommand("pulumi", "config")
@@ -155,7 +157,7 @@ func TestConfigCommands(t *testing.T) {
 config:
   pulumi-test:a: A
 $`
-		b, err := os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err := os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -169,7 +171,7 @@ config:
   pulumi-test:b:
     secure: \S*
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -183,7 +185,7 @@ config:
   pulumi-test:b:
     secure: \S*
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -197,7 +199,7 @@ config:
   pulumi-test:b:
     secure: \S*
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -213,7 +215,7 @@ config:
     secure: \S*
   pulumi-test:c: C
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -231,7 +233,7 @@ config:
   pulumi-test:d:
     a: D
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -251,7 +253,7 @@ config:
   pulumi-test:e:
     - E
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -274,7 +276,7 @@ config:
     g:
       - F
 $`
-		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi.test.yaml"))
+		b, err = os.ReadFile(filepath.Join(e.CWD, "Pulumi."+stackName+".yaml"))
 		assert.NoError(t, err)
 		assert.Regexp(t, regexp.MustCompile(expected), string(b))
 
@@ -302,7 +304,8 @@ config:
 
 	integration.CreatePulumiRepo(e, pulumiProject)
 	e.SetBackend(e.LocalURL())
-	e.RunCommand("pulumi", "stack", "init", "test")
+	stackName := ptesting.RandomStackName()
+	e.RunCommand("pulumi", "stack", "init", stackName)
 	stdout, _ := e.RunCommand("pulumi", "config", "get", "first-value")
 	assert.Equal(t, "first", strings.Trim(stdout, "\r\n"))
 }
@@ -334,7 +337,8 @@ config:
 
 	integration.CreatePulumiRepo(e, pulumiProject)
 	e.SetBackend(e.LocalURL())
-	e.RunCommand("pulumi", "stack", "init", "test")
+	stackName := ptesting.RandomStackName()
+	e.RunCommand("pulumi", "stack", "init", stackName)
 	e.RunCommand("pulumi", "config", "set", "second-value", "second")
 	stdout, _ := e.RunCommand("pulumi", "config", "--json")
 	// check that stdout is an array containing 2 objects
@@ -362,7 +366,8 @@ func TestConfigCommandsUsingEnvironments(t *testing.T) {
 
 	integration.CreateBasicPulumiRepo(e)
 	e.RunCommand("pulumi", "org", "set-default", getTestOrg())
-	e.RunCommand("pulumi", "stack", "init", "test")
+	stackName := ptesting.RandomStackName()
+	e.RunCommand("pulumi", "stack", "init", stackName)
 
 	// check config is empty
 	stdout, _ := e.RunCommand("pulumi", "config")
@@ -405,7 +410,7 @@ test_secret  [unknown]`, strings.Trim(stdout, "\r\n"))
 	assert.Equal(t, "[unknown]", strings.Trim(stdout, "\r\n"))
 
 	// delete the stack
-	e.RunCommand("pulumi", "stack", "rm", "-s", "test", "--yes")
+	e.RunCommand("pulumi", "stack", "rm", "-s", stackName, "--yes")
 }
 
 func getTestOrg() string {

--- a/tests/integration/backend/diy/helpers.go
+++ b/tests/integration/backend/diy/helpers.go
@@ -1,27 +1,18 @@
 package diy
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"os/exec"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func randomStackName() string {
-	b := make([]byte, 4)
-	_, err := rand.Read(b)
-	contract.AssertNoErrorf(err, "failed to generate random stack name")
-	return "test" + hex.EncodeToString(b)
-}
-
 func loginAndCreateStack(t *testing.T, cloudURL string) {
 	t.Helper()
 
-	stackName := randomStackName()
+	stackName := pulumi_testing.RandomStackName()
 	out, err := exec.Command("pulumi", "login", cloudURL).CombinedOutput()
 	require.NoError(t, err, string(out))
 

--- a/tests/integration/backend/diy/helpers.go
+++ b/tests/integration/backend/diy/helpers.go
@@ -4,7 +4,7 @@ import (
 	"os/exec"
 	"testing"
 
-	pulumi_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +12,7 @@ import (
 func loginAndCreateStack(t *testing.T, cloudURL string) {
 	t.Helper()
 
-	stackName := pulumi_testing.RandomStackName()
+	stackName := ptesting.RandomStackName()
 	out, err := exec.Command("pulumi", "login", cloudURL).CombinedOutput()
 	require.NoError(t, err, string(out))
 


### PR DESCRIPTION
I noticed in another PR that the tests in `config_test.go` are failing because of duplicate stack names. Use the randomStackName function there to avoid this.  Since we're using this function in a few places now, also factor it out so we can re-use it.  

Also standardize the naming of the go/common/testing import.  So, the PR is doing a few things, but hopefully it's still easy enough to review.