### PR TITLE
[program-gen/go] Fix optional primitive values being derefrenced

### DIFF
--- a/changelog/pending/20240305--programgen-go--fix-optional-primitive-values-being-derefrenced.yaml
+++ b/changelog/pending/20240305--programgen-go--fix-optional-primitive-values-being-derefrenced.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix optional primitive values being derefrenced

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -927,7 +927,10 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 
 func (g *generator) argumentTypeNamePtr(expr model.Expression, destType model.Type, isInput bool) (result string) {
 	res := g.argumentTypeName(expr, destType, isInput)
-	return "*" + res
+	if !strings.HasPrefix(res, "pulumi.") {
+		return "*" + res
+	}
+	return res
 }
 
 func (g *generator) genRelativeTraversal(w io.Writer,

--- a/tests/testdata/codegen/components-pp/go/exampleComponent.go
+++ b/tests/testdata/codegen/components-pp/go/exampleComponent.go
@@ -84,7 +84,7 @@ func NewExampleComponent(
 		__res, err := random.NewRandomPassword(ctx, fmt.Sprintf("%s-zonePasswords-%v", name, key0), &random.RandomPasswordArgs{
 			Length:          pulumi.Int(16),
 			Special:         pulumi.Bool(true),
-			OverrideSpecial: *pulumi.String(val0),
+			OverrideSpecial: pulumi.String(val0),
 		}, pulumi.Parent(&componentResource))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

Fixes #15524 where the primitive optional types were being derefrenced. It took me a while to figure where the problem was because I couldn't really reproduce the original issue with a new PCL program. The `aws-optionals-pp` test case program in PCL would repro the issue when converted from the CLI via `convert --from pcl` but not from the unit tests even when using the exact same schema 🤔 this was really weird. That said, the fix turned out straightforward and it does fix the same issue in generated component resources. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
