### PR TITLE
acquire plugin in python acceptance test

### DIFF
--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -19,6 +19,7 @@ package ints
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -221,9 +222,11 @@ func optsForConstructPython(
 	}
 }
 
-//nolint:paralleltest // sets env var, must be run in isolation
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
-	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+	t.Parallel()
+
+	err := exec.Command("pulumi", "plugin", "install", "resource", "tls", "v4.10.0").Run()
+	assert.NoError(t, err)
 
 	const testDir = "construct_component_configure_provider"
 	runComponentSetup(t, testDir)

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -221,8 +221,8 @@ func optsForConstructPython(
 	}
 }
 
+//nolint:paralleltest // sets env var, must be run in isolation
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
-	t.Parallel()
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 	const testDir = "construct_component_configure_provider"

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -224,10 +223,7 @@ func optsForConstructPython(
 
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "darwin" {
-		// TODO[pulumi/pulumi#15240]: Address issue and re-enable the test.
-		t.Skip("Temporarily skip on macOS due to https://github.com/pulumi/pulumi/issues/15240")
-	}
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 	const testDir = "construct_component_configure_provider"
 	runComponentSetup(t, testDir)


### PR DESCRIPTION
This test was disabled on MacOS due to what looks like a failure to acquire a plugin.  This probably worked accidentally (and is working accidentally on other platforms) because presumably the plugin gets acquired by another test and is thus available.  We should however not rely on that, end enable plugin acquisition where necessary.  With that we also fix the test on MacOS and can unskip it.

This addresses part of https://github.com/pulumi/pulumi/issues/15240.  Note that I don't think it fixes the flakyness, looking back through the test logs I think I was conflating two separate things here.