### PR TITLE
[program-gen] Fix panic when generating programs for MLC packages using external types

### DIFF
--- a/changelog/pending/20240306--programgen-dotnet-go-python--fix-panic-when-generating-programs-for-mlc-packages-where-they-include-type-references-to-external-packages.yaml
+++ b/changelog/pending/20240306--programgen-dotnet-go-python--fix-panic-when-generating-programs-for-mlc-packages-where-they-include-type-references-to-external-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet,go,python
+  description: Fix panic when generating programs for MLC packages where they include type references to external packages

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1051,9 +1051,14 @@ func (g *generator) argumentTypeNameWithSuffix(expr model.Expression, destType m
 		qualifier = ""
 	}
 
-	pkg, _, member, diags := pcl.DecomposeToken(token, tokenRange)
+	pkg, modName, member, diags := pcl.DecomposeToken(token, tokenRange)
 	contract.Assertf(len(diags) == 0, "error decomposing token: %v", diags)
-	module := g.tokenToModules[pkg](token)
+	var module string
+	if getModule, ok := g.tokenToModules[pkg]; ok {
+		module = getModule(token)
+	} else {
+		module = strings.SplitN(modName, "/", 2)[0]
+	}
 	namespaces := g.namespaces[pkg]
 	rootNamespace := namespaceName(namespaces, pkg)
 	namespace := namespaceName(namespaces, module)

