### PR TITLE
don't run conformance test tests in parallel

### DIFF
--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -28,9 +28,11 @@ import (
 )
 
 // Check that an invalid schema triggers an error
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestInvalidSchema(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -173,9 +173,11 @@ func (h *L1EmptyLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 }
 
 // Run a simple successful test with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -296,9 +298,11 @@ func TestL1Empty_FailPrepare(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty_BadSnapshot(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
@@ -335,9 +339,11 @@ func TestL1Empty_BadSnapshot(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty_MissingStack(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l1main_test.go
+++ b/cmd/pulumi-test-language/l1main_test.go
@@ -188,9 +188,11 @@ func (h *L1MainLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest)
 }
 
 // Run a simple successful test
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Main(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l2destroy_test.go
+++ b/cmd/pulumi-test-language/l2destroy_test.go
@@ -249,9 +249,11 @@ func (h *L2DestroyLanguageHost) Run(
 }
 
 // Run a simple successful test with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2Destroy(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -233,9 +233,11 @@ func (h *L2ResourceSimpleLanguageHost) Run(
 }
 
 // Run a simple successful test with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2ResourceSimple(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -270,9 +272,11 @@ func TestL2ResourceSimple(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad sdk snapshot with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_BadSnapshot(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
@@ -309,9 +313,11 @@ func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_MissingResource(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -351,9 +357,11 @@ func TestL2SimpleResource_MissingResource(t *testing.T) {
 }
 
 // Run a simple failing test because GetRequiredPlugins doesn't return the right plugins.
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -211,9 +211,11 @@ func (h *RuntimeOptionsLanguageHost) Run(
 }
 
 // Run a simple test with a mocked runtime that uses runtime options
+//
+// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
+//
+//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestRuntimeOptions(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}


### PR DESCRIPTION
Currently conformance tests can't be run in parallel because the engine will internally chdir, and have some global state.  This is tracked in https://github.com/pulumi/pulumi/issues/13945.  This means also the tests testing the pulumi-test-language program can't run in parallel, or they will be flaky.

Make them execute serially and link to the issue mentioned above to de-flake them.

Fixes #15580
