### PR TITLE
[sdk/python] Add an `invoke_async` function

### DIFF
--- a/changelog/pending/20240305--sdk-python--add-support-for-asynchronous-invokes-via-a-new-invoke_async-function.yaml
+++ b/changelog/pending/20240305--sdk-python--add-support-for-asynchronous-invokes-via-a-new-invoke_async-function.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add support for asynchronous invokes via a new `invoke_async` function

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -49,6 +49,7 @@ from .stack import (
 
 from .invoke import (
     invoke,
+    invoke_async,
     call,
 )
 
@@ -87,6 +88,8 @@ __all__ = [
     "register_stack_transformation",
     # invoke
     "invoke",
+    "invoke_async",
+    "call",
     # _json
     "to_json",
     # rpc

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -14,7 +14,18 @@
 import asyncio
 import os
 import traceback
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Coroutine,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    overload,
+)
 
 import grpc
 from google.protobuf import struct_pb2
@@ -101,6 +112,46 @@ def invoke(
     can be a bag of computed values (Ts or Awaitable[T]s), and the result is a Awaitable[Any] that
     resolves when the invoke finishes.
     """
+    return _invoke(tok, props, opts, typ, run_async=False)
+
+
+async def invoke_async(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[InvokeOptions] = None,
+    typ: Optional[type] = None,
+) -> Any:
+    """
+    invoke_async dynamically asynchronously invokes the function, tok, which is offered by a provider plugin.
+    the inputs can be a bag of computed values (Ts or Awaitable[T]s), and the result is a Awaitable[Any] that
+    resolves when the invoke finishes.
+    """
+    return await _invoke(tok, props, opts, typ, run_async=True)
+
+
+@overload
+def _invoke(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[InvokeOptions],
+    typ: Optional[type],
+    run_async: Literal[False],
+) -> InvokeResult: ...
+@overload
+def _invoke(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[InvokeOptions],
+    typ: Optional[type],
+    run_async: Literal[True],
+) -> Coroutine[Any, Any, Any]: ...
+def _invoke(
+    tok: str,
+    props: "Inputs",
+    opts: Optional[InvokeOptions],
+    typ: Optional[type],
+    run_async: bool,
+):
     log.debug(f"Invoking function: tok={tok}")
     if opts is None:
         opts = InvokeOptions()
@@ -185,9 +236,21 @@ def invoke(
             raise exn
         return resp
 
+    fut = asyncio.ensure_future(do_rpc())
+
+    if run_async:
+
+        async def wait_for_fut():
+            invoke_result, invoke_error = await fut
+            if invoke_error is not None:
+                raise invoke_error
+            return invoke_result
+
+        return wait_for_fut()
+
     # Run the RPC callback asynchronously and then immediately await it.
     # If there was a semantic error, raise it now, otherwise return the resulting value.
-    invoke_result, invoke_error = _sync_await(asyncio.ensure_future(do_rpc()))
+    invoke_result, invoke_error = _sync_await(fut)
     if invoke_error is not None:
         raise invoke_error
     return InvokeResult(invoke_result)

--- a/sdk/python/lib/test/langhost/invoke/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke/__main__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import asyncio
 from pulumi import CustomResource, Output, log
-from pulumi.runtime import invoke
+from pulumi.runtime import invoke, invoke_async
 
 def assert_eq(l, r):
     assert l == r
@@ -38,8 +38,15 @@ async def await_invoke():
     value = await invoke("test:index:MyFunction", props={"value": 41, "value2": get_value2()})
     return value["value"]
 
+async def await_invoke_async():
+    value = await invoke_async("test:index:MyFunction", props={"value": 41, "value2": get_value2()})
+    return value["value"]
+
 res = MyResource("resourceA", do_invoke())
 res.value.apply(lambda v: assert_eq(v, 42))
 
 res2 = MyResource("resourceB", await_invoke())
 res2.value.apply(lambda v: assert_eq(v, 42))
+
+res3 = MyResource("resourceC", await_invoke_async())
+res3.value.apply(lambda v: assert_eq(v, 42))

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -19,7 +19,7 @@ class TestInvoke(LanghostTest):
     def test_invoke_success(self):
         self.run_test(
             program=path.join(self.base_path(), "invoke"),
-            expected_resource_count=2)
+            expected_resource_count=3)
 
     def invoke(self, _ctx, token, args, provider, _version):
         self.assertEqual("test:index:MyFunction", token)

--- a/sdk/python/lib/test/langhost/invoke_empty_return/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke_empty_return/__main__.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulumi.runtime import invoke
+from pulumi import Output
+from pulumi.runtime import invoke, invoke_async
+
+
+def assert_eq(l, r):
+    assert l == r
 
 
 ret = invoke("test:index:MyFunction", {})
 assert ret.value == {}, "Expected the return value of the invoke to be an empty dict"
+
+ret2 = Output.from_input(invoke_async("test:index:MyFunction", {})).apply(lambda v: assert_eq(v, {}))


### PR DESCRIPTION
This commit adds a new `pulumi.runtime.invoke_async` function that allows calling invokes asynchronously. The initial intended use for this is inside the Kubernetes Python SDK's `yaml.ConfigFile`, `yaml.ConfigGroup`, `helm`, `kustomize`, etc. components to avoid stalls in resource registrations which severely limits parallelism.

I'd love to add some kind of benchmark, perhaps along the lines of the repro in #15462, but we can add that as a fast-follow.

Part of #15462 and #15591

After this is merged and released, we can ship an updated version of the Kubernetes Python SDK that makes use of it.