--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -119,6 +119,8 @@ func dotnetDependencies(deps codegen.StringSet) []dep {
 			result[i] = dep{"Pulumi.Kubernetes", test.KubernetesSchema}
 		case "random":
 			result[i] = dep{"Pulumi.Random", test.RandomSchema}
+		case "aws-static-website":
+			result[i] = dep{"Pulumi.AwsStaticWebsite", test.AwsStaticWebsiteSchema}
 		default:
 			result[i] = dep{"Pulumi." + Title(d), ""}
 		}

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -683,6 +683,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 
 func (g *generator) collectTypeImports(program *pcl.Program, t schema.Type) {
 	var token string
+	var packageRef schema.PackageReference
 	switch t := t.(type) {
 	case *schema.InputType:
 		g.collectTypeImports(program, t.ElementType)
@@ -703,20 +704,32 @@ func (g *generator) collectTypeImports(program *pcl.Program, t schema.Type) {
 		return
 	case *schema.ObjectType:
 		token = t.Token
+		packageRef = t.PackageReference
 	case *schema.EnumType:
 		token = t.Token
+		packageRef = t.PackageReference
 	case *schema.TokenType:
 		token = t.Token
+		var tokenRange hcl.Range
+		pkg, mod, name, _ := pcl.DecomposeToken(token, tokenRange)
+		vPath, err := g.getVersionPath(program, pkg)
+		if err != nil {
+			panic(err)
+		}
+		g.addPulumiImport(pkg, vPath, mod, name)
 	case *schema.ResourceType:
 		token = t.Token
+		if t.Resource != nil {
+			packageRef = t.Resource.PackageReference
+		}
 	}
-	if token == "" {
+	if token == "" || packageRef == nil {
 		return
 	}
 
 	var tokenRange hcl.Range
 	pkg, mod, name, _ := pcl.DecomposeToken(token, tokenRange)
-	vPath, err := g.getVersionPath(program, pkg)
+	vPath, err := g.packageVersionPath(packageRef)
 	if err != nil {
 		panic(err)
 	}
@@ -845,6 +858,13 @@ func (g *generator) collectConvertImports(
 	}
 }
 
+func (g *generator) packageVersionPath(packageRef schema.PackageReference) (string, error) {
+	if ver := packageRef.Version(); ver != nil && ver.Major > 1 {
+		return fmt.Sprintf("/v%d", ver.Major), nil
+	}
+	return "", nil
+}
+
 func (g *generator) getVersionPath(program *pcl.Program, pkg string) (string, error) {
 	for _, p := range program.PackageReferences() {
 		if p.Name() == pkg {
@@ -883,6 +903,7 @@ func (g *generator) addPulumiImport(pkg, versionPath, mod, name string) {
 	// module named IndexToken.
 	info, hasInfo := g.getGoPackageInfo(pkg) // We're allowing `info` to be zero-initialized
 	if !hasInfo {
+		mod = strings.SplitN(mod, "/", 2)[0]
 		path := importPath(mod, "")
 		// users hasn't provided any extra overrides
 		if mod == "" || mod == IndexToken {
@@ -1685,6 +1706,7 @@ func (fi *fileImporter) Import(importPath string, name string) (actualName strin
 	contract.Requiref(importPath != "", "importPath", "must not be empty")
 	contract.Requiref(name != "", "name", "must not be empty (importPath: %q)", importPath)
 
+	name = strings.ReplaceAll(name, "-", "")
 	// For readability, always add an alias if the package name
 	// does not match the base name of the import path.
 	// For example, "example.com/foo-go" with package "foo"

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -101,6 +101,8 @@ func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
 			set(test.RandomSchema)
 		case "eks":
 			set(test.EksSchema)
+		case "aws-static-website":
+			set(test.AwsStaticWebsiteSchema)
 		default:
 			t.Logf("Unknown package requested: %s", d)
 		}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -524,8 +524,8 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 			if r.Schema != nil && r.Schema.PackageReference != nil {
 				pkg, err := r.Schema.PackageReference.Definition()
 				if err == nil {
-					if info, ok := pkg.Language["python"].(PackageInfo); ok && info.PackageName != "" {
-						packageName = info.PackageName
+					if pkgInfo, ok := pkg.Language["python"].(PackageInfo); ok && pkgInfo.PackageName != "" {
+						packageName = pkgInfo.PackageName
 					}
 				}
 			}
@@ -652,9 +652,10 @@ func resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 			err = pkg.ImportLanguages(map[string]schema.Language{"python": Importer})
 			contract.AssertNoErrorf(err, "failed to import python language plugin for package %s", pkg.Name)
 			if lang, ok := pkg.Language["python"]; ok {
-				pkgInfo := lang.(PackageInfo)
-				if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
-					module = m
+				if pkgInfo, ok := lang.(PackageInfo); ok {
+					if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
+						module = m
+					}
 				}
 			}
 		}
@@ -690,9 +691,10 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type)
 	pkg, err := objType.PackageReference.Definition()
 	contract.AssertNoErrorf(err, "error loading definition for package %q", objType.PackageReference.Name())
 	if lang, ok := pkg.Language["python"]; ok {
-		pkgInfo := lang.(PackageInfo)
-		if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
-			modName = m
+		if pkgInfo, ok := lang.(PackageInfo); ok {
+			if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
+				modName = m
+			}
 		}
 	}
 	return tokenToQualifiedName(pkgName, modName, member) + "Args"

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -367,12 +367,13 @@ type SchemaVersion = string
 // Schemas are downloaded in the makefile, and the versions specified here
 // should be in sync with the makefile.
 const (
-	AwsSchema         SchemaVersion = "4.26.0"
-	AzureNativeSchema SchemaVersion = "1.29.0"
-	AzureSchema       SchemaVersion = "4.18.0"
-	KubernetesSchema  SchemaVersion = "3.7.2"
-	RandomSchema      SchemaVersion = "4.11.2"
-	EksSchema         SchemaVersion = "0.37.1"
+	AwsSchema              SchemaVersion = "4.26.0"
+	AzureNativeSchema      SchemaVersion = "1.29.0"
+	AzureSchema            SchemaVersion = "4.18.0"
+	KubernetesSchema       SchemaVersion = "3.7.2"
+	RandomSchema           SchemaVersion = "4.11.2"
+	EksSchema              SchemaVersion = "0.37.1"
+	AwsStaticWebsiteSchema SchemaVersion = "0.4.0"
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -93,6 +93,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "AWS Fargate",
 	},
 	{
+		Directory:   "aws-static-website",
+		Description: "an example resource from AWS static website multi-language component",
+		// TODO: blocked on resolving imports (python) / using statements (C#) for types from external packages
+		SkipCompile: codegen.NewStringSet("dotnet", "python"),
+	},
+	{
 		Directory:   "aws-fargate-output-versioned",
 		Description: "AWS Fargate Using Output-versioned invokes for python and typescript",
 		Skip:        codegen.NewStringSet("go", "dotnet"),

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -93,5 +93,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"enum", "1.0.0"},
 		SchemaProvider{"plain-properties", "1.0.0"},
 		SchemaProvider{"recursive", "1.0.0"},
+		SchemaProvider{"aws-static-website", "0.4.0"},
 	)
 }

--- a/tests/testdata/codegen/aws-static-website-0.4.0.json
+++ b/tests/testdata/codegen/aws-static-website-0.4.0.json
@@ -1,0 +1,204 @@
+{
+  "name": "aws-static-website",
+  "displayName": "AWS Static Website",
+  "version": "0.4.0",
+  "description": "A Pulumi component to deploy a static website to AWS",
+  "keywords": [
+    "pulumi",
+    "aws",
+    "category/cloud",
+    "kind/component",
+    "web"
+  ],
+  "homepage": "https://pulumi.com",
+  "repository": "https://github.com/pulumi/pulumi-aws-static-website",
+  "publisher": "Pulumi",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "packageReferences": {
+        "Pulumi": "3.*",
+        "Pulumi.Aws": "5.*"
+      }
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-aws-static-website/sdk/go/aws-static-website"
+    },
+    "nodejs": {
+      "dependencies": {
+        "@pulumi/aws": "^5.0.0",
+        "@pulumi/pulumi": "^3.37.0"
+      },
+      "devDependencies": {
+        "typescript": "^3.7.0"
+      }
+    },
+    "python": {
+      "requires": {
+        "pulumi": "\u003e=3.0.0,\u003c4.0.0",
+        "pulumi-aws": "\u003e=5.0.0,\u003c6.0.0"
+      }
+    }
+  },
+  "config": {},
+  "types": {
+    "aws-static-website:index:CDNArgs": {
+      "properties": {
+        "cloudfrontFunctionAssociations": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v5.16.2/schema.json#/types/aws:cloudfront%2FDistributionOrderedCacheBehaviorFunctionAssociation:DistributionOrderedCacheBehaviorFunctionAssociation"
+          },
+          "description": "A config block that triggers a cloudfront\nfunction with specific actions.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "forwardedValues": {
+          "$ref": "/aws/v5.16.2/schema.json#/types/aws:cloudfront%2FDistributionDefaultCacheBehaviorForwardedValues:DistributionDefaultCacheBehaviorForwardedValues",
+          "description": "The forwarded values configuration that specifies how CloudFront handles query strings, cookies and headers."
+        },
+        "lambdaFunctionAssociations": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v5.16.2/schema.json#/types/aws:cloudfront%2FDistributionOrderedCacheBehaviorLambdaFunctionAssociation:DistributionOrderedCacheBehaviorLambdaFunctionAssociation"
+          },
+          "description": "A config block that triggers a lambda\nfunction with specific actions.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "aws-static-website:index:PublicBucketPolicy": {
+      "properties": {
+        "ownershipControls": {
+          "$ref": "/aws/v5.16.2/schema.json#/resources/aws:s3%2FbucketOwnershipControls:BucketOwnershipControls"
+        },
+        "publicAccessBlock": {
+          "$ref": "/aws/v5.16.2/schema.json#/resources/aws:s3%2FbucketPublicAccessBlock:BucketPublicAccessBlock"
+        }
+      },
+      "type": "object",
+      "required": [
+        "ownershipControls",
+        "publicAccessBlock"
+      ],
+      "inputProperties": {
+        "bucket": {
+          "$ref": "/aws/v5.16.2/schema.json#/resources/aws:s3%2Fbucket:Bucket",
+          "description": "The bucket to apply the public policy to."
+        }
+      },
+      "requiredInputs": [
+        "bucket"
+      ],
+      "isComponent": true
+    },
+    "aws-static-website:index:Website": {
+      "properties": {
+        "bucketName": {
+          "type": "string",
+          "description": "The name of the s3 bucket containing the website contents."
+        },
+        "bucketWebsiteURL": {
+          "type": "string",
+          "description": "The website URL for the s3 bucket."
+        },
+        "cdnDomainName": {
+          "type": "string",
+          "description": "The domain name for the CDN."
+        },
+        "cdnURL": {
+          "type": "string",
+          "description": "The URL for the CDN"
+        },
+        "logsBucketName": {
+          "type": "string",
+          "description": "The name of the s3 bucket containing the access logs."
+        },
+        "websiteURL": {
+          "type": "string",
+          "description": "The URL to access the website"
+        }
+      },
+      "type": "object",
+      "required": [
+        "bucketName",
+        "bucketWebsiteURL",
+        "websiteURL"
+      ],
+      "inputProperties": {
+        "addWebsiteVersionHeader": {
+          "type": "boolean",
+          "description": "Enable a cache control header to be attached to every request from an Cloudfront Function."
+        },
+        "atomicDeployments": {
+          "type": "boolean",
+          "description": "Provision a new bucket on each deployment."
+        },
+        "cacheTTL": {
+          "type": "number",
+          "description": "TTL in seconds for cached objects. "
+        },
+        "cdnArgs": {
+          "$ref": "#/types/aws-static-website:index:CDNArgs",
+          "description": "Optional arguments used to configure the CDN."
+        },
+        "certificateARN": {
+          "type": "string",
+          "description": "The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process."
+        },
+        "error404": {
+          "type": "string",
+          "description": "default 404 page"
+        },
+        "indexHTML": {
+          "type": "string",
+          "description": "The default document for the site. Defaults to index.html"
+        },
+        "priceClass": {
+          "type": "string",
+          "description": "The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`"
+        },
+        "sitePath": {
+          "type": "string",
+          "description": "The root directory containing the website's contents."
+        },
+        "subdomain": {
+          "type": "string",
+          "description": "An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com)."
+        },
+        "targetDomain": {
+          "type": "string",
+          "description": "The domain used to serve the content. A Route53 hosted zone must exist for this domain."
+        },
+        "withCDN": {
+          "type": "boolean",
+          "description": "Provision CloudFront CDN to serve content."
+        },
+        "withLogs": {
+          "type": "boolean",
+          "description": "Provision a bucket to hold access logs."
+        }
+      },
+      "requiredInputs": [
+        "sitePath"
+      ],
+      "isComponent": true
+    }
+  }
+}

