### PR TITLE
Revert "push post-release changelog and go.mod updates straight to master"

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -152,4 +152,5 @@ jobs:
   #     version: ${{ needs.info.outputs.version }}
   #     release-notes: ${{ needs.info.outputs.release-notes }}
   #     version-set: ${{ needs.matrix.outputs.version-set }}
+  #     queue-merge: false
   #   secrets: inherit

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -37,5 +37,6 @@ jobs:
       ref: ${{ github.event.release.tag_name }}
       version: ${{ needs.info.outputs.version }}
       release-notes: ${{ github.event.release.body }}
+      queue-merge: true
       run-dispatch-commands: true
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -70,10 +70,13 @@ jobs:
           git add -A
           git commit -m "chore: post-release go.mod updates"
 
-          # Publish pkg module on another tag.
-          git tag "pkg/v${PULUMI_VERSION}"
-          git push origin "pkg/v${PULUMI_VERSION}"
-          git push -u origin HEAD
+          # TODO: https://github.com/pulumi/pulumi/issues/15458
+          # Temporarily disable tagging `pkg`. For now, we'll have to manually do it
+          # once the change lands in `master`.
+          # # Publish pkg module on another tag.
+          # git tag "pkg/v${PULUMI_VERSION}"
+          # git push origin "pkg/v${PULUMI_VERSION}"
+          # git push -u origin HEAD
 
           PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}" --body "")
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,11 @@ on:
         required: true
         description: "Release notes to publish"
         type: string
+      queue-merge:
+        required: false
+        default: false
+        description: "Whether to queue the release for immediate merge"
+        type: boolean
 
 jobs:
   version-bump:
@@ -33,8 +38,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.19.0' # decoupled from version sets, only used by changelog tool
@@ -42,16 +45,21 @@ jobs:
         env:
           PULUMI_VERSION: ${{ inputs.version }}
           RELEASE_NOTES: ${{ inputs.release-notes }}
+          QUEUE_MERGE: ${{ inputs.queue-merge }}
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
           set -euo pipefail
+          git switch --create "automation/release-v${PULUMI_VERSION}"
 
           echo -en "# Changelog\n\n${RELEASE_NOTES}\n\n$(tail -n+3 CHANGELOG.md)" > ./CHANGELOG.md
 
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          rm -f ./changelog/pending/*.yaml
+          rm ./changelog/pending/*.yaml || true
+          git add -A
+
+          git commit -m "chore: changelog for v${PULUMI_VERSION}"
 
           # Update go module dependencies
           (
@@ -60,16 +68,15 @@ jobs:
           )
           make tidy
           git add -A
-          git commit -m "chore: post-release go.mod and changelog updates for v${PULUMI_VERSION}"
-
-          # Rebase on the latest upstream commit.  We want to make sure to only clear
-          # the changelog at the latest tag (which we check out originally), but rebase
-          # here in case a commit has been merged to master.  This is to minimize the
-          # chance of races.
-          git pull
-          git rebase origin/master
+          git commit -m "chore: post-release go.mod updates"
 
           # Publish pkg module on another tag.
           git tag "pkg/v${PULUMI_VERSION}"
           git push origin "pkg/v${PULUMI_VERSION}"
-          git push -u origin HEAD:master
+          git push -u origin HEAD
+
+          PR=$(gh pr create --title "Changelog and go.mod updates for v${PULUMI_VERSION}" --body "")
+
+          if [ "${QUEUE_MERGE}" = "true" ]; then
+            gh pr merge --auto --squash "${PR}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ on:
         required: true
         description: "Release notes to publish"
         type: string
+      queue-merge:
+        required: false
+        default: false
+        description: "Whether to queue the release for immediate merge"
+        type: boolean
       run-dispatch-commands:
         required: false
         default: false
@@ -134,6 +139,7 @@ jobs:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
       release-notes: ${{ inputs.release-notes }}
+      queue-merge: ${{ inputs.queue-merge }}
     secrets: inherit
 
   dispatch:


### PR DESCRIPTION
This PR reverts the change from https://github.com/pulumi/pulumi/pull/15515 because it's currently broken, and even if we fix the problem where it is broken, I'm not sure we can make it work without unchecking the "Do not allow bypassing the above settings" in `master`'s branch protection rules, which I think we do want to keep checked (some more details in #15554).

An additional commit also temporarily disables tagging `pkg/<version>` in the workflow. Instead, that will have to be done manually as part of the release process when the change lands in `master`. As a fast follow, I'd like to see if there's a way we can automate adding the tag after the change lands in master, perhaps if the PR has a certain label or is named a certain way?

I mainly want to do this because it looks like we may have a Node.js SDK regression and will need to do a quick v3.108.1 release, and I want to make sure we can get that out without a broken workflow and needing to go through a bunch of manual temporary workarounds to unblock that release.

@tgummerer, what do you think?

Fixes #15554

(If we merge this, we should re-open https://github.com/pulumi/pulumi/issues/15458 to track fixing this)