### PR TITLE
ci: Fix PR workflow errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
             --partition-package github.com/pulumi/pulumi/tests/integration tests/integration 8
           )
 
+          ACCEPTANCE_TEST_MATRIX_WIN="{}"
           if [[ " ${ACCEPTANCE_PLATFORMS[*]} " =~ [[:space:]]windows-latest[[:space:]] ]]; then
             ACCEPTANCE_TEST_MATRIX_WIN=$(
               ./scripts/get-job-matrix.py \
@@ -201,6 +202,7 @@ jobs:
             )
           fi
 
+          ACCEPTANCE_TEST_MATRIX_MACOS="{}"
           if [[ " ${ACCEPTANCE_PLATFORMS[*]} " =~ [[:space:]]macos-latest[[:space:]] ]]; then
             ACCEPTANCE_TEST_MATRIX_MACOS=$(
               ./scripts/get-job-matrix.py \


### PR DESCRIPTION
I keep getting "PR run failed" email notifications even when all the checks in a PR succeeds. It looks like this may be due to the following two errors in the workflow:

![Screenshot 2024-02-15 at 4 16 23 PM](https://github.com/pulumi/pulumi/assets/710598/fc6aa0b1-348e-432f-95e2-41262e4f8afe)

It looks like we're getting these errors because `ACCEPTANCE_TEST_MATRIX_WIN` and `ACCEPTANCE_TEST_MATRIX_MACOS` envvars aren't being set for PRs.

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L187-L188

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L204-L205

Which end up feeding into here:

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L362-L363

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L387-L389

And the error happens because these are empty strings.

Instead, if we initialize these envvars as an empty JSON object string, then they won't be empty. And it should allow these jobs to be skipped, because of these `if` checks:

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L360

https://github.com/pulumi/pulumi/blob/3d45f4f5db247885d50465c9aaca2848da3c9189/.github/workflows/ci.yml#L385

Fixes #15445