--- a/tests/testdata/codegen/aws-static-website-pp/aws-static-website.pp
+++ b/tests/testdata/codegen/aws-static-website-pp/aws-static-website.pp
@@ -1,0 +1,34 @@
+resource "websiteResource" "aws-static-website:index:Website" {
+  sitePath = "string"
+  indexHTML = "string"
+  cacheTTL = 0.0
+  cdnArgs = {
+    cloudfrontFunctionAssociations = [{
+      eventType = "string"
+      functionArn = "string"
+    }]
+    forwardedValues = {
+      cookies = {
+        forward = "string"
+        whitelistedNames = ["string"]
+      }
+      queryString = false
+      headers = ["string"]
+      queryStringCacheKeys = ["string"]
+    }
+    lambdaFunctionAssociations = [{
+      eventType = "string"
+      lambdaArn = "string"
+      includeBody = false
+    }]
+  }
+  certificateARN = "string"
+  error404 = "string"
+  addWebsiteVersionHeader = false
+  priceClass = "string"
+  atomicDeployments = false
+  subdomain = "string"
+  targetDomain = "string"
+  withCDN = false
+  withLogs = false
+}

--- a/tests/testdata/codegen/aws-static-website-pp/dotnet/aws-static-website.cs
+++ b/tests/testdata/codegen/aws-static-website-pp/dotnet/aws-static-website.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using AwsStaticWebsite = Pulumi.AwsStaticWebsite;
+
+return await Deployment.RunAsync(() => 
+{
+    var websiteResource = new AwsStaticWebsite.Website("websiteResource", new()
+    {
+        SitePath = "string",
+        IndexHTML = "string",
+        CacheTTL = 0,
+        CdnArgs = new AwsStaticWebsite.Inputs.CDNArgsArgs
+        {
+            CloudfrontFunctionAssociations = new[]
+            {
+                new Aws.Cloudfront.Inputs.DistributionOrderedCacheBehaviorFunctionAssociationArgs
+                {
+                    EventType = "string",
+                    FunctionArn = "string",
+                },
+            },
+            ForwardedValues = new Aws.Cloudfront.Inputs.DistributionDefaultCacheBehaviorForwardedValuesArgs
+            {
+                Cookies = new Aws.Cloudfront.Inputs.DistributionDefaultCacheBehaviorForwardedValuesCookiesArgs
+                {
+                    Forward = "string",
+                    WhitelistedNames = new[]
+                    {
+                        "string",
+                    },
+                },
+                QueryString = false,
+                Headers = new[]
+                {
+                    "string",
+                },
+                QueryStringCacheKeys = new[]
+                {
+                    "string",
+                },
+            },
+            LambdaFunctionAssociations = new[]
+            {
+                new Aws.Cloudfront.Inputs.DistributionOrderedCacheBehaviorLambdaFunctionAssociationArgs
+                {
+                    EventType = "string",
+                    LambdaArn = "string",
+                    IncludeBody = false,
+                },
+            },
+        },
+        CertificateARN = "string",
+        Error404 = "string",
+        AddWebsiteVersionHeader = false,
+        PriceClass = "string",
+        AtomicDeployments = false,
+        Subdomain = "string",
+        TargetDomain = "string",
+        WithCDN = false,
+        WithLogs = false,
+    });
+
+});
+

