### PR TITLE
Add `blocking_call` to the pulumi python api

### DIFF
--- a/changelog/pending/20240307--sdk-python--add-blocking_call-api-to-allow-programs-to-run-blocking-calls-synchronously-without-stopping-the-event-loop.yaml
+++ b/changelog/pending/20240307--sdk-python--add-blocking_call-api-to-allow-programs-to-run-blocking-calls-synchronously-without-stopping-the-event-loop.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add `blocking_call` api to allow programs to run blocking calls synchronously without stopping the event loop

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -100,6 +100,8 @@ from ._types import (
 
 from . import runtime, dynamic, policy, automation
 
+from .runtime.sync_await import blocking_call
+
 __all__ = [
     # asset
     "Asset",
@@ -159,6 +161,8 @@ __all__ = [
     "getter",
     "get",
     "set",
+    # runtime.sync_await
+    "blocking_call",
     # sub-modules
     "runtime",
     "dynamic",

--- a/sdk/python/lib/test/runtime/test_sync_await.py
+++ b/sdk/python/lib/test/runtime/test_sync_await.py
@@ -1,0 +1,90 @@
+# Copyright 2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+import unittest
+from typing import Dict, Tuple
+
+import pulumi
+from pulumi.runtime import settings
+
+def pulumi_test(coro):
+    wrapped = pulumi.runtime.test(coro)
+    def wrapper(*args, **kwargs):
+        settings.configure(settings.Settings("project", "stack"))
+
+        wrapped(*args, **kwargs)
+
+    return wrapper
+
+
+async def return_slowly(value: int, settings: Dict[str, bool]) -> Tuple[int, bool]:
+    await asyncio.sleep(value * 0.001)
+    return value, settings['before']
+
+
+class BlockingCallTests(unittest.TestCase):
+    @pulumi_test
+    async def test_blocking_call_allows_async_tasks(self):
+        # create a bunch of tasks numbered from 0 to 100, these will
+        # each sleep (asynchronously) for that number of milliseconds
+        settings = {'before':True}
+        tasks = [return_slowly(i, settings) for i in range(100)]
+        gather = asyncio.gather(*tasks)
+
+        # block for 50 milliseconds, so roughly half of the tasks should have completed
+        # by the time this call is completed, but most importantly they should be able to 
+        # proceed while this is 'blocking'
+        pulumi.blocking_call(time.sleep, 0.05)
+        settings['before'] = False
+        # Wait for the "slow" tasks
+        results = await gather
+
+        # verify that every task ran by using the sum of 0-99 as a crude checksum
+        numbers = [el[0] for el in results]
+        self.assertEqual(4950, sum(numbers))
+
+        # roughly half of the tasks should complete before the blocking call, 
+        # and roughly half after. We're checking that more than 10 and fewer than 90 did
+        before = sum(1 if el[1] else 0 for el in results)
+        self.assertAlmostEqual(50, before, delta=40)
+    
+
+    @pulumi_test
+    async def test_blocking_thread_prevents_tasks(self):
+        # create a bunch of tasks numbered from 0 to 100, these will
+        # each sleep (asynchronously) for that number of milliseconds
+        settings = {'before':True}
+        tasks = [return_slowly(i, settings) for i in range(100)]
+        gather = asyncio.gather(*tasks)
+
+        # block for 50 milliseconds. None of the async tasks will be
+        # able to proceed while this is happening
+        time.sleep(0.05)
+        settings['before'] = False
+
+        # wait for the "slow" tasks
+        results = await gather
+
+        # verify that every task ran by using the sum of 0-99 as a crude checksum
+        numbers = [el[0] for el in results]
+        self.assertEqual(4950, sum(numbers))
+
+        # zero, of the tasks will have been scheduled before the blocking call to 
+        # time.sleep because the thread never yielded.
+        before = sum(1 if el[1] else 0 for el in results)
+        self.assertEqual(0, before)
+    
+


### PR DESCRIPTION
# Description

This allows a python program to make a blocking call (e.g. a `requests.get` or a `subprocess.check_output`) without preventing the main thread's event loop from pumping events.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
