### PR TITLE
remove chdir

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -281,13 +280,6 @@ type runActions interface {
 func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 	preview bool,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	// Change into the plugin context's working directory.
-	chdir, err := fsutil.Chdir(deployment.Plugctx.Pwd)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer chdir()
-
 	// Create a new context for cancellation and tracing.
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
@@ -335,6 +327,7 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 		}
 	}()
 
+	var err error
 	// Wait for the deployment to finish executing or for the user to terminate the run.
 	select {
 	case <-cancelCtx.Cancel.Terminated():


### PR DESCRIPTION
Remove the Chdir we currently do in the engine.  This probably was
required at one point, but it no longer is.

The engine itself doesn't do anything with the CWD.  At the time the
deployment is running all the data it needs has already been read, and
all it does at this point is communicated with the language plugin and
the providers.

Those providers are already started with the correct CWD passed in to
its execution (see https://github.com/pulumi/pulumi/blob/f1f4d223f4ad275f7ade1e34b6229931cf7636ac/sdk/go/common/resource/plugin/plugin.go#L377).

And as these subprocesses are executed as binaries, they are
unaffected by the Chdir anyway.  Remove the Chdir, as it unlocks
further improvements, especially in tests.

If this fails in some manner, it should be pretty obvious, as the program should just blow up in that case.  It will be good to run this at least through the examples/templates tests via the dev channel SDK mechanism as well.

