### PR TITLE
set PULUMI_HOME in ProgramTests

### DIFF
--- a/changelog/pending/20240301--pkg-testing--make-programtest-use-a-temporary-pulumi_home-for-each-test.yaml
+++ b/changelog/pending/20240301--pkg-testing--make-programtest-use-a-temporary-pulumi_home-for-each-test.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg/testing
+  description: Make ProgramTest use a temporary PULUMI_HOME for each test

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -31,8 +31,16 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 }
 
 // RunCommandPulumiHome executes the specified command and additional arguments, wrapping any output in the
-// specialized test output streams that list the location the test is running in, and sets the PULUMI_HOME environment variable.
-func RunCommandPulumiHome(t *testing.T, name string, args []string, wd string, opts *ProgramTestOptions, pulumiHome string) error {
+// specialized test output streams that list the location the test is running in, and sets the PULUMI_HOME
+// environment variable.
+func RunCommandPulumiHome(
+	t *testing.T,
+	name string,
+	args []string,
+	wd string,
+	opts *ProgramTestOptions,
+	pulumiHome string,
+) error {
 	path := args[0]
 	command := strings.Join(args, " ")
 	t.Logf("**** Invoke '%v' in '%v'", command, wd)

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -26,9 +26,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// RunCommand executes the specified command and additional arguments, wrapping any output in the
-// specialized test output streams that list the location the test is running in.
 func RunCommand(t *testing.T, name string, args []string, wd string, opts *ProgramTestOptions) error {
+	return RunCommandPulumiHome(t, name, args, wd, opts, "")
+}
+
+// RunCommandPulumiHome executes the specified command and additional arguments, wrapping any output in the
+// specialized test output streams that list the location the test is running in, and sets the PULUMI_HOME environment variable.
+func RunCommandPulumiHome(t *testing.T, name string, args []string, wd string, opts *ProgramTestOptions, pulumiHome string) error {
 	path := args[0]
 	command := strings.Join(args, " ")
 	t.Logf("**** Invoke '%v' in '%v'", command, wd)
@@ -40,6 +44,9 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 	env = append(env, "PULUMI_DEBUG_COMMANDS=true")
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
+	if pulumiHome != "" {
+		env = append(env, fmt.Sprintf("PULUMI_HOME=%s", pulumiHome))
+	}
 
 	cmd := exec.Cmd{
 		Path: path,

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -875,6 +875,7 @@ type ProgramTester struct {
 	tmpdir         string              // the temporary directory we use for our test environment
 	projdir        string              // the project directory we use for this run
 	TestFinished   bool                // whether or not the test if finished
+	pulumiHome     string              // The directory PULUMI_HOME will be set to
 }
 
 func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
@@ -883,11 +884,14 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 	if opts.RetryFailedSteps {
 		maxStepTries = 3
 	}
+	home, err := os.MkdirTemp("", "test-env-home")
+	assert.NoError(t, err, "creating temp PULUMI_HOME directory")
 	return &ProgramTester{
 		t:              t,
 		opts:           opts,
 		updateEventLog: filepath.Join(os.TempDir(), string(stackName)+"-events.json"),
 		maxStepTries:   maxStepTries,
+		pulumiHome:     home,
 	}
 }
 
@@ -995,7 +999,7 @@ func (pt *ProgramTester) pipenvCmd(args []string) ([]string, error) {
 }
 
 func (pt *ProgramTester) runCommand(name string, args []string, wd string) error {
-	return RunCommand(pt.t, name, args, wd, pt.opts)
+	return RunCommandPulumiHome(pt.t, name, args, wd, pt.opts, pt.pulumiHome)
 }
 
 // RunPulumiCommand runs a Pulumi command in the project directory.


### PR DESCRIPTION
Currently program test runs all programs with PULUMI_HOME unset.  This means that if programs run in parallel they share the same directory. E.g. for login this means running in parallel only works if we always log into the same backend, and there is no racyness between tests.

Set PULUMI_HOME to a temp directory, so each program test has its own setup.

Fixes https://github.com/pulumi/pulumi/issues/15240

This complements https://github.com/pulumi/pulumi/pull/15559
