### PR TITLE
Downgrade remediate policy violations to mandatory

### DIFF
--- a/changelog/pending/20240307--engine--downgrade-remediate-policy-violations-to-mandatory.yaml
+++ b/changelog/pending/20240307--engine--downgrade-remediate-policy-violations-to-mandatory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Downgrade remediate policy violations to mandatory


### PR DESCRIPTION
Policy violations should not have a remediate enforcement level. The Policy SDK currently downgrades the level from remediate to mandatory for resource policy violations, but isn't currently doing that for stack policies. A change to the Policy SDK is in-progress to do that.

This change applies the same behavior to the engine. If a resource policy still has a violation after running remediations and the level is remediate, "downgrade" the level to mandatory. Similarly, if a stack policy has a violation with a remediate level, downgrade it to mandatory.

This avoids a panic when getting a policy violation from a stack policy and the enforcement level is remediate.

Related: https://github.com/pulumi/pulumi-policy/pull/339

Fixes https://github.com/pulumi/pulumi-policy/issues/332