### PR TITLE
fix panic on deserializing deployment

### DIFF
--- a/changelog/pending/20240305--cli--fix-a-panic-when-the-secrets-provider-is-missing-from-the-deployment-snapshot.yaml
+++ b/changelog/pending/20240305--cli--fix-a-panic-when-the-secrets-provider-is-missing-from-the-deployment-snapshot.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic when the secrets provider is missing from the deployment snapshot

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -249,7 +249,7 @@ func DeserializeDeploymentV3(
 			// If there are ciphertexts, but we couldn't set up a secrets manager, error out early
 			// to avoid panic'ing later on.  This snapshot is broken and needs to be repaired
 			// manually.
-			return nil, errors.New("snapshot contains encrypted secrets but no secrets manager could be found.")
+			return nil, errors.New("snapshot contains encrypted secrets but no secrets manager could be found")
 		}
 		dec = config.NewPanicCrypter()
 		enc = config.NewPanicCrypter()

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -520,6 +520,7 @@ func TestDeserializeMissingSecretsManager(t *testing.T) {
 			},
 		},
 	}, b64.Base64SecretsProvider)
+	require.NoError(t, err)
 	assert.Equal(t, deployment, &deploy.Snapshot{
 		Manifest: deploy.Manifest{
 			Time:    time.Time{},
@@ -543,7 +544,6 @@ func TestDeserializeMissingSecretsManager(t *testing.T) {
 		},
 		PendingOperations: nil,
 	})
-	assert.NoError(t, err)
 }
 
 func TestSerializePropertyValue(t *testing.T) {


### PR DESCRIPTION
When a serialized deployment doesn't include a secrets provider configuration, but does include ciphertexts, currently we end up with a panic.  Error out earlier if this is the case to avoid the panic.

This fixes the panic seen in https://github.com/pulumi/pulumi/issues/15547 and https://github.com/pulumi/pulumi/issues/14761, but it doesn't quite explain why this is happening in the first place.  I asked for some more info from the users in these issues for that. 

Putting this up as PR anyway in case anyone has any idea of why this could be happening in the first place.  I've tried spelunking through the code, but nothing obvious stood out.  It is possible that these were still v2 snapshots that included no secrets manager, but I would be somewhat surprised if those still existed in the wild.  

Another potential solution here would be to try to pass the secret manager from the config in to the DeserializeDeployment function, so we could use that in these cases.  It might not always be correct though, so I'm not sure it's the right thing to do.

Thoughts?

