### PR TITLE
show all paths when we have multipe local policy packs with the same name

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -563,7 +563,7 @@ func (display *ProgressDisplay) printDiagnostics() bool {
 }
 
 type policyPackSummary struct {
-	IsLocal           bool
+	HasCloudPack      bool
 	LocalPaths        []string
 	ViolationEvents   []engine.PolicyViolationEventPayload
 	RemediationEvents []engine.PolicyRemediationEventPayload
@@ -592,11 +592,14 @@ func (display *ProgressDisplay) printPolicies() bool {
 				summary = s
 				summary.LocalPaths = append(summary.LocalPaths, path)
 			} else {
-				summary.IsLocal = true
 				summary.LocalPaths = []string{path}
 			}
 		} else {
 			key = fmt.Sprintf("%s@v%s", name, version)
+			if s, has := policyPackInfos[key]; has {
+				summary = s
+				summary.HasCloudPack = true
+			}
 		}
 		policyPackInfos[key] = summary
 	}
@@ -648,7 +651,7 @@ func (display *ProgressDisplay) printPolicies() bool {
 		}
 
 		var localMark string
-		if info.IsLocal {
+		if len(info.LocalPaths) > 0 {
 			localMark = fmt.Sprintf(" (local: ")
 			sort.Strings(info.LocalPaths)
 			for i, path := range info.LocalPaths {
@@ -658,6 +661,10 @@ func (display *ProgressDisplay) printPolicies() bool {
 				localMark += path
 			}
 			localMark += ")"
+
+			if info.HasCloudPack {
+				localMark += " + (cloud)"
+			}
 		}
 
 		display.println(fmt.Sprintf("    %s %s%s%s%s", passFailWarn, colors.SpecInfo, key, colors.Reset, localMark))

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -652,7 +652,7 @@ func (display *ProgressDisplay) printPolicies() bool {
 
 		var localMark string
 		if len(info.LocalPaths) > 0 {
-			localMark = fmt.Sprintf(" (local: ")
+			localMark = " (local: "
 			sort.Strings(info.LocalPaths)
 			for i, path := range info.LocalPaths {
 				if i > 0 {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1162,5 +1162,5 @@ func TestMultiplePolicyPacks(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, stdout, "Failing advisory policy pack for testing\n          foobar")
 	assert.Contains(t, stdout, "error: update failed")
-	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: mandatory_policy_pack)")
+	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: advisory_policy_pack; mandatory_policy_pack)")
 }


### PR DESCRIPTION
It is possible for multiple local policy packs to have the same name. When there are policy violation, we currently only show one of the paths for those policy packs (as we consider them the same policy pack because it has the same name).

Display both of the paths in this case to avoid any confusion.  Also sort the names, so the test we have for this is deterministic.

I think in ideal world it would be better to just error out if there are multiple policy packs with the same name, but given this behaviour worked for a long time I wouldn't be surprised if that ends up breaking some use case, so I'd be a bit worried about doing that now.

A possible alternative would be to not consider policy packs with the same name as a single policy pack, but if we name it differently I could imagine people getting confused with that.  Happy to hear alternative opinions on what the right behaviour here is since I'm not quite sure myself.

Fixes #15566 