### PR TITLE
[cli/new] Strip sensitive data from template URLs

### DIFF
--- a/changelog/pending/20240304--cli-new--strip-credentials-and-query-strings-from-template-urls-saved-to-project.yaml
+++ b/changelog/pending/20240304--cli-new--strip-credentials-and-query-strings-from-template-urls-saved-to-project.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Strip credentials and query strings from template URLs saved to project


### PR DESCRIPTION
This change strips credentials and query strings from template URLs that are saved in the generated projects from `pulumi new`.

Note: I considered a different approach where we'd only keep templates from the default templates repo or Pulumi AI. However, the implementation ended up being more complex to figure out what was a default template (and not a local file path, for example), and this way other sources are still included to help with code searches and other tools to identify the source of a project.

Fixes #15431