--- a/tests/testdata/codegen/aws-static-website-pp/go/aws-static-website.go
+++ b/tests/testdata/codegen/aws-static-website-pp/go/aws-static-website.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	awsstaticwebsite "github.com/pulumi/pulumi-aws-static-website/sdk/go/aws-static-website"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cloudfront"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := awsstaticwebsite.NewWebsite(ctx, "websiteResource", &awsstaticwebsite.WebsiteArgs{
+			SitePath:  pulumi.String("string"),
+			IndexHTML: pulumi.String("string"),
+			CacheTTL:  pulumi.Float64(0),
+			CdnArgs: &awsstaticwebsite.CDNArgsArgs{
+				CloudfrontFunctionAssociations: cloudfront.DistributionOrderedCacheBehaviorFunctionAssociationArray{
+					&cloudfront.DistributionOrderedCacheBehaviorFunctionAssociationArgs{
+						EventType:   pulumi.String("string"),
+						FunctionArn: pulumi.String("string"),
+					},
+				},
+				ForwardedValues: &cloudfront.DistributionDefaultCacheBehaviorForwardedValuesArgs{
+					Cookies: &cloudfront.DistributionDefaultCacheBehaviorForwardedValuesCookiesArgs{
+						Forward: pulumi.String("string"),
+						WhitelistedNames: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+					},
+					QueryString: pulumi.Bool(false),
+					Headers: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					QueryStringCacheKeys: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+				},
+				LambdaFunctionAssociations: cloudfront.DistributionOrderedCacheBehaviorLambdaFunctionAssociationArray{
+					&cloudfront.DistributionOrderedCacheBehaviorLambdaFunctionAssociationArgs{
+						EventType:   pulumi.String("string"),
+						LambdaArn:   pulumi.String("string"),
+						IncludeBody: pulumi.Bool(false),
+					},
+				},
+			},
+			CertificateARN:          pulumi.String("string"),
+			Error404:                pulumi.String("string"),
+			AddWebsiteVersionHeader: pulumi.Bool(false),
+			PriceClass:              pulumi.String("string"),
+			AtomicDeployments:       pulumi.Bool(false),
+			Subdomain:               pulumi.String("string"),
+			TargetDomain:            pulumi.String("string"),
+			WithCDN:                 pulumi.Bool(false),
+			WithLogs:                pulumi.Bool(false),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/tests/testdata/codegen/aws-static-website-pp/nodejs/aws-static-website.ts
+++ b/tests/testdata/codegen/aws-static-website-pp/nodejs/aws-static-website.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws_static_website from "@pulumi/aws-static-website";
+
+const websiteResource = new aws_static_website.Website("websiteResource", {
+    sitePath: "string",
+    indexHTML: "string",
+    cacheTTL: 0,
+    cdnArgs: {
+        cloudfrontFunctionAssociations: [{
+            eventType: "string",
+            functionArn: "string",
+        }],
+        forwardedValues: {
+            cookies: {
+                forward: "string",
+                whitelistedNames: ["string"],
+            },
+            queryString: false,
+            headers: ["string"],
+            queryStringCacheKeys: ["string"],
+        },
+        lambdaFunctionAssociations: [{
+            eventType: "string",
+            lambdaArn: "string",
+            includeBody: false,
+        }],
+    },
+    certificateARN: "string",
+    error404: "string",
+    addWebsiteVersionHeader: false,
+    priceClass: "string",
+    atomicDeployments: false,
+    subdomain: "string",
+    targetDomain: "string",
+    withCDN: false,
+    withLogs: false,
+});

