### PR TITLE
Remove check for version==nil in PluginLoader

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -144,7 +144,7 @@ func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version)
 	defer l.m.Unlock()
 
 	key := packageIdentity(pkg, version)
-	if p, ok := l.getPackage(key); ok && version == nil {
+	if p, ok := l.getPackage(key); ok {
 		return p, nil
 	}
 


### PR DESCRIPTION
Not clear why this nil check was ever included. We should use the cache even if a version wasn't given.