### PR TITLE
do a case insentitive PATH check on windows

### DIFF
--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -320,14 +320,15 @@ func fixupPath(env []string, pulumiBin string) []string {
 	copy(newEnv, env)
 	pathIndex := -1
 	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
+		// Case-insensitive compare, as Windows will normally be "Path", not "PATH".
+		if strings.EqualFold(e[0:4], "PATH") {
 			pathIndex = i
 			break
 		}
 	}
 	if pathIndex >= 0 {
 		pathEntry := pulumiBin
-		oldPath := strings.TrimPrefix(env[pathIndex], "PATH=")
+		oldPath := env[pathIndex][5:]
 		if oldPath != "" {
 			pathEntry = pulumiBin + string(os.PathListSeparator) + oldPath
 		}


### PR DESCRIPTION
We're trying to fix up the PATH in the automation API.  However on windows, the environment variable might be "Path" instead of "PATH". Make sure to do a case insensitive match in case the platform we're on doesn't use an all uppercase PATH.

I just noticed we're doing this [here](https://github.com/pulumi/pulumi/blob/master/sdk/python/python.go#L202-L203) while reading some code for unrelated reasons.  I haven't actually tested this, so if anyone has more Windows experience here to verify that this is actually needed I'd appreciate that.  We might also have to do the same thing for nodejs and python, although I don't know if those languages just always uppercase all environment variables?

/cc @julienp 