--- a/tests/testdata/codegen/aws-static-website-pp/python/aws-static-website.py
+++ b/tests/testdata/codegen/aws-static-website-pp/python/aws-static-website.py
@@ -1,0 +1,36 @@
+import pulumi
+import pulumi_aws_static_website as aws_static_website
+
+website_resource = aws_static_website.Website("websiteResource",
+    site_path="string",
+    index_html="string",
+    cache_ttl=0,
+    cdn_args=aws_static_website.CDNArgsArgs(
+        cloudfront_function_associations=[aws.cloudfront.DistributionOrderedCacheBehaviorFunctionAssociationArgs(
+            event_type="string",
+            function_arn="string",
+        )],
+        forwarded_values=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesArgs(
+            cookies=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesCookiesArgs(
+                forward="string",
+                whitelisted_names=["string"],
+            ),
+            query_string=False,
+            headers=["string"],
+            query_string_cache_keys=["string"],
+        ),
+        lambda_function_associations=[aws.cloudfront.DistributionOrderedCacheBehaviorLambdaFunctionAssociationArgs(
+            event_type="string",
+            lambda_arn="string",
+            include_body=False,
+        )],
+    ),
+    certificate_arn="string",
+    error404="string",
+    add_website_version_header=False,
+    price_class="string",
+    atomic_deployments=False,
+    subdomain="string",
+    target_domain="string",
+    with_cdn=False,
+    with_logs=False)


### PR DESCRIPTION
# Description

For an MLC package such as `aws-static-website`, it has some types which are referenced from the `aws` package. Program-gen assumes packages are inferred from resources and invokes, not types which caused panics in Go (#15597), dotnet and python (https://github.com/pulumi/pulumi-converter-constructor-syntax/issues/2)

This PR fixes those panics. In Go the panic was due to using package name instead of the package reference from the imported type. In dotnet and python was due to assuming no external type references. Now we generate nice code for all these languages. 

That said, there is still an issue of resolving imports for the packages of these external types. It works in Go, TypeScript doesn't need it but dotnet and python do. That is why the latter are added in `SkipCompile` in the test program.


Fixes #15597
Fixes https://github.com/pulumi/pulumi-converter-constructor-syntax/issues/3
Fixes https://github.com/pulumi/pulumi-converter-constructor-syntax/issues/2

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
