### PR TITLE
Add an `Output.to_thread` method

### DIFF
--- a/changelog/pending/20240306--sdk-python--adds-a-to_thread-static-method-to-output-to-allow-running-code-in-another-thread-and-capturing-the-result-as-an-output.yaml
+++ b/changelog/pending/20240306--sdk-python--adds-a-to_thread-static-method-to-output-to-allow-running-code-in-another-thread-and-capturing-the-result-as-an-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Adds a `to_thread` static method to output, to allow running code in another thread and capturing the result as an output

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -381,6 +381,25 @@ class Output(Generic[T_co]):
         return Output(set(), value_fut, is_known_fut, is_secret_fut)
 
     @staticmethod
+    def to_thread(
+        func: Callable[[Any], T], *args: Tuple[Any], **kwargs: Dict[str, Any]
+    ) -> "Output[T]":
+        """
+        Asynchronously run function *func* in a different thread.
+
+        This has the same semantics as `asyncio.to_thread` except it returns an Output rather than a coroutine.
+
+        Any *args and **kwargs supplied for this function are passed directly to *func*
+
+        :param Callable[[Any], T] func: A function that will be called on a new thread.
+        :param Tuple[Any] *args: The arguments list if any to pass to *func*
+        :param Dict[str, Any] **kwargs: The keyword arguments that will be passed to *func*
+        :return: The result of *func* as an Output.
+        :rtype: Output[T]
+        """
+        return Output._from_input_shallow(asyncio.to_thread(func, *args, **kwargs))
+
+    @staticmethod
     def unsecret(val: "Output[T]") -> "Output[T]":
         """
         Takes an existing Output, deeply unwraps the nested values and returns a new Output without any secrets included


### PR DESCRIPTION
# Description

This adds a `to_thread` static method to the `Output` class

This has the same general semantics as `asyncio.to_thread` but returns an Output of the result, rather than an awaitable coroutine.

This allows customers to call blocking code on another thread and feed the result back into their pulumi program as an Output which can be simply consumed by resources.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
