### PR TITLE
Add a title prefix to downstream test PRs

### DIFF
--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -47,7 +47,7 @@ jobs:
                  "pr-reviewers": ${{ toJSON( github.triggering_actor || 'justinvp' ) }},
                  "pr-description": "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}. (run-id: ${{ github.run_id }})",
                  "automerge": false,
-                 "pr-title-prefix": "[DOWNSTREAM TEST][PU/PU]"
+                 "pr-title-prefix": "[DOWNSTREAM TEST][PLATFORM]"
               }
         - name: Await PR opened for pulumi-${{ matrix.provider }}
           run: |

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -46,7 +46,8 @@ jobs:
                  "target-bridge-version": "",
                  "pr-reviewers": ${{ toJSON( github.triggering_actor || 'justinvp' ) }},
                  "pr-description": "This is a downstream codegen test for pulumi/pulumi#${{ github.event.pull_request.number }}. (run-id: ${{ github.run_id }})",
-                 "automerge": false
+                 "automerge": false,
+                 "pr-title-prefix": "[DOWNSTREAM TEST][PU/PU]"
               }
         - name: Await PR opened for pulumi-${{ matrix.provider }}
           run: |


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds a prefix to the titles of PRs created in provider repos for downstream tests. It'd make it easier for provider maintainers to recognise test PRs from real upgrades and help with not automatically raising P1 issues on the PR CI failing.

We added a similar change to the bridge: https://github.com/pulumi/pulumi-terraform-bridge/pull/1726

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
