### PR TITLE
display/progress: sort the correct array

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -671,7 +671,7 @@ func (display *ProgressDisplay) printPolicies() bool {
 				}
 				policyRemediationCounts[name]++
 			}
-			sort.Strings(policyKeys)
+			sort.Strings(policyNames)
 			for _, policyName := range policyNames {
 				count := policyRemediationCounts[policyName]
 				display.println(fmt.Sprintf("%s- %s[remediate]  %s%s  (%d %s)",


### PR DESCRIPTION
We're doing a sort here, so the output is consistent.  However we sort the policyKeys array, which is no longer used at this point, instead of the policyNames array, which is being displayed just after this point.  Fix this typo.

I noticed this while reading the code for https://github.com/pulumi/pulumi/pull/15582.  