### PR TITLE
[docs] Emit example constructor syntax for resources in typescript, python, go and csharp

### DIFF
--- a/changelog/pending/20240312--docs--implement-constructor-syntax-examples-for-every-resource-in-typescript-python-csharp-and-go.yaml
+++ b/changelog/pending/20240312--docs--implement-constructor-syntax-examples-for-every-resource-in-typescript-python-csharp-and-go.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: docs
+  description: Implement constructor syntax examples for every resource in typescript, python, csharp and go

--- a/pkg/codegen/docs/constructor_syntax_extractor.go
+++ b/pkg/codegen/docs/constructor_syntax_extractor.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"fmt"
+	"strings"
+)
+
+func extractConstructorSyntaxExamples(
+	program string,
+	indentToTrim string,
+	commentDelimiter string,
+	exampleEndPredicate func(string) bool,
+) *languageConstructorSyntax {
+	resources := map[string]string{}
+	invokes := map[string]string{}
+	currentExample := ""
+	currentToken := ""
+	readingResource := false
+	readingInvoke := false
+
+	for _, line := range strings.Split(program, "\n") {
+		line = strings.TrimPrefix(line, indentToTrim)
+		if strings.HasPrefix(line, fmt.Sprintf("%s Resource", commentDelimiter)) {
+			currentExample = ""
+			readingResource = true
+			readingInvoke = false
+			commentParts := strings.Split(line, " ")
+			currentToken = commentParts[len(commentParts)-1]
+			continue
+		}
+
+		if strings.HasPrefix(line, fmt.Sprintf("%s Invoke", commentDelimiter)) {
+			currentExample = ""
+			readingInvoke = true
+			readingResource = false
+			commentParts := strings.Split(line, " ")
+			currentToken = commentParts[len(commentParts)-1]
+			continue
+		}
+
+		if readingResource || readingInvoke {
+			if currentExample != "" {
+				currentExample = currentExample + "\n" + line
+			} else {
+				currentExample = line
+			}
+		}
+
+		if exampleEndPredicate(line) && currentToken != "" {
+			if readingResource {
+				resources[currentToken] = currentExample
+			} else if readingInvoke {
+				invokes[currentToken] = currentExample
+			}
+			currentToken = ""
+			readingResource = false
+			readingInvoke = false
+		}
+	}
+
+	return &languageConstructorSyntax{
+		resources: resources,
+		invokes:   invokes,
+	}
+}

--- a/pkg/codegen/docs/constructor_syntax_generator.go
+++ b/pkg/codegen/docs/constructor_syntax_generator.go
@@ -1,0 +1,433 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type constructorSyntaxGenerator struct {
+	indentSize             int
+	requiredPropertiesOnly bool
+}
+
+type generateAllOptions struct {
+	includeResources bool
+	includeFunctions bool
+	resourcesToSkip  []string
+}
+
+func (g *constructorSyntaxGenerator) indented(f func()) {
+	g.indentSize += 2
+	f()
+	g.indentSize -= 2
+}
+
+func (g *constructorSyntaxGenerator) indent(buffer *bytes.Buffer) {
+	buffer.WriteString(strings.Repeat(" ", g.indentSize))
+}
+
+func (g *constructorSyntaxGenerator) write(buffer *bytes.Buffer, format string, args ...interface{}) {
+	buffer.WriteString(fmt.Sprintf(format, args...))
+}
+
+func (g *constructorSyntaxGenerator) writeValue(
+	buffer *bytes.Buffer,
+	valueType schema.Type,
+	seenTypes codegen.StringSet,
+) {
+	write := func(format string, args ...interface{}) {
+		g.write(buffer, format, args...)
+	}
+
+	writeValue := func(valueType schema.Type) {
+		g.writeValue(buffer, valueType, seenTypes)
+	}
+
+	switch valueType {
+	case schema.AnyType:
+		write("\"any\"")
+	case schema.JSONType:
+		write("\"{}\"")
+	case schema.BoolType:
+		write("false")
+	case schema.IntType:
+		write("0")
+	case schema.NumberType:
+		write("0.0")
+	case schema.StringType:
+		write("\"string\"")
+	case schema.ArchiveType:
+		write("fileArchive(\"./path/to/archive\")")
+	case schema.AssetType:
+		write("stringAsset(\"content\")")
+	}
+
+	switch valueType := valueType.(type) {
+	case *schema.ArrayType:
+		write("[")
+		if !isResourceType(valueType.ElementType) {
+			writeValue(valueType.ElementType)
+		}
+		write("]")
+	case *schema.MapType:
+		write("{\n")
+		g.indented(func() {
+			g.indent(buffer)
+			if !isResourceType(valueType.ElementType) {
+				write("\"string\" = ")
+				writeValue(valueType.ElementType)
+				write("\n")
+			}
+		})
+		g.indent(buffer)
+		write("}")
+	case *schema.ObjectType:
+		if seenTypes.Has(valueType.Token) && objectTypeHasRecursiveReference(valueType) {
+			write("notImplemented(%q)", valueType.Token)
+			return
+		}
+
+		seenTypes.Add(valueType.Token)
+		write("{\n")
+		g.indented(func() {
+			sortPropertiesByRequiredFirst(valueType.Properties)
+			for _, p := range valueType.Properties {
+				if p.DeprecationMessage != "" {
+					continue
+				}
+
+				if g.requiredPropertiesOnly && !p.IsRequired() {
+					continue
+				}
+
+				if isResourceType(p.Type) {
+					// skip properties that have type resource
+					continue
+				}
+
+				g.indent(buffer)
+				write("%s = ", p.Name)
+				if p.ConstValue != nil {
+					// constant values used for discriminator properties of object need to be exact
+					// we write them out here as strings to generate correct programs
+					if stringValue, ok := p.ConstValue.(string); ok {
+						write("%q", stringValue)
+					} else {
+						writeValue(p.Type)
+					}
+				} else {
+					writeValue(p.Type)
+				}
+
+				write("\n")
+			}
+		})
+		g.indent(buffer)
+		write("}")
+	case *schema.ResourceType:
+		write("notImplemented(%q)", valueType.Token)
+	case *schema.EnumType:
+		cases := make([]string, len(valueType.Elements))
+		for index, c := range valueType.Elements {
+			if c.DeprecationMessage != "" {
+				continue
+			}
+
+			if stringCase, ok := c.Value.(string); ok && stringCase != "" {
+				cases[index] = stringCase
+			} else if intCase, ok := c.Value.(int); ok {
+				cases[index] = strconv.Itoa(intCase)
+			} else {
+				if c.Name != "" {
+					cases[index] = c.Name
+				}
+			}
+		}
+
+		if len(cases) > 0 {
+			write(fmt.Sprintf("%q", cases[0]))
+		} else {
+			write("null")
+		}
+	case *schema.UnionType:
+		if isUnionOfObjects(valueType) && len(valueType.ElementTypes) >= 1 {
+			writeValue(valueType.ElementTypes[0])
+			return
+		}
+
+		for _, elem := range valueType.ElementTypes {
+			if isPrimitiveType(elem) {
+				writeValue(elem)
+				return
+			}
+		}
+		write("null")
+
+	case *schema.InputType:
+		writeValue(valueType.ElementType)
+	case *schema.OptionalType:
+		writeValue(valueType.ElementType)
+	case *schema.TokenType:
+		writeValue(valueType.UnderlyingType)
+	}
+}
+
+func (g *constructorSyntaxGenerator) exampleResourceWithName(r *schema.Resource, name func(string) string) string {
+	buffer := bytes.Buffer{}
+	seenTypes := codegen.NewStringSet()
+	resourceName := name(r.Token)
+	g.write(&buffer, "resource \"%s\" %q {\n", resourceName, r.Token)
+	g.indented(func() {
+		sortPropertiesByRequiredFirst(r.InputProperties)
+		for _, p := range r.InputProperties {
+			if p.DeprecationMessage != "" {
+				continue
+			}
+
+			if g.requiredPropertiesOnly && !p.IsRequired() {
+				continue
+			}
+
+			g.indent(&buffer)
+			g.write(&buffer, "%s = ", p.Name)
+			g.writeValue(&buffer, codegen.ResolvedType(p.Type), seenTypes)
+			g.write(&buffer, "\n")
+		}
+	})
+
+	g.write(&buffer, "}")
+	return buffer.String()
+}
+
+func (g *constructorSyntaxGenerator) exampleInvokeWithName(function *schema.Function, name func(string) string) string {
+	buffer := bytes.Buffer{}
+	seenTypes := codegen.NewStringSet()
+	functionName := name(function.Token)
+	g.write(&buffer, "%s = invoke(\"%s\", {\n", functionName, function.Token)
+	g.indented(func() {
+		if function.Inputs == nil {
+			return
+		}
+
+		sortPropertiesByRequiredFirst(function.Inputs.Properties)
+		for _, p := range function.Inputs.Properties {
+			if p.DeprecationMessage != "" {
+				continue
+			}
+
+			if g.requiredPropertiesOnly && !p.IsRequired() {
+				continue
+			}
+
+			g.indent(&buffer)
+			g.write(&buffer, "%s = ", p.Name)
+			g.writeValue(&buffer, codegen.ResolvedType(p.Type), seenTypes)
+			g.write(&buffer, "\n")
+		}
+	})
+
+	g.write(&buffer, "})")
+	return buffer.String()
+}
+
+func (g *constructorSyntaxGenerator) bindProgram(loader schema.ReferenceLoader, program string) (*pcl.Program, error) {
+	parser := syntax.NewParser()
+	err := parser.ParseFile(bytes.NewReader([]byte(program)), "main.pp")
+	if err != nil {
+		return nil, fmt.Errorf("could not parse program: %w", err)
+	}
+
+	if parser.Diagnostics.HasErrors() {
+		return nil, fmt.Errorf("failed to parse program: %w", parser.Diagnostics)
+	}
+
+	bindOptions := make([]pcl.BindOption, 0)
+	bindOptions = append(bindOptions, pcl.Loader(loader))
+	bindOptions = append(bindOptions, pcl.NonStrictBindOptions()...)
+	boundProgram, diagnostics, err := pcl.BindProgram(parser.Files, bindOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("could not bind program: %w", err)
+	}
+
+	if diagnostics.HasErrors() {
+		return nil, fmt.Errorf("failed to bind program: %w", diagnostics)
+	}
+
+	return boundProgram, nil
+}
+
+func camelCase(s string) string {
+	return cgstrings.Camel(s)
+}
+
+func isResourceType(t schema.Type) bool {
+	if optional, ok := t.(*schema.OptionalType); ok {
+		return isResourceType(optional.ElementType)
+	}
+	if inputType, ok := t.(*schema.InputType); ok {
+		return isResourceType(inputType.ElementType)
+	}
+	if tokenType, isTokenType := t.(*schema.TokenType); isTokenType {
+		return isResourceType(tokenType.UnderlyingType)
+	}
+	_, isResource := t.(*schema.ResourceType)
+	return isResource
+}
+
+func cleanModuleName(moduleName string) string {
+	return strings.ReplaceAll(moduleName, "/", "")
+}
+
+func (g *constructorSyntaxGenerator) generateAll(schema *schema.Package, opts generateAllOptions) string {
+	buffer := bytes.Buffer{}
+	seenNames := codegen.NewStringSet()
+	resourcesToSkip := codegen.NewStringSet(opts.resourcesToSkip...)
+	if opts.includeResources {
+		for _, r := range schema.Resources {
+			if r.DeprecationMessage != "" {
+				continue
+			}
+
+			if resourcesToSkip.Has(r.Token) {
+				continue
+			}
+
+			resourceCode := g.exampleResourceWithName(r, func(resourceToken string) string {
+				pkg, modName, memberName, _ := pcl.DecomposeToken(resourceToken, hcl.Range{})
+				resourceName := fmt.Sprintf("%sResource", camelCase(memberName))
+				if !seenNames.Has(resourceName) {
+					seenNames.Add(resourceName)
+					return resourceName
+				}
+
+				resourceNameWithPkg := fmt.Sprintf("%s%sResource", pkg, memberName)
+				if !seenNames.Has(resourceNameWithPkg) {
+					seenNames.Add(resourceNameWithPkg)
+					return resourceNameWithPkg
+				}
+
+				resourceNameWithModule := fmt.Sprintf(
+					"example%sResourceFrom%s", resourceName, cgstrings.UppercaseFirst(cleanModuleName(modName)))
+				seenNames.Add(resourceNameWithModule)
+				return resourceNameWithModule
+			})
+
+			buffer.WriteString(fmt.Sprintf("// Resource %s", r.Token))
+			buffer.WriteString("\n")
+			buffer.WriteString(resourceCode)
+			buffer.WriteString("\n")
+		}
+	}
+
+	if opts.includeFunctions {
+		for _, f := range schema.Functions {
+			if f.DeprecationMessage != "" {
+				continue
+			}
+
+			functionCode := g.exampleInvokeWithName(f, func(functionToken string) string {
+				pkg, moduleName, memberName, _ := pcl.DecomposeToken(functionToken, hcl.Range{})
+				if !seenNames.Has(memberName) {
+					seenNames.Add(memberName)
+					return memberName
+				}
+
+				functionName := fmt.Sprintf("%sResult", memberName)
+				if !seenNames.Has(functionName) {
+					seenNames.Add(functionName)
+					return functionName
+				}
+
+				functionNameWithPkg := fmt.Sprintf("%sFrom%s", functionName, cgstrings.UppercaseFirst(pkg))
+				if !seenNames.Has(functionNameWithPkg) {
+					seenNames.Add(functionNameWithPkg)
+					return functionNameWithPkg
+				}
+
+				functionNameWithMod := fmt.Sprintf(
+					"example%sFrom%s",
+					cgstrings.UppercaseFirst(functionName),
+					cgstrings.UppercaseFirst(cleanModuleName(moduleName)))
+				seenNames.Add(functionNameWithMod)
+				return functionNameWithMod
+			})
+
+			buffer.WriteString(fmt.Sprintf("// Invoking %s", f.Token))
+			buffer.WriteString("\n")
+			buffer.WriteString(functionCode)
+			buffer.WriteString("\n")
+		}
+	}
+
+	return buffer.String()
+}
+
+func sortPropertiesByRequiredFirst(props []*schema.Property) {
+	sort.Slice(props, func(i, j int) bool {
+		return props[i].IsRequired() && !props[j].IsRequired()
+	})
+}
+
+func isPrimitiveType(t schema.Type) bool {
+	switch t {
+	case schema.BoolType, schema.IntType, schema.NumberType, schema.StringType:
+		return true
+	default:
+		switch argType := t.(type) {
+		case *schema.OptionalType:
+			return isPrimitiveType(argType.ElementType)
+		case *schema.EnumType, *schema.ResourceType:
+			return true
+		}
+		return false
+	}
+}
+
+func isUnionOfObjects(schemaType *schema.UnionType) bool {
+	for _, elementType := range schemaType.ElementTypes {
+		if _, isObjectType := elementType.(*schema.ObjectType); !isObjectType {
+			return false
+		}
+	}
+
+	return true
+}
+
+func objectTypeHasRecursiveReference(objectType *schema.ObjectType) bool {
+	isRecursive := false
+	codegen.VisitTypeClosure(objectType.Properties, func(t schema.Type) {
+		if objectRef, ok := t.(*schema.ObjectType); ok {
+			if objectRef.Token == objectType.Token {
+				isRecursive = true
+			}
+		}
+	})
+
+	return isRecursive
+}

--- a/pkg/codegen/docs/constructor_syntax_generator_test.go
+++ b/pkg/codegen/docs/constructor_syntax_generator_test.go
@@ -1,0 +1,150 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func bindTestSchema(t *testing.T, spec schema.PackageSpec) *schema.Package {
+	pkg, diags, err := schema.BindSpec(spec, nil)
+	assert.Nil(t, diags)
+	assert.Nil(t, err)
+	return pkg
+}
+
+func TestConstructorSyntaxGeneratorForSchema(t *testing.T) {
+	t.Parallel()
+	pkg := bindTestSchema(t, schema.PackageSpec{
+		Name: "test",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:First": {
+				InputProperties: map[string]schema.PropertySpec{
+					"fooString": {
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
+					},
+					"fooInt": {
+						TypeSpec: schema.TypeSpec{
+							Type: "integer",
+						},
+					},
+					"fooBool": {
+						TypeSpec: schema.TypeSpec{
+							Type: "boolean",
+						},
+					},
+				},
+			},
+			"test:index:Second": {
+				InputProperties: map[string]schema.PropertySpec{
+					"barString": {
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
+					},
+				},
+			},
+			"test:index:NoInputs": {
+				InputProperties: map[string]schema.PropertySpec{},
+			},
+		},
+	})
+
+	languages := []string{"csharp", "go", "nodejs", "python", "yaml", "java"}
+	constructorSyntax := generateConstructorSyntaxData(pkg, languages)
+
+	trim := func(s string) string {
+		return strings.TrimPrefix(strings.TrimSuffix(s, "\n"), "\n")
+	}
+
+	equalPrograms := func(language *languageConstructorSyntax, token string, expected string) {
+		program, has := language.resources[token]
+		assert.True(t, has, "Expected to find program for token %s", token)
+		assert.Equal(t, trim(expected), trim(program))
+	}
+
+	expectedResources := 3
+	assert.Equal(t, expectedResources, len(constructorSyntax.csharp.resources))
+	equalPrograms(constructorSyntax.csharp, "test:index:First", `
+var firstResource = new Test.First("firstResource", new()
+{
+    FooBool = false,
+    FooInt = 0,
+    FooString = "string",
+});
+`)
+
+	equalPrograms(constructorSyntax.csharp, "test:index:Second", `
+var secondResource = new Test.Second("secondResource", new()
+{
+    BarString = "string",
+});
+`)
+
+	equalPrograms(constructorSyntax.csharp, "test:index:NoInputs", `
+var noInputsResource = new Test.NoInputs("noInputsResource");
+`)
+
+	assert.Equal(t, expectedResources, len(constructorSyntax.typescript.resources))
+	equalPrograms(constructorSyntax.typescript, "test:index:First", `
+const firstResource = new test.First("firstResource", {
+    fooBool: false,
+    fooInt: 0,
+    fooString: "string",
+});`)
+	equalPrograms(constructorSyntax.typescript, "test:index:Second", `
+const secondResource = new test.Second("secondResource", {barString: "string"});
+`)
+
+	equalPrograms(constructorSyntax.typescript, "test:index:NoInputs", `
+const noInputsResource = new test.NoInputs("noInputsResource", {});
+`)
+
+	assert.Equal(t, expectedResources, len(constructorSyntax.python.resources))
+	equalPrograms(constructorSyntax.python, "test:index:First", `
+first_resource = test.First("firstResource",
+    foo_bool=False,
+    foo_int=0,
+    foo_string="string")`)
+	equalPrograms(constructorSyntax.python, "test:index:Second", `
+second_resource = test.Second("secondResource", bar_string="string")`)
+
+	equalPrograms(constructorSyntax.python, "test:index:NoInputs", `
+no_inputs_resource = test.NoInputs("noInputsResource")
+`)
+
+	assert.Equal(t, expectedResources, len(constructorSyntax.golang.resources))
+	equalPrograms(constructorSyntax.golang, "test:index:First", `
+_, err := test.NewFirst(ctx, "firstResource", &test.FirstArgs{
+	FooBool:   pulumi.Bool(false),
+	FooInt:    pulumi.Int(0),
+	FooString: pulumi.String("string"),
+})`)
+
+	equalPrograms(constructorSyntax.golang, "test:index:Second", `
+_, err = test.NewSecond(ctx, "secondResource", &test.SecondArgs{
+	BarString: pulumi.String("string"),
+})`)
+
+	equalPrograms(constructorSyntax.golang, "test:index:NoInputs", `
+_, err = test.NewNoInputs(ctx, "noInputsResource", nil)
+`)
+}

--- a/pkg/codegen/docs/static_schema_loader.go
+++ b/pkg/codegen/docs/static_schema_loader.go
@@ -1,0 +1,49 @@
+package docs
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type staticSchemaLoader struct {
+	schema           *schema.Package
+	schemaReferences map[string]*schema.Package
+}
+
+var _ schema.ReferenceLoader = (*staticSchemaLoader)(nil)
+
+func NewStaticSchemaLoader(loadedSchema *schema.Package) schema.ReferenceLoader {
+	// TODO: resolve schema references from input schema
+	references := map[string]*schema.Package{}
+
+	return &staticSchemaLoader{
+		schema:           loadedSchema,
+		schemaReferences: references,
+	}
+}
+
+func (loader *staticSchemaLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
+	if loader.schema.Name == pkg {
+		return loader.schema, nil
+	}
+
+	if ref, ok := loader.schemaReferences[pkg]; ok {
+		return ref, nil
+	}
+
+	return nil, fmt.Errorf("package %s not found", pkg)
+}
+
+func (loader *staticSchemaLoader) LoadPackageReference(
+	pkg string,
+	version *semver.Version,
+) (schema.PackageReference, error) {
+	loadedPackage, err := loader.LoadPackage(pkg, version)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadedPackage.Reference(), nil
+}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -14,8 +14,32 @@
 {{- end }}
 
 <!-- Create resource -->
-## Create {{ .Header.Title }} Resource {#create}
+{{ if ne (len .CreationExampleSyntax) 0 }}## Create {{ .Header.Title }} Resource
+{{- if eq .LangChooserLanguages "" }}
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+{{- else }}
+<div>
+<pulumi-chooser type="language" options="{{ .LangChooserLanguages }}"></pulumi-chooser>
+</div>
+{{- end }}
 
+{{ range $lang, $code := .CreationExampleSyntax }}
+<div>
+{{ htmlSafe "<pulumi-choosable type=\"language\" values=\"" }}{{ $lang }}{{ htmlSafe "\">" }}
+
+```{{ $lang }}
+{{ htmlSafe $code }}
+```
+
+</pulumi-choosable>
+</div>
+
+{{ end }}
+## Definition of {{ .Header.Title }} {#create}{{ else }}
+## Create {{ .Header.Title }} Resource {#create}
+{{- end }}
 {{- if eq .LangChooserLanguages "" }}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -293,6 +293,8 @@ func buildEnumValue(v interface{}) cty.Value {
 		return cty.BoolVal(v)
 	case int:
 		return cty.NumberIntVal(int64(v))
+	case int32:
+		return cty.NumberIntVal(int64(v))
 	case int64:
 		return cty.NumberIntVal(v)
 	case float64:

--- a/tests/testdata/codegen/assets-and-archives/docs/provider/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
@@ -15,7 +15,116 @@ no_edit_this_page: true
 
 
 
-## Create ResourceWithAssets Resource {#create}
+## Create ResourceWithAssets Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceWithAssetsResource = new Example.ResourceWithAssets("resourceWithAssetsResource", new()
+{
+    Source = new StringAsset("content"),
+    Archive = new FileArchive("./path/to/archive"),
+    Nested = new Example.Inputs.TypeWithAssetsArgs
+    {
+        Asset = new StringAsset("content"),
+        PlainArchive = new FileArchive("./path/to/archive"),
+        Archive = new FileArchive("./path/to/archive"),
+        PlainAsset = new StringAsset("content"),
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResourceWithAssets(ctx, "resourceWithAssetsResource", &example.ResourceWithAssetsArgs{
+	Source:  pulumi.NewStringAsset("content"),
+	Archive: pulumi.NewFileArchive("./path/to/archive"),
+	Nested: &example.TypeWithAssetsArgs{
+		Asset:        pulumi.NewStringAsset("content"),
+		PlainArchive: pulumi.NewFileArchive("./path/to/archive"),
+		Archive:      pulumi.NewFileArchive("./path/to/archive"),
+		PlainAsset:   pulumi.NewStringAsset("content"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_with_assets_resource = example.ResourceWithAssets("resourceWithAssetsResource",
+    source=pulumi.StringAsset("content"),
+    archive=pulumi.FileArchive("./path/to/archive"),
+    nested=example.TypeWithAssetsArgs(
+        asset=pulumi.StringAsset("content"),
+        plain_archive=pulumi.FileArchive("./path/to/archive"),
+        archive=pulumi.FileArchive("./path/to/archive"),
+        plain_asset=pulumi.StringAsset("content"),
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceWithAssetsResource = new example.ResourceWithAssets("resourceWithAssetsResource", {
+    source: new pulumi.asset.StringAsset("content"),
+    archive: new pulumi.asset.FileArchive("./path/to/archive"),
+    nested: {
+        asset: new pulumi.asset.StringAsset("content"),
+        plainArchive: new pulumi.asset.FileArchive("./path/to/archive"),
+        archive: new pulumi.asset.FileArchive("./path/to/archive"),
+        plainAsset: new pulumi.asset.StringAsset("content"),
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ResourceWithAssets {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,9 +141,9 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ResourceWithAssets</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                        <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
+                       <span class="nx">source</span><span class="p">:</span> <span class="nx">Optional[Union[pulumi.Asset, pulumi.Archive]]</span> = None<span class="p">,</span>
                        <span class="nx">archive</span><span class="p">:</span> <span class="nx">Optional[pulumi.Archive]</span> = None<span class="p">,</span>
-                       <span class="nx">nested</span><span class="p">:</span> <span class="nx">Optional[TypeWithAssetsArgs]</span> = None<span class="p">,</span>
-                       <span class="nx">source</span><span class="p">:</span> <span class="nx">Optional[Union[pulumi.Asset, pulumi.Archive]]</span> = None<span class="p">)</span>
+                       <span class="nx">nested</span><span class="p">:</span> <span class="nx">Optional[TypeWithAssetsArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ResourceWithAssets</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                        <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ResourceWithAssetsArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -347,7 +347,79 @@ Coming soon!
 
 
 
-## Create SqlResourceSqlContainer Resource {#create}
+## Create SqlResourceSqlContainer Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var sqlResourceSqlContainerResource = new AzureNative.DocumentDB.SqlResourceSqlContainer("sqlResourceSqlContainerResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := documentdb.NewSqlResourceSqlContainer(ctx, "sqlResourceSqlContainerResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+sql_resource_sql_container_resource = azure_native.documentdb.SqlResourceSqlContainer("sqlResourceSqlContainerResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const sqlResourceSqlContainerResource = new azure_native.documentdb.SqlResourceSqlContainer("sqlResourceSqlContainerResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of SqlResourceSqlContainer {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/azure-native-nested-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/cyclic-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/cyclic-types/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/dash-named-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create FOOEncryptedBarClass Resource {#create}
+## Create FOOEncryptedBarClass Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var fooencryptedBarClassResource = new FooBar.Submodule1.FOOEncryptedBarClass("fooencryptedBarClassResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := submodule1.NewFOOEncryptedBarClass(ctx, "fooencryptedBarClassResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+fooencrypted_bar_class_resource = foo_bar.submodule1.FOOEncryptedBarClass("fooencryptedBarClassResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const fooencryptedBarClassResource = new foo_bar.submodule1.FOOEncryptedBarClass("fooencryptedBarClassResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of FOOEncryptedBarClass {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -15,7 +15,93 @@ no_edit_this_page: true
 
 
 
-## Create ModuleResource Resource {#create}
+## Create ModuleResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var moduleResourceResource = new FooBar.Submodule1.ModuleResource("moduleResourceResource", new()
+{
+    Thing = new FooBar.Inputs.TopLevelArgs
+    {
+        Buzz = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := submodule1.NewModuleResource(ctx, "moduleResourceResource", &submodule1.ModuleResourceArgs{
+	Thing: &foo.TopLevelArgs{
+		Buzz: pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+module_resource_resource = foo_bar.submodule1.ModuleResource("moduleResourceResource", thing=foo_bar.TopLevelArgs(
+    buzz="string",
+))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const moduleResourceResource = new foo_bar.submodule1.ModuleResource("moduleResourceResource", {thing: {
+    buzz: "string",
+}});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ModuleResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/dashed-import-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,105 @@ no_edit_this_page: true
 
 
 
-## Create Nursery Resource {#create}
+## Create Nursery Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
+{
+    Varieties = new[]
+    {
+        Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    },
+    Sizes = 
+    {
+        { "string", Plant.Tree.V1.TreeSize.Small },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
+Varieties: treev1.RubberTreeVarietyArray{
+tree.RubberTreeVarietyBurgundy,
+},
+Sizes: treev1.TreeSizeMap{
+"string": tree.TreeSizeSmall,
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+nursery_resource = plant.tree.v1.Nursery("nurseryResource",
+    varieties=[plant.tree.v1.RubberTreeVariety.BURGUNDY],
+    sizes={
+        "string": plant.tree.v1.TreeSize.SMALL,
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const nurseryResource = new plant.tree.v1.Nursery("nurseryResource", {
+    varieties: [plant.tree.v1.RubberTreeVariety.Burgundy],
+    sizes: {
+        string: plant.tree.v1.TreeSize.Small,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Nursery {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,8 +130,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
-            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
+            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">NurseryArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create RubberTree Resource {#create}
+## Create RubberTree Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of RubberTree {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,11 +104,11 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
+               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
-               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">RubberTreeArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/different-enum/docs/provider/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,105 @@ no_edit_this_page: true
 
 
 
-## Create Nursery Resource {#create}
+## Create Nursery Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
+{
+    Varieties = new[]
+    {
+        Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    },
+    Sizes = 
+    {
+        { "string", Plant.Tree.V1.TreeSize.Small },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
+Varieties: treev1.RubberTreeVarietyArray{
+tree.RubberTreeVarietyBurgundy,
+},
+Sizes: treev1.TreeSizeMap{
+"string": tree.TreeSizeSmall,
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+nursery_resource = plant.tree.v1.Nursery("nurseryResource",
+    varieties=[plant.tree.v1.RubberTreeVariety.BURGUNDY],
+    sizes={
+        "string": plant.tree.v1.TreeSize.SMALL,
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const nurseryResource = new plant.tree.v1.Nursery("nurseryResource", {
+    varieties: [plant.tree.v1.RubberTreeVariety.Burgundy],
+    sizes: {
+        string: plant.tree.v1.TreeSize.Small,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Nursery {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,8 +130,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
-            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
+            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">NurseryArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create RubberTree Resource {#create}
+## Create RubberTree Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of RubberTree {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,11 +104,11 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
+               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
-               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">RubberTreeArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Overlay Resource {#create}
+## Create Overlay Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var exampleOverlayResource = new Example.Overlay.Overlay("exampleOverlayResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := overlay.NewOverlay(ctx, "exampleOverlayResource", &overlay.OverlayArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+example_overlay_resource = example.overlay.Overlay("exampleOverlayResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const exampleOverlayResource = new example.overlay.Overlay("exampleOverlayResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Overlay {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/docs-collision/docs/provider/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Overlay Resource {#create}
+## Create Overlay Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var overlayResource = new Example.Overlay("overlayResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewOverlay(ctx, "overlayResource", &example.OverlayArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+overlay_resource = example.Overlay("overlayResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const overlayResource = new example.Overlay("overlayResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Overlay {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
@@ -15,7 +15,6803 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var componentResource = new Foo.Component("componentResource", new()
+{
+    EniConfig = 
+    {
+        { "string", new Kubernetes.Crd.k8s.amazonaws.com.Inputs.ENIConfigSpecArgs
+        {
+            SecurityGroups = new[]
+            {
+                "string",
+            },
+            Subnet = "string",
+        } },
+    },
+    Pod = new Kubernetes.Core.Inputs.PodArgs
+    {
+        ApiVersion = "v1",
+        Kind = "Pod",
+        Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+        {
+            Annotations = 
+            {
+                { "string", "string" },
+            },
+            ClusterName = "string",
+            CreationTimestamp = "string",
+            DeletionGracePeriodSeconds = 0,
+            DeletionTimestamp = "string",
+            Finalizers = new[]
+            {
+                "string",
+            },
+            GenerateName = "string",
+            Generation = 0,
+            Labels = 
+            {
+                { "string", "string" },
+            },
+            ManagedFields = new[]
+            {
+                new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                {
+                    ApiVersion = "string",
+                    FieldsType = "string",
+                    FieldsV1 = "{}",
+                    Manager = "string",
+                    Operation = "string",
+                    Subresource = "string",
+                    Time = "string",
+                },
+            },
+            Name = "string",
+            Namespace = "string",
+            OwnerReferences = new[]
+            {
+                new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                {
+                    ApiVersion = "string",
+                    Kind = "string",
+                    Name = "string",
+                    Uid = "string",
+                    BlockOwnerDeletion = false,
+                    Controller = false,
+                },
+            },
+            ResourceVersion = "string",
+            SelfLink = "string",
+            Uid = "string",
+        },
+        Spec = new Kubernetes.Core.Inputs.PodSpecArgs
+        {
+            Containers = new[]
+            {
+                new Kubernetes.Core.Inputs.ContainerArgs
+                {
+                    Name = "string",
+                    ReadinessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    ImagePullPolicy = "string",
+                    Resources = new Kubernetes.Core.Inputs.ResourceRequirementsArgs
+                    {
+                        Limits = 
+                        {
+                            { "string", "string" },
+                        },
+                        Requests = 
+                        {
+                            { "string", "string" },
+                        },
+                    },
+                    StartupProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    SecurityContext = new Kubernetes.Core.Inputs.SecurityContextArgs
+                    {
+                        AllowPrivilegeEscalation = false,
+                        Capabilities = new Kubernetes.Core.Inputs.CapabilitiesArgs
+                        {
+                            Add = new[]
+                            {
+                                "string",
+                            },
+                            Drop = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        Privileged = false,
+                        ProcMount = "string",
+                        ReadOnlyRootFilesystem = false,
+                        RunAsGroup = 0,
+                        RunAsNonRoot = false,
+                        RunAsUser = 0,
+                        SeLinuxOptions = new Kubernetes.Core.Inputs.SELinuxOptionsArgs
+                        {
+                            Level = "string",
+                            Role = "string",
+                            Type = "string",
+                            User = "string",
+                        },
+                        SeccompProfile = new Kubernetes.Core.Inputs.SeccompProfileArgs
+                        {
+                            Type = "string",
+                            LocalhostProfile = "string",
+                        },
+                        WindowsOptions = new Kubernetes.Core.Inputs.WindowsSecurityContextOptionsArgs
+                        {
+                            GmsaCredentialSpec = "string",
+                            GmsaCredentialSpecName = "string",
+                            HostProcess = false,
+                            RunAsUserName = "string",
+                        },
+                    },
+                    Lifecycle = new Kubernetes.Core.Inputs.LifecycleArgs
+                    {
+                        PostStart = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                        PreStop = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                    },
+                    LivenessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    Command = new[]
+                    {
+                        "string",
+                    },
+                    Ports = new[]
+                    {
+                        new Kubernetes.Core.Inputs.ContainerPortArgs
+                        {
+                            ContainerPort = 0,
+                            HostIP = "string",
+                            HostPort = 0,
+                            Name = "string",
+                            Protocol = "string",
+                        },
+                    },
+                    Args = new[]
+                    {
+                        "string",
+                    },
+                    EnvFrom = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvFromSourceArgs
+                        {
+                            ConfigMapRef = new Kubernetes.Core.Inputs.ConfigMapEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                            Prefix = "string",
+                            SecretRef = new Kubernetes.Core.Inputs.SecretEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                        },
+                    },
+                    Env = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvVarArgs
+                        {
+                            Name = "string",
+                            Value = "string",
+                            ValueFrom = new Kubernetes.Core.Inputs.EnvVarSourceArgs
+                            {
+                                ConfigMapKeyRef = new Kubernetes.Core.Inputs.ConfigMapKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                                FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                {
+                                    FieldPath = "string",
+                                    ApiVersion = "string",
+                                },
+                                ResourceFieldRef = new Kubernetes.Core.Inputs.ResourceFieldSelectorArgs
+                                {
+                                    Resource = "string",
+                                    ContainerName = "string",
+                                    Divisor = "string",
+                                },
+                                SecretKeyRef = new Kubernetes.Core.Inputs.SecretKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                            },
+                        },
+                    },
+                    Image = "string",
+                    Stdin = false,
+                    StdinOnce = false,
+                    TerminationMessagePath = "string",
+                    TerminationMessagePolicy = "string",
+                    Tty = false,
+                    VolumeDevices = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeDeviceArgs
+                        {
+                            DevicePath = "string",
+                            Name = "string",
+                        },
+                    },
+                    VolumeMounts = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeMountArgs
+                        {
+                            MountPath = "string",
+                            Name = "string",
+                            MountPropagation = "string",
+                            ReadOnly = false,
+                            SubPath = "string",
+                            SubPathExpr = "string",
+                        },
+                    },
+                    WorkingDir = "string",
+                },
+            },
+            NodeSelector = 
+            {
+                { "string", "string" },
+            },
+            HostAliases = new[]
+            {
+                new Kubernetes.Core.Inputs.HostAliasArgs
+                {
+                    Hostnames = new[]
+                    {
+                        "string",
+                    },
+                    Ip = "string",
+                },
+            },
+            Affinity = new Kubernetes.Core.Inputs.AffinityArgs
+            {
+                NodeAffinity = new Kubernetes.Core.Inputs.NodeAffinityArgs
+                {
+                    PreferredDuringSchedulingIgnoredDuringExecution = new[]
+                    {
+                        new Kubernetes.Core.Inputs.PreferredSchedulingTermArgs
+                        {
+                            Preference = new Kubernetes.Core.Inputs.NodeSelectorTermArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.NodeSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchFields = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.NodeSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                            },
+                            Weight = 0,
+                        },
+                    },
+                    RequiredDuringSchedulingIgnoredDuringExecution = new Kubernetes.Core.Inputs.NodeSelectorArgs
+                    {
+                        NodeSelectorTerms = new[]
+                        {
+                            new Kubernetes.Core.Inputs.NodeSelectorTermArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.NodeSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchFields = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.NodeSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                PodAffinity = new Kubernetes.Core.Inputs.PodAffinityArgs
+                {
+                    PreferredDuringSchedulingIgnoredDuringExecution = new[]
+                    {
+                        new Kubernetes.Core.Inputs.WeightedPodAffinityTermArgs
+                        {
+                            PodAffinityTerm = new Kubernetes.Core.Inputs.PodAffinityTermArgs
+                            {
+                                TopologyKey = "string",
+                                LabelSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                                {
+                                    MatchExpressions = new[]
+                                    {
+                                        new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                        {
+                                            Key = "string",
+                                            Operator = "string",
+                                            Values = new[]
+                                            {
+                                                "string",
+                                            },
+                                        },
+                                    },
+                                    MatchLabels = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                NamespaceSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                                {
+                                    MatchExpressions = new[]
+                                    {
+                                        new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                        {
+                                            Key = "string",
+                                            Operator = "string",
+                                            Values = new[]
+                                            {
+                                                "string",
+                                            },
+                                        },
+                                    },
+                                    MatchLabels = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                Namespaces = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            Weight = 0,
+                        },
+                    },
+                    RequiredDuringSchedulingIgnoredDuringExecution = new[]
+                    {
+                        new Kubernetes.Core.Inputs.PodAffinityTermArgs
+                        {
+                            TopologyKey = "string",
+                            LabelSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchLabels = 
+                                {
+                                    { "string", "string" },
+                                },
+                            },
+                            NamespaceSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchLabels = 
+                                {
+                                    { "string", "string" },
+                                },
+                            },
+                            Namespaces = new[]
+                            {
+                                "string",
+                            },
+                        },
+                    },
+                },
+                PodAntiAffinity = new Kubernetes.Core.Inputs.PodAntiAffinityArgs
+                {
+                    PreferredDuringSchedulingIgnoredDuringExecution = new[]
+                    {
+                        new Kubernetes.Core.Inputs.WeightedPodAffinityTermArgs
+                        {
+                            PodAffinityTerm = new Kubernetes.Core.Inputs.PodAffinityTermArgs
+                            {
+                                TopologyKey = "string",
+                                LabelSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                                {
+                                    MatchExpressions = new[]
+                                    {
+                                        new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                        {
+                                            Key = "string",
+                                            Operator = "string",
+                                            Values = new[]
+                                            {
+                                                "string",
+                                            },
+                                        },
+                                    },
+                                    MatchLabels = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                NamespaceSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                                {
+                                    MatchExpressions = new[]
+                                    {
+                                        new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                        {
+                                            Key = "string",
+                                            Operator = "string",
+                                            Values = new[]
+                                            {
+                                                "string",
+                                            },
+                                        },
+                                    },
+                                    MatchLabels = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                Namespaces = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            Weight = 0,
+                        },
+                    },
+                    RequiredDuringSchedulingIgnoredDuringExecution = new[]
+                    {
+                        new Kubernetes.Core.Inputs.PodAffinityTermArgs
+                        {
+                            TopologyKey = "string",
+                            LabelSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchLabels = 
+                                {
+                                    { "string", "string" },
+                                },
+                            },
+                            NamespaceSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                            {
+                                MatchExpressions = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                    {
+                                        Key = "string",
+                                        Operator = "string",
+                                        Values = new[]
+                                        {
+                                            "string",
+                                        },
+                                    },
+                                },
+                                MatchLabels = 
+                                {
+                                    { "string", "string" },
+                                },
+                            },
+                            Namespaces = new[]
+                            {
+                                "string",
+                            },
+                        },
+                    },
+                },
+            },
+            DnsConfig = new Kubernetes.Core.Inputs.PodDNSConfigArgs
+            {
+                Nameservers = new[]
+                {
+                    "string",
+                },
+                Options = new[]
+                {
+                    new Kubernetes.Core.Inputs.PodDNSConfigOptionArgs
+                    {
+                        Name = "string",
+                        Value = "string",
+                    },
+                },
+                Searches = new[]
+                {
+                    "string",
+                },
+            },
+            Overhead = 
+            {
+                { "string", "string" },
+            },
+            EnableServiceLinks = false,
+            EphemeralContainers = new[]
+            {
+                new Kubernetes.Core.Inputs.EphemeralContainerArgs
+                {
+                    Name = "string",
+                    ReadinessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    EnvFrom = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvFromSourceArgs
+                        {
+                            ConfigMapRef = new Kubernetes.Core.Inputs.ConfigMapEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                            Prefix = "string",
+                            SecretRef = new Kubernetes.Core.Inputs.SecretEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                        },
+                    },
+                    SecurityContext = new Kubernetes.Core.Inputs.SecurityContextArgs
+                    {
+                        AllowPrivilegeEscalation = false,
+                        Capabilities = new Kubernetes.Core.Inputs.CapabilitiesArgs
+                        {
+                            Add = new[]
+                            {
+                                "string",
+                            },
+                            Drop = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        Privileged = false,
+                        ProcMount = "string",
+                        ReadOnlyRootFilesystem = false,
+                        RunAsGroup = 0,
+                        RunAsNonRoot = false,
+                        RunAsUser = 0,
+                        SeLinuxOptions = new Kubernetes.Core.Inputs.SELinuxOptionsArgs
+                        {
+                            Level = "string",
+                            Role = "string",
+                            Type = "string",
+                            User = "string",
+                        },
+                        SeccompProfile = new Kubernetes.Core.Inputs.SeccompProfileArgs
+                        {
+                            Type = "string",
+                            LocalhostProfile = "string",
+                        },
+                        WindowsOptions = new Kubernetes.Core.Inputs.WindowsSecurityContextOptionsArgs
+                        {
+                            GmsaCredentialSpec = "string",
+                            GmsaCredentialSpecName = "string",
+                            HostProcess = false,
+                            RunAsUserName = "string",
+                        },
+                    },
+                    Image = "string",
+                    ImagePullPolicy = "string",
+                    Lifecycle = new Kubernetes.Core.Inputs.LifecycleArgs
+                    {
+                        PostStart = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                        PreStop = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                    },
+                    LivenessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    Command = new[]
+                    {
+                        "string",
+                    },
+                    StartupProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    Args = new[]
+                    {
+                        "string",
+                    },
+                    WorkingDir = "string",
+                    Env = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvVarArgs
+                        {
+                            Name = "string",
+                            Value = "string",
+                            ValueFrom = new Kubernetes.Core.Inputs.EnvVarSourceArgs
+                            {
+                                ConfigMapKeyRef = new Kubernetes.Core.Inputs.ConfigMapKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                                FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                {
+                                    FieldPath = "string",
+                                    ApiVersion = "string",
+                                },
+                                ResourceFieldRef = new Kubernetes.Core.Inputs.ResourceFieldSelectorArgs
+                                {
+                                    Resource = "string",
+                                    ContainerName = "string",
+                                    Divisor = "string",
+                                },
+                                SecretKeyRef = new Kubernetes.Core.Inputs.SecretKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                            },
+                        },
+                    },
+                    Ports = new[]
+                    {
+                        new Kubernetes.Core.Inputs.ContainerPortArgs
+                        {
+                            ContainerPort = 0,
+                            HostIP = "string",
+                            HostPort = 0,
+                            Name = "string",
+                            Protocol = "string",
+                        },
+                    },
+                    Stdin = false,
+                    StdinOnce = false,
+                    TargetContainerName = "string",
+                    TerminationMessagePath = "string",
+                    TerminationMessagePolicy = "string",
+                    Tty = false,
+                    VolumeDevices = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeDeviceArgs
+                        {
+                            DevicePath = "string",
+                            Name = "string",
+                        },
+                    },
+                    VolumeMounts = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeMountArgs
+                        {
+                            MountPath = "string",
+                            Name = "string",
+                            MountPropagation = "string",
+                            ReadOnly = false,
+                            SubPath = "string",
+                            SubPathExpr = "string",
+                        },
+                    },
+                    Resources = new Kubernetes.Core.Inputs.ResourceRequirementsArgs
+                    {
+                        Limits = 
+                        {
+                            { "string", "string" },
+                        },
+                        Requests = 
+                        {
+                            { "string", "string" },
+                        },
+                    },
+                },
+            },
+            PreemptionPolicy = "string",
+            HostIPC = false,
+            Priority = 0,
+            HostPID = false,
+            Hostname = "string",
+            ImagePullSecrets = new[]
+            {
+                new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                {
+                    Name = "string",
+                },
+            },
+            InitContainers = new[]
+            {
+                new Kubernetes.Core.Inputs.ContainerArgs
+                {
+                    Name = "string",
+                    ReadinessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    ImagePullPolicy = "string",
+                    Resources = new Kubernetes.Core.Inputs.ResourceRequirementsArgs
+                    {
+                        Limits = 
+                        {
+                            { "string", "string" },
+                        },
+                        Requests = 
+                        {
+                            { "string", "string" },
+                        },
+                    },
+                    StartupProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    SecurityContext = new Kubernetes.Core.Inputs.SecurityContextArgs
+                    {
+                        AllowPrivilegeEscalation = false,
+                        Capabilities = new Kubernetes.Core.Inputs.CapabilitiesArgs
+                        {
+                            Add = new[]
+                            {
+                                "string",
+                            },
+                            Drop = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        Privileged = false,
+                        ProcMount = "string",
+                        ReadOnlyRootFilesystem = false,
+                        RunAsGroup = 0,
+                        RunAsNonRoot = false,
+                        RunAsUser = 0,
+                        SeLinuxOptions = new Kubernetes.Core.Inputs.SELinuxOptionsArgs
+                        {
+                            Level = "string",
+                            Role = "string",
+                            Type = "string",
+                            User = "string",
+                        },
+                        SeccompProfile = new Kubernetes.Core.Inputs.SeccompProfileArgs
+                        {
+                            Type = "string",
+                            LocalhostProfile = "string",
+                        },
+                        WindowsOptions = new Kubernetes.Core.Inputs.WindowsSecurityContextOptionsArgs
+                        {
+                            GmsaCredentialSpec = "string",
+                            GmsaCredentialSpecName = "string",
+                            HostProcess = false,
+                            RunAsUserName = "string",
+                        },
+                    },
+                    Lifecycle = new Kubernetes.Core.Inputs.LifecycleArgs
+                    {
+                        PostStart = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                        PreStop = new Kubernetes.Core.Inputs.HandlerArgs
+                        {
+                            Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                            {
+                                Command = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                            HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                                HttpHeaders = new[]
+                                {
+                                    new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                    {
+                                        Name = "string",
+                                        Value = "string",
+                                    },
+                                },
+                                Path = "string",
+                                Scheme = "string",
+                            },
+                            TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                            {
+                                Port = 0,
+                                Host = "string",
+                            },
+                        },
+                    },
+                    LivenessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                    {
+                        Exec = new Kubernetes.Core.Inputs.ExecActionArgs
+                        {
+                            Command = new[]
+                            {
+                                "string",
+                            },
+                        },
+                        FailureThreshold = 0,
+                        HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                            HttpHeaders = new[]
+                            {
+                                new Kubernetes.Core.Inputs.HTTPHeaderArgs
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                },
+                            },
+                            Path = "string",
+                            Scheme = "string",
+                        },
+                        InitialDelaySeconds = 0,
+                        PeriodSeconds = 0,
+                        SuccessThreshold = 0,
+                        TcpSocket = new Kubernetes.Core.Inputs.TCPSocketActionArgs
+                        {
+                            Port = 0,
+                            Host = "string",
+                        },
+                        TerminationGracePeriodSeconds = 0,
+                        TimeoutSeconds = 0,
+                    },
+                    Command = new[]
+                    {
+                        "string",
+                    },
+                    Ports = new[]
+                    {
+                        new Kubernetes.Core.Inputs.ContainerPortArgs
+                        {
+                            ContainerPort = 0,
+                            HostIP = "string",
+                            HostPort = 0,
+                            Name = "string",
+                            Protocol = "string",
+                        },
+                    },
+                    Args = new[]
+                    {
+                        "string",
+                    },
+                    EnvFrom = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvFromSourceArgs
+                        {
+                            ConfigMapRef = new Kubernetes.Core.Inputs.ConfigMapEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                            Prefix = "string",
+                            SecretRef = new Kubernetes.Core.Inputs.SecretEnvSourceArgs
+                            {
+                                Name = "string",
+                                Optional = false,
+                            },
+                        },
+                    },
+                    Env = new[]
+                    {
+                        new Kubernetes.Core.Inputs.EnvVarArgs
+                        {
+                            Name = "string",
+                            Value = "string",
+                            ValueFrom = new Kubernetes.Core.Inputs.EnvVarSourceArgs
+                            {
+                                ConfigMapKeyRef = new Kubernetes.Core.Inputs.ConfigMapKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                                FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                {
+                                    FieldPath = "string",
+                                    ApiVersion = "string",
+                                },
+                                ResourceFieldRef = new Kubernetes.Core.Inputs.ResourceFieldSelectorArgs
+                                {
+                                    Resource = "string",
+                                    ContainerName = "string",
+                                    Divisor = "string",
+                                },
+                                SecretKeyRef = new Kubernetes.Core.Inputs.SecretKeySelectorArgs
+                                {
+                                    Key = "string",
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                            },
+                        },
+                    },
+                    Image = "string",
+                    Stdin = false,
+                    StdinOnce = false,
+                    TerminationMessagePath = "string",
+                    TerminationMessagePolicy = "string",
+                    Tty = false,
+                    VolumeDevices = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeDeviceArgs
+                        {
+                            DevicePath = "string",
+                            Name = "string",
+                        },
+                    },
+                    VolumeMounts = new[]
+                    {
+                        new Kubernetes.Core.Inputs.VolumeMountArgs
+                        {
+                            MountPath = "string",
+                            Name = "string",
+                            MountPropagation = "string",
+                            ReadOnly = false,
+                            SubPath = "string",
+                            SubPathExpr = "string",
+                        },
+                    },
+                    WorkingDir = "string",
+                },
+            },
+            NodeName = "string",
+            ActiveDeadlineSeconds = 0,
+            DnsPolicy = "string",
+            AutomountServiceAccountToken = false,
+            HostNetwork = false,
+            PriorityClassName = "string",
+            ReadinessGates = new[]
+            {
+                new Kubernetes.Core.Inputs.PodReadinessGateArgs
+                {
+                    ConditionType = "string",
+                },
+            },
+            RestartPolicy = "string",
+            RuntimeClassName = "string",
+            SchedulerName = "string",
+            SecurityContext = new Kubernetes.Core.Inputs.PodSecurityContextArgs
+            {
+                FsGroup = 0,
+                FsGroupChangePolicy = "string",
+                RunAsGroup = 0,
+                RunAsNonRoot = false,
+                RunAsUser = 0,
+                SeLinuxOptions = new Kubernetes.Core.Inputs.SELinuxOptionsArgs
+                {
+                    Level = "string",
+                    Role = "string",
+                    Type = "string",
+                    User = "string",
+                },
+                SeccompProfile = new Kubernetes.Core.Inputs.SeccompProfileArgs
+                {
+                    Type = "string",
+                    LocalhostProfile = "string",
+                },
+                SupplementalGroups = new[]
+                {
+                    0,
+                },
+                Sysctls = new[]
+                {
+                    new Kubernetes.Core.Inputs.SysctlArgs
+                    {
+                        Name = "string",
+                        Value = "string",
+                    },
+                },
+                WindowsOptions = new Kubernetes.Core.Inputs.WindowsSecurityContextOptionsArgs
+                {
+                    GmsaCredentialSpec = "string",
+                    GmsaCredentialSpecName = "string",
+                    HostProcess = false,
+                    RunAsUserName = "string",
+                },
+            },
+            ServiceAccount = "string",
+            ServiceAccountName = "string",
+            SetHostnameAsFQDN = false,
+            ShareProcessNamespace = false,
+            Subdomain = "string",
+            TerminationGracePeriodSeconds = 0,
+            Tolerations = new[]
+            {
+                new Kubernetes.Core.Inputs.TolerationArgs
+                {
+                    Effect = "string",
+                    Key = "string",
+                    Operator = "string",
+                    TolerationSeconds = 0,
+                    Value = "string",
+                },
+            },
+            TopologySpreadConstraints = new[]
+            {
+                new Kubernetes.Core.Inputs.TopologySpreadConstraintArgs
+                {
+                    MaxSkew = 0,
+                    TopologyKey = "string",
+                    WhenUnsatisfiable = "string",
+                    LabelSelector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                    {
+                        MatchExpressions = new[]
+                        {
+                            new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                            {
+                                Key = "string",
+                                Operator = "string",
+                                Values = new[]
+                                {
+                                    "string",
+                                },
+                            },
+                        },
+                        MatchLabels = 
+                        {
+                            { "string", "string" },
+                        },
+                    },
+                },
+            },
+            Volumes = new[]
+            {
+                new Kubernetes.Core.Inputs.VolumeArgs
+                {
+                    Name = "string",
+                    GitRepo = new Kubernetes.Core.Inputs.GitRepoVolumeSourceArgs
+                    {
+                        Repository = "string",
+                        Directory = "string",
+                        Revision = "string",
+                    },
+                    ConfigMap = new Kubernetes.Core.Inputs.ConfigMapVolumeSourceArgs
+                    {
+                        DefaultMode = 0,
+                        Items = new[]
+                        {
+                            new Kubernetes.Core.Inputs.KeyToPathArgs
+                            {
+                                Key = "string",
+                                Path = "string",
+                                Mode = 0,
+                            },
+                        },
+                        Name = "string",
+                        Optional = false,
+                    },
+                    Glusterfs = new Kubernetes.Core.Inputs.GlusterfsVolumeSourceArgs
+                    {
+                        Endpoints = "string",
+                        Path = "string",
+                        ReadOnly = false,
+                    },
+                    Cinder = new Kubernetes.Core.Inputs.CinderVolumeSourceArgs
+                    {
+                        VolumeID = "string",
+                        FsType = "string",
+                        ReadOnly = false,
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                    },
+                    HostPath = new Kubernetes.Core.Inputs.HostPathVolumeSourceArgs
+                    {
+                        Path = "string",
+                        Type = "string",
+                    },
+                    Csi = new Kubernetes.Core.Inputs.CSIVolumeSourceArgs
+                    {
+                        Driver = "string",
+                        FsType = "string",
+                        NodePublishSecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                        ReadOnly = false,
+                        VolumeAttributes = 
+                        {
+                            { "string", "string" },
+                        },
+                    },
+                    DownwardAPI = new Kubernetes.Core.Inputs.DownwardAPIVolumeSourceArgs
+                    {
+                        DefaultMode = 0,
+                        Items = new[]
+                        {
+                            new Kubernetes.Core.Inputs.DownwardAPIVolumeFileArgs
+                            {
+                                Path = "string",
+                                FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                {
+                                    FieldPath = "string",
+                                    ApiVersion = "string",
+                                },
+                                Mode = 0,
+                                ResourceFieldRef = new Kubernetes.Core.Inputs.ResourceFieldSelectorArgs
+                                {
+                                    Resource = "string",
+                                    ContainerName = "string",
+                                    Divisor = "string",
+                                },
+                            },
+                        },
+                    },
+                    EmptyDir = new Kubernetes.Core.Inputs.EmptyDirVolumeSourceArgs
+                    {
+                        Medium = "string",
+                        SizeLimit = "string",
+                    },
+                    Ephemeral = new Kubernetes.Core.Inputs.EphemeralVolumeSourceArgs
+                    {
+                        ReadOnly = false,
+                        VolumeClaimTemplate = new Kubernetes.Core.Inputs.PersistentVolumeClaimTemplateArgs
+                        {
+                            Spec = new Kubernetes.Core.Inputs.PersistentVolumeClaimSpecArgs
+                            {
+                                AccessModes = new[]
+                                {
+                                    "string",
+                                },
+                                DataSource = new Kubernetes.Core.Inputs.TypedLocalObjectReferenceArgs
+                                {
+                                    Kind = "string",
+                                    Name = "string",
+                                    ApiGroup = "string",
+                                },
+                                DataSourceRef = new Kubernetes.Core.Inputs.TypedLocalObjectReferenceArgs
+                                {
+                                    Kind = "string",
+                                    Name = "string",
+                                    ApiGroup = "string",
+                                },
+                                Resources = new Kubernetes.Core.Inputs.ResourceRequirementsArgs
+                                {
+                                    Limits = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                    Requests = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                Selector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                                {
+                                    MatchExpressions = new[]
+                                    {
+                                        new Kubernetes.Meta.Inputs.LabelSelectorRequirementArgs
+                                        {
+                                            Key = "string",
+                                            Operator = "string",
+                                            Values = new[]
+                                            {
+                                                "string",
+                                            },
+                                        },
+                                    },
+                                    MatchLabels = 
+                                    {
+                                        { "string", "string" },
+                                    },
+                                },
+                                StorageClassName = "string",
+                                VolumeMode = "string",
+                                VolumeName = "string",
+                            },
+                            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+                            {
+                                Annotations = 
+                                {
+                                    { "string", "string" },
+                                },
+                                ClusterName = "string",
+                                CreationTimestamp = "string",
+                                DeletionGracePeriodSeconds = 0,
+                                DeletionTimestamp = "string",
+                                Finalizers = new[]
+                                {
+                                    "string",
+                                },
+                                GenerateName = "string",
+                                Generation = 0,
+                                Labels = 
+                                {
+                                    { "string", "string" },
+                                },
+                                ManagedFields = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                                    {
+                                        ApiVersion = "string",
+                                        FieldsType = "string",
+                                        FieldsV1 = "{}",
+                                        Manager = "string",
+                                        Operation = "string",
+                                        Subresource = "string",
+                                        Time = "string",
+                                    },
+                                },
+                                Name = "string",
+                                Namespace = "string",
+                                OwnerReferences = new[]
+                                {
+                                    new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                                    {
+                                        ApiVersion = "string",
+                                        Kind = "string",
+                                        Name = "string",
+                                        Uid = "string",
+                                        BlockOwnerDeletion = false,
+                                        Controller = false,
+                                    },
+                                },
+                                ResourceVersion = "string",
+                                SelfLink = "string",
+                                Uid = "string",
+                            },
+                        },
+                    },
+                    Fc = new Kubernetes.Core.Inputs.FCVolumeSourceArgs
+                    {
+                        FsType = "string",
+                        Lun = 0,
+                        ReadOnly = false,
+                        TargetWWNs = new[]
+                        {
+                            "string",
+                        },
+                        Wwids = new[]
+                        {
+                            "string",
+                        },
+                    },
+                    FlexVolume = new Kubernetes.Core.Inputs.FlexVolumeSourceArgs
+                    {
+                        Driver = "string",
+                        FsType = "string",
+                        Options = 
+                        {
+                            { "string", "string" },
+                        },
+                        ReadOnly = false,
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                    },
+                    Iscsi = new Kubernetes.Core.Inputs.ISCSIVolumeSourceArgs
+                    {
+                        Iqn = "string",
+                        Lun = 0,
+                        TargetPortal = "string",
+                        ChapAuthDiscovery = false,
+                        ChapAuthSession = false,
+                        FsType = "string",
+                        InitiatorName = "string",
+                        IscsiInterface = "string",
+                        Portals = new[]
+                        {
+                            "string",
+                        },
+                        ReadOnly = false,
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                    },
+                    GcePersistentDisk = new Kubernetes.Core.Inputs.GCEPersistentDiskVolumeSourceArgs
+                    {
+                        PdName = "string",
+                        FsType = "string",
+                        Partition = 0,
+                        ReadOnly = false,
+                    },
+                    AwsElasticBlockStore = new Kubernetes.Core.Inputs.AWSElasticBlockStoreVolumeSourceArgs
+                    {
+                        VolumeID = "string",
+                        FsType = "string",
+                        Partition = 0,
+                        ReadOnly = false,
+                    },
+                    Cephfs = new Kubernetes.Core.Inputs.CephFSVolumeSourceArgs
+                    {
+                        Monitors = new[]
+                        {
+                            "string",
+                        },
+                        Path = "string",
+                        ReadOnly = false,
+                        SecretFile = "string",
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                        User = "string",
+                    },
+                    AzureFile = new Kubernetes.Core.Inputs.AzureFileVolumeSourceArgs
+                    {
+                        SecretName = "string",
+                        ShareName = "string",
+                        ReadOnly = false,
+                    },
+                    Flocker = new Kubernetes.Core.Inputs.FlockerVolumeSourceArgs
+                    {
+                        DatasetName = "string",
+                        DatasetUUID = "string",
+                    },
+                    AzureDisk = new Kubernetes.Core.Inputs.AzureDiskVolumeSourceArgs
+                    {
+                        DiskName = "string",
+                        DiskURI = "string",
+                        CachingMode = "string",
+                        FsType = "string",
+                        Kind = "string",
+                        ReadOnly = false,
+                    },
+                    Nfs = new Kubernetes.Core.Inputs.NFSVolumeSourceArgs
+                    {
+                        Path = "string",
+                        Server = "string",
+                        ReadOnly = false,
+                    },
+                    PersistentVolumeClaim = new Kubernetes.Core.Inputs.PersistentVolumeClaimVolumeSourceArgs
+                    {
+                        ClaimName = "string",
+                        ReadOnly = false,
+                    },
+                    PhotonPersistentDisk = new Kubernetes.Core.Inputs.PhotonPersistentDiskVolumeSourceArgs
+                    {
+                        PdID = "string",
+                        FsType = "string",
+                    },
+                    PortworxVolume = new Kubernetes.Core.Inputs.PortworxVolumeSourceArgs
+                    {
+                        VolumeID = "string",
+                        FsType = "string",
+                        ReadOnly = false,
+                    },
+                    Projected = new Kubernetes.Core.Inputs.ProjectedVolumeSourceArgs
+                    {
+                        Sources = new[]
+                        {
+                            new Kubernetes.Core.Inputs.VolumeProjectionArgs
+                            {
+                                ConfigMap = new Kubernetes.Core.Inputs.ConfigMapProjectionArgs
+                                {
+                                    Items = new[]
+                                    {
+                                        new Kubernetes.Core.Inputs.KeyToPathArgs
+                                        {
+                                            Key = "string",
+                                            Path = "string",
+                                            Mode = 0,
+                                        },
+                                    },
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                                DownwardAPI = new Kubernetes.Core.Inputs.DownwardAPIProjectionArgs
+                                {
+                                    Items = new[]
+                                    {
+                                        new Kubernetes.Core.Inputs.DownwardAPIVolumeFileArgs
+                                        {
+                                            Path = "string",
+                                            FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                            {
+                                                FieldPath = "string",
+                                                ApiVersion = "string",
+                                            },
+                                            Mode = 0,
+                                            ResourceFieldRef = new Kubernetes.Core.Inputs.ResourceFieldSelectorArgs
+                                            {
+                                                Resource = "string",
+                                                ContainerName = "string",
+                                                Divisor = "string",
+                                            },
+                                        },
+                                    },
+                                },
+                                Secret = new Kubernetes.Core.Inputs.SecretProjectionArgs
+                                {
+                                    Items = new[]
+                                    {
+                                        new Kubernetes.Core.Inputs.KeyToPathArgs
+                                        {
+                                            Key = "string",
+                                            Path = "string",
+                                            Mode = 0,
+                                        },
+                                    },
+                                    Name = "string",
+                                    Optional = false,
+                                },
+                                ServiceAccountToken = new Kubernetes.Core.Inputs.ServiceAccountTokenProjectionArgs
+                                {
+                                    Path = "string",
+                                    Audience = "string",
+                                    ExpirationSeconds = 0,
+                                },
+                            },
+                        },
+                        DefaultMode = 0,
+                    },
+                    Quobyte = new Kubernetes.Core.Inputs.QuobyteVolumeSourceArgs
+                    {
+                        Registry = "string",
+                        Volume = "string",
+                        Group = "string",
+                        ReadOnly = false,
+                        Tenant = "string",
+                        User = "string",
+                    },
+                    Rbd = new Kubernetes.Core.Inputs.RBDVolumeSourceArgs
+                    {
+                        Image = "string",
+                        Monitors = new[]
+                        {
+                            "string",
+                        },
+                        FsType = "string",
+                        Keyring = "string",
+                        Pool = "string",
+                        ReadOnly = false,
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                        User = "string",
+                    },
+                    ScaleIO = new Kubernetes.Core.Inputs.ScaleIOVolumeSourceArgs
+                    {
+                        Gateway = "string",
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                        System = "string",
+                        FsType = "string",
+                        ProtectionDomain = "string",
+                        ReadOnly = false,
+                        SslEnabled = false,
+                        StorageMode = "string",
+                        StoragePool = "string",
+                        VolumeName = "string",
+                    },
+                    Secret = new Kubernetes.Core.Inputs.SecretVolumeSourceArgs
+                    {
+                        DefaultMode = 0,
+                        Items = new[]
+                        {
+                            new Kubernetes.Core.Inputs.KeyToPathArgs
+                            {
+                                Key = "string",
+                                Path = "string",
+                                Mode = 0,
+                            },
+                        },
+                        Optional = false,
+                        SecretName = "string",
+                    },
+                    Storageos = new Kubernetes.Core.Inputs.StorageOSVolumeSourceArgs
+                    {
+                        FsType = "string",
+                        ReadOnly = false,
+                        SecretRef = new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                        {
+                            Name = "string",
+                        },
+                        VolumeName = "string",
+                        VolumeNamespace = "string",
+                    },
+                    VsphereVolume = new Kubernetes.Core.Inputs.VsphereVirtualDiskVolumeSourceArgs
+                    {
+                        VolumePath = "string",
+                        FsType = "string",
+                        StoragePolicyID = "string",
+                        StoragePolicyName = "string",
+                    },
+                },
+            },
+        },
+        Status = new Kubernetes.Core.Inputs.PodStatusArgs
+        {
+            Conditions = new[]
+            {
+                new Kubernetes.Core.Inputs.PodConditionArgs
+                {
+                    Status = "string",
+                    Type = "string",
+                    LastProbeTime = "string",
+                    LastTransitionTime = "string",
+                    Message = "string",
+                    Reason = "string",
+                },
+            },
+            ContainerStatuses = new[]
+            {
+                new Kubernetes.Core.Inputs.ContainerStatusArgs
+                {
+                    Image = "string",
+                    ImageID = "string",
+                    Name = "string",
+                    Ready = false,
+                    RestartCount = 0,
+                    ContainerID = "string",
+                    LastState = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                    Started = false,
+                    State = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                },
+            },
+            EphemeralContainerStatuses = new[]
+            {
+                new Kubernetes.Core.Inputs.ContainerStatusArgs
+                {
+                    Image = "string",
+                    ImageID = "string",
+                    Name = "string",
+                    Ready = false,
+                    RestartCount = 0,
+                    ContainerID = "string",
+                    LastState = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                    Started = false,
+                    State = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                },
+            },
+            HostIP = "string",
+            InitContainerStatuses = new[]
+            {
+                new Kubernetes.Core.Inputs.ContainerStatusArgs
+                {
+                    Image = "string",
+                    ImageID = "string",
+                    Name = "string",
+                    Ready = false,
+                    RestartCount = 0,
+                    ContainerID = "string",
+                    LastState = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                    Started = false,
+                    State = new Kubernetes.Core.Inputs.ContainerStateArgs
+                    {
+                        Running = new Kubernetes.Core.Inputs.ContainerStateRunningArgs
+                        {
+                            StartedAt = "string",
+                        },
+                        Terminated = new Kubernetes.Core.Inputs.ContainerStateTerminatedArgs
+                        {
+                            ExitCode = 0,
+                            ContainerID = "string",
+                            FinishedAt = "string",
+                            Message = "string",
+                            Reason = "string",
+                            Signal = 0,
+                            StartedAt = "string",
+                        },
+                        Waiting = new Kubernetes.Core.Inputs.ContainerStateWaitingArgs
+                        {
+                            Message = "string",
+                            Reason = "string",
+                        },
+                    },
+                },
+            },
+            Message = "string",
+            NominatedNodeName = "string",
+            Phase = "string",
+            PodIP = "string",
+            PodIPs = new[]
+            {
+                new Kubernetes.Core.Inputs.PodIPArgs
+                {
+                    Ip = "string",
+                },
+            },
+            QosClass = "string",
+            Reason = "string",
+            StartTime = "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := foo.NewComponent(ctx, "componentResource", &foo.ComponentArgs{
+	EniConfig: v1alpha1.ENIConfigSpecMap{
+		"string": &v1alpha1.ENIConfigSpecArgs{
+			SecurityGroups: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			Subnet: pulumi.String("string"),
+		},
+	},
+	Pod: &corev1.PodTypeArgs{
+		ApiVersion: pulumi.String("v1"),
+		Kind:       pulumi.String("Pod"),
+		Metadata: &metav1.ObjectMetaArgs{
+			Annotations: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ClusterName:                pulumi.String("string"),
+			CreationTimestamp:          pulumi.String("string"),
+			DeletionGracePeriodSeconds: pulumi.Int(0),
+			DeletionTimestamp:          pulumi.String("string"),
+			Finalizers: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			GenerateName: pulumi.String("string"),
+			Generation:   pulumi.Int(0),
+			Labels: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ManagedFields: metav1.ManagedFieldsEntryArray{
+				&metav1.ManagedFieldsEntryArgs{
+					ApiVersion:  pulumi.String("string"),
+					FieldsType:  pulumi.String("string"),
+					FieldsV1:    pulumi.Any("{}"),
+					Manager:     pulumi.String("string"),
+					Operation:   pulumi.String("string"),
+					Subresource: pulumi.String("string"),
+					Time:        pulumi.String("string"),
+				},
+			},
+			Name:      pulumi.String("string"),
+			Namespace: pulumi.String("string"),
+			OwnerReferences: metav1.OwnerReferenceArray{
+				&metav1.OwnerReferenceArgs{
+					ApiVersion:         pulumi.String("string"),
+					Kind:               pulumi.String("string"),
+					Name:               pulumi.String("string"),
+					Uid:                pulumi.String("string"),
+					BlockOwnerDeletion: pulumi.Bool(false),
+					Controller:         pulumi.Bool(false),
+				},
+			},
+			ResourceVersion: pulumi.String("string"),
+			SelfLink:        pulumi.String("string"),
+			Uid:             pulumi.String("string"),
+		},
+		Spec: &corev1.PodSpecArgs{
+			Containers: corev1.ContainerArray{
+				&corev1.ContainerArgs{
+					Name: pulumi.String("string"),
+					ReadinessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					ImagePullPolicy: pulumi.String("string"),
+					Resources: &corev1.ResourceRequirementsArgs{
+						Limits: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+						Requests: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+					},
+					StartupProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					SecurityContext: &corev1.SecurityContextArgs{
+						AllowPrivilegeEscalation: pulumi.Bool(false),
+						Capabilities: &corev1.CapabilitiesArgs{
+							Add: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+							Drop: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						Privileged:             pulumi.Bool(false),
+						ProcMount:              pulumi.String("string"),
+						ReadOnlyRootFilesystem: pulumi.Bool(false),
+						RunAsGroup:             pulumi.Int(0),
+						RunAsNonRoot:           pulumi.Bool(false),
+						RunAsUser:              pulumi.Int(0),
+						SeLinuxOptions: &corev1.SELinuxOptionsArgs{
+							Level: pulumi.String("string"),
+							Role:  pulumi.String("string"),
+							Type:  pulumi.String("string"),
+							User:  pulumi.String("string"),
+						},
+						SeccompProfile: &corev1.SeccompProfileArgs{
+							Type:             pulumi.String("string"),
+							LocalhostProfile: pulumi.String("string"),
+						},
+						WindowsOptions: &corev1.WindowsSecurityContextOptionsArgs{
+							GmsaCredentialSpec:     pulumi.String("string"),
+							GmsaCredentialSpecName: pulumi.String("string"),
+							HostProcess:            pulumi.Bool(false),
+							RunAsUserName:          pulumi.String("string"),
+						},
+					},
+					Lifecycle: &corev1.LifecycleArgs{
+						PostStart: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+						PreStop: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+					},
+					LivenessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					Command: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					Ports: corev1.ContainerPortArray{
+						&corev1.ContainerPortArgs{
+							ContainerPort: pulumi.Int(0),
+							HostIP:        pulumi.String("string"),
+							HostPort:      pulumi.Int(0),
+							Name:          pulumi.String("string"),
+							Protocol:      pulumi.String("string"),
+						},
+					},
+					Args: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					EnvFrom: corev1.EnvFromSourceArray{
+						&corev1.EnvFromSourceArgs{
+							ConfigMapRef: &corev1.ConfigMapEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+							Prefix: pulumi.String("string"),
+							SecretRef: &corev1.SecretEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+						},
+					},
+					Env: corev1.EnvVarArray{
+						&corev1.EnvVarArgs{
+							Name:  pulumi.String("string"),
+							Value: pulumi.String("string"),
+							ValueFrom: &corev1.EnvVarSourceArgs{
+								ConfigMapKeyRef: &corev1.ConfigMapKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+								FieldRef: &corev1.ObjectFieldSelectorArgs{
+									FieldPath:  pulumi.String("string"),
+									ApiVersion: pulumi.String("string"),
+								},
+								ResourceFieldRef: &corev1.ResourceFieldSelectorArgs{
+									Resource:      pulumi.String("string"),
+									ContainerName: pulumi.String("string"),
+									Divisor:       pulumi.String("string"),
+								},
+								SecretKeyRef: &corev1.SecretKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+							},
+						},
+					},
+					Image:                    pulumi.String("string"),
+					Stdin:                    pulumi.Bool(false),
+					StdinOnce:                pulumi.Bool(false),
+					TerminationMessagePath:   pulumi.String("string"),
+					TerminationMessagePolicy: pulumi.String("string"),
+					Tty:                      pulumi.Bool(false),
+					VolumeDevices: corev1.VolumeDeviceArray{
+						&corev1.VolumeDeviceArgs{
+							DevicePath: pulumi.String("string"),
+							Name:       pulumi.String("string"),
+						},
+					},
+					VolumeMounts: corev1.VolumeMountArray{
+						&corev1.VolumeMountArgs{
+							MountPath:        pulumi.String("string"),
+							Name:             pulumi.String("string"),
+							MountPropagation: pulumi.String("string"),
+							ReadOnly:         pulumi.Bool(false),
+							SubPath:          pulumi.String("string"),
+							SubPathExpr:      pulumi.String("string"),
+						},
+					},
+					WorkingDir: pulumi.String("string"),
+				},
+			},
+			NodeSelector: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			HostAliases: corev1.HostAliasArray{
+				&corev1.HostAliasArgs{
+					Hostnames: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					Ip: pulumi.String("string"),
+				},
+			},
+			Affinity: &corev1.AffinityArgs{
+				NodeAffinity: &corev1.NodeAffinityArgs{
+					PreferredDuringSchedulingIgnoredDuringExecution: corev1.PreferredSchedulingTermArray{
+						&corev1.PreferredSchedulingTermArgs{
+							Preference: &corev1.NodeSelectorTermArgs{
+								MatchExpressions: corev1.NodeSelectorRequirementArray{
+									&corev1.NodeSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchFields: corev1.NodeSelectorRequirementArray{
+									&corev1.NodeSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+							},
+							Weight: pulumi.Int(0),
+						},
+					},
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelectorArgs{
+						NodeSelectorTerms: corev1.NodeSelectorTermArray{
+							&corev1.NodeSelectorTermArgs{
+								MatchExpressions: corev1.NodeSelectorRequirementArray{
+									&corev1.NodeSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchFields: corev1.NodeSelectorRequirementArray{
+									&corev1.NodeSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				PodAffinity: &corev1.PodAffinityArgs{
+					PreferredDuringSchedulingIgnoredDuringExecution: corev1.WeightedPodAffinityTermArray{
+						&corev1.WeightedPodAffinityTermArgs{
+							PodAffinityTerm: &corev1.PodAffinityTermArgs{
+								TopologyKey: pulumi.String("string"),
+								LabelSelector: &metav1.LabelSelectorArgs{
+									MatchExpressions: metav1.LabelSelectorRequirementArray{
+										&metav1.LabelSelectorRequirementArgs{
+											Key:      pulumi.String("string"),
+											Operator: pulumi.String("string"),
+											Values: pulumi.StringArray{
+												pulumi.String("string"),
+											},
+										},
+									},
+									MatchLabels: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelectorArgs{
+									MatchExpressions: metav1.LabelSelectorRequirementArray{
+										&metav1.LabelSelectorRequirementArgs{
+											Key:      pulumi.String("string"),
+											Operator: pulumi.String("string"),
+											Values: pulumi.StringArray{
+												pulumi.String("string"),
+											},
+										},
+									},
+									MatchLabels: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								Namespaces: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							Weight: pulumi.Int(0),
+						},
+					},
+					RequiredDuringSchedulingIgnoredDuringExecution: corev1.PodAffinityTermArray{
+						&corev1.PodAffinityTermArgs{
+							TopologyKey: pulumi.String("string"),
+							LabelSelector: &metav1.LabelSelectorArgs{
+								MatchExpressions: metav1.LabelSelectorRequirementArray{
+									&metav1.LabelSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchLabels: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelectorArgs{
+								MatchExpressions: metav1.LabelSelectorRequirementArray{
+									&metav1.LabelSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchLabels: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+							},
+							Namespaces: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+					},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinityArgs{
+					PreferredDuringSchedulingIgnoredDuringExecution: corev1.WeightedPodAffinityTermArray{
+						&corev1.WeightedPodAffinityTermArgs{
+							PodAffinityTerm: &corev1.PodAffinityTermArgs{
+								TopologyKey: pulumi.String("string"),
+								LabelSelector: &metav1.LabelSelectorArgs{
+									MatchExpressions: metav1.LabelSelectorRequirementArray{
+										&metav1.LabelSelectorRequirementArgs{
+											Key:      pulumi.String("string"),
+											Operator: pulumi.String("string"),
+											Values: pulumi.StringArray{
+												pulumi.String("string"),
+											},
+										},
+									},
+									MatchLabels: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelectorArgs{
+									MatchExpressions: metav1.LabelSelectorRequirementArray{
+										&metav1.LabelSelectorRequirementArgs{
+											Key:      pulumi.String("string"),
+											Operator: pulumi.String("string"),
+											Values: pulumi.StringArray{
+												pulumi.String("string"),
+											},
+										},
+									},
+									MatchLabels: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								Namespaces: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							Weight: pulumi.Int(0),
+						},
+					},
+					RequiredDuringSchedulingIgnoredDuringExecution: corev1.PodAffinityTermArray{
+						&corev1.PodAffinityTermArgs{
+							TopologyKey: pulumi.String("string"),
+							LabelSelector: &metav1.LabelSelectorArgs{
+								MatchExpressions: metav1.LabelSelectorRequirementArray{
+									&metav1.LabelSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchLabels: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelectorArgs{
+								MatchExpressions: metav1.LabelSelectorRequirementArray{
+									&metav1.LabelSelectorRequirementArgs{
+										Key:      pulumi.String("string"),
+										Operator: pulumi.String("string"),
+										Values: pulumi.StringArray{
+											pulumi.String("string"),
+										},
+									},
+								},
+								MatchLabels: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+							},
+							Namespaces: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+					},
+				},
+			},
+			DnsConfig: &corev1.PodDNSConfigArgs{
+				Nameservers: pulumi.StringArray{
+					pulumi.String("string"),
+				},
+				Options: corev1.PodDNSConfigOptionArray{
+					&corev1.PodDNSConfigOptionArgs{
+						Name:  pulumi.String("string"),
+						Value: pulumi.String("string"),
+					},
+				},
+				Searches: pulumi.StringArray{
+					pulumi.String("string"),
+				},
+			},
+			Overhead: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			EnableServiceLinks: pulumi.Bool(false),
+			EphemeralContainers: corev1.EphemeralContainerArray{
+				&corev1.EphemeralContainerArgs{
+					Name: pulumi.String("string"),
+					ReadinessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					EnvFrom: corev1.EnvFromSourceArray{
+						&corev1.EnvFromSourceArgs{
+							ConfigMapRef: &corev1.ConfigMapEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+							Prefix: pulumi.String("string"),
+							SecretRef: &corev1.SecretEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+						},
+					},
+					SecurityContext: &corev1.SecurityContextArgs{
+						AllowPrivilegeEscalation: pulumi.Bool(false),
+						Capabilities: &corev1.CapabilitiesArgs{
+							Add: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+							Drop: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						Privileged:             pulumi.Bool(false),
+						ProcMount:              pulumi.String("string"),
+						ReadOnlyRootFilesystem: pulumi.Bool(false),
+						RunAsGroup:             pulumi.Int(0),
+						RunAsNonRoot:           pulumi.Bool(false),
+						RunAsUser:              pulumi.Int(0),
+						SeLinuxOptions: &corev1.SELinuxOptionsArgs{
+							Level: pulumi.String("string"),
+							Role:  pulumi.String("string"),
+							Type:  pulumi.String("string"),
+							User:  pulumi.String("string"),
+						},
+						SeccompProfile: &corev1.SeccompProfileArgs{
+							Type:             pulumi.String("string"),
+							LocalhostProfile: pulumi.String("string"),
+						},
+						WindowsOptions: &corev1.WindowsSecurityContextOptionsArgs{
+							GmsaCredentialSpec:     pulumi.String("string"),
+							GmsaCredentialSpecName: pulumi.String("string"),
+							HostProcess:            pulumi.Bool(false),
+							RunAsUserName:          pulumi.String("string"),
+						},
+					},
+					Image:           pulumi.String("string"),
+					ImagePullPolicy: pulumi.String("string"),
+					Lifecycle: &corev1.LifecycleArgs{
+						PostStart: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+						PreStop: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+					},
+					LivenessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					Command: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					StartupProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					Args: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					WorkingDir: pulumi.String("string"),
+					Env: corev1.EnvVarArray{
+						&corev1.EnvVarArgs{
+							Name:  pulumi.String("string"),
+							Value: pulumi.String("string"),
+							ValueFrom: &corev1.EnvVarSourceArgs{
+								ConfigMapKeyRef: &corev1.ConfigMapKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+								FieldRef: &corev1.ObjectFieldSelectorArgs{
+									FieldPath:  pulumi.String("string"),
+									ApiVersion: pulumi.String("string"),
+								},
+								ResourceFieldRef: &corev1.ResourceFieldSelectorArgs{
+									Resource:      pulumi.String("string"),
+									ContainerName: pulumi.String("string"),
+									Divisor:       pulumi.String("string"),
+								},
+								SecretKeyRef: &corev1.SecretKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+							},
+						},
+					},
+					Ports: corev1.ContainerPortArray{
+						&corev1.ContainerPortArgs{
+							ContainerPort: pulumi.Int(0),
+							HostIP:        pulumi.String("string"),
+							HostPort:      pulumi.Int(0),
+							Name:          pulumi.String("string"),
+							Protocol:      pulumi.String("string"),
+						},
+					},
+					Stdin:                    pulumi.Bool(false),
+					StdinOnce:                pulumi.Bool(false),
+					TargetContainerName:      pulumi.String("string"),
+					TerminationMessagePath:   pulumi.String("string"),
+					TerminationMessagePolicy: pulumi.String("string"),
+					Tty:                      pulumi.Bool(false),
+					VolumeDevices: corev1.VolumeDeviceArray{
+						&corev1.VolumeDeviceArgs{
+							DevicePath: pulumi.String("string"),
+							Name:       pulumi.String("string"),
+						},
+					},
+					VolumeMounts: corev1.VolumeMountArray{
+						&corev1.VolumeMountArgs{
+							MountPath:        pulumi.String("string"),
+							Name:             pulumi.String("string"),
+							MountPropagation: pulumi.String("string"),
+							ReadOnly:         pulumi.Bool(false),
+							SubPath:          pulumi.String("string"),
+							SubPathExpr:      pulumi.String("string"),
+						},
+					},
+					Resources: &corev1.ResourceRequirementsArgs{
+						Limits: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+						Requests: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+					},
+				},
+			},
+			PreemptionPolicy: pulumi.String("string"),
+			HostIPC:          pulumi.Bool(false),
+			Priority:         pulumi.Int(0),
+			HostPID:          pulumi.Bool(false),
+			Hostname:         pulumi.String("string"),
+			ImagePullSecrets: corev1.LocalObjectReferenceArray{
+				&corev1.LocalObjectReferenceArgs{
+					Name: pulumi.String("string"),
+				},
+			},
+			InitContainers: corev1.ContainerArray{
+				&corev1.ContainerArgs{
+					Name: pulumi.String("string"),
+					ReadinessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					ImagePullPolicy: pulumi.String("string"),
+					Resources: &corev1.ResourceRequirementsArgs{
+						Limits: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+						Requests: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+					},
+					StartupProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					SecurityContext: &corev1.SecurityContextArgs{
+						AllowPrivilegeEscalation: pulumi.Bool(false),
+						Capabilities: &corev1.CapabilitiesArgs{
+							Add: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+							Drop: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						Privileged:             pulumi.Bool(false),
+						ProcMount:              pulumi.String("string"),
+						ReadOnlyRootFilesystem: pulumi.Bool(false),
+						RunAsGroup:             pulumi.Int(0),
+						RunAsNonRoot:           pulumi.Bool(false),
+						RunAsUser:              pulumi.Int(0),
+						SeLinuxOptions: &corev1.SELinuxOptionsArgs{
+							Level: pulumi.String("string"),
+							Role:  pulumi.String("string"),
+							Type:  pulumi.String("string"),
+							User:  pulumi.String("string"),
+						},
+						SeccompProfile: &corev1.SeccompProfileArgs{
+							Type:             pulumi.String("string"),
+							LocalhostProfile: pulumi.String("string"),
+						},
+						WindowsOptions: &corev1.WindowsSecurityContextOptionsArgs{
+							GmsaCredentialSpec:     pulumi.String("string"),
+							GmsaCredentialSpecName: pulumi.String("string"),
+							HostProcess:            pulumi.Bool(false),
+							RunAsUserName:          pulumi.String("string"),
+						},
+					},
+					Lifecycle: &corev1.LifecycleArgs{
+						PostStart: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+						PreStop: &corev1.HandlerArgs{
+							Exec: &corev1.ExecActionArgs{
+								Command: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+							HttpGet: &corev1.HTTPGetActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+								HttpHeaders: corev1.HTTPHeaderArray{
+									&corev1.HTTPHeaderArgs{
+										Name:  pulumi.String("string"),
+										Value: pulumi.String("string"),
+									},
+								},
+								Path:   pulumi.String("string"),
+								Scheme: pulumi.String("string"),
+							},
+							TcpSocket: &corev1.TCPSocketActionArgs{
+								Port: pulumi.Any(0),
+								Host: pulumi.String("string"),
+							},
+						},
+					},
+					LivenessProbe: &corev1.ProbeArgs{
+						Exec: &corev1.ExecActionArgs{
+							Command: pulumi.StringArray{
+								pulumi.String("string"),
+							},
+						},
+						FailureThreshold: pulumi.Int(0),
+						HttpGet: &corev1.HTTPGetActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+							HttpHeaders: corev1.HTTPHeaderArray{
+								&corev1.HTTPHeaderArgs{
+									Name:  pulumi.String("string"),
+									Value: pulumi.String("string"),
+								},
+							},
+							Path:   pulumi.String("string"),
+							Scheme: pulumi.String("string"),
+						},
+						InitialDelaySeconds: pulumi.Int(0),
+						PeriodSeconds:       pulumi.Int(0),
+						SuccessThreshold:    pulumi.Int(0),
+						TcpSocket: &corev1.TCPSocketActionArgs{
+							Port: pulumi.Any(0),
+							Host: pulumi.String("string"),
+						},
+						TerminationGracePeriodSeconds: pulumi.Int(0),
+						TimeoutSeconds:                pulumi.Int(0),
+					},
+					Command: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					Ports: corev1.ContainerPortArray{
+						&corev1.ContainerPortArgs{
+							ContainerPort: pulumi.Int(0),
+							HostIP:        pulumi.String("string"),
+							HostPort:      pulumi.Int(0),
+							Name:          pulumi.String("string"),
+							Protocol:      pulumi.String("string"),
+						},
+					},
+					Args: pulumi.StringArray{
+						pulumi.String("string"),
+					},
+					EnvFrom: corev1.EnvFromSourceArray{
+						&corev1.EnvFromSourceArgs{
+							ConfigMapRef: &corev1.ConfigMapEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+							Prefix: pulumi.String("string"),
+							SecretRef: &corev1.SecretEnvSourceArgs{
+								Name:     pulumi.String("string"),
+								Optional: pulumi.Bool(false),
+							},
+						},
+					},
+					Env: corev1.EnvVarArray{
+						&corev1.EnvVarArgs{
+							Name:  pulumi.String("string"),
+							Value: pulumi.String("string"),
+							ValueFrom: &corev1.EnvVarSourceArgs{
+								ConfigMapKeyRef: &corev1.ConfigMapKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+								FieldRef: &corev1.ObjectFieldSelectorArgs{
+									FieldPath:  pulumi.String("string"),
+									ApiVersion: pulumi.String("string"),
+								},
+								ResourceFieldRef: &corev1.ResourceFieldSelectorArgs{
+									Resource:      pulumi.String("string"),
+									ContainerName: pulumi.String("string"),
+									Divisor:       pulumi.String("string"),
+								},
+								SecretKeyRef: &corev1.SecretKeySelectorArgs{
+									Key:      pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+							},
+						},
+					},
+					Image:                    pulumi.String("string"),
+					Stdin:                    pulumi.Bool(false),
+					StdinOnce:                pulumi.Bool(false),
+					TerminationMessagePath:   pulumi.String("string"),
+					TerminationMessagePolicy: pulumi.String("string"),
+					Tty:                      pulumi.Bool(false),
+					VolumeDevices: corev1.VolumeDeviceArray{
+						&corev1.VolumeDeviceArgs{
+							DevicePath: pulumi.String("string"),
+							Name:       pulumi.String("string"),
+						},
+					},
+					VolumeMounts: corev1.VolumeMountArray{
+						&corev1.VolumeMountArgs{
+							MountPath:        pulumi.String("string"),
+							Name:             pulumi.String("string"),
+							MountPropagation: pulumi.String("string"),
+							ReadOnly:         pulumi.Bool(false),
+							SubPath:          pulumi.String("string"),
+							SubPathExpr:      pulumi.String("string"),
+						},
+					},
+					WorkingDir: pulumi.String("string"),
+				},
+			},
+			NodeName:                     pulumi.String("string"),
+			ActiveDeadlineSeconds:        pulumi.Int(0),
+			DnsPolicy:                    pulumi.String("string"),
+			AutomountServiceAccountToken: pulumi.Bool(false),
+			HostNetwork:                  pulumi.Bool(false),
+			PriorityClassName:            pulumi.String("string"),
+			ReadinessGates: corev1.PodReadinessGateArray{
+				&corev1.PodReadinessGateArgs{
+					ConditionType: pulumi.String("string"),
+				},
+			},
+			RestartPolicy:    pulumi.String("string"),
+			RuntimeClassName: pulumi.String("string"),
+			SchedulerName:    pulumi.String("string"),
+			SecurityContext: &corev1.PodSecurityContextArgs{
+				FsGroup:             pulumi.Int(0),
+				FsGroupChangePolicy: pulumi.String("string"),
+				RunAsGroup:          pulumi.Int(0),
+				RunAsNonRoot:        pulumi.Bool(false),
+				RunAsUser:           pulumi.Int(0),
+				SeLinuxOptions: &corev1.SELinuxOptionsArgs{
+					Level: pulumi.String("string"),
+					Role:  pulumi.String("string"),
+					Type:  pulumi.String("string"),
+					User:  pulumi.String("string"),
+				},
+				SeccompProfile: &corev1.SeccompProfileArgs{
+					Type:             pulumi.String("string"),
+					LocalhostProfile: pulumi.String("string"),
+				},
+				SupplementalGroups: pulumi.IntArray{
+					pulumi.Int(0),
+				},
+				Sysctls: corev1.SysctlArray{
+					&corev1.SysctlArgs{
+						Name:  pulumi.String("string"),
+						Value: pulumi.String("string"),
+					},
+				},
+				WindowsOptions: &corev1.WindowsSecurityContextOptionsArgs{
+					GmsaCredentialSpec:     pulumi.String("string"),
+					GmsaCredentialSpecName: pulumi.String("string"),
+					HostProcess:            pulumi.Bool(false),
+					RunAsUserName:          pulumi.String("string"),
+				},
+			},
+			ServiceAccount:                pulumi.String("string"),
+			ServiceAccountName:            pulumi.String("string"),
+			SetHostnameAsFQDN:             pulumi.Bool(false),
+			ShareProcessNamespace:         pulumi.Bool(false),
+			Subdomain:                     pulumi.String("string"),
+			TerminationGracePeriodSeconds: pulumi.Int(0),
+			Tolerations: corev1.TolerationArray{
+				&corev1.TolerationArgs{
+					Effect:            pulumi.String("string"),
+					Key:               pulumi.String("string"),
+					Operator:          pulumi.String("string"),
+					TolerationSeconds: pulumi.Int(0),
+					Value:             pulumi.String("string"),
+				},
+			},
+			TopologySpreadConstraints: corev1.TopologySpreadConstraintArray{
+				&corev1.TopologySpreadConstraintArgs{
+					MaxSkew:           pulumi.Int(0),
+					TopologyKey:       pulumi.String("string"),
+					WhenUnsatisfiable: pulumi.String("string"),
+					LabelSelector: &metav1.LabelSelectorArgs{
+						MatchExpressions: metav1.LabelSelectorRequirementArray{
+							&metav1.LabelSelectorRequirementArgs{
+								Key:      pulumi.String("string"),
+								Operator: pulumi.String("string"),
+								Values: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+							},
+						},
+						MatchLabels: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+					},
+				},
+			},
+			Volumes: corev1.VolumeArray{
+				&corev1.VolumeArgs{
+					Name: pulumi.String("string"),
+					GitRepo: &corev1.GitRepoVolumeSourceArgs{
+						Repository: pulumi.String("string"),
+						Directory:  pulumi.String("string"),
+						Revision:   pulumi.String("string"),
+					},
+					ConfigMap: &corev1.ConfigMapVolumeSourceArgs{
+						DefaultMode: pulumi.Int(0),
+						Items: corev1.KeyToPathArray{
+							&corev1.KeyToPathArgs{
+								Key:  pulumi.String("string"),
+								Path: pulumi.String("string"),
+								Mode: pulumi.Int(0),
+							},
+						},
+						Name:     pulumi.String("string"),
+						Optional: pulumi.Bool(false),
+					},
+					Glusterfs: &corev1.GlusterfsVolumeSourceArgs{
+						Endpoints: pulumi.String("string"),
+						Path:      pulumi.String("string"),
+						ReadOnly:  pulumi.Bool(false),
+					},
+					Cinder: &corev1.CinderVolumeSourceArgs{
+						VolumeID: pulumi.String("string"),
+						FsType:   pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+					},
+					HostPath: &corev1.HostPathVolumeSourceArgs{
+						Path: pulumi.String("string"),
+						Type: pulumi.String("string"),
+					},
+					Csi: &corev1.CSIVolumeSourceArgs{
+						Driver: pulumi.String("string"),
+						FsType: pulumi.String("string"),
+						NodePublishSecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+						ReadOnly: pulumi.Bool(false),
+						VolumeAttributes: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+					},
+					DownwardAPI: &corev1.DownwardAPIVolumeSourceArgs{
+						DefaultMode: pulumi.Int(0),
+						Items: corev1.DownwardAPIVolumeFileArray{
+							&corev1.DownwardAPIVolumeFileArgs{
+								Path: pulumi.String("string"),
+								FieldRef: &corev1.ObjectFieldSelectorArgs{
+									FieldPath:  pulumi.String("string"),
+									ApiVersion: pulumi.String("string"),
+								},
+								Mode: pulumi.Int(0),
+								ResourceFieldRef: &corev1.ResourceFieldSelectorArgs{
+									Resource:      pulumi.String("string"),
+									ContainerName: pulumi.String("string"),
+									Divisor:       pulumi.String("string"),
+								},
+							},
+						},
+					},
+					EmptyDir: &corev1.EmptyDirVolumeSourceArgs{
+						Medium:    pulumi.String("string"),
+						SizeLimit: pulumi.String("string"),
+					},
+					Ephemeral: &corev1.EphemeralVolumeSourceArgs{
+						ReadOnly: pulumi.Bool(false),
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplateArgs{
+							Spec: &corev1.PersistentVolumeClaimSpecArgs{
+								AccessModes: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+								DataSource: &corev1.TypedLocalObjectReferenceArgs{
+									Kind:     pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									ApiGroup: pulumi.String("string"),
+								},
+								DataSourceRef: &corev1.TypedLocalObjectReferenceArgs{
+									Kind:     pulumi.String("string"),
+									Name:     pulumi.String("string"),
+									ApiGroup: pulumi.String("string"),
+								},
+								Resources: &corev1.ResourceRequirementsArgs{
+									Limits: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+									Requests: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								Selector: &metav1.LabelSelectorArgs{
+									MatchExpressions: metav1.LabelSelectorRequirementArray{
+										&metav1.LabelSelectorRequirementArgs{
+											Key:      pulumi.String("string"),
+											Operator: pulumi.String("string"),
+											Values: pulumi.StringArray{
+												pulumi.String("string"),
+											},
+										},
+									},
+									MatchLabels: pulumi.StringMap{
+										"string": pulumi.String("string"),
+									},
+								},
+								StorageClassName: pulumi.String("string"),
+								VolumeMode:       pulumi.String("string"),
+								VolumeName:       pulumi.String("string"),
+							},
+							Metadata: &metav1.ObjectMetaArgs{
+								Annotations: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+								ClusterName:                pulumi.String("string"),
+								CreationTimestamp:          pulumi.String("string"),
+								DeletionGracePeriodSeconds: pulumi.Int(0),
+								DeletionTimestamp:          pulumi.String("string"),
+								Finalizers: pulumi.StringArray{
+									pulumi.String("string"),
+								},
+								GenerateName: pulumi.String("string"),
+								Generation:   pulumi.Int(0),
+								Labels: pulumi.StringMap{
+									"string": pulumi.String("string"),
+								},
+								ManagedFields: metav1.ManagedFieldsEntryArray{
+									&metav1.ManagedFieldsEntryArgs{
+										ApiVersion:  pulumi.String("string"),
+										FieldsType:  pulumi.String("string"),
+										FieldsV1:    pulumi.Any("{}"),
+										Manager:     pulumi.String("string"),
+										Operation:   pulumi.String("string"),
+										Subresource: pulumi.String("string"),
+										Time:        pulumi.String("string"),
+									},
+								},
+								Name:      pulumi.String("string"),
+								Namespace: pulumi.String("string"),
+								OwnerReferences: metav1.OwnerReferenceArray{
+									&metav1.OwnerReferenceArgs{
+										ApiVersion:         pulumi.String("string"),
+										Kind:               pulumi.String("string"),
+										Name:               pulumi.String("string"),
+										Uid:                pulumi.String("string"),
+										BlockOwnerDeletion: pulumi.Bool(false),
+										Controller:         pulumi.Bool(false),
+									},
+								},
+								ResourceVersion: pulumi.String("string"),
+								SelfLink:        pulumi.String("string"),
+								Uid:             pulumi.String("string"),
+							},
+						},
+					},
+					Fc: &corev1.FCVolumeSourceArgs{
+						FsType:   pulumi.String("string"),
+						Lun:      pulumi.Int(0),
+						ReadOnly: pulumi.Bool(false),
+						TargetWWNs: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+						Wwids: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+					},
+					FlexVolume: &corev1.FlexVolumeSourceArgs{
+						Driver: pulumi.String("string"),
+						FsType: pulumi.String("string"),
+						Options: pulumi.StringMap{
+							"string": pulumi.String("string"),
+						},
+						ReadOnly: pulumi.Bool(false),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+					},
+					Iscsi: &corev1.ISCSIVolumeSourceArgs{
+						Iqn:               pulumi.String("string"),
+						Lun:               pulumi.Int(0),
+						TargetPortal:      pulumi.String("string"),
+						ChapAuthDiscovery: pulumi.Bool(false),
+						ChapAuthSession:   pulumi.Bool(false),
+						FsType:            pulumi.String("string"),
+						InitiatorName:     pulumi.String("string"),
+						IscsiInterface:    pulumi.String("string"),
+						Portals: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+						ReadOnly: pulumi.Bool(false),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+					},
+					GcePersistentDisk: &corev1.GCEPersistentDiskVolumeSourceArgs{
+						PdName:    pulumi.String("string"),
+						FsType:    pulumi.String("string"),
+						Partition: pulumi.Int(0),
+						ReadOnly:  pulumi.Bool(false),
+					},
+					AwsElasticBlockStore: &corev1.AWSElasticBlockStoreVolumeSourceArgs{
+						VolumeID:  pulumi.String("string"),
+						FsType:    pulumi.String("string"),
+						Partition: pulumi.Int(0),
+						ReadOnly:  pulumi.Bool(false),
+					},
+					Cephfs: &corev1.CephFSVolumeSourceArgs{
+						Monitors: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+						Path:       pulumi.String("string"),
+						ReadOnly:   pulumi.Bool(false),
+						SecretFile: pulumi.String("string"),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+						User: pulumi.String("string"),
+					},
+					AzureFile: &corev1.AzureFileVolumeSourceArgs{
+						SecretName: pulumi.String("string"),
+						ShareName:  pulumi.String("string"),
+						ReadOnly:   pulumi.Bool(false),
+					},
+					Flocker: &corev1.FlockerVolumeSourceArgs{
+						DatasetName: pulumi.String("string"),
+						DatasetUUID: pulumi.String("string"),
+					},
+					AzureDisk: &corev1.AzureDiskVolumeSourceArgs{
+						DiskName:    pulumi.String("string"),
+						DiskURI:     pulumi.String("string"),
+						CachingMode: pulumi.String("string"),
+						FsType:      pulumi.String("string"),
+						Kind:        pulumi.String("string"),
+						ReadOnly:    pulumi.Bool(false),
+					},
+					Nfs: &corev1.NFSVolumeSourceArgs{
+						Path:     pulumi.String("string"),
+						Server:   pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+					},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSourceArgs{
+						ClaimName: pulumi.String("string"),
+						ReadOnly:  pulumi.Bool(false),
+					},
+					PhotonPersistentDisk: &corev1.PhotonPersistentDiskVolumeSourceArgs{
+						PdID:   pulumi.String("string"),
+						FsType: pulumi.String("string"),
+					},
+					PortworxVolume: &corev1.PortworxVolumeSourceArgs{
+						VolumeID: pulumi.String("string"),
+						FsType:   pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+					},
+					Projected: &corev1.ProjectedVolumeSourceArgs{
+						Sources: corev1.VolumeProjectionArray{
+							&corev1.VolumeProjectionArgs{
+								ConfigMap: &corev1.ConfigMapProjectionArgs{
+									Items: corev1.KeyToPathArray{
+										&corev1.KeyToPathArgs{
+											Key:  pulumi.String("string"),
+											Path: pulumi.String("string"),
+											Mode: pulumi.Int(0),
+										},
+									},
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+								DownwardAPI: &corev1.DownwardAPIProjectionArgs{
+									Items: corev1.DownwardAPIVolumeFileArray{
+										&corev1.DownwardAPIVolumeFileArgs{
+											Path: pulumi.String("string"),
+											FieldRef: &corev1.ObjectFieldSelectorArgs{
+												FieldPath:  pulumi.String("string"),
+												ApiVersion: pulumi.String("string"),
+											},
+											Mode: pulumi.Int(0),
+											ResourceFieldRef: &corev1.ResourceFieldSelectorArgs{
+												Resource:      pulumi.String("string"),
+												ContainerName: pulumi.String("string"),
+												Divisor:       pulumi.String("string"),
+											},
+										},
+									},
+								},
+								Secret: &corev1.SecretProjectionArgs{
+									Items: corev1.KeyToPathArray{
+										&corev1.KeyToPathArgs{
+											Key:  pulumi.String("string"),
+											Path: pulumi.String("string"),
+											Mode: pulumi.Int(0),
+										},
+									},
+									Name:     pulumi.String("string"),
+									Optional: pulumi.Bool(false),
+								},
+								ServiceAccountToken: &corev1.ServiceAccountTokenProjectionArgs{
+									Path:              pulumi.String("string"),
+									Audience:          pulumi.String("string"),
+									ExpirationSeconds: pulumi.Int(0),
+								},
+							},
+						},
+						DefaultMode: pulumi.Int(0),
+					},
+					Quobyte: &corev1.QuobyteVolumeSourceArgs{
+						Registry: pulumi.String("string"),
+						Volume:   pulumi.String("string"),
+						Group:    pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+						Tenant:   pulumi.String("string"),
+						User:     pulumi.String("string"),
+					},
+					Rbd: &corev1.RBDVolumeSourceArgs{
+						Image: pulumi.String("string"),
+						Monitors: pulumi.StringArray{
+							pulumi.String("string"),
+						},
+						FsType:   pulumi.String("string"),
+						Keyring:  pulumi.String("string"),
+						Pool:     pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+						User: pulumi.String("string"),
+					},
+					ScaleIO: &corev1.ScaleIOVolumeSourceArgs{
+						Gateway: pulumi.String("string"),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+						System:           pulumi.String("string"),
+						FsType:           pulumi.String("string"),
+						ProtectionDomain: pulumi.String("string"),
+						ReadOnly:         pulumi.Bool(false),
+						SslEnabled:       pulumi.Bool(false),
+						StorageMode:      pulumi.String("string"),
+						StoragePool:      pulumi.String("string"),
+						VolumeName:       pulumi.String("string"),
+					},
+					Secret: &corev1.SecretVolumeSourceArgs{
+						DefaultMode: pulumi.Int(0),
+						Items: corev1.KeyToPathArray{
+							&corev1.KeyToPathArgs{
+								Key:  pulumi.String("string"),
+								Path: pulumi.String("string"),
+								Mode: pulumi.Int(0),
+							},
+						},
+						Optional:   pulumi.Bool(false),
+						SecretName: pulumi.String("string"),
+					},
+					Storageos: &corev1.StorageOSVolumeSourceArgs{
+						FsType:   pulumi.String("string"),
+						ReadOnly: pulumi.Bool(false),
+						SecretRef: &corev1.LocalObjectReferenceArgs{
+							Name: pulumi.String("string"),
+						},
+						VolumeName:      pulumi.String("string"),
+						VolumeNamespace: pulumi.String("string"),
+					},
+					VsphereVolume: &corev1.VsphereVirtualDiskVolumeSourceArgs{
+						VolumePath:        pulumi.String("string"),
+						FsType:            pulumi.String("string"),
+						StoragePolicyID:   pulumi.String("string"),
+						StoragePolicyName: pulumi.String("string"),
+					},
+				},
+			},
+		},
+		Status: &corev1.PodStatusArgs{
+			Conditions: corev1.PodConditionArray{
+				&corev1.PodConditionArgs{
+					Status:             pulumi.String("string"),
+					Type:               pulumi.String("string"),
+					LastProbeTime:      pulumi.String("string"),
+					LastTransitionTime: pulumi.String("string"),
+					Message:            pulumi.String("string"),
+					Reason:             pulumi.String("string"),
+				},
+			},
+			ContainerStatuses: corev1.ContainerStatusArray{
+				&corev1.ContainerStatusArgs{
+					Image:        pulumi.String("string"),
+					ImageID:      pulumi.String("string"),
+					Name:         pulumi.String("string"),
+					Ready:        pulumi.Bool(false),
+					RestartCount: pulumi.Int(0),
+					ContainerID:  pulumi.String("string"),
+					LastState: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+					Started: pulumi.Bool(false),
+					State: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+				},
+			},
+			EphemeralContainerStatuses: corev1.ContainerStatusArray{
+				&corev1.ContainerStatusArgs{
+					Image:        pulumi.String("string"),
+					ImageID:      pulumi.String("string"),
+					Name:         pulumi.String("string"),
+					Ready:        pulumi.Bool(false),
+					RestartCount: pulumi.Int(0),
+					ContainerID:  pulumi.String("string"),
+					LastState: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+					Started: pulumi.Bool(false),
+					State: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+				},
+			},
+			HostIP: pulumi.String("string"),
+			InitContainerStatuses: corev1.ContainerStatusArray{
+				&corev1.ContainerStatusArgs{
+					Image:        pulumi.String("string"),
+					ImageID:      pulumi.String("string"),
+					Name:         pulumi.String("string"),
+					Ready:        pulumi.Bool(false),
+					RestartCount: pulumi.Int(0),
+					ContainerID:  pulumi.String("string"),
+					LastState: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+					Started: pulumi.Bool(false),
+					State: &corev1.ContainerStateArgs{
+						Running: &corev1.ContainerStateRunningArgs{
+							StartedAt: pulumi.String("string"),
+						},
+						Terminated: &corev1.ContainerStateTerminatedArgs{
+							ExitCode:    pulumi.Int(0),
+							ContainerID: pulumi.String("string"),
+							FinishedAt:  pulumi.String("string"),
+							Message:     pulumi.String("string"),
+							Reason:      pulumi.String("string"),
+							Signal:      pulumi.Int(0),
+							StartedAt:   pulumi.String("string"),
+						},
+						Waiting: &corev1.ContainerStateWaitingArgs{
+							Message: pulumi.String("string"),
+							Reason:  pulumi.String("string"),
+						},
+					},
+				},
+			},
+			Message:           pulumi.String("string"),
+			NominatedNodeName: pulumi.String("string"),
+			Phase:             pulumi.String("string"),
+			PodIP:             pulumi.String("string"),
+			PodIPs: corev1.PodIPArray{
+				&corev1.PodIPArgs{
+					Ip: pulumi.String("string"),
+				},
+			},
+			QosClass:  pulumi.String("string"),
+			Reason:    pulumi.String("string"),
+			StartTime: pulumi.String("string"),
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+component_resource = foo.Component("componentResource",
+    eni_config={
+        "string": kubernetes.crd_k8s_amazonaws_com.v1alpha1.ENIConfigSpecArgs(
+            security_groups=["string"],
+            subnet="string",
+        ),
+    },
+    pod=kubernetes.core.v1.PodArgs(
+        api_version="v1",
+        kind="Pod",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            annotations={
+                "string": "string",
+            },
+            cluster_name="string",
+            creation_timestamp="string",
+            deletion_grace_period_seconds=0,
+            deletion_timestamp="string",
+            finalizers=["string"],
+            generate_name="string",
+            generation=0,
+            labels={
+                "string": "string",
+            },
+            managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+                api_version="string",
+                fields_type="string",
+                fields_v1="{}",
+                manager="string",
+                operation="string",
+                subresource="string",
+                time="string",
+            )],
+            name="string",
+            namespace="string",
+            owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+                api_version="string",
+                kind="string",
+                name="string",
+                uid="string",
+                block_owner_deletion=False,
+                controller=False,
+            )],
+            resource_version="string",
+            self_link="string",
+            uid="string",
+        ),
+        spec=kubernetes.core.v1.PodSpecArgs(
+            containers=[kubernetes.core.v1.ContainerArgs(
+                name="string",
+                readiness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                image_pull_policy="string",
+                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                    limits={
+                        "string": "string",
+                    },
+                    requests={
+                        "string": "string",
+                    },
+                ),
+                startup_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                security_context=kubernetes.core.v1.SecurityContextArgs(
+                    allow_privilege_escalation=False,
+                    capabilities=kubernetes.core.v1.CapabilitiesArgs(
+                        add=["string"],
+                        drop=["string"],
+                    ),
+                    privileged=False,
+                    proc_mount="string",
+                    read_only_root_filesystem=False,
+                    run_as_group=0,
+                    run_as_non_root=False,
+                    run_as_user=0,
+                    se_linux_options=kubernetes.core.v1.SELinuxOptionsArgs(
+                        level="string",
+                        role="string",
+                        type="string",
+                        user="string",
+                    ),
+                    seccomp_profile=kubernetes.core.v1.SeccompProfileArgs(
+                        type="string",
+                        localhost_profile="string",
+                    ),
+                    windows_options=kubernetes.core.v1.WindowsSecurityContextOptionsArgs(
+                        gmsa_credential_spec="string",
+                        gmsa_credential_spec_name="string",
+                        host_process=False,
+                        run_as_user_name="string",
+                    ),
+                ),
+                lifecycle=kubernetes.core.v1.LifecycleArgs(
+                    post_start=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                    pre_stop=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                ),
+                liveness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                command=["string"],
+                ports=[kubernetes.core.v1.ContainerPortArgs(
+                    container_port=0,
+                    host_ip="string",
+                    host_port=0,
+                    name="string",
+                    protocol="string",
+                )],
+                args=["string"],
+                env_from=[kubernetes.core.v1.EnvFromSourceArgs(
+                    config_map_ref=kubernetes.core.v1.ConfigMapEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                    prefix="string",
+                    secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                )],
+                env=[kubernetes.core.v1.EnvVarArgs(
+                    name="string",
+                    value="string",
+                    value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                        config_map_key_ref=kubernetes.core.v1.ConfigMapKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                        field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                            field_path="string",
+                            api_version="string",
+                        ),
+                        resource_field_ref=kubernetes.core.v1.ResourceFieldSelectorArgs(
+                            resource="string",
+                            container_name="string",
+                            divisor="string",
+                        ),
+                        secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                    ),
+                )],
+                image="string",
+                stdin=False,
+                stdin_once=False,
+                termination_message_path="string",
+                termination_message_policy="string",
+                tty=False,
+                volume_devices=[kubernetes.core.v1.VolumeDeviceArgs(
+                    device_path="string",
+                    name="string",
+                )],
+                volume_mounts=[kubernetes.core.v1.VolumeMountArgs(
+                    mount_path="string",
+                    name="string",
+                    mount_propagation="string",
+                    read_only=False,
+                    sub_path="string",
+                    sub_path_expr="string",
+                )],
+                working_dir="string",
+            )],
+            node_selector={
+                "string": "string",
+            },
+            host_aliases=[kubernetes.core.v1.HostAliasArgs(
+                hostnames=["string"],
+                ip="string",
+            )],
+            affinity=kubernetes.core.v1.AffinityArgs(
+                node_affinity=kubernetes.core.v1.NodeAffinityArgs(
+                    preferred_during_scheduling_ignored_during_execution=[kubernetes.core.v1.PreferredSchedulingTermArgs(
+                        preference=kubernetes.core.v1.NodeSelectorTermArgs(
+                            match_expressions=[kubernetes.core.v1.NodeSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_fields=[kubernetes.core.v1.NodeSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                        ),
+                        weight=0,
+                    )],
+                    required_during_scheduling_ignored_during_execution=kubernetes.core.v1.NodeSelectorArgs(
+                        node_selector_terms=[kubernetes.core.v1.NodeSelectorTermArgs(
+                            match_expressions=[kubernetes.core.v1.NodeSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_fields=[kubernetes.core.v1.NodeSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                        )],
+                    ),
+                ),
+                pod_affinity=kubernetes.core.v1.PodAffinityArgs(
+                    preferred_during_scheduling_ignored_during_execution=[kubernetes.core.v1.WeightedPodAffinityTermArgs(
+                        pod_affinity_term=kubernetes.core.v1.PodAffinityTermArgs(
+                            topology_key="string",
+                            label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                    key="string",
+                                    operator="string",
+                                    values=["string"],
+                                )],
+                                match_labels={
+                                    "string": "string",
+                                },
+                            ),
+                            namespace_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                    key="string",
+                                    operator="string",
+                                    values=["string"],
+                                )],
+                                match_labels={
+                                    "string": "string",
+                                },
+                            ),
+                            namespaces=["string"],
+                        ),
+                        weight=0,
+                    )],
+                    required_during_scheduling_ignored_during_execution=[kubernetes.core.v1.PodAffinityTermArgs(
+                        topology_key="string",
+                        label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                            match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_labels={
+                                "string": "string",
+                            },
+                        ),
+                        namespace_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                            match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_labels={
+                                "string": "string",
+                            },
+                        ),
+                        namespaces=["string"],
+                    )],
+                ),
+                pod_anti_affinity=kubernetes.core.v1.PodAntiAffinityArgs(
+                    preferred_during_scheduling_ignored_during_execution=[kubernetes.core.v1.WeightedPodAffinityTermArgs(
+                        pod_affinity_term=kubernetes.core.v1.PodAffinityTermArgs(
+                            topology_key="string",
+                            label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                    key="string",
+                                    operator="string",
+                                    values=["string"],
+                                )],
+                                match_labels={
+                                    "string": "string",
+                                },
+                            ),
+                            namespace_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                    key="string",
+                                    operator="string",
+                                    values=["string"],
+                                )],
+                                match_labels={
+                                    "string": "string",
+                                },
+                            ),
+                            namespaces=["string"],
+                        ),
+                        weight=0,
+                    )],
+                    required_during_scheduling_ignored_during_execution=[kubernetes.core.v1.PodAffinityTermArgs(
+                        topology_key="string",
+                        label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                            match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_labels={
+                                "string": "string",
+                            },
+                        ),
+                        namespace_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                            match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                key="string",
+                                operator="string",
+                                values=["string"],
+                            )],
+                            match_labels={
+                                "string": "string",
+                            },
+                        ),
+                        namespaces=["string"],
+                    )],
+                ),
+            ),
+            dns_config=kubernetes.core.v1.PodDNSConfigArgs(
+                nameservers=["string"],
+                options=[kubernetes.core.v1.PodDNSConfigOptionArgs(
+                    name="string",
+                    value="string",
+                )],
+                searches=["string"],
+            ),
+            overhead={
+                "string": "string",
+            },
+            enable_service_links=False,
+            ephemeral_containers=[kubernetes.core.v1.EphemeralContainerArgs(
+                name="string",
+                readiness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                env_from=[kubernetes.core.v1.EnvFromSourceArgs(
+                    config_map_ref=kubernetes.core.v1.ConfigMapEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                    prefix="string",
+                    secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                )],
+                security_context=kubernetes.core.v1.SecurityContextArgs(
+                    allow_privilege_escalation=False,
+                    capabilities=kubernetes.core.v1.CapabilitiesArgs(
+                        add=["string"],
+                        drop=["string"],
+                    ),
+                    privileged=False,
+                    proc_mount="string",
+                    read_only_root_filesystem=False,
+                    run_as_group=0,
+                    run_as_non_root=False,
+                    run_as_user=0,
+                    se_linux_options=kubernetes.core.v1.SELinuxOptionsArgs(
+                        level="string",
+                        role="string",
+                        type="string",
+                        user="string",
+                    ),
+                    seccomp_profile=kubernetes.core.v1.SeccompProfileArgs(
+                        type="string",
+                        localhost_profile="string",
+                    ),
+                    windows_options=kubernetes.core.v1.WindowsSecurityContextOptionsArgs(
+                        gmsa_credential_spec="string",
+                        gmsa_credential_spec_name="string",
+                        host_process=False,
+                        run_as_user_name="string",
+                    ),
+                ),
+                image="string",
+                image_pull_policy="string",
+                lifecycle=kubernetes.core.v1.LifecycleArgs(
+                    post_start=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                    pre_stop=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                ),
+                liveness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                command=["string"],
+                startup_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                args=["string"],
+                working_dir="string",
+                env=[kubernetes.core.v1.EnvVarArgs(
+                    name="string",
+                    value="string",
+                    value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                        config_map_key_ref=kubernetes.core.v1.ConfigMapKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                        field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                            field_path="string",
+                            api_version="string",
+                        ),
+                        resource_field_ref=kubernetes.core.v1.ResourceFieldSelectorArgs(
+                            resource="string",
+                            container_name="string",
+                            divisor="string",
+                        ),
+                        secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                    ),
+                )],
+                ports=[kubernetes.core.v1.ContainerPortArgs(
+                    container_port=0,
+                    host_ip="string",
+                    host_port=0,
+                    name="string",
+                    protocol="string",
+                )],
+                stdin=False,
+                stdin_once=False,
+                target_container_name="string",
+                termination_message_path="string",
+                termination_message_policy="string",
+                tty=False,
+                volume_devices=[kubernetes.core.v1.VolumeDeviceArgs(
+                    device_path="string",
+                    name="string",
+                )],
+                volume_mounts=[kubernetes.core.v1.VolumeMountArgs(
+                    mount_path="string",
+                    name="string",
+                    mount_propagation="string",
+                    read_only=False,
+                    sub_path="string",
+                    sub_path_expr="string",
+                )],
+                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                    limits={
+                        "string": "string",
+                    },
+                    requests={
+                        "string": "string",
+                    },
+                ),
+            )],
+            preemption_policy="string",
+            host_ipc=False,
+            priority=0,
+            host_pid=False,
+            hostname="string",
+            image_pull_secrets=[kubernetes.core.v1.LocalObjectReferenceArgs(
+                name="string",
+            )],
+            init_containers=[kubernetes.core.v1.ContainerArgs(
+                name="string",
+                readiness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                image_pull_policy="string",
+                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                    limits={
+                        "string": "string",
+                    },
+                    requests={
+                        "string": "string",
+                    },
+                ),
+                startup_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                security_context=kubernetes.core.v1.SecurityContextArgs(
+                    allow_privilege_escalation=False,
+                    capabilities=kubernetes.core.v1.CapabilitiesArgs(
+                        add=["string"],
+                        drop=["string"],
+                    ),
+                    privileged=False,
+                    proc_mount="string",
+                    read_only_root_filesystem=False,
+                    run_as_group=0,
+                    run_as_non_root=False,
+                    run_as_user=0,
+                    se_linux_options=kubernetes.core.v1.SELinuxOptionsArgs(
+                        level="string",
+                        role="string",
+                        type="string",
+                        user="string",
+                    ),
+                    seccomp_profile=kubernetes.core.v1.SeccompProfileArgs(
+                        type="string",
+                        localhost_profile="string",
+                    ),
+                    windows_options=kubernetes.core.v1.WindowsSecurityContextOptionsArgs(
+                        gmsa_credential_spec="string",
+                        gmsa_credential_spec_name="string",
+                        host_process=False,
+                        run_as_user_name="string",
+                    ),
+                ),
+                lifecycle=kubernetes.core.v1.LifecycleArgs(
+                    post_start=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                    pre_stop=kubernetes.core.v1.HandlerArgs(
+                        exec_=kubernetes.core.v1.ExecActionArgs(
+                            command=["string"],
+                        ),
+                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                            port=0,
+                            host="string",
+                            http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                                name="string",
+                                value="string",
+                            )],
+                            path="string",
+                            scheme="string",
+                        ),
+                        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                            port=0,
+                            host="string",
+                        ),
+                    ),
+                ),
+                liveness_probe=kubernetes.core.v1.ProbeArgs(
+                    exec_=kubernetes.core.v1.ExecActionArgs(
+                        command=["string"],
+                    ),
+                    failure_threshold=0,
+                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                        port=0,
+                        host="string",
+                        http_headers=[kubernetes.core.v1.HTTPHeaderArgs(
+                            name="string",
+                            value="string",
+                        )],
+                        path="string",
+                        scheme="string",
+                    ),
+                    initial_delay_seconds=0,
+                    period_seconds=0,
+                    success_threshold=0,
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                        port=0,
+                        host="string",
+                    ),
+                    termination_grace_period_seconds=0,
+                    timeout_seconds=0,
+                ),
+                command=["string"],
+                ports=[kubernetes.core.v1.ContainerPortArgs(
+                    container_port=0,
+                    host_ip="string",
+                    host_port=0,
+                    name="string",
+                    protocol="string",
+                )],
+                args=["string"],
+                env_from=[kubernetes.core.v1.EnvFromSourceArgs(
+                    config_map_ref=kubernetes.core.v1.ConfigMapEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                    prefix="string",
+                    secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                        name="string",
+                        optional=False,
+                    ),
+                )],
+                env=[kubernetes.core.v1.EnvVarArgs(
+                    name="string",
+                    value="string",
+                    value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                        config_map_key_ref=kubernetes.core.v1.ConfigMapKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                        field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                            field_path="string",
+                            api_version="string",
+                        ),
+                        resource_field_ref=kubernetes.core.v1.ResourceFieldSelectorArgs(
+                            resource="string",
+                            container_name="string",
+                            divisor="string",
+                        ),
+                        secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                            key="string",
+                            name="string",
+                            optional=False,
+                        ),
+                    ),
+                )],
+                image="string",
+                stdin=False,
+                stdin_once=False,
+                termination_message_path="string",
+                termination_message_policy="string",
+                tty=False,
+                volume_devices=[kubernetes.core.v1.VolumeDeviceArgs(
+                    device_path="string",
+                    name="string",
+                )],
+                volume_mounts=[kubernetes.core.v1.VolumeMountArgs(
+                    mount_path="string",
+                    name="string",
+                    mount_propagation="string",
+                    read_only=False,
+                    sub_path="string",
+                    sub_path_expr="string",
+                )],
+                working_dir="string",
+            )],
+            node_name="string",
+            active_deadline_seconds=0,
+            dns_policy="string",
+            automount_service_account_token=False,
+            host_network=False,
+            priority_class_name="string",
+            readiness_gates=[kubernetes.core.v1.PodReadinessGateArgs(
+                condition_type="string",
+            )],
+            restart_policy="string",
+            runtime_class_name="string",
+            scheduler_name="string",
+            security_context=kubernetes.core.v1.PodSecurityContextArgs(
+                fs_group=0,
+                fs_group_change_policy="string",
+                run_as_group=0,
+                run_as_non_root=False,
+                run_as_user=0,
+                se_linux_options=kubernetes.core.v1.SELinuxOptionsArgs(
+                    level="string",
+                    role="string",
+                    type="string",
+                    user="string",
+                ),
+                seccomp_profile=kubernetes.core.v1.SeccompProfileArgs(
+                    type="string",
+                    localhost_profile="string",
+                ),
+                supplemental_groups=[0],
+                sysctls=[kubernetes.core.v1.SysctlArgs(
+                    name="string",
+                    value="string",
+                )],
+                windows_options=kubernetes.core.v1.WindowsSecurityContextOptionsArgs(
+                    gmsa_credential_spec="string",
+                    gmsa_credential_spec_name="string",
+                    host_process=False,
+                    run_as_user_name="string",
+                ),
+            ),
+            service_account="string",
+            service_account_name="string",
+            set_hostname_as_fqdn=False,
+            share_process_namespace=False,
+            subdomain="string",
+            termination_grace_period_seconds=0,
+            tolerations=[kubernetes.core.v1.TolerationArgs(
+                effect="string",
+                key="string",
+                operator="string",
+                toleration_seconds=0,
+                value="string",
+            )],
+            topology_spread_constraints=[kubernetes.core.v1.TopologySpreadConstraintArgs(
+                max_skew=0,
+                topology_key="string",
+                when_unsatisfiable="string",
+                label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                    match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                        key="string",
+                        operator="string",
+                        values=["string"],
+                    )],
+                    match_labels={
+                        "string": "string",
+                    },
+                ),
+            )],
+            volumes=[kubernetes.core.v1.VolumeArgs(
+                name="string",
+                git_repo=kubernetes.core.v1.GitRepoVolumeSourceArgs(
+                    repository="string",
+                    directory="string",
+                    revision="string",
+                ),
+                config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                    default_mode=0,
+                    items=[kubernetes.core.v1.KeyToPathArgs(
+                        key="string",
+                        path="string",
+                        mode=0,
+                    )],
+                    name="string",
+                    optional=False,
+                ),
+                glusterfs=kubernetes.core.v1.GlusterfsVolumeSourceArgs(
+                    endpoints="string",
+                    path="string",
+                    read_only=False,
+                ),
+                cinder=kubernetes.core.v1.CinderVolumeSourceArgs(
+                    volume_id="string",
+                    fs_type="string",
+                    read_only=False,
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                ),
+                host_path=kubernetes.core.v1.HostPathVolumeSourceArgs(
+                    path="string",
+                    type="string",
+                ),
+                csi=kubernetes.core.v1.CSIVolumeSourceArgs(
+                    driver="string",
+                    fs_type="string",
+                    node_publish_secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                    read_only=False,
+                    volume_attributes={
+                        "string": "string",
+                    },
+                ),
+                downward_api=kubernetes.core.v1.DownwardAPIVolumeSourceArgs(
+                    default_mode=0,
+                    items=[kubernetes.core.v1.DownwardAPIVolumeFileArgs(
+                        path="string",
+                        field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                            field_path="string",
+                            api_version="string",
+                        ),
+                        mode=0,
+                        resource_field_ref=kubernetes.core.v1.ResourceFieldSelectorArgs(
+                            resource="string",
+                            container_name="string",
+                            divisor="string",
+                        ),
+                    )],
+                ),
+                empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(
+                    medium="string",
+                    size_limit="string",
+                ),
+                ephemeral=kubernetes.core.v1.EphemeralVolumeSourceArgs(
+                    read_only=False,
+                    volume_claim_template=kubernetes.core.v1.PersistentVolumeClaimTemplateArgs(
+                        spec=kubernetes.core.v1.PersistentVolumeClaimSpecArgs(
+                            access_modes=["string"],
+                            data_source=kubernetes.core.v1.TypedLocalObjectReferenceArgs(
+                                kind="string",
+                                name="string",
+                                api_group="string",
+                            ),
+                            data_source_ref=kubernetes.core.v1.TypedLocalObjectReferenceArgs(
+                                kind="string",
+                                name="string",
+                                api_group="string",
+                            ),
+                            resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                limits={
+                                    "string": "string",
+                                },
+                                requests={
+                                    "string": "string",
+                                },
+                            ),
+                            selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                match_expressions=[kubernetes.meta.v1.LabelSelectorRequirementArgs(
+                                    key="string",
+                                    operator="string",
+                                    values=["string"],
+                                )],
+                                match_labels={
+                                    "string": "string",
+                                },
+                            ),
+                            storage_class_name="string",
+                            volume_mode="string",
+                            volume_name="string",
+                        ),
+                        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                            annotations={
+                                "string": "string",
+                            },
+                            cluster_name="string",
+                            creation_timestamp="string",
+                            deletion_grace_period_seconds=0,
+                            deletion_timestamp="string",
+                            finalizers=["string"],
+                            generate_name="string",
+                            generation=0,
+                            labels={
+                                "string": "string",
+                            },
+                            managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+                                api_version="string",
+                                fields_type="string",
+                                fields_v1="{}",
+                                manager="string",
+                                operation="string",
+                                subresource="string",
+                                time="string",
+                            )],
+                            name="string",
+                            namespace="string",
+                            owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+                                api_version="string",
+                                kind="string",
+                                name="string",
+                                uid="string",
+                                block_owner_deletion=False,
+                                controller=False,
+                            )],
+                            resource_version="string",
+                            self_link="string",
+                            uid="string",
+                        ),
+                    ),
+                ),
+                fc=kubernetes.core.v1.FCVolumeSourceArgs(
+                    fs_type="string",
+                    lun=0,
+                    read_only=False,
+                    target_wwns=["string"],
+                    wwids=["string"],
+                ),
+                flex_volume=kubernetes.core.v1.FlexVolumeSourceArgs(
+                    driver="string",
+                    fs_type="string",
+                    options={
+                        "string": "string",
+                    },
+                    read_only=False,
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                ),
+                iscsi=kubernetes.core.v1.ISCSIVolumeSourceArgs(
+                    iqn="string",
+                    lun=0,
+                    target_portal="string",
+                    chap_auth_discovery=False,
+                    chap_auth_session=False,
+                    fs_type="string",
+                    initiator_name="string",
+                    iscsi_interface="string",
+                    portals=["string"],
+                    read_only=False,
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                ),
+                gce_persistent_disk=kubernetes.core.v1.GCEPersistentDiskVolumeSourceArgs(
+                    pd_name="string",
+                    fs_type="string",
+                    partition=0,
+                    read_only=False,
+                ),
+                aws_elastic_block_store=kubernetes.core.v1.AWSElasticBlockStoreVolumeSourceArgs(
+                    volume_id="string",
+                    fs_type="string",
+                    partition=0,
+                    read_only=False,
+                ),
+                cephfs=kubernetes.core.v1.CephFSVolumeSourceArgs(
+                    monitors=["string"],
+                    path="string",
+                    read_only=False,
+                    secret_file="string",
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                    user="string",
+                ),
+                azure_file=kubernetes.core.v1.AzureFileVolumeSourceArgs(
+                    secret_name="string",
+                    share_name="string",
+                    read_only=False,
+                ),
+                flocker=kubernetes.core.v1.FlockerVolumeSourceArgs(
+                    dataset_name="string",
+                    dataset_uuid="string",
+                ),
+                azure_disk=kubernetes.core.v1.AzureDiskVolumeSourceArgs(
+                    disk_name="string",
+                    disk_uri="string",
+                    caching_mode="string",
+                    fs_type="string",
+                    kind="string",
+                    read_only=False,
+                ),
+                nfs=kubernetes.core.v1.NFSVolumeSourceArgs(
+                    path="string",
+                    server="string",
+                    read_only=False,
+                ),
+                persistent_volume_claim=kubernetes.core.v1.PersistentVolumeClaimVolumeSourceArgs(
+                    claim_name="string",
+                    read_only=False,
+                ),
+                photon_persistent_disk=kubernetes.core.v1.PhotonPersistentDiskVolumeSourceArgs(
+                    pd_id="string",
+                    fs_type="string",
+                ),
+                portworx_volume=kubernetes.core.v1.PortworxVolumeSourceArgs(
+                    volume_id="string",
+                    fs_type="string",
+                    read_only=False,
+                ),
+                projected=kubernetes.core.v1.ProjectedVolumeSourceArgs(
+                    sources=[kubernetes.core.v1.VolumeProjectionArgs(
+                        config_map=kubernetes.core.v1.ConfigMapProjectionArgs(
+                            items=[kubernetes.core.v1.KeyToPathArgs(
+                                key="string",
+                                path="string",
+                                mode=0,
+                            )],
+                            name="string",
+                            optional=False,
+                        ),
+                        downward_api=kubernetes.core.v1.DownwardAPIProjectionArgs(
+                            items=[kubernetes.core.v1.DownwardAPIVolumeFileArgs(
+                                path="string",
+                                field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                                    field_path="string",
+                                    api_version="string",
+                                ),
+                                mode=0,
+                                resource_field_ref=kubernetes.core.v1.ResourceFieldSelectorArgs(
+                                    resource="string",
+                                    container_name="string",
+                                    divisor="string",
+                                ),
+                            )],
+                        ),
+                        secret=kubernetes.core.v1.SecretProjectionArgs(
+                            items=[kubernetes.core.v1.KeyToPathArgs(
+                                key="string",
+                                path="string",
+                                mode=0,
+                            )],
+                            name="string",
+                            optional=False,
+                        ),
+                        service_account_token=kubernetes.core.v1.ServiceAccountTokenProjectionArgs(
+                            path="string",
+                            audience="string",
+                            expiration_seconds=0,
+                        ),
+                    )],
+                    default_mode=0,
+                ),
+                quobyte=kubernetes.core.v1.QuobyteVolumeSourceArgs(
+                    registry="string",
+                    volume="string",
+                    group="string",
+                    read_only=False,
+                    tenant="string",
+                    user="string",
+                ),
+                rbd=kubernetes.core.v1.RBDVolumeSourceArgs(
+                    image="string",
+                    monitors=["string"],
+                    fs_type="string",
+                    keyring="string",
+                    pool="string",
+                    read_only=False,
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                    user="string",
+                ),
+                scale_io=kubernetes.core.v1.ScaleIOVolumeSourceArgs(
+                    gateway="string",
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                    system="string",
+                    fs_type="string",
+                    protection_domain="string",
+                    read_only=False,
+                    ssl_enabled=False,
+                    storage_mode="string",
+                    storage_pool="string",
+                    volume_name="string",
+                ),
+                secret=kubernetes.core.v1.SecretVolumeSourceArgs(
+                    default_mode=0,
+                    items=[kubernetes.core.v1.KeyToPathArgs(
+                        key="string",
+                        path="string",
+                        mode=0,
+                    )],
+                    optional=False,
+                    secret_name="string",
+                ),
+                storageos=kubernetes.core.v1.StorageOSVolumeSourceArgs(
+                    fs_type="string",
+                    read_only=False,
+                    secret_ref=kubernetes.core.v1.LocalObjectReferenceArgs(
+                        name="string",
+                    ),
+                    volume_name="string",
+                    volume_namespace="string",
+                ),
+                vsphere_volume=kubernetes.core.v1.VsphereVirtualDiskVolumeSourceArgs(
+                    volume_path="string",
+                    fs_type="string",
+                    storage_policy_id="string",
+                    storage_policy_name="string",
+                ),
+            )],
+        ),
+        status=kubernetes.core.v1.PodStatusArgs(
+            conditions=[kubernetes.core.v1.PodConditionArgs(
+                status="string",
+                type="string",
+                last_probe_time="string",
+                last_transition_time="string",
+                message="string",
+                reason="string",
+            )],
+            container_statuses=[kubernetes.core.v1.ContainerStatusArgs(
+                image="string",
+                image_id="string",
+                name="string",
+                ready=False,
+                restart_count=0,
+                container_id="string",
+                last_state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+                started=False,
+                state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+            )],
+            ephemeral_container_statuses=[kubernetes.core.v1.ContainerStatusArgs(
+                image="string",
+                image_id="string",
+                name="string",
+                ready=False,
+                restart_count=0,
+                container_id="string",
+                last_state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+                started=False,
+                state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+            )],
+            host_ip="string",
+            init_container_statuses=[kubernetes.core.v1.ContainerStatusArgs(
+                image="string",
+                image_id="string",
+                name="string",
+                ready=False,
+                restart_count=0,
+                container_id="string",
+                last_state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+                started=False,
+                state=kubernetes.core.v1.ContainerStateArgs(
+                    running=kubernetes.core.v1.ContainerStateRunningArgs(
+                        started_at="string",
+                    ),
+                    terminated=kubernetes.core.v1.ContainerStateTerminatedArgs(
+                        exit_code=0,
+                        container_id="string",
+                        finished_at="string",
+                        message="string",
+                        reason="string",
+                        signal=0,
+                        started_at="string",
+                    ),
+                    waiting=kubernetes.core.v1.ContainerStateWaitingArgs(
+                        message="string",
+                        reason="string",
+                    ),
+                ),
+            )],
+            message="string",
+            nominated_node_name="string",
+            phase="string",
+            pod_ip="string",
+            pod_ips=[kubernetes.core.v1.PodIPArgs(
+                ip="string",
+            )],
+            qos_class="string",
+            reason="string",
+            start_time="string",
+        ),
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const componentResource = new foo.Component("componentResource", {
+    eniConfig: {
+        string: {
+            securityGroups: ["string"],
+            subnet: "string",
+        },
+    },
+    pod: {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: {
+            annotations: {
+                string: "string",
+            },
+            clusterName: "string",
+            creationTimestamp: "string",
+            deletionGracePeriodSeconds: 0,
+            deletionTimestamp: "string",
+            finalizers: ["string"],
+            generateName: "string",
+            generation: 0,
+            labels: {
+                string: "string",
+            },
+            managedFields: [{
+                apiVersion: "string",
+                fieldsType: "string",
+                fieldsV1: "{}",
+                manager: "string",
+                operation: "string",
+                subresource: "string",
+                time: "string",
+            }],
+            name: "string",
+            namespace: "string",
+            ownerReferences: [{
+                apiVersion: "string",
+                kind: "string",
+                name: "string",
+                uid: "string",
+                blockOwnerDeletion: false,
+                controller: false,
+            }],
+            resourceVersion: "string",
+            selfLink: "string",
+            uid: "string",
+        },
+        spec: {
+            containers: [{
+                name: "string",
+                readinessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                imagePullPolicy: "string",
+                resources: {
+                    limits: {
+                        string: "string",
+                    },
+                    requests: {
+                        string: "string",
+                    },
+                },
+                startupProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                securityContext: {
+                    allowPrivilegeEscalation: false,
+                    capabilities: {
+                        add: ["string"],
+                        drop: ["string"],
+                    },
+                    privileged: false,
+                    procMount: "string",
+                    readOnlyRootFilesystem: false,
+                    runAsGroup: 0,
+                    runAsNonRoot: false,
+                    runAsUser: 0,
+                    seLinuxOptions: {
+                        level: "string",
+                        role: "string",
+                        type: "string",
+                        user: "string",
+                    },
+                    seccompProfile: {
+                        type: "string",
+                        localhostProfile: "string",
+                    },
+                    windowsOptions: {
+                        gmsaCredentialSpec: "string",
+                        gmsaCredentialSpecName: "string",
+                        hostProcess: false,
+                        runAsUserName: "string",
+                    },
+                },
+                lifecycle: {
+                    postStart: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                    preStop: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                },
+                livenessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                command: ["string"],
+                ports: [{
+                    containerPort: 0,
+                    hostIP: "string",
+                    hostPort: 0,
+                    name: "string",
+                    protocol: "string",
+                }],
+                args: ["string"],
+                envFrom: [{
+                    configMapRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                    prefix: "string",
+                    secretRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                }],
+                env: [{
+                    name: "string",
+                    value: "string",
+                    valueFrom: {
+                        configMapKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                        fieldRef: {
+                            fieldPath: "string",
+                            apiVersion: "string",
+                        },
+                        resourceFieldRef: {
+                            resource: "string",
+                            containerName: "string",
+                            divisor: "string",
+                        },
+                        secretKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                    },
+                }],
+                image: "string",
+                stdin: false,
+                stdinOnce: false,
+                terminationMessagePath: "string",
+                terminationMessagePolicy: "string",
+                tty: false,
+                volumeDevices: [{
+                    devicePath: "string",
+                    name: "string",
+                }],
+                volumeMounts: [{
+                    mountPath: "string",
+                    name: "string",
+                    mountPropagation: "string",
+                    readOnly: false,
+                    subPath: "string",
+                    subPathExpr: "string",
+                }],
+                workingDir: "string",
+            }],
+            nodeSelector: {
+                string: "string",
+            },
+            hostAliases: [{
+                hostnames: ["string"],
+                ip: "string",
+            }],
+            affinity: {
+                nodeAffinity: {
+                    preferredDuringSchedulingIgnoredDuringExecution: [{
+                        preference: {
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchFields: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                        },
+                        weight: 0,
+                    }],
+                    requiredDuringSchedulingIgnoredDuringExecution: {
+                        nodeSelectorTerms: [{
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchFields: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                        }],
+                    },
+                },
+                podAffinity: {
+                    preferredDuringSchedulingIgnoredDuringExecution: [{
+                        podAffinityTerm: {
+                            topologyKey: "string",
+                            labelSelector: {
+                                matchExpressions: [{
+                                    key: "string",
+                                    operator: "string",
+                                    values: ["string"],
+                                }],
+                                matchLabels: {
+                                    string: "string",
+                                },
+                            },
+                            namespaceSelector: {
+                                matchExpressions: [{
+                                    key: "string",
+                                    operator: "string",
+                                    values: ["string"],
+                                }],
+                                matchLabels: {
+                                    string: "string",
+                                },
+                            },
+                            namespaces: ["string"],
+                        },
+                        weight: 0,
+                    }],
+                    requiredDuringSchedulingIgnoredDuringExecution: [{
+                        topologyKey: "string",
+                        labelSelector: {
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchLabels: {
+                                string: "string",
+                            },
+                        },
+                        namespaceSelector: {
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchLabels: {
+                                string: "string",
+                            },
+                        },
+                        namespaces: ["string"],
+                    }],
+                },
+                podAntiAffinity: {
+                    preferredDuringSchedulingIgnoredDuringExecution: [{
+                        podAffinityTerm: {
+                            topologyKey: "string",
+                            labelSelector: {
+                                matchExpressions: [{
+                                    key: "string",
+                                    operator: "string",
+                                    values: ["string"],
+                                }],
+                                matchLabels: {
+                                    string: "string",
+                                },
+                            },
+                            namespaceSelector: {
+                                matchExpressions: [{
+                                    key: "string",
+                                    operator: "string",
+                                    values: ["string"],
+                                }],
+                                matchLabels: {
+                                    string: "string",
+                                },
+                            },
+                            namespaces: ["string"],
+                        },
+                        weight: 0,
+                    }],
+                    requiredDuringSchedulingIgnoredDuringExecution: [{
+                        topologyKey: "string",
+                        labelSelector: {
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchLabels: {
+                                string: "string",
+                            },
+                        },
+                        namespaceSelector: {
+                            matchExpressions: [{
+                                key: "string",
+                                operator: "string",
+                                values: ["string"],
+                            }],
+                            matchLabels: {
+                                string: "string",
+                            },
+                        },
+                        namespaces: ["string"],
+                    }],
+                },
+            },
+            dnsConfig: {
+                nameservers: ["string"],
+                options: [{
+                    name: "string",
+                    value: "string",
+                }],
+                searches: ["string"],
+            },
+            overhead: {
+                string: "string",
+            },
+            enableServiceLinks: false,
+            ephemeralContainers: [{
+                name: "string",
+                readinessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                envFrom: [{
+                    configMapRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                    prefix: "string",
+                    secretRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                }],
+                securityContext: {
+                    allowPrivilegeEscalation: false,
+                    capabilities: {
+                        add: ["string"],
+                        drop: ["string"],
+                    },
+                    privileged: false,
+                    procMount: "string",
+                    readOnlyRootFilesystem: false,
+                    runAsGroup: 0,
+                    runAsNonRoot: false,
+                    runAsUser: 0,
+                    seLinuxOptions: {
+                        level: "string",
+                        role: "string",
+                        type: "string",
+                        user: "string",
+                    },
+                    seccompProfile: {
+                        type: "string",
+                        localhostProfile: "string",
+                    },
+                    windowsOptions: {
+                        gmsaCredentialSpec: "string",
+                        gmsaCredentialSpecName: "string",
+                        hostProcess: false,
+                        runAsUserName: "string",
+                    },
+                },
+                image: "string",
+                imagePullPolicy: "string",
+                lifecycle: {
+                    postStart: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                    preStop: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                },
+                livenessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                command: ["string"],
+                startupProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                args: ["string"],
+                workingDir: "string",
+                env: [{
+                    name: "string",
+                    value: "string",
+                    valueFrom: {
+                        configMapKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                        fieldRef: {
+                            fieldPath: "string",
+                            apiVersion: "string",
+                        },
+                        resourceFieldRef: {
+                            resource: "string",
+                            containerName: "string",
+                            divisor: "string",
+                        },
+                        secretKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                    },
+                }],
+                ports: [{
+                    containerPort: 0,
+                    hostIP: "string",
+                    hostPort: 0,
+                    name: "string",
+                    protocol: "string",
+                }],
+                stdin: false,
+                stdinOnce: false,
+                targetContainerName: "string",
+                terminationMessagePath: "string",
+                terminationMessagePolicy: "string",
+                tty: false,
+                volumeDevices: [{
+                    devicePath: "string",
+                    name: "string",
+                }],
+                volumeMounts: [{
+                    mountPath: "string",
+                    name: "string",
+                    mountPropagation: "string",
+                    readOnly: false,
+                    subPath: "string",
+                    subPathExpr: "string",
+                }],
+                resources: {
+                    limits: {
+                        string: "string",
+                    },
+                    requests: {
+                        string: "string",
+                    },
+                },
+            }],
+            preemptionPolicy: "string",
+            hostIPC: false,
+            priority: 0,
+            hostPID: false,
+            hostname: "string",
+            imagePullSecrets: [{
+                name: "string",
+            }],
+            initContainers: [{
+                name: "string",
+                readinessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                imagePullPolicy: "string",
+                resources: {
+                    limits: {
+                        string: "string",
+                    },
+                    requests: {
+                        string: "string",
+                    },
+                },
+                startupProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                securityContext: {
+                    allowPrivilegeEscalation: false,
+                    capabilities: {
+                        add: ["string"],
+                        drop: ["string"],
+                    },
+                    privileged: false,
+                    procMount: "string",
+                    readOnlyRootFilesystem: false,
+                    runAsGroup: 0,
+                    runAsNonRoot: false,
+                    runAsUser: 0,
+                    seLinuxOptions: {
+                        level: "string",
+                        role: "string",
+                        type: "string",
+                        user: "string",
+                    },
+                    seccompProfile: {
+                        type: "string",
+                        localhostProfile: "string",
+                    },
+                    windowsOptions: {
+                        gmsaCredentialSpec: "string",
+                        gmsaCredentialSpecName: "string",
+                        hostProcess: false,
+                        runAsUserName: "string",
+                    },
+                },
+                lifecycle: {
+                    postStart: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                    preStop: {
+                        exec: {
+                            command: ["string"],
+                        },
+                        httpGet: {
+                            port: 0,
+                            host: "string",
+                            httpHeaders: [{
+                                name: "string",
+                                value: "string",
+                            }],
+                            path: "string",
+                            scheme: "string",
+                        },
+                        tcpSocket: {
+                            port: 0,
+                            host: "string",
+                        },
+                    },
+                },
+                livenessProbe: {
+                    exec: {
+                        command: ["string"],
+                    },
+                    failureThreshold: 0,
+                    httpGet: {
+                        port: 0,
+                        host: "string",
+                        httpHeaders: [{
+                            name: "string",
+                            value: "string",
+                        }],
+                        path: "string",
+                        scheme: "string",
+                    },
+                    initialDelaySeconds: 0,
+                    periodSeconds: 0,
+                    successThreshold: 0,
+                    tcpSocket: {
+                        port: 0,
+                        host: "string",
+                    },
+                    terminationGracePeriodSeconds: 0,
+                    timeoutSeconds: 0,
+                },
+                command: ["string"],
+                ports: [{
+                    containerPort: 0,
+                    hostIP: "string",
+                    hostPort: 0,
+                    name: "string",
+                    protocol: "string",
+                }],
+                args: ["string"],
+                envFrom: [{
+                    configMapRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                    prefix: "string",
+                    secretRef: {
+                        name: "string",
+                        optional: false,
+                    },
+                }],
+                env: [{
+                    name: "string",
+                    value: "string",
+                    valueFrom: {
+                        configMapKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                        fieldRef: {
+                            fieldPath: "string",
+                            apiVersion: "string",
+                        },
+                        resourceFieldRef: {
+                            resource: "string",
+                            containerName: "string",
+                            divisor: "string",
+                        },
+                        secretKeyRef: {
+                            key: "string",
+                            name: "string",
+                            optional: false,
+                        },
+                    },
+                }],
+                image: "string",
+                stdin: false,
+                stdinOnce: false,
+                terminationMessagePath: "string",
+                terminationMessagePolicy: "string",
+                tty: false,
+                volumeDevices: [{
+                    devicePath: "string",
+                    name: "string",
+                }],
+                volumeMounts: [{
+                    mountPath: "string",
+                    name: "string",
+                    mountPropagation: "string",
+                    readOnly: false,
+                    subPath: "string",
+                    subPathExpr: "string",
+                }],
+                workingDir: "string",
+            }],
+            nodeName: "string",
+            activeDeadlineSeconds: 0,
+            dnsPolicy: "string",
+            automountServiceAccountToken: false,
+            hostNetwork: false,
+            priorityClassName: "string",
+            readinessGates: [{
+                conditionType: "string",
+            }],
+            restartPolicy: "string",
+            runtimeClassName: "string",
+            schedulerName: "string",
+            securityContext: {
+                fsGroup: 0,
+                fsGroupChangePolicy: "string",
+                runAsGroup: 0,
+                runAsNonRoot: false,
+                runAsUser: 0,
+                seLinuxOptions: {
+                    level: "string",
+                    role: "string",
+                    type: "string",
+                    user: "string",
+                },
+                seccompProfile: {
+                    type: "string",
+                    localhostProfile: "string",
+                },
+                supplementalGroups: [0],
+                sysctls: [{
+                    name: "string",
+                    value: "string",
+                }],
+                windowsOptions: {
+                    gmsaCredentialSpec: "string",
+                    gmsaCredentialSpecName: "string",
+                    hostProcess: false,
+                    runAsUserName: "string",
+                },
+            },
+            serviceAccount: "string",
+            serviceAccountName: "string",
+            setHostnameAsFQDN: false,
+            shareProcessNamespace: false,
+            subdomain: "string",
+            terminationGracePeriodSeconds: 0,
+            tolerations: [{
+                effect: "string",
+                key: "string",
+                operator: "string",
+                tolerationSeconds: 0,
+                value: "string",
+            }],
+            topologySpreadConstraints: [{
+                maxSkew: 0,
+                topologyKey: "string",
+                whenUnsatisfiable: "string",
+                labelSelector: {
+                    matchExpressions: [{
+                        key: "string",
+                        operator: "string",
+                        values: ["string"],
+                    }],
+                    matchLabels: {
+                        string: "string",
+                    },
+                },
+            }],
+            volumes: [{
+                name: "string",
+                gitRepo: {
+                    repository: "string",
+                    directory: "string",
+                    revision: "string",
+                },
+                configMap: {
+                    defaultMode: 0,
+                    items: [{
+                        key: "string",
+                        path: "string",
+                        mode: 0,
+                    }],
+                    name: "string",
+                    optional: false,
+                },
+                glusterfs: {
+                    endpoints: "string",
+                    path: "string",
+                    readOnly: false,
+                },
+                cinder: {
+                    volumeID: "string",
+                    fsType: "string",
+                    readOnly: false,
+                    secretRef: {
+                        name: "string",
+                    },
+                },
+                hostPath: {
+                    path: "string",
+                    type: "string",
+                },
+                csi: {
+                    driver: "string",
+                    fsType: "string",
+                    nodePublishSecretRef: {
+                        name: "string",
+                    },
+                    readOnly: false,
+                    volumeAttributes: {
+                        string: "string",
+                    },
+                },
+                downwardAPI: {
+                    defaultMode: 0,
+                    items: [{
+                        path: "string",
+                        fieldRef: {
+                            fieldPath: "string",
+                            apiVersion: "string",
+                        },
+                        mode: 0,
+                        resourceFieldRef: {
+                            resource: "string",
+                            containerName: "string",
+                            divisor: "string",
+                        },
+                    }],
+                },
+                emptyDir: {
+                    medium: "string",
+                    sizeLimit: "string",
+                },
+                ephemeral: {
+                    readOnly: false,
+                    volumeClaimTemplate: {
+                        spec: {
+                            accessModes: ["string"],
+                            dataSource: {
+                                kind: "string",
+                                name: "string",
+                                apiGroup: "string",
+                            },
+                            dataSourceRef: {
+                                kind: "string",
+                                name: "string",
+                                apiGroup: "string",
+                            },
+                            resources: {
+                                limits: {
+                                    string: "string",
+                                },
+                                requests: {
+                                    string: "string",
+                                },
+                            },
+                            selector: {
+                                matchExpressions: [{
+                                    key: "string",
+                                    operator: "string",
+                                    values: ["string"],
+                                }],
+                                matchLabels: {
+                                    string: "string",
+                                },
+                            },
+                            storageClassName: "string",
+                            volumeMode: "string",
+                            volumeName: "string",
+                        },
+                        metadata: {
+                            annotations: {
+                                string: "string",
+                            },
+                            clusterName: "string",
+                            creationTimestamp: "string",
+                            deletionGracePeriodSeconds: 0,
+                            deletionTimestamp: "string",
+                            finalizers: ["string"],
+                            generateName: "string",
+                            generation: 0,
+                            labels: {
+                                string: "string",
+                            },
+                            managedFields: [{
+                                apiVersion: "string",
+                                fieldsType: "string",
+                                fieldsV1: "{}",
+                                manager: "string",
+                                operation: "string",
+                                subresource: "string",
+                                time: "string",
+                            }],
+                            name: "string",
+                            namespace: "string",
+                            ownerReferences: [{
+                                apiVersion: "string",
+                                kind: "string",
+                                name: "string",
+                                uid: "string",
+                                blockOwnerDeletion: false,
+                                controller: false,
+                            }],
+                            resourceVersion: "string",
+                            selfLink: "string",
+                            uid: "string",
+                        },
+                    },
+                },
+                fc: {
+                    fsType: "string",
+                    lun: 0,
+                    readOnly: false,
+                    targetWWNs: ["string"],
+                    wwids: ["string"],
+                },
+                flexVolume: {
+                    driver: "string",
+                    fsType: "string",
+                    options: {
+                        string: "string",
+                    },
+                    readOnly: false,
+                    secretRef: {
+                        name: "string",
+                    },
+                },
+                iscsi: {
+                    iqn: "string",
+                    lun: 0,
+                    targetPortal: "string",
+                    chapAuthDiscovery: false,
+                    chapAuthSession: false,
+                    fsType: "string",
+                    initiatorName: "string",
+                    iscsiInterface: "string",
+                    portals: ["string"],
+                    readOnly: false,
+                    secretRef: {
+                        name: "string",
+                    },
+                },
+                gcePersistentDisk: {
+                    pdName: "string",
+                    fsType: "string",
+                    partition: 0,
+                    readOnly: false,
+                },
+                awsElasticBlockStore: {
+                    volumeID: "string",
+                    fsType: "string",
+                    partition: 0,
+                    readOnly: false,
+                },
+                cephfs: {
+                    monitors: ["string"],
+                    path: "string",
+                    readOnly: false,
+                    secretFile: "string",
+                    secretRef: {
+                        name: "string",
+                    },
+                    user: "string",
+                },
+                azureFile: {
+                    secretName: "string",
+                    shareName: "string",
+                    readOnly: false,
+                },
+                flocker: {
+                    datasetName: "string",
+                    datasetUUID: "string",
+                },
+                azureDisk: {
+                    diskName: "string",
+                    diskURI: "string",
+                    cachingMode: "string",
+                    fsType: "string",
+                    kind: "string",
+                    readOnly: false,
+                },
+                nfs: {
+                    path: "string",
+                    server: "string",
+                    readOnly: false,
+                },
+                persistentVolumeClaim: {
+                    claimName: "string",
+                    readOnly: false,
+                },
+                photonPersistentDisk: {
+                    pdID: "string",
+                    fsType: "string",
+                },
+                portworxVolume: {
+                    volumeID: "string",
+                    fsType: "string",
+                    readOnly: false,
+                },
+                projected: {
+                    sources: [{
+                        configMap: {
+                            items: [{
+                                key: "string",
+                                path: "string",
+                                mode: 0,
+                            }],
+                            name: "string",
+                            optional: false,
+                        },
+                        downwardAPI: {
+                            items: [{
+                                path: "string",
+                                fieldRef: {
+                                    fieldPath: "string",
+                                    apiVersion: "string",
+                                },
+                                mode: 0,
+                                resourceFieldRef: {
+                                    resource: "string",
+                                    containerName: "string",
+                                    divisor: "string",
+                                },
+                            }],
+                        },
+                        secret: {
+                            items: [{
+                                key: "string",
+                                path: "string",
+                                mode: 0,
+                            }],
+                            name: "string",
+                            optional: false,
+                        },
+                        serviceAccountToken: {
+                            path: "string",
+                            audience: "string",
+                            expirationSeconds: 0,
+                        },
+                    }],
+                    defaultMode: 0,
+                },
+                quobyte: {
+                    registry: "string",
+                    volume: "string",
+                    group: "string",
+                    readOnly: false,
+                    tenant: "string",
+                    user: "string",
+                },
+                rbd: {
+                    image: "string",
+                    monitors: ["string"],
+                    fsType: "string",
+                    keyring: "string",
+                    pool: "string",
+                    readOnly: false,
+                    secretRef: {
+                        name: "string",
+                    },
+                    user: "string",
+                },
+                scaleIO: {
+                    gateway: "string",
+                    secretRef: {
+                        name: "string",
+                    },
+                    system: "string",
+                    fsType: "string",
+                    protectionDomain: "string",
+                    readOnly: false,
+                    sslEnabled: false,
+                    storageMode: "string",
+                    storagePool: "string",
+                    volumeName: "string",
+                },
+                secret: {
+                    defaultMode: 0,
+                    items: [{
+                        key: "string",
+                        path: "string",
+                        mode: 0,
+                    }],
+                    optional: false,
+                    secretName: "string",
+                },
+                storageos: {
+                    fsType: "string",
+                    readOnly: false,
+                    secretRef: {
+                        name: "string",
+                    },
+                    volumeName: "string",
+                    volumeNamespace: "string",
+                },
+                vsphereVolume: {
+                    volumePath: "string",
+                    fsType: "string",
+                    storagePolicyID: "string",
+                    storagePolicyName: "string",
+                },
+            }],
+        },
+        status: {
+            conditions: [{
+                status: "string",
+                type: "string",
+                lastProbeTime: "string",
+                lastTransitionTime: "string",
+                message: "string",
+                reason: "string",
+            }],
+            containerStatuses: [{
+                image: "string",
+                imageID: "string",
+                name: "string",
+                ready: false,
+                restartCount: 0,
+                containerID: "string",
+                lastState: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+                started: false,
+                state: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+            }],
+            ephemeralContainerStatuses: [{
+                image: "string",
+                imageID: "string",
+                name: "string",
+                ready: false,
+                restartCount: 0,
+                containerID: "string",
+                lastState: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+                started: false,
+                state: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+            }],
+            hostIP: "string",
+            initContainerStatuses: [{
+                image: "string",
+                imageID: "string",
+                name: "string",
+                ready: false,
+                restartCount: 0,
+                containerID: "string",
+                lastState: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+                started: false,
+                state: {
+                    running: {
+                        startedAt: "string",
+                    },
+                    terminated: {
+                        exitCode: 0,
+                        containerID: "string",
+                        finishedAt: "string",
+                        message: "string",
+                        reason: "string",
+                        signal: 0,
+                        startedAt: "string",
+                    },
+                    waiting: {
+                        message: "string",
+                        reason: "string",
+                    },
+                },
+            }],
+            message: "string",
+            nominatedNodeName: "string",
+            phase: "string",
+            podIP: "string",
+            podIPs: [{
+                ip: "string",
+            }],
+            qosClass: "string",
+            reason: "string",
+            startTime: "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/embedded-crd-types/docs/provider/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
@@ -15,7 +15,97 @@ no_edit_this_page: true
 
 
 
-## Create IamResource Resource {#create}
+## Create IamResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := myModule.NewIamResource(ctx, "iamResourceResource", &myModule.IamResourceArgs{
+	Config: &iam.AuditConfigArgs{
+		AuditLogConfigs: iam.AuditLogConfigArray{
+			&iam.AuditLogConfigArgs{
+				ExemptedMembers: pulumi.StringArray{
+					pulumi.String("string"),
+				},
+				LogType: iam / v1.AuditLogConfigLogTypeLogTypeUnspecified,
+			},
+		},
+		Service: pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const iamResourceResource = new example.mymodule.IamResource("iamResourceResource", {config: {
+    auditLogConfigs: [{
+        exemptedMembers: ["string"],
+        logType: google_native.iam.v1.AuditLogConfigLogType.LogTypeUnspecified,
+    }],
+    service: "string",
+}});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of IamResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/enum-reference/docs/provider/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/external-enum/docs/component/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/component/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/external-enum/docs/provider/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
@@ -15,7 +15,116 @@ no_edit_this_page: true
 
 
 
-## Create Cat Resource {#create}
+## Create Cat Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var catResource = new Example.Cat("catResource", new()
+{
+    Age = 0,
+    Pet = new Example.Inputs.PetArgs
+    {
+        RequiredNameArray = new() { },
+        RequiredNameMap = null,
+        Age = 0,
+        NameArray = new() { },
+        NameMap = null,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewCat(ctx, "catResource", &example.CatArgs{
+	Age: pulumi.Int(0),
+	Pet: &example.PetArgs{
+		RequiredNameArray: random.RandomPetArray{},
+		RequiredNameMap:   nil,
+		Age:               pulumi.Int(0),
+		NameArray:         random.RandomPetArray{},
+		NameMap:           nil,
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+cat_resource = example.Cat("catResource",
+    age=0,
+    pet=example.PetArgs(
+        required_name_array=[],
+        required_name_map={},
+        age=0,
+        name_array=[],
+        name_map={},
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const catResource = new example.Cat("catResource", {
+    age: 0,
+    pet: {
+        requiredNameArray: [],
+        requiredNameMap: {},
+        age: 0,
+        nameArray: [],
+        nameMap: {},
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Cat {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
@@ -15,7 +15,1119 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var componentResource = new Example.Component("componentResource", new()
+{
+    RequiredMetadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+    {
+        Annotations = 
+        {
+            { "string", "string" },
+        },
+        ClusterName = "string",
+        CreationTimestamp = "string",
+        DeletionGracePeriodSeconds = 0,
+        DeletionTimestamp = "string",
+        Finalizers = new[]
+        {
+            "string",
+        },
+        GenerateName = "string",
+        Generation = 0,
+        Labels = 
+        {
+            { "string", "string" },
+        },
+        ManagedFields = new[]
+        {
+            new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+            {
+                ApiVersion = "string",
+                FieldsType = "string",
+                FieldsV1 = "{}",
+                Manager = "string",
+                Operation = "string",
+                Subresource = "string",
+                Time = "string",
+            },
+        },
+        Name = "string",
+        Namespace = "string",
+        OwnerReferences = new[]
+        {
+            new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+            {
+                ApiVersion = "string",
+                Kind = "string",
+                Name = "string",
+                Uid = "string",
+                BlockOwnerDeletion = false,
+                Controller = false,
+            },
+        },
+        ResourceVersion = "string",
+        SelfLink = "string",
+        Uid = "string",
+    },
+    RequiredMetadataArray = new[]
+    {
+        new Kubernetes.Meta.Inputs.ObjectMetaArgs
+        {
+            Annotations = 
+            {
+                { "string", "string" },
+            },
+            ClusterName = "string",
+            CreationTimestamp = "string",
+            DeletionGracePeriodSeconds = 0,
+            DeletionTimestamp = "string",
+            Finalizers = new[]
+            {
+                "string",
+            },
+            GenerateName = "string",
+            Generation = 0,
+            Labels = 
+            {
+                { "string", "string" },
+            },
+            ManagedFields = new[]
+            {
+                new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                {
+                    ApiVersion = "string",
+                    FieldsType = "string",
+                    FieldsV1 = "{}",
+                    Manager = "string",
+                    Operation = "string",
+                    Subresource = "string",
+                    Time = "string",
+                },
+            },
+            Name = "string",
+            Namespace = "string",
+            OwnerReferences = new[]
+            {
+                new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                {
+                    ApiVersion = "string",
+                    Kind = "string",
+                    Name = "string",
+                    Uid = "string",
+                    BlockOwnerDeletion = false,
+                    Controller = false,
+                },
+            },
+            ResourceVersion = "string",
+            SelfLink = "string",
+            Uid = "string",
+        },
+    },
+    RequiredMetadataMap = 
+    {
+        { "string", new Kubernetes.Meta.Inputs.ObjectMetaArgs
+        {
+            Annotations = 
+            {
+                { "string", "string" },
+            },
+            ClusterName = "string",
+            CreationTimestamp = "string",
+            DeletionGracePeriodSeconds = 0,
+            DeletionTimestamp = "string",
+            Finalizers = new[]
+            {
+                "string",
+            },
+            GenerateName = "string",
+            Generation = 0,
+            Labels = 
+            {
+                { "string", "string" },
+            },
+            ManagedFields = new[]
+            {
+                new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                {
+                    ApiVersion = "string",
+                    FieldsType = "string",
+                    FieldsV1 = "{}",
+                    Manager = "string",
+                    Operation = "string",
+                    Subresource = "string",
+                    Time = "string",
+                },
+            },
+            Name = "string",
+            Namespace = "string",
+            OwnerReferences = new[]
+            {
+                new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                {
+                    ApiVersion = "string",
+                    Kind = "string",
+                    Name = "string",
+                    Uid = "string",
+                    BlockOwnerDeletion = false,
+                    Controller = false,
+                },
+            },
+            ResourceVersion = "string",
+            SelfLink = "string",
+            Uid = "string",
+        } },
+    },
+    Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+    {
+        Annotations = 
+        {
+            { "string", "string" },
+        },
+        ClusterName = "string",
+        CreationTimestamp = "string",
+        DeletionGracePeriodSeconds = 0,
+        DeletionTimestamp = "string",
+        Finalizers = new[]
+        {
+            "string",
+        },
+        GenerateName = "string",
+        Generation = 0,
+        Labels = 
+        {
+            { "string", "string" },
+        },
+        ManagedFields = new[]
+        {
+            new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+            {
+                ApiVersion = "string",
+                FieldsType = "string",
+                FieldsV1 = "{}",
+                Manager = "string",
+                Operation = "string",
+                Subresource = "string",
+                Time = "string",
+            },
+        },
+        Name = "string",
+        Namespace = "string",
+        OwnerReferences = new[]
+        {
+            new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+            {
+                ApiVersion = "string",
+                Kind = "string",
+                Name = "string",
+                Uid = "string",
+                BlockOwnerDeletion = false,
+                Controller = false,
+            },
+        },
+        ResourceVersion = "string",
+        SelfLink = "string",
+        Uid = "string",
+    },
+    MetadataArray = new[]
+    {
+        new Kubernetes.Meta.Inputs.ObjectMetaArgs
+        {
+            Annotations = 
+            {
+                { "string", "string" },
+            },
+            ClusterName = "string",
+            CreationTimestamp = "string",
+            DeletionGracePeriodSeconds = 0,
+            DeletionTimestamp = "string",
+            Finalizers = new[]
+            {
+                "string",
+            },
+            GenerateName = "string",
+            Generation = 0,
+            Labels = 
+            {
+                { "string", "string" },
+            },
+            ManagedFields = new[]
+            {
+                new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                {
+                    ApiVersion = "string",
+                    FieldsType = "string",
+                    FieldsV1 = "{}",
+                    Manager = "string",
+                    Operation = "string",
+                    Subresource = "string",
+                    Time = "string",
+                },
+            },
+            Name = "string",
+            Namespace = "string",
+            OwnerReferences = new[]
+            {
+                new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                {
+                    ApiVersion = "string",
+                    Kind = "string",
+                    Name = "string",
+                    Uid = "string",
+                    BlockOwnerDeletion = false,
+                    Controller = false,
+                },
+            },
+            ResourceVersion = "string",
+            SelfLink = "string",
+            Uid = "string",
+        },
+    },
+    MetadataMap = 
+    {
+        { "string", new Kubernetes.Meta.Inputs.ObjectMetaArgs
+        {
+            Annotations = 
+            {
+                { "string", "string" },
+            },
+            ClusterName = "string",
+            CreationTimestamp = "string",
+            DeletionGracePeriodSeconds = 0,
+            DeletionTimestamp = "string",
+            Finalizers = new[]
+            {
+                "string",
+            },
+            GenerateName = "string",
+            Generation = 0,
+            Labels = 
+            {
+                { "string", "string" },
+            },
+            ManagedFields = new[]
+            {
+                new Kubernetes.Meta.Inputs.ManagedFieldsEntryArgs
+                {
+                    ApiVersion = "string",
+                    FieldsType = "string",
+                    FieldsV1 = "{}",
+                    Manager = "string",
+                    Operation = "string",
+                    Subresource = "string",
+                    Time = "string",
+                },
+            },
+            Name = "string",
+            Namespace = "string",
+            OwnerReferences = new[]
+            {
+                new Kubernetes.Meta.Inputs.OwnerReferenceArgs
+                {
+                    ApiVersion = "string",
+                    Kind = "string",
+                    Name = "string",
+                    Uid = "string",
+                    BlockOwnerDeletion = false,
+                    Controller = false,
+                },
+            },
+            ResourceVersion = "string",
+            SelfLink = "string",
+            Uid = "string",
+        } },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewComponent(ctx, "componentResource", &example.ComponentArgs{
+	RequiredMetadata: &metav1.ObjectMetaArgs{
+		Annotations: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ClusterName:                pulumi.String("string"),
+		CreationTimestamp:          pulumi.String("string"),
+		DeletionGracePeriodSeconds: pulumi.Int(0),
+		DeletionTimestamp:          pulumi.String("string"),
+		Finalizers: pulumi.StringArray{
+			pulumi.String("string"),
+		},
+		GenerateName: pulumi.String("string"),
+		Generation:   pulumi.Int(0),
+		Labels: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ManagedFields: metav1.ManagedFieldsEntryArray{
+			&metav1.ManagedFieldsEntryArgs{
+				ApiVersion:  pulumi.String("string"),
+				FieldsType:  pulumi.String("string"),
+				FieldsV1:    pulumi.Any("{}"),
+				Manager:     pulumi.String("string"),
+				Operation:   pulumi.String("string"),
+				Subresource: pulumi.String("string"),
+				Time:        pulumi.String("string"),
+			},
+		},
+		Name:      pulumi.String("string"),
+		Namespace: pulumi.String("string"),
+		OwnerReferences: metav1.OwnerReferenceArray{
+			&metav1.OwnerReferenceArgs{
+				ApiVersion:         pulumi.String("string"),
+				Kind:               pulumi.String("string"),
+				Name:               pulumi.String("string"),
+				Uid:                pulumi.String("string"),
+				BlockOwnerDeletion: pulumi.Bool(false),
+				Controller:         pulumi.Bool(false),
+			},
+		},
+		ResourceVersion: pulumi.String("string"),
+		SelfLink:        pulumi.String("string"),
+		Uid:             pulumi.String("string"),
+	},
+	RequiredMetadataArray: metav1.ObjectMetaArray{
+		&metav1.ObjectMetaArgs{
+			Annotations: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ClusterName:                pulumi.String("string"),
+			CreationTimestamp:          pulumi.String("string"),
+			DeletionGracePeriodSeconds: pulumi.Int(0),
+			DeletionTimestamp:          pulumi.String("string"),
+			Finalizers: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			GenerateName: pulumi.String("string"),
+			Generation:   pulumi.Int(0),
+			Labels: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ManagedFields: metav1.ManagedFieldsEntryArray{
+				&metav1.ManagedFieldsEntryArgs{
+					ApiVersion:  pulumi.String("string"),
+					FieldsType:  pulumi.String("string"),
+					FieldsV1:    pulumi.Any("{}"),
+					Manager:     pulumi.String("string"),
+					Operation:   pulumi.String("string"),
+					Subresource: pulumi.String("string"),
+					Time:        pulumi.String("string"),
+				},
+			},
+			Name:      pulumi.String("string"),
+			Namespace: pulumi.String("string"),
+			OwnerReferences: metav1.OwnerReferenceArray{
+				&metav1.OwnerReferenceArgs{
+					ApiVersion:         pulumi.String("string"),
+					Kind:               pulumi.String("string"),
+					Name:               pulumi.String("string"),
+					Uid:                pulumi.String("string"),
+					BlockOwnerDeletion: pulumi.Bool(false),
+					Controller:         pulumi.Bool(false),
+				},
+			},
+			ResourceVersion: pulumi.String("string"),
+			SelfLink:        pulumi.String("string"),
+			Uid:             pulumi.String("string"),
+		},
+	},
+	RequiredMetadataMap: metav1.ObjectMetaMap{
+		"string": &metav1.ObjectMetaArgs{
+			Annotations: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ClusterName:                pulumi.String("string"),
+			CreationTimestamp:          pulumi.String("string"),
+			DeletionGracePeriodSeconds: pulumi.Int(0),
+			DeletionTimestamp:          pulumi.String("string"),
+			Finalizers: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			GenerateName: pulumi.String("string"),
+			Generation:   pulumi.Int(0),
+			Labels: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ManagedFields: metav1.ManagedFieldsEntryArray{
+				&metav1.ManagedFieldsEntryArgs{
+					ApiVersion:  pulumi.String("string"),
+					FieldsType:  pulumi.String("string"),
+					FieldsV1:    pulumi.Any("{}"),
+					Manager:     pulumi.String("string"),
+					Operation:   pulumi.String("string"),
+					Subresource: pulumi.String("string"),
+					Time:        pulumi.String("string"),
+				},
+			},
+			Name:      pulumi.String("string"),
+			Namespace: pulumi.String("string"),
+			OwnerReferences: metav1.OwnerReferenceArray{
+				&metav1.OwnerReferenceArgs{
+					ApiVersion:         pulumi.String("string"),
+					Kind:               pulumi.String("string"),
+					Name:               pulumi.String("string"),
+					Uid:                pulumi.String("string"),
+					BlockOwnerDeletion: pulumi.Bool(false),
+					Controller:         pulumi.Bool(false),
+				},
+			},
+			ResourceVersion: pulumi.String("string"),
+			SelfLink:        pulumi.String("string"),
+			Uid:             pulumi.String("string"),
+		},
+	},
+	Metadata: &metav1.ObjectMetaArgs{
+		Annotations: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ClusterName:                pulumi.String("string"),
+		CreationTimestamp:          pulumi.String("string"),
+		DeletionGracePeriodSeconds: pulumi.Int(0),
+		DeletionTimestamp:          pulumi.String("string"),
+		Finalizers: pulumi.StringArray{
+			pulumi.String("string"),
+		},
+		GenerateName: pulumi.String("string"),
+		Generation:   pulumi.Int(0),
+		Labels: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ManagedFields: metav1.ManagedFieldsEntryArray{
+			&metav1.ManagedFieldsEntryArgs{
+				ApiVersion:  pulumi.String("string"),
+				FieldsType:  pulumi.String("string"),
+				FieldsV1:    pulumi.Any("{}"),
+				Manager:     pulumi.String("string"),
+				Operation:   pulumi.String("string"),
+				Subresource: pulumi.String("string"),
+				Time:        pulumi.String("string"),
+			},
+		},
+		Name:      pulumi.String("string"),
+		Namespace: pulumi.String("string"),
+		OwnerReferences: metav1.OwnerReferenceArray{
+			&metav1.OwnerReferenceArgs{
+				ApiVersion:         pulumi.String("string"),
+				Kind:               pulumi.String("string"),
+				Name:               pulumi.String("string"),
+				Uid:                pulumi.String("string"),
+				BlockOwnerDeletion: pulumi.Bool(false),
+				Controller:         pulumi.Bool(false),
+			},
+		},
+		ResourceVersion: pulumi.String("string"),
+		SelfLink:        pulumi.String("string"),
+		Uid:             pulumi.String("string"),
+	},
+	MetadataArray: metav1.ObjectMetaArray{
+		&metav1.ObjectMetaArgs{
+			Annotations: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ClusterName:                pulumi.String("string"),
+			CreationTimestamp:          pulumi.String("string"),
+			DeletionGracePeriodSeconds: pulumi.Int(0),
+			DeletionTimestamp:          pulumi.String("string"),
+			Finalizers: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			GenerateName: pulumi.String("string"),
+			Generation:   pulumi.Int(0),
+			Labels: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ManagedFields: metav1.ManagedFieldsEntryArray{
+				&metav1.ManagedFieldsEntryArgs{
+					ApiVersion:  pulumi.String("string"),
+					FieldsType:  pulumi.String("string"),
+					FieldsV1:    pulumi.Any("{}"),
+					Manager:     pulumi.String("string"),
+					Operation:   pulumi.String("string"),
+					Subresource: pulumi.String("string"),
+					Time:        pulumi.String("string"),
+				},
+			},
+			Name:      pulumi.String("string"),
+			Namespace: pulumi.String("string"),
+			OwnerReferences: metav1.OwnerReferenceArray{
+				&metav1.OwnerReferenceArgs{
+					ApiVersion:         pulumi.String("string"),
+					Kind:               pulumi.String("string"),
+					Name:               pulumi.String("string"),
+					Uid:                pulumi.String("string"),
+					BlockOwnerDeletion: pulumi.Bool(false),
+					Controller:         pulumi.Bool(false),
+				},
+			},
+			ResourceVersion: pulumi.String("string"),
+			SelfLink:        pulumi.String("string"),
+			Uid:             pulumi.String("string"),
+		},
+	},
+	MetadataMap: metav1.ObjectMetaMap{
+		"string": &metav1.ObjectMetaArgs{
+			Annotations: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ClusterName:                pulumi.String("string"),
+			CreationTimestamp:          pulumi.String("string"),
+			DeletionGracePeriodSeconds: pulumi.Int(0),
+			DeletionTimestamp:          pulumi.String("string"),
+			Finalizers: pulumi.StringArray{
+				pulumi.String("string"),
+			},
+			GenerateName: pulumi.String("string"),
+			Generation:   pulumi.Int(0),
+			Labels: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			ManagedFields: metav1.ManagedFieldsEntryArray{
+				&metav1.ManagedFieldsEntryArgs{
+					ApiVersion:  pulumi.String("string"),
+					FieldsType:  pulumi.String("string"),
+					FieldsV1:    pulumi.Any("{}"),
+					Manager:     pulumi.String("string"),
+					Operation:   pulumi.String("string"),
+					Subresource: pulumi.String("string"),
+					Time:        pulumi.String("string"),
+				},
+			},
+			Name:      pulumi.String("string"),
+			Namespace: pulumi.String("string"),
+			OwnerReferences: metav1.OwnerReferenceArray{
+				&metav1.OwnerReferenceArgs{
+					ApiVersion:         pulumi.String("string"),
+					Kind:               pulumi.String("string"),
+					Name:               pulumi.String("string"),
+					Uid:                pulumi.String("string"),
+					BlockOwnerDeletion: pulumi.Bool(false),
+					Controller:         pulumi.Bool(false),
+				},
+			},
+			ResourceVersion: pulumi.String("string"),
+			SelfLink:        pulumi.String("string"),
+			Uid:             pulumi.String("string"),
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+component_resource = example.Component("componentResource",
+    required_metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        annotations={
+            "string": "string",
+        },
+        cluster_name="string",
+        creation_timestamp="string",
+        deletion_grace_period_seconds=0,
+        deletion_timestamp="string",
+        finalizers=["string"],
+        generate_name="string",
+        generation=0,
+        labels={
+            "string": "string",
+        },
+        managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+            api_version="string",
+            fields_type="string",
+            fields_v1="{}",
+            manager="string",
+            operation="string",
+            subresource="string",
+            time="string",
+        )],
+        name="string",
+        namespace="string",
+        owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+            api_version="string",
+            kind="string",
+            name="string",
+            uid="string",
+            block_owner_deletion=False,
+            controller=False,
+        )],
+        resource_version="string",
+        self_link="string",
+        uid="string",
+    ),
+    required_metadata_array=[kubernetes.meta.v1.ObjectMetaArgs(
+        annotations={
+            "string": "string",
+        },
+        cluster_name="string",
+        creation_timestamp="string",
+        deletion_grace_period_seconds=0,
+        deletion_timestamp="string",
+        finalizers=["string"],
+        generate_name="string",
+        generation=0,
+        labels={
+            "string": "string",
+        },
+        managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+            api_version="string",
+            fields_type="string",
+            fields_v1="{}",
+            manager="string",
+            operation="string",
+            subresource="string",
+            time="string",
+        )],
+        name="string",
+        namespace="string",
+        owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+            api_version="string",
+            kind="string",
+            name="string",
+            uid="string",
+            block_owner_deletion=False,
+            controller=False,
+        )],
+        resource_version="string",
+        self_link="string",
+        uid="string",
+    )],
+    required_metadata_map={
+        "string": kubernetes.meta.v1.ObjectMetaArgs(
+            annotations={
+                "string": "string",
+            },
+            cluster_name="string",
+            creation_timestamp="string",
+            deletion_grace_period_seconds=0,
+            deletion_timestamp="string",
+            finalizers=["string"],
+            generate_name="string",
+            generation=0,
+            labels={
+                "string": "string",
+            },
+            managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+                api_version="string",
+                fields_type="string",
+                fields_v1="{}",
+                manager="string",
+                operation="string",
+                subresource="string",
+                time="string",
+            )],
+            name="string",
+            namespace="string",
+            owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+                api_version="string",
+                kind="string",
+                name="string",
+                uid="string",
+                block_owner_deletion=False,
+                controller=False,
+            )],
+            resource_version="string",
+            self_link="string",
+            uid="string",
+        ),
+    },
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        annotations={
+            "string": "string",
+        },
+        cluster_name="string",
+        creation_timestamp="string",
+        deletion_grace_period_seconds=0,
+        deletion_timestamp="string",
+        finalizers=["string"],
+        generate_name="string",
+        generation=0,
+        labels={
+            "string": "string",
+        },
+        managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+            api_version="string",
+            fields_type="string",
+            fields_v1="{}",
+            manager="string",
+            operation="string",
+            subresource="string",
+            time="string",
+        )],
+        name="string",
+        namespace="string",
+        owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+            api_version="string",
+            kind="string",
+            name="string",
+            uid="string",
+            block_owner_deletion=False,
+            controller=False,
+        )],
+        resource_version="string",
+        self_link="string",
+        uid="string",
+    ),
+    metadata_array=[kubernetes.meta.v1.ObjectMetaArgs(
+        annotations={
+            "string": "string",
+        },
+        cluster_name="string",
+        creation_timestamp="string",
+        deletion_grace_period_seconds=0,
+        deletion_timestamp="string",
+        finalizers=["string"],
+        generate_name="string",
+        generation=0,
+        labels={
+            "string": "string",
+        },
+        managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+            api_version="string",
+            fields_type="string",
+            fields_v1="{}",
+            manager="string",
+            operation="string",
+            subresource="string",
+            time="string",
+        )],
+        name="string",
+        namespace="string",
+        owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+            api_version="string",
+            kind="string",
+            name="string",
+            uid="string",
+            block_owner_deletion=False,
+            controller=False,
+        )],
+        resource_version="string",
+        self_link="string",
+        uid="string",
+    )],
+    metadata_map={
+        "string": kubernetes.meta.v1.ObjectMetaArgs(
+            annotations={
+                "string": "string",
+            },
+            cluster_name="string",
+            creation_timestamp="string",
+            deletion_grace_period_seconds=0,
+            deletion_timestamp="string",
+            finalizers=["string"],
+            generate_name="string",
+            generation=0,
+            labels={
+                "string": "string",
+            },
+            managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+                api_version="string",
+                fields_type="string",
+                fields_v1="{}",
+                manager="string",
+                operation="string",
+                subresource="string",
+                time="string",
+            )],
+            name="string",
+            namespace="string",
+            owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+                api_version="string",
+                kind="string",
+                name="string",
+                uid="string",
+                block_owner_deletion=False,
+                controller=False,
+            )],
+            resource_version="string",
+            self_link="string",
+            uid="string",
+        ),
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const componentResource = new example.Component("componentResource", {
+    requiredMetadata: {
+        annotations: {
+            string: "string",
+        },
+        clusterName: "string",
+        creationTimestamp: "string",
+        deletionGracePeriodSeconds: 0,
+        deletionTimestamp: "string",
+        finalizers: ["string"],
+        generateName: "string",
+        generation: 0,
+        labels: {
+            string: "string",
+        },
+        managedFields: [{
+            apiVersion: "string",
+            fieldsType: "string",
+            fieldsV1: "{}",
+            manager: "string",
+            operation: "string",
+            subresource: "string",
+            time: "string",
+        }],
+        name: "string",
+        namespace: "string",
+        ownerReferences: [{
+            apiVersion: "string",
+            kind: "string",
+            name: "string",
+            uid: "string",
+            blockOwnerDeletion: false,
+            controller: false,
+        }],
+        resourceVersion: "string",
+        selfLink: "string",
+        uid: "string",
+    },
+    requiredMetadataArray: [{
+        annotations: {
+            string: "string",
+        },
+        clusterName: "string",
+        creationTimestamp: "string",
+        deletionGracePeriodSeconds: 0,
+        deletionTimestamp: "string",
+        finalizers: ["string"],
+        generateName: "string",
+        generation: 0,
+        labels: {
+            string: "string",
+        },
+        managedFields: [{
+            apiVersion: "string",
+            fieldsType: "string",
+            fieldsV1: "{}",
+            manager: "string",
+            operation: "string",
+            subresource: "string",
+            time: "string",
+        }],
+        name: "string",
+        namespace: "string",
+        ownerReferences: [{
+            apiVersion: "string",
+            kind: "string",
+            name: "string",
+            uid: "string",
+            blockOwnerDeletion: false,
+            controller: false,
+        }],
+        resourceVersion: "string",
+        selfLink: "string",
+        uid: "string",
+    }],
+    requiredMetadataMap: {
+        string: {
+            annotations: {
+                string: "string",
+            },
+            clusterName: "string",
+            creationTimestamp: "string",
+            deletionGracePeriodSeconds: 0,
+            deletionTimestamp: "string",
+            finalizers: ["string"],
+            generateName: "string",
+            generation: 0,
+            labels: {
+                string: "string",
+            },
+            managedFields: [{
+                apiVersion: "string",
+                fieldsType: "string",
+                fieldsV1: "{}",
+                manager: "string",
+                operation: "string",
+                subresource: "string",
+                time: "string",
+            }],
+            name: "string",
+            namespace: "string",
+            ownerReferences: [{
+                apiVersion: "string",
+                kind: "string",
+                name: "string",
+                uid: "string",
+                blockOwnerDeletion: false,
+                controller: false,
+            }],
+            resourceVersion: "string",
+            selfLink: "string",
+            uid: "string",
+        },
+    },
+    metadata: {
+        annotations: {
+            string: "string",
+        },
+        clusterName: "string",
+        creationTimestamp: "string",
+        deletionGracePeriodSeconds: 0,
+        deletionTimestamp: "string",
+        finalizers: ["string"],
+        generateName: "string",
+        generation: 0,
+        labels: {
+            string: "string",
+        },
+        managedFields: [{
+            apiVersion: "string",
+            fieldsType: "string",
+            fieldsV1: "{}",
+            manager: "string",
+            operation: "string",
+            subresource: "string",
+            time: "string",
+        }],
+        name: "string",
+        namespace: "string",
+        ownerReferences: [{
+            apiVersion: "string",
+            kind: "string",
+            name: "string",
+            uid: "string",
+            blockOwnerDeletion: false,
+            controller: false,
+        }],
+        resourceVersion: "string",
+        selfLink: "string",
+        uid: "string",
+    },
+    metadataArray: [{
+        annotations: {
+            string: "string",
+        },
+        clusterName: "string",
+        creationTimestamp: "string",
+        deletionGracePeriodSeconds: 0,
+        deletionTimestamp: "string",
+        finalizers: ["string"],
+        generateName: "string",
+        generation: 0,
+        labels: {
+            string: "string",
+        },
+        managedFields: [{
+            apiVersion: "string",
+            fieldsType: "string",
+            fieldsV1: "{}",
+            manager: "string",
+            operation: "string",
+            subresource: "string",
+            time: "string",
+        }],
+        name: "string",
+        namespace: "string",
+        ownerReferences: [{
+            apiVersion: "string",
+            kind: "string",
+            name: "string",
+            uid: "string",
+            blockOwnerDeletion: false,
+            controller: false,
+        }],
+        resourceVersion: "string",
+        selfLink: "string",
+        uid: "string",
+    }],
+    metadataMap: {
+        string: {
+            annotations: {
+                string: "string",
+            },
+            clusterName: "string",
+            creationTimestamp: "string",
+            deletionGracePeriodSeconds: 0,
+            deletionTimestamp: "string",
+            finalizers: ["string"],
+            generateName: "string",
+            generation: 0,
+            labels: {
+                string: "string",
+            },
+            managedFields: [{
+                apiVersion: "string",
+                fieldsType: "string",
+                fieldsV1: "{}",
+                manager: "string",
+                operation: "string",
+                subresource: "string",
+                time: "string",
+            }],
+            name: "string",
+            namespace: "string",
+            ownerReferences: [{
+                apiVersion: "string",
+                kind: "string",
+                name: "string",
+                uid: "string",
+                blockOwnerDeletion: false,
+                controller: false,
+            }],
+            resourceVersion: "string",
+            selfLink: "string",
+            uid: "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,12 +1144,12 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
-              <span class="nx">metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
-              <span class="nx">metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
               <span class="nx">required_metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
               <span class="nx">required_metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
-              <span class="nx">required_metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">)</span>
+              <span class="nx">required_metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/external-resource-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Workload Resource {#create}
+## Create Workload Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var workloadResource = new Example.Workload("workloadResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewWorkload(ctx, "workloadResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+workload_resource = example.Workload("workloadResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const workloadResource = new example.Workload("workloadResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Workload {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/external-resource-schema/go/example/argFunction.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/argFunction.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"reflect"
 
+	"external-resource-schema/example/internal"
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 func ArgFunction(ctx *pulumi.Context, args *ArgFunctionArgs, opts ...pulumi.InvokeOption) (*ArgFunctionResult, error) {

--- a/tests/testdata/codegen/external-resource-schema/go/example/cat.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/cat.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"external-resource-schema/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Cat struct {

--- a/tests/testdata/codegen/external-resource-schema/go/example/component.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/component.go
@@ -8,12 +8,12 @@ import (
 	"reflect"
 
 	"errors"
+	"external-resource-schema/example/internal"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/ec2"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
 	storagev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/storage/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Component struct {

--- a/tests/testdata/codegen/external-resource-schema/go/example/init.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/init.go
@@ -6,9 +6,9 @@ package example
 import (
 	"fmt"
 
+	"external-resource-schema/example/internal"
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type module struct {

--- a/tests/testdata/codegen/external-resource-schema/go/example/provider.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/provider.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"external-resource-schema/example/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Provider struct {

--- a/tests/testdata/codegen/external-resource-schema/go/example/pulumiTypes.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/pulumiTypes.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"reflect"
 
+	"external-resource-schema/example/internal"
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 var _ = internal.GetEnvOrDefault

--- a/tests/testdata/codegen/external-resource-schema/go/example/workload.go
+++ b/tests/testdata/codegen/external-resource-schema/go/example/workload.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"reflect"
 
+	"external-resource-schema/example/internal"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Workload struct {

--- a/tests/testdata/codegen/external-resource-schema/schema.json
+++ b/tests/testdata/codegen/external-resource-schema/schema.json
@@ -151,7 +151,8 @@
     },
     "go": {
       "generateResourceContainerTypes": true,
-      "generateExtraInputTypes": true
+      "generateExtraInputTypes": true,
+      "importBasePath": "external-resource-schema/example"
     },
     "nodejs": {
       "dependencies": {

--- a/tests/testdata/codegen/functions-secrets/docs/provider/_index.md
+++ b/tests/testdata/codegen/functions-secrets/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/hyphen-url/docs/provider/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create RegistryGeoReplication Resource {#create}
+## Create RegistryGeoReplication Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of RegistryGeoReplication {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
@@ -17,7 +17,289 @@ A non-overlay, non-component, Kubernetes resource.
 
 
 
-## Create ConfigMap Resource {#create}
+## Create ConfigMap Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var configMapResource = new Kubernetes.Core.V1.ConfigMap("configMapResource", new()
+{
+    ApiVersion = "string",
+    BinaryData = 
+    {
+        { "string", "string" },
+    },
+    Data = 
+    {
+        { "string", "string" },
+    },
+    Immutable = false,
+    Kind = "string",
+    Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+    {
+        Annotations = 
+        {
+            { "string", "string" },
+        },
+        ClusterName = "string",
+        CreationTimestamp = "string",
+        DeletionGracePeriodSeconds = 0,
+        DeletionTimestamp = "string",
+        Finalizers = new[]
+        {
+            "string",
+        },
+        GenerateName = "string",
+        Generation = 0,
+        Labels = 
+        {
+            { "string", "string" },
+        },
+        ManagedFields = new[]
+        {
+            new Kubernetes.Types.Inputs.Meta.V1.ManagedFieldsEntryArgs
+            {
+                ApiVersion = "string",
+                FieldsType = "string",
+                FieldsV1 = "{}",
+                Manager = "string",
+                Operation = "string",
+                Subresource = "string",
+                Time = "string",
+            },
+        },
+        Name = "string",
+        Namespace = "string",
+        OwnerReferences = new[]
+        {
+            new Kubernetes.Types.Inputs.Meta.V1.OwnerReferenceArgs
+            {
+                ApiVersion = "string",
+                Kind = "string",
+                Name = "string",
+                Uid = "string",
+                BlockOwnerDeletion = false,
+                Controller = false,
+            },
+        },
+        ResourceVersion = "string",
+        SelfLink = "string",
+        Uid = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := corev1.NewConfigMap(ctx, "configMapResource", &corev1.ConfigMapArgs{
+ApiVersion: pulumi.String("string"),
+BinaryData: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+Data: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+Immutable: pulumi.Bool(false),
+Kind: pulumi.String("string"),
+Metadata: &metav1.ObjectMetaArgs{
+Annotations: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+ClusterName: pulumi.String("string"),
+CreationTimestamp: pulumi.String("string"),
+DeletionGracePeriodSeconds: pulumi.Int(0),
+DeletionTimestamp: pulumi.String("string"),
+Finalizers: pulumi.StringArray{
+pulumi.String("string"),
+},
+GenerateName: pulumi.String("string"),
+Generation: pulumi.Int(0),
+Labels: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+ManagedFields: metav1.ManagedFieldsEntryArray{
+&metav1.ManagedFieldsEntryArgs{
+ApiVersion: pulumi.String("string"),
+FieldsType: pulumi.String("string"),
+FieldsV1: pulumi.Any("{}"),
+Manager: pulumi.String("string"),
+Operation: pulumi.String("string"),
+Subresource: pulumi.String("string"),
+Time: pulumi.String("string"),
+},
+},
+Name: pulumi.String("string"),
+Namespace: pulumi.String("string"),
+OwnerReferences: metav1.OwnerReferenceArray{
+&metav1.OwnerReferenceArgs{
+ApiVersion: pulumi.String("string"),
+Kind: pulumi.String("string"),
+Name: pulumi.String("string"),
+Uid: pulumi.String("string"),
+BlockOwnerDeletion: pulumi.Bool(false),
+Controller: pulumi.Bool(false),
+},
+},
+ResourceVersion: pulumi.String("string"),
+SelfLink: pulumi.String("string"),
+Uid: pulumi.String("string"),
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+config_map_resource = kubernetes.core.v1.ConfigMap("configMapResource",
+    api_version="string",
+    binary_data={
+        "string": "string",
+    },
+    data={
+        "string": "string",
+    },
+    immutable=False,
+    kind="string",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        annotations={
+            "string": "string",
+        },
+        cluster_name="string",
+        creation_timestamp="string",
+        deletion_grace_period_seconds=0,
+        deletion_timestamp="string",
+        finalizers=["string"],
+        generate_name="string",
+        generation=0,
+        labels={
+            "string": "string",
+        },
+        managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+            api_version="string",
+            fields_type="string",
+            fields_v1="{}",
+            manager="string",
+            operation="string",
+            subresource="string",
+            time="string",
+        )],
+        name="string",
+        namespace="string",
+        owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+            api_version="string",
+            kind="string",
+            name="string",
+            uid="string",
+            block_owner_deletion=False,
+            controller=False,
+        )],
+        resource_version="string",
+        self_link="string",
+        uid="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const configMapResource = new kubernetes.core.v1.ConfigMap("configMapResource", {
+    apiVersion: "string",
+    binaryData: {
+        string: "string",
+    },
+    data: {
+        string: "string",
+    },
+    immutable: false,
+    kind: "string",
+    metadata: {
+        annotations: {
+            string: "string",
+        },
+        clusterName: "string",
+        creationTimestamp: "string",
+        deletionGracePeriodSeconds: 0,
+        deletionTimestamp: "string",
+        finalizers: ["string"],
+        generateName: "string",
+        generation: 0,
+        labels: {
+            string: "string",
+        },
+        managedFields: [{
+            apiVersion: "string",
+            fieldsType: "string",
+            fieldsV1: "{}",
+            manager: "string",
+            operation: "string",
+            subresource: "string",
+            time: "string",
+        }],
+        name: "string",
+        namespace: "string",
+        ownerReferences: [{
+            apiVersion: "string",
+            kind: "string",
+            name: "string",
+            uid: "string",
+            blockOwnerDeletion: false,
+            controller: false,
+        }],
+        resourceVersion: "string",
+        selfLink: "string",
+        uid: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ConfigMap {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
@@ -17,7 +17,336 @@ A Kubernetes list resource.
 
 
 
-## Create ConfigMapList Resource {#create}
+## Create ConfigMapList Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var configMapListResource = new Kubernetes.Core.V1.ConfigMapList("configMapListResource", new()
+{
+    Items = new[]
+    {
+        new Kubernetes.Types.Inputs.Core.V1.ConfigMapArgs
+        {
+            ApiVersion = "v1",
+            BinaryData = 
+            {
+                { "string", "string" },
+            },
+            Data = 
+            {
+                { "string", "string" },
+            },
+            Immutable = false,
+            Kind = "ConfigMap",
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+            {
+                Annotations = 
+                {
+                    { "string", "string" },
+                },
+                ClusterName = "string",
+                CreationTimestamp = "string",
+                DeletionGracePeriodSeconds = 0,
+                DeletionTimestamp = "string",
+                Finalizers = new[]
+                {
+                    "string",
+                },
+                GenerateName = "string",
+                Generation = 0,
+                Labels = 
+                {
+                    { "string", "string" },
+                },
+                ManagedFields = new[]
+                {
+                    new Kubernetes.Types.Inputs.Meta.V1.ManagedFieldsEntryArgs
+                    {
+                        ApiVersion = "string",
+                        FieldsType = "string",
+                        FieldsV1 = "{}",
+                        Manager = "string",
+                        Operation = "string",
+                        Subresource = "string",
+                        Time = "string",
+                    },
+                },
+                Name = "string",
+                Namespace = "string",
+                OwnerReferences = new[]
+                {
+                    new Kubernetes.Types.Inputs.Meta.V1.OwnerReferenceArgs
+                    {
+                        ApiVersion = "string",
+                        Kind = "string",
+                        Name = "string",
+                        Uid = "string",
+                        BlockOwnerDeletion = false,
+                        Controller = false,
+                    },
+                },
+                ResourceVersion = "string",
+                SelfLink = "string",
+                Uid = "string",
+            },
+        },
+    },
+    ApiVersion = "string",
+    Kind = "string",
+    Metadata = new Kubernetes.Types.Inputs.Meta.V1.ListMetaArgs
+    {
+        Continue = "string",
+        RemainingItemCount = 0,
+        ResourceVersion = "string",
+        SelfLink = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := corev1.NewConfigMapList(ctx, "configMapListResource", &corev1.ConfigMapListArgs{
+Items: corev1.ConfigMapTypeArray{
+interface{}{
+ApiVersion: pulumi.String("v1"),
+BinaryData: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+Data: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+Immutable: pulumi.Bool(false),
+Kind: pulumi.String("ConfigMap"),
+Metadata: &metav1.ObjectMetaArgs{
+Annotations: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+ClusterName: pulumi.String("string"),
+CreationTimestamp: pulumi.String("string"),
+DeletionGracePeriodSeconds: pulumi.Int(0),
+DeletionTimestamp: pulumi.String("string"),
+Finalizers: pulumi.StringArray{
+pulumi.String("string"),
+},
+GenerateName: pulumi.String("string"),
+Generation: pulumi.Int(0),
+Labels: pulumi.StringMap{
+"string": pulumi.String("string"),
+},
+ManagedFields: metav1.ManagedFieldsEntryArray{
+&metav1.ManagedFieldsEntryArgs{
+ApiVersion: pulumi.String("string"),
+FieldsType: pulumi.String("string"),
+FieldsV1: pulumi.Any("{}"),
+Manager: pulumi.String("string"),
+Operation: pulumi.String("string"),
+Subresource: pulumi.String("string"),
+Time: pulumi.String("string"),
+},
+},
+Name: pulumi.String("string"),
+Namespace: pulumi.String("string"),
+OwnerReferences: metav1.OwnerReferenceArray{
+&metav1.OwnerReferenceArgs{
+ApiVersion: pulumi.String("string"),
+Kind: pulumi.String("string"),
+Name: pulumi.String("string"),
+Uid: pulumi.String("string"),
+BlockOwnerDeletion: pulumi.Bool(false),
+Controller: pulumi.Bool(false),
+},
+},
+ResourceVersion: pulumi.String("string"),
+SelfLink: pulumi.String("string"),
+Uid: pulumi.String("string"),
+},
+},
+},
+ApiVersion: pulumi.String("string"),
+Kind: pulumi.String("string"),
+Metadata: &metav1.ListMetaArgs{
+Continue: pulumi.String("string"),
+RemainingItemCount: pulumi.Int(0),
+ResourceVersion: pulumi.String("string"),
+SelfLink: pulumi.String("string"),
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+config_map_list_resource = kubernetes.core.v1.ConfigMapList("configMapListResource",
+    items=[kubernetes.core.v1.ConfigMapArgs(
+        api_version="v1",
+        binary_data={
+            "string": "string",
+        },
+        data={
+            "string": "string",
+        },
+        immutable=False,
+        kind="ConfigMap",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            annotations={
+                "string": "string",
+            },
+            cluster_name="string",
+            creation_timestamp="string",
+            deletion_grace_period_seconds=0,
+            deletion_timestamp="string",
+            finalizers=["string"],
+            generate_name="string",
+            generation=0,
+            labels={
+                "string": "string",
+            },
+            managed_fields=[kubernetes.meta.v1.ManagedFieldsEntryArgs(
+                api_version="string",
+                fields_type="string",
+                fields_v1="{}",
+                manager="string",
+                operation="string",
+                subresource="string",
+                time="string",
+            )],
+            name="string",
+            namespace="string",
+            owner_references=[kubernetes.meta.v1.OwnerReferenceArgs(
+                api_version="string",
+                kind="string",
+                name="string",
+                uid="string",
+                block_owner_deletion=False,
+                controller=False,
+            )],
+            resource_version="string",
+            self_link="string",
+            uid="string",
+        ),
+    )],
+    api_version="string",
+    kind="string",
+    metadata=kubernetes.meta.v1.ListMetaArgs(
+        continue_="string",
+        remaining_item_count=0,
+        resource_version="string",
+        self_link="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const configMapListResource = new kubernetes.core.v1.ConfigMapList("configMapListResource", {
+    items: [{
+        apiVersion: "v1",
+        binaryData: {
+            string: "string",
+        },
+        data: {
+            string: "string",
+        },
+        immutable: false,
+        kind: "ConfigMap",
+        metadata: {
+            annotations: {
+                string: "string",
+            },
+            clusterName: "string",
+            creationTimestamp: "string",
+            deletionGracePeriodSeconds: 0,
+            deletionTimestamp: "string",
+            finalizers: ["string"],
+            generateName: "string",
+            generation: 0,
+            labels: {
+                string: "string",
+            },
+            managedFields: [{
+                apiVersion: "string",
+                fieldsType: "string",
+                fieldsV1: "{}",
+                manager: "string",
+                operation: "string",
+                subresource: "string",
+                time: "string",
+            }],
+            name: "string",
+            namespace: "string",
+            ownerReferences: [{
+                apiVersion: "string",
+                kind: "string",
+                name: "string",
+                uid: "string",
+                blockOwnerDeletion: false,
+                controller: false,
+            }],
+            resourceVersion: "string",
+            selfLink: "string",
+            uid: "string",
+        },
+    }],
+    apiVersion: "string",
+    kind: "string",
+    metadata: {
+        "continue": "string",
+        remainingItemCount: 0,
+        resourceVersion: "string",
+        selfLink: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ConfigMapList {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
@@ -17,7 +17,109 @@ A non-overlay, non-component, non-Kubernetes resource.
 
 
 
-## Create Release Resource {#create}
+## Create Release Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var releaseResource = new Kubernetes.Helm.V3.Release("releaseResource", new()
+{
+    Chart = "string",
+    ValueYamlFiles = new[]
+    {
+        new StringAsset("content"),
+    },
+    Values = 
+    {
+        { "string", "any" },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := helmv3.NewRelease(ctx, "releaseResource", &helmv3.ReleaseArgs{
+Chart: pulumi.String("string"),
+ValueYamlFiles: pulumi.AssetOrArchiveArray{
+pulumi.NewStringAsset("content"),
+},
+Values: pulumi.Map{
+"string": pulumi.Any("any"),
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+release_resource = kubernetes.helm.v3.Release("releaseResource",
+    chart="string",
+    value_yaml_files=[pulumi.StringAsset("content")],
+    values={
+        "string": "any",
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const releaseResource = new kubernetes.helm.v3.Release("releaseResource", {
+    chart: "string",
+    valueYamlFiles: [new pulumi.asset.StringAsset("content")],
+    values: {
+        string: "any",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Release {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/provider/_index.md
@@ -17,6 +17,7 @@ The provider type for the kubernetes package.
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
@@ -17,7 +17,108 @@ An overlay component resource.
 
 
 
-## Create ConfigGroup Resource {#create}
+## Create ConfigGroup Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var kubernetesConfigGroupResource = new Kubernetes.Yaml.ConfigGroup("kubernetesConfigGroupResource", new()
+{
+    Files = "string",
+    Objs = null,
+    ResourcePrefix = "string",
+    Transformations = new[]
+    {
+        "any",
+    },
+    Yaml = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := yaml.NewConfigGroup(ctx, "kubernetesConfigGroupResource", &yaml.ConfigGroupArgs{
+Files: pulumi.Any("string"),
+Objs: nil,
+ResourcePrefix: pulumi.String("string"),
+Transformations: pulumi.Array{
+pulumi.Any("any"),
+},
+Yaml: pulumi.Any("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+kubernetes_config_group_resource = kubernetes.yaml.ConfigGroup("kubernetesConfigGroupResource",
+    files="string",
+    objs=None,
+    resource_prefix="string",
+    transformations=["any"],
+    yaml="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const kubernetesConfigGroupResource = new kubernetes.yaml.ConfigGroup("kubernetesConfigGroupResource", {
+    files: "string",
+    objs: undefined,
+    resourcePrefix: "string",
+    transformations: ["any"],
+    yaml: "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ConfigGroup {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
@@ -17,7 +17,99 @@ A non-overlay component resource.
 
 
 
-## Create ConfigGroup Resource {#create}
+## Create ConfigGroup Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var configGroupResource = new Kubernetes.Yaml.V2.ConfigGroup("configGroupResource", new()
+{
+    Files = "string",
+    Objs = null,
+    ResourcePrefix = "string",
+    Yaml = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := yamlv2.NewConfigGroup(ctx, "configGroupResource", &yamlv2.ConfigGroupArgs{
+Files: pulumi.Any("string"),
+Objs: nil,
+ResourcePrefix: pulumi.String("string"),
+Yaml: pulumi.Any("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+config_group_resource = kubernetes.yaml.v2.ConfigGroup("configGroupResource",
+    files="string",
+    objs=None,
+    resource_prefix="string",
+    yaml="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const configGroupResource = new kubernetes.yaml.v2.ConfigGroup("configGroupResource", {
+    files: "string",
+    objs: undefined,
+    resourcePrefix: "string",
+    yaml: "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ConfigGroup {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
@@ -15,7 +15,97 @@ no_edit_this_page: true
 
 
 
-## Create Example_resource Resource {#create}
+## Create Example_resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := legacy_names.Newexample_resource(ctx, "example_resourceResource", &legacy_names.example_resourceArgs{
+	Map_enum: legacy_names.Enum_XYZMapArray{
+		legacy_names.Enum_XYZMap{
+			"string": legacy_names.Enum_XYZPlain,
+		},
+	},
+	Request_HTTP: &http_module.RequestArgs{
+		URL:          pulumi.String("string"),
+		Content_body: pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const example_resourceResource = new legacy_names.Example_resource("example_resourceResource", {
+    map_enum: [{
+        string: legacy_names.Enum_XYZ.Plain,
+    }],
+    request_HTTP: {
+        URL: "string",
+        content_body: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Example_resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/legacy-names/docs/provider/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Configurer Resource {#create}
+## Create Configurer Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var configurerResource = new Metaprovider.Configurer("configurerResource", new()
+{
+    TlsProxy = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := metaprovider.NewConfigurer(ctx, "configurerResource", &metaprovider.ConfigurerArgs{
+	TlsProxy: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+configurer_resource = metaprovider.Configurer("configurerResource", tls_proxy="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const configurerResource = new metaprovider.Configurer("configurerResource", {tlsProxy: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Configurer {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/provider/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create MainComponent Resource {#create}
+## Create MainComponent Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var mainComponentResource = new Example.MainComponent("mainComponentResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewMainComponent(ctx, "mainComponentResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+main_component_resource = example.MainComponent("mainComponentResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const mainComponentResource = new example.MainComponent("mainComponentResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of MainComponent {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Component2 Resource {#create}
+## Create Component2 Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var component2Resource = new Example.Mod.Component2("component2Resource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := mod.NewComponent2(ctx, "component2Resource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+component2_resource = example.mod.Component2("component2Resource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const component2Resource = new example.mod.Component2("component2Resource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component2 {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/naming-collisions/docs/provider/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Example.Resource("resourceResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResource(ctx, "resourceResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = example.Resource("resourceResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new example.Resource("resourceResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create ResourceInput Resource {#create}
+## Create ResourceInput Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceInputResource = new Example.ResourceInput("resourceInputResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResourceInput(ctx, "resourceInputResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_input_resource = example.ResourceInput("resourceInputResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceInputResource = new example.ResourceInput("resourceInputResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ResourceInput {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new FooBar.Deeply.Nested.Module.Resource("resourceResource", new()
+{
+    Baz = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := deeply.NewResource(ctx, "resourceResource", &deeply.ResourceArgs{
+	Baz: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = foo_bar.deeply.nested.module.Resource("resourceResource", baz="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new foo_bar.deeply.nested.module.Resource("resourceResource", {baz: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/nested-module-thirdparty/docs/provider/_index.md
+++ b/tests/testdata/codegen/nested-module-thirdparty/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Foo.Nested.Module.Resource("resourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := nested.NewResource(ctx, "resourceResource", &nested.ResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = foo.nested.module.Resource("resourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new foo.nested.module.Resource("resourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/nested-module/docs/provider/_index.md
+++ b/tests/testdata/codegen/nested-module/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/other-owned/docs/barresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/barresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create BarResource Resource {#create}
+## Create BarResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of BarResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create FooResource Resource {#create}
+## Create FooResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of FooResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create OtherResource Resource {#create}
+## Create OtherResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OtherResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
@@ -15,7 +15,100 @@ no_edit_this_page: true
 
 
 
-## Create OverlayResource Resource {#create}
+## Create OverlayResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var overlayResourceResource = new Example.OverlayResource("overlayResourceResource", new()
+{
+    Bar = Example.EnumOverlay.SomeEnumValue,
+    Foo = new Example.Inputs.ConfigMapOverlayArgs
+    {
+        Config = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewOverlayResource(ctx, "overlayResourceResource", &example.OverlayResourceArgs{
+	Bar: example.EnumOverlaySomeEnumValue,
+	Foo: &example.ConfigMapOverlayArgs{
+		Config: pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+overlay_resource_resource = example.OverlayResource("overlayResourceResource",
+    bar=example.EnumOverlay.SOME_ENUM_VALUE,
+    foo=example.ConfigMapOverlayArgs(
+        config="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const overlayResourceResource = new example.OverlayResource("overlayResourceResource", {
+    bar: example.EnumOverlay.SomeEnumValue,
+    foo: {
+        config: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OverlayResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/other-owned/docs/provider/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/other-owned/docs/resource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Example.Resource("resourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResource(ctx, "resourceResource", &example.ResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = example.Resource("resourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new example.Resource("resourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
@@ -15,7 +15,194 @@ no_edit_this_page: true
 
 
 
-## Create TypeUses Resource {#create}
+## Create TypeUses Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var typeUsesResource = new Example.TypeUses("typeUsesResource", new()
+{
+    Bar = new Example.Inputs.SomeOtherObjectArgs
+    {
+        Baz = "string",
+    },
+    Baz = new Example.Inputs.ObjectWithNodeOptionalInputsArgs
+    {
+        Foo = "string",
+        Bar = 0,
+    },
+    Foo = new Example.Inputs.ObjectArgs
+    {
+        Bar = "string",
+        Configs = new[]
+        {
+            new Example.Inputs.ConfigMapArgs
+            {
+                Config = "string",
+            },
+        },
+        Others = new[]
+        {
+            new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            },
+        },
+        StillOthers = 
+        {
+            { "string", new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            } },
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewTypeUses(ctx, "typeUsesResource", &example.TypeUsesArgs{
+	Bar: &example.SomeOtherObjectArgs{
+		Baz: pulumi.String("string"),
+	},
+	Baz: &example.ObjectWithNodeOptionalInputsArgs{
+		Foo: pulumi.String("string"),
+		Bar: pulumi.Int(0),
+	},
+	Foo: &example.ObjectArgs{
+		Bar: pulumi.String("string"),
+		Configs: example.ConfigMapArray{
+			&example.ConfigMapArgs{
+				Config: pulumi.String("string"),
+			},
+		},
+		Others: example.SomeOtherObjectArrayArray{
+			example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+		StillOthers: example.SomeOtherObjectArrayMap{
+			"string": example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+type_uses_resource = example.TypeUses("typeUsesResource",
+    bar=example.SomeOtherObjectArgs(
+        baz="string",
+    ),
+    baz=example.ObjectWithNodeOptionalInputsArgs(
+        foo="string",
+        bar=0,
+    ),
+    foo=example.ObjectArgs(
+        bar="string",
+        configs=[example.ConfigMapArgs(
+            config="string",
+        )],
+        others=[[example.SomeOtherObjectArgs(
+            baz="string",
+        )]],
+        still_others={
+            "string": [example.SomeOtherObjectArgs(
+                baz="string",
+            )],
+        },
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const typeUsesResource = new example.TypeUses("typeUsesResource", {
+    bar: {
+        baz: "string",
+    },
+    baz: {
+        foo: "string",
+        bar: 0,
+    },
+    foo: {
+        bar: "string",
+        configs: [{
+            config: "string",
+        }],
+        others: [[{
+            baz: "string",
+        }]],
+        stillOthers: {
+            string: [{
+                baz: "string",
+            }],
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of TypeUses {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/output-funcs-edgeorder/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs-edgeorder/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/output-funcs/docs/provider/_index.md
+++ b/tests/testdata/codegen/output-funcs/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create ModuleResource Resource {#create}
+## Create ModuleResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ModuleResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,20 +104,20 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                   <span class="nx">optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_enum</span><span class="p">:</span> <span class="nx">Optional[EnumThing]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-                   <span class="nx">plain_optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-                   <span class="nx">plain_optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
-                   <span class="nx">plain_optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                    <span class="nx">plain_required_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-                   <span class="nx">plain_required_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
-                   <span class="nx">plain_required_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-                   <span class="nx">required_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-                   <span class="nx">required_enum</span><span class="p">:</span> <span class="nx">Optional[EnumThing]</span> = None<span class="p">,</span>
+                   <span class="nx">required_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                    <span class="nx">required_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
-                   <span class="nx">required_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+                   <span class="nx">required_enum</span><span class="p">:</span> <span class="nx">Optional[EnumThing]</span> = None<span class="p">,</span>
+                   <span class="nx">required_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+                   <span class="nx">plain_required_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
+                   <span class="nx">plain_required_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
+                   <span class="nx">plain_optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
+                   <span class="nx">plain_optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
+                   <span class="nx">plain_optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_enum</span><span class="p">:</span> <span class="nx">Optional[EnumThing]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                    <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ModuleResourceArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/plain-and-default/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
@@ -17,7 +17,79 @@ test new feature with resoruces
 
 
 
-## Create Foo Resource {#create}
+## Create Foo Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Foo {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -34,8 +106,8 @@ test new feature with resoruces
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Foo</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">backup_kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
+        <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
         <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[LayeredTypeArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>

--- a/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
@@ -15,7 +15,148 @@ no_edit_this_page: true
 
 
 
-## Create ModuleTest Resource {#create}
+## Create ModuleTest Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var moduleTestResource = new Example.ModuleTest("moduleTestResource", new()
+{
+    Mod1 = new Example.Mod1.Inputs.TypArgs
+    {
+        Val = "string",
+    },
+    Val = new Example.Inputs.TypArgs
+    {
+        Mod1 = new Example.Mod1.Inputs.TypArgs
+        {
+            Val = "string",
+        },
+        Mod2 = new Example.Mod2.Inputs.TypArgs
+        {
+            Mod1 = new Example.Mod1.Inputs.TypArgs
+            {
+                Val = "string",
+            },
+            Val = "string",
+        },
+        Val = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewmoduleTest(ctx, "moduleTestResource", &example.moduleTestArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Val: &example.TypArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Mod2: &mod2.TypArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Val: pulumi.String("string"),
+},
+Val: pulumi.String("string"),
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+module_test_resource = example.ModuleTest("moduleTestResource",
+    mod1=example.mod1.TypArgs(
+        val="string",
+    ),
+    val=example.TypArgs(
+        mod1=example.mod1.TypArgs(
+            val="string",
+        ),
+        mod2=example.mod2.TypArgs(
+            mod1=example.mod1.TypArgs(
+                val="string",
+            ),
+            val="string",
+        ),
+        val="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const moduleTestResource = new example.ModuleTest("moduleTestResource", {
+    mod1: {
+        val: "string",
+    },
+    val: {
+        mod1: {
+            val: "string",
+        },
+        mod2: {
+            mod1: {
+                val: "string",
+            },
+            val: "string",
+        },
+        val: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ModuleTest {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/provider/_index.md
@@ -17,6 +17,7 @@ The provider type for the kubernetes package.
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
@@ -17,7 +17,79 @@ test new feature with resoruces
 
 
 
-## Create Foo Resource {#create}
+## Create Foo Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Foo {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -34,8 +106,8 @@ test new feature with resoruces
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Foo</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">backup_kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
+        <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
         <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[LayeredTypeArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -15,7 +15,148 @@ no_edit_this_page: true
 
 
 
-## Create ModuleTest Resource {#create}
+## Create ModuleTest Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var moduleTestResource = new Example.ModuleTest("moduleTestResource", new()
+{
+    Mod1 = new Example.Mod1.Inputs.TypArgs
+    {
+        Val = "string",
+    },
+    Val = new Example.Inputs.TypArgs
+    {
+        Mod1 = new Example.Mod1.Inputs.TypArgs
+        {
+            Val = "string",
+        },
+        Mod2 = new Example.Mod2.Inputs.TypArgs
+        {
+            Mod1 = new Example.Mod1.Inputs.TypArgs
+            {
+                Val = "string",
+            },
+            Val = "string",
+        },
+        Val = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewmoduleTest(ctx, "moduleTestResource", &example.moduleTestArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Val: &example.TypArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Mod2: &mod2.TypArgs{
+Mod1: &mod1.TypArgs{
+Val: pulumi.String("string"),
+},
+Val: pulumi.String("string"),
+},
+Val: pulumi.String("string"),
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+module_test_resource = example.ModuleTest("moduleTestResource",
+    mod1=example.mod1.TypArgs(
+        val="string",
+    ),
+    val=example.TypArgs(
+        mod1=example.mod1.TypArgs(
+            val="string",
+        ),
+        mod2=example.mod2.TypArgs(
+            mod1=example.mod1.TypArgs(
+                val="string",
+            ),
+            val="string",
+        ),
+        val="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const moduleTestResource = new example.ModuleTest("moduleTestResource", {
+    mod1: {
+        val: "string",
+    },
+    val: {
+        mod1: {
+            val: "string",
+        },
+        mod2: {
+            mod1: {
+                val: "string",
+            },
+            val: "string",
+        },
+        val: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ModuleTest {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/provider/_index.md
@@ -17,6 +17,7 @@ The provider type for the kubernetes package.
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/provider/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
@@ -15,7 +15,100 @@ no_edit_this_page: true
 
 
 
-## Create StaticPage Resource {#create}
+## Create StaticPage Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var staticPageResource = new Xyz.StaticPage("staticPageResource", new()
+{
+    IndexContent = "string",
+    Foo = new Xyz.Inputs.FooArgs
+    {
+        A = false,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := xyz.NewStaticPage(ctx, "staticPageResource", &xyz.StaticPageArgs{
+	IndexContent: pulumi.String("string"),
+	Foo: &xyz.FooArgs{
+		A: pulumi.Bool(false),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+static_page_resource = xyz.StaticPage("staticPageResource",
+    index_content="string",
+    foo=xyz.FooArgs(
+        a=False,
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const staticPageResource = new xyz.StaticPage("staticPageResource", {
+    indexContent: "string",
+    foo: {
+        a: false,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of StaticPage {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,8 +125,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">StaticPage</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">,</span>
-               <span class="nx">index_content</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+               <span class="nx">index_content</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
+               <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">StaticPage</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">StaticPageArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/provider-config-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/provider-config-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/provider-type-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/provider-type-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
+++ b/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Provider Resource {#create}
+## Create Provider Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var providerResource = new ProviderType.Submod.Provider("providerResource", new()
+{
+    A = false,
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := submod.Newprovider(ctx, "providerResource", &submod.providerArgs{
+	A: false,
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+provider_resource = provider_type.submod.Provider("providerResource", a=False)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const providerResource = new providerType.submod.Provider("providerResource", {a: false});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Provider {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/regress-8403/docs/provider/_index.md
+++ b/tests/testdata/codegen/regress-8403/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/regress-node-8110/docs/provider/_index.md
+++ b/tests/testdata/codegen/regress-node-8110/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Cat Resource {#create}
+## Create Cat Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var catResource = new Example.Cat("catResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewCat(ctx, "catResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+cat_resource = example.Cat("catResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const catResource = new example.Cat("catResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Cat {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Dog Resource {#create}
+## Create Dog Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var dogResource = new Example.Dog("dogResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewDog(ctx, "dogResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+dog_resource = example.Dog("dogResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const dogResource = new example.Dog("dogResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Dog {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/replace-on-change/docs/god/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/god/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create God Resource {#create}
+## Create God Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var godResource = new Example.God("godResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewGod(ctx, "godResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+god_resource = example.God("godResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const godResource = new example.God("godResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of God {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create NoRecursive Resource {#create}
+## Create NoRecursive Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var noRecursiveResource = new Example.NoRecursive("noRecursiveResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewNoRecursive(ctx, "noRecursiveResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+no_recursive_resource = example.NoRecursive("noRecursiveResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const noRecursiveResource = new example.NoRecursive("noRecursiveResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of NoRecursive {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/replace-on-change/docs/provider/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create ToyStore Resource {#create}
+## Create ToyStore Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var toyStoreResource = new Example.ToyStore("toyStoreResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewToyStore(ctx, "toyStoreResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+toy_store_resource = example.ToyStore("toyStoreResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const toyStoreResource = new example.ToyStore("toyStoreResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ToyStore {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
@@ -15,7 +15,105 @@ no_edit_this_page: true
 
 
 
-## Create Person Resource {#create}
+## Create Person Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var personResource = new Example.Person("personResource", new()
+{
+    Name = "string",
+    Pets = new[]
+    {
+        new Example.Inputs.PetArgs
+        {
+            Name = "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewPerson(ctx, "personResource", &example.PersonArgs{
+	Name: pulumi.String("string"),
+	Pets: example.PetTypeArray{
+		&example.PetTypeArgs{
+			Name: pulumi.String("string"),
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+person_resource = example.Person("personResource",
+    name="string",
+    pets=[example.PetArgs(
+        name="string",
+    )])
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const personResource = new example.Person("personResource", {
+    name: "string",
+    pets: [{
+        name: "string",
+    }],
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Person {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Pet Resource {#create}
+## Create Pet Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var petResource = new Example.Pet("petResource", new()
+{
+    Name = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewPet(ctx, "petResource", &example.PetArgs{
+	Name: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+pet_resource = example.Pet("petResource", name="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const petResource = new example.Pet("petResource", {name: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Pet {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/resource-args-python/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/person/_index.md
@@ -15,7 +15,105 @@ no_edit_this_page: true
 
 
 
-## Create Person Resource {#create}
+## Create Person Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var personResource = new Example.Person("personResource", new()
+{
+    Name = "string",
+    Pets = new[]
+    {
+        new Example.Inputs.PetArgs
+        {
+            Name = "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewPerson(ctx, "personResource", &example.PersonArgs{
+	Name: pulumi.String("string"),
+	Pets: example.PetTypeArray{
+		&example.PetTypeArgs{
+			Name: pulumi.String("string"),
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+person_resource = example.Person("personResource",
+    name="string",
+    pets=[example.PetArgs(
+        name="string",
+    )])
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const personResource = new example.Person("personResource", {
+    name: "string",
+    pets: [{
+        name: "string",
+    }],
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Person {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Pet Resource {#create}
+## Create Pet Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var petResource = new Example.Pet("petResource", new()
+{
+    Name = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewPet(ctx, "petResource", &example.PetArgs{
+	Name: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+pet_resource = example.Pet("petResource", name="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const petResource = new example.Pet("petResource", {name: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Pet {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/resource-args-python/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/resource-property-overlap/docs/provider/_index.md
+++ b/tests/testdata/codegen/resource-property-overlap/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
+++ b/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Rec Resource {#create}
+## Create Rec Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var recResource = new Example.Rec("recResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewRec(ctx, "recResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+rec_resource = example.Rec("recResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const recResource = new example.Rec("recResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Rec {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/secrets/docs/provider/_index.md
+++ b/tests/testdata/codegen/secrets/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/secrets/docs/resource/_index.md
+++ b/tests/testdata/codegen/secrets/docs/resource/_index.md
@@ -15,7 +15,162 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Mypkg.Resource("resourceResource", new()
+{
+    Config = new Mypkg.Inputs.ConfigArgs
+    {
+        Foo = "string",
+    },
+    ConfigArray = new[]
+    {
+        new Mypkg.Inputs.ConfigArgs
+        {
+            Foo = "string",
+        },
+    },
+    ConfigMap = 
+    {
+        { "string", new Mypkg.Inputs.ConfigArgs
+        {
+            Foo = "string",
+        } },
+    },
+    Foo = "string",
+    FooArray = new[]
+    {
+        "string",
+    },
+    FooMap = 
+    {
+        { "string", "string" },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := mypkg.NewResource(ctx, "resourceResource", &mypkg.ResourceArgs{
+	Config: &mypkg.ConfigArgs{
+		Foo: pulumi.String("string"),
+	},
+	ConfigArray: mypkg.ConfigArray{
+		&mypkg.ConfigArgs{
+			Foo: pulumi.String("string"),
+		},
+	},
+	ConfigMap: mypkg.ConfigMap{
+		"string": &mypkg.ConfigArgs{
+			Foo: pulumi.String("string"),
+		},
+	},
+	Foo: pulumi.String("string"),
+	FooArray: pulumi.StringArray{
+		pulumi.String("string"),
+	},
+	FooMap: pulumi.StringMap{
+		"string": pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = mypkg.Resource("resourceResource",
+    config=mypkg.ConfigArgs(
+        foo="string",
+    ),
+    config_array=[mypkg.ConfigArgs(
+        foo="string",
+    )],
+    config_map={
+        "string": mypkg.ConfigArgs(
+            foo="string",
+        ),
+    },
+    foo="string",
+    foo_array=["string"],
+    foo_map={
+        "string": "string",
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new mypkg.Resource("resourceResource", {
+    config: {
+        foo: "string",
+    },
+    configArray: [{
+        foo: "string",
+    }],
+    configMap: {
+        string: {
+            foo: "string",
+        },
+    },
+    foo: "string",
+    fooArray: ["string"],
+    fooMap: {
+        string: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-enum-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,105 @@ no_edit_this_page: true
 
 
 
-## Create Nursery Resource {#create}
+## Create Nursery Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
+{
+    Varieties = new[]
+    {
+        Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    },
+    Sizes = 
+    {
+        { "string", Plant.Tree.V1.TreeSize.Small },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
+Varieties: treev1.RubberTreeVarietyArray{
+tree.RubberTreeVarietyBurgundy,
+},
+Sizes: treev1.TreeSizeMap{
+"string": tree.TreeSizeSmall,
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+nursery_resource = plant.tree.v1.Nursery("nurseryResource",
+    varieties=[plant.tree.v1.RubberTreeVariety.BURGUNDY],
+    sizes={
+        "string": plant.tree.v1.TreeSize.SMALL,
+    })
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const nurseryResource = new plant.tree.v1.Nursery("nurseryResource", {
+    varieties: [plant.tree.v1.RubberTreeVariety.Burgundy],
+    sizes: {
+        string: plant.tree.v1.TreeSize.Small,
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Nursery {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,8 +130,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
-            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
+            <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">NurseryArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create RubberTree Resource {#create}
+## Create RubberTree Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of RubberTree {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -32,11 +104,11 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
+               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
                <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
-               <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">RubberTreeArgs</a></span><span class="p">,</span>

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Foo Resource {#create}
+## Create Foo Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var fooResource = new Example.Foo("fooResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewFoo(ctx, "fooResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+foo_resource = example.Foo("fooResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const fooResource = new example.Foo("fooResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Foo {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create Foo Resource {#create}
+## Create Foo Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var fooResource = new Example.Foo("fooResource");
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewFoo(ctx, "fooResource", nil)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+foo_resource = example.Foo("fooResource")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const fooResource = new example.Foo("fooResource", {});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Foo {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-methods-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -15,7 +15,211 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var componentResource = new Example.Component("componentResource", new()
+{
+    A = false,
+    C = 0,
+    E = "string",
+    B = false,
+    Bar = new Example.Inputs.FooArgs
+    {
+        A = false,
+        C = 0,
+        E = "string",
+        B = false,
+        D = 0,
+        F = "string",
+    },
+    Baz = new()
+    {
+        new Example.Inputs.FooArgs
+        {
+            A = false,
+            C = 0,
+            E = "string",
+            B = false,
+            D = 0,
+            F = "string",
+        },
+    },
+    D = 0,
+    F = "string",
+    Foo = new Example.Inputs.FooArgs
+    {
+        A = false,
+        C = 0,
+        E = "string",
+        B = false,
+        D = 0,
+        F = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewComponent(ctx, "componentResource", &example.ComponentArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+Bar: &.FooArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+Baz: [].FooArgs{
+{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+},
+D: 0,
+F: "string",
+Foo: &.FooArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+component_resource = example.Component("componentResource",
+    a=False,
+    c=0,
+    e="string",
+    b=False,
+    bar=example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    ),
+    baz=[example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    )],
+    d=0,
+    f="string",
+    foo=example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const componentResource = new example.Component("componentResource", {
+    a: false,
+    c: 0,
+    e: "string",
+    b: false,
+    bar: {
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    },
+    baz: [{
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    }],
+    d: 0,
+    f: "string",
+    foo: {
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -33,12 +237,12 @@ no_edit_this_page: true
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
               <span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+              <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
+              <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
               <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">,</span>
               <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Sequence[FooArgs]]</span> = None<span class="p">,</span>
-              <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
-              <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">f</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
@@ -15,7 +15,253 @@ no_edit_this_page: true
 
 
 
-## Create Component Resource {#create}
+## Create Component Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var componentResource = new Example.Component("componentResource", new()
+{
+    A = false,
+    C = 0,
+    E = "string",
+    B = false,
+    Bar = new Example.Inputs.FooArgs
+    {
+        A = false,
+        C = 0,
+        E = "string",
+        B = false,
+        D = 0,
+        F = "string",
+    },
+    Baz = new()
+    {
+        new Example.Inputs.FooArgs
+        {
+            A = false,
+            C = 0,
+            E = "string",
+            B = false,
+            D = 0,
+            F = "string",
+        },
+    },
+    BazMap = 
+    {
+        { "string", new Example.Inputs.FooArgs
+        {
+            A = false,
+            C = 0,
+            E = "string",
+            B = false,
+            D = 0,
+            F = "string",
+        } },
+    },
+    D = 0,
+    F = "string",
+    Foo = new Example.Inputs.FooArgs
+    {
+        A = false,
+        C = 0,
+        E = "string",
+        B = false,
+        D = 0,
+        F = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewComponent(ctx, "componentResource", &example.ComponentArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+Bar: &example.FooArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+Baz: []example.FooArgs{
+{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+},
+BazMap: interface{}{
+String: &example.FooArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+},
+D: 0,
+F: "string",
+Foo: &example.FooArgs{
+A: false,
+C: 0,
+E: "string",
+B: false,
+D: 0,
+F: "string",
+},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+component_resource = example.Component("componentResource",
+    a=False,
+    c=0,
+    e="string",
+    b=False,
+    bar=example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    ),
+    baz=[example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    )],
+    baz_map={
+        "string": example.FooArgs(
+            a=False,
+            c=0,
+            e="string",
+            b=False,
+            d=0,
+            f="string",
+        ),
+    },
+    d=0,
+    f="string",
+    foo=example.FooArgs(
+        a=False,
+        c=0,
+        e="string",
+        b=False,
+        d=0,
+        f="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const componentResource = new example.Component("componentResource", {
+    a: false,
+    c: 0,
+    e: "string",
+    b: false,
+    bar: {
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    },
+    baz: [{
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    }],
+    bazMap: {
+        string: {
+            a: false,
+            c: 0,
+            e: "string",
+            b: false,
+            d: 0,
+            f: "string",
+        },
+    },
+    d: 0,
+    f: "string",
+    foo: {
+        a: false,
+        c: 0,
+        e: "string",
+        b: false,
+        d: 0,
+        f: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Component {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -33,13 +279,13 @@ no_edit_this_page: true
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
               <span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+              <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
+              <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
               <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">,</span>
               <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Sequence[FooArgs]]</span> = None<span class="p">,</span>
               <span class="nx">baz_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, FooArgs]]</span> = None<span class="p">,</span>
-              <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
-              <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">f</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>

--- a/tests/testdata/codegen/simple-plain-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create OtherResource Resource {#create}
+## Create OtherResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OtherResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Example.Resource("resourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResource(ctx, "resourceResource", &example.ResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = example.Resource("resourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new example.Resource("resourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create BarResource Resource {#create}
+## Create BarResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of BarResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create FooResource Resource {#create}
+## Create FooResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of FooResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create OtherResource Resource {#create}
+## Create OtherResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OtherResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
@@ -15,7 +15,100 @@ no_edit_this_page: true
 
 
 
-## Create OverlayResource Resource {#create}
+## Create OverlayResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var overlayResourceResource = new Example.OverlayResource("overlayResourceResource", new()
+{
+    Bar = Example.EnumOverlay.SomeEnumValue,
+    Foo = new Example.Inputs.ConfigMapOverlayArgs
+    {
+        Config = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewOverlayResource(ctx, "overlayResourceResource", &example.OverlayResourceArgs{
+	Bar: example.EnumOverlaySomeEnumValue,
+	Foo: &example.ConfigMapOverlayArgs{
+		Config: pulumi.String("string"),
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+overlay_resource_resource = example.OverlayResource("overlayResourceResource",
+    bar=example.EnumOverlay.SOME_ENUM_VALUE,
+    foo=example.ConfigMapOverlayArgs(
+        config="string",
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const overlayResourceResource = new example.OverlayResource("overlayResourceResource", {
+    bar: example.EnumOverlay.SomeEnumValue,
+    foo: {
+        config: "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OverlayResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Example.Resource("resourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResource(ctx, "resourceResource", &example.ResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = example.Resource("resourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new example.Resource("resourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
@@ -15,7 +15,194 @@ no_edit_this_page: true
 
 
 
-## Create TypeUses Resource {#create}
+## Create TypeUses Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var typeUsesResource = new Example.TypeUses("typeUsesResource", new()
+{
+    Bar = new Example.Inputs.SomeOtherObjectArgs
+    {
+        Baz = "string",
+    },
+    Baz = new Example.Inputs.ObjectWithNodeOptionalInputsArgs
+    {
+        Foo = "string",
+        Bar = 0,
+    },
+    Foo = new Example.Inputs.ObjectArgs
+    {
+        Bar = "string",
+        Configs = new[]
+        {
+            new Example.Inputs.ConfigMapArgs
+            {
+                Config = "string",
+            },
+        },
+        Others = new[]
+        {
+            new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            },
+        },
+        StillOthers = 
+        {
+            { "string", new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            } },
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewTypeUses(ctx, "typeUsesResource", &example.TypeUsesArgs{
+	Bar: &example.SomeOtherObjectArgs{
+		Baz: pulumi.String("string"),
+	},
+	Baz: &example.ObjectWithNodeOptionalInputsArgs{
+		Foo: pulumi.String("string"),
+		Bar: pulumi.Int(0),
+	},
+	Foo: &example.ObjectArgs{
+		Bar: pulumi.String("string"),
+		Configs: example.ConfigMapArray{
+			&example.ConfigMapArgs{
+				Config: pulumi.String("string"),
+			},
+		},
+		Others: example.SomeOtherObjectArrayArray{
+			example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+		StillOthers: example.SomeOtherObjectArrayMap{
+			"string": example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+type_uses_resource = example.TypeUses("typeUsesResource",
+    bar=example.SomeOtherObjectArgs(
+        baz="string",
+    ),
+    baz=example.ObjectWithNodeOptionalInputsArgs(
+        foo="string",
+        bar=0,
+    ),
+    foo=example.ObjectArgs(
+        bar="string",
+        configs=[example.ConfigMapArgs(
+            config="string",
+        )],
+        others=[[example.SomeOtherObjectArgs(
+            baz="string",
+        )]],
+        still_others={
+            "string": [example.SomeOtherObjectArgs(
+                baz="string",
+            )],
+        },
+    ))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const typeUsesResource = new example.TypeUses("typeUsesResource", {
+    bar: {
+        baz: "string",
+    },
+    baz: {
+        foo: "string",
+        bar: 0,
+    },
+    foo: {
+        bar: "string",
+        configs: [{
+            config: "string",
+        }],
+        others: [[{
+            baz: "string",
+        }]],
+        stillOthers: {
+            string: [{
+                baz: "string",
+            }],
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of TypeUses {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create BasicResource Resource {#create}
+## Create BasicResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var basicResourceResource = new Example.BasicResource("basicResourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewBasicResource(ctx, "basicResourceResource", &example.BasicResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+basic_resource_resource = example.BasicResource("basicResourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const basicResourceResource = new example.BasicResource("basicResourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of BasicResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create BasicResourceV2 Resource {#create}
+## Create BasicResourceV2 Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var basicResourceV2Resource = new Example.BasicResourceV2("basicResourceV2Resource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewBasicResourceV2(ctx, "basicResourceV2Resource", &example.BasicResourceV2Args{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+basic_resource_v2_resource = example.BasicResourceV2("basicResourceV2Resource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const basicResourceV2Resource = new example.BasicResourceV2("basicResourceV2Resource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of BasicResourceV2 {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create BasicResourceV3 Resource {#create}
+## Create BasicResourceV3 Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var basicResourceV3Resource = new Example.BasicResourceV3("basicResourceV3Resource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewBasicResourceV3(ctx, "basicResourceV3Resource", &example.BasicResourceV3Args{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+basic_resource_v3_resource = example.BasicResourceV3("basicResourceV3Resource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const basicResourceV3Resource = new example.BasicResourceV3("basicResourceV3Resource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of BasicResourceV3 {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-schema-pyproject/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-schema-pyproject/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
@@ -15,7 +15,79 @@ no_edit_this_page: true
 
 
 
-## Create OtherResource Resource {#create}
+## Create OtherResource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of OtherResource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/provider/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
@@ -15,7 +15,84 @@ no_edit_this_page: true
 
 
 
-## Create Resource Resource {#create}
+## Create Resource Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resourceResource = new Example.Resource("resourceResource", new()
+{
+    Bar = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewResource(ctx, "resourceResource", &example.ResourceArgs{
+	Bar: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+resource_resource = example.Resource("resourceResource", bar="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resourceResource = new example.Resource("resourceResource", {bar: "string"});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
@@ -15,7 +15,198 @@ no_edit_this_page: true
 
 
 
-## Create TypeUses Resource {#create}
+## Create TypeUses Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var typeUsesResource = new Example.TypeUses("typeUsesResource", new()
+{
+    Bar = new Example.Inputs.SomeOtherObjectArgs
+    {
+        Baz = "string",
+    },
+    Baz = new Example.Inputs.ObjectWithNodeOptionalInputsArgs
+    {
+        Foo = "string",
+        Bar = 0,
+    },
+    Foo = new Example.Inputs.ObjectArgs
+    {
+        Bar = "string",
+        Configs = new[]
+        {
+            new Example.Inputs.ConfigMapArgs
+            {
+                Config = "string",
+            },
+        },
+        Others = new[]
+        {
+            new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            },
+        },
+        StillOthers = 
+        {
+            { "string", new[]
+            {
+                new Example.Inputs.SomeOtherObjectArgs
+                {
+                    Baz = "string",
+                },
+            } },
+        },
+    },
+    Qux = Example.RubberTreeVariety.Burgundy,
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewTypeUses(ctx, "typeUsesResource", &example.TypeUsesArgs{
+	Bar: &example.SomeOtherObjectArgs{
+		Baz: pulumi.String("string"),
+	},
+	Baz: &example.ObjectWithNodeOptionalInputsArgs{
+		Foo: pulumi.String("string"),
+		Bar: pulumi.Int(0),
+	},
+	Foo: &example.ObjectArgs{
+		Bar: pulumi.String("string"),
+		Configs: example.ConfigMapArray{
+			&example.ConfigMapArgs{
+				Config: pulumi.String("string"),
+			},
+		},
+		Others: example.SomeOtherObjectArrayArray{
+			example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+		StillOthers: example.SomeOtherObjectArrayMap{
+			"string": example.SomeOtherObjectArray{
+				&example.SomeOtherObjectArgs{
+					Baz: pulumi.String("string"),
+				},
+			},
+		},
+	},
+	Qux: example.RubberTreeVarietyBurgundy,
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+type_uses_resource = example.TypeUses("typeUsesResource",
+    bar=example.SomeOtherObjectArgs(
+        baz="string",
+    ),
+    baz=example.ObjectWithNodeOptionalInputsArgs(
+        foo="string",
+        bar=0,
+    ),
+    foo=example.ObjectArgs(
+        bar="string",
+        configs=[example.ConfigMapArgs(
+            config="string",
+        )],
+        others=[[example.SomeOtherObjectArgs(
+            baz="string",
+        )]],
+        still_others={
+            "string": [example.SomeOtherObjectArgs(
+                baz="string",
+            )],
+        },
+    ),
+    qux=example.RubberTreeVariety.BURGUNDY)
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const typeUsesResource = new example.TypeUses("typeUsesResource", {
+    bar: {
+        baz: "string",
+    },
+    baz: {
+        foo: "string",
+        bar: 0,
+    },
+    foo: {
+        bar: "string",
+        configs: [{
+            config: "string",
+        }],
+        others: [[{
+            baz: "string",
+        }]],
+        stillOthers: {
+            string: [{
+                baz: "string",
+            }],
+        },
+    },
+    qux: example.RubberTreeVariety.Burgundy,
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of TypeUses {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/simplified-invokes/docs/provider/_index.md
+++ b/tests/testdata/codegen/simplified-invokes/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
@@ -15,7 +15,97 @@ no_edit_this_page: true
 
 
 
-## Create ExampleServer Resource {#create}
+## Create ExampleServer Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var exampleServerResource = new Example.ExampleServer("exampleServerResource", new()
+{
+    Properties = new Example.Inputs.ServerPropertiesForReplicaArgs
+    {
+        CreateMode = "Replica",
+        Version = "string",
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewExampleServer(ctx, "exampleServerResource", &example.ExampleServerArgs{
+	Properties: example.ServerPropertiesForReplica{
+		CreateMode: "Replica",
+		Version:    "string",
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+example_server_resource = example.ExampleServer("exampleServerResource", properties=example.ServerPropertiesForReplicaArgs(
+    create_mode="Replica",
+    version="string",
+))
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const exampleServerResource = new example.ExampleServer("exampleServerResource", {properties: {
+    createMode: "Replica",
+    version: "string",
+}});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ExampleServer {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/unions-inline/docs/provider/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
@@ -15,7 +15,102 @@ no_edit_this_page: true
 
 
 
-## Create ExampleServer Resource {#create}
+## Create ExampleServer Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var exampleServerResource = new Example.ExampleServer("exampleServerResource", new()
+{
+    PropertiesCollection = new[]
+    {
+        new Example.Inputs.ServerPropertiesForReplicaArgs
+        {
+            CreateMode = "Replica",
+            Version = "string",
+        },
+    },
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := example.NewExampleServer(ctx, "exampleServerResource", &example.ExampleServerArgs{
+	PropertiesCollection: pulumi.Array{
+		example.ServerPropertiesForReplica{
+			CreateMode: "Replica",
+			Version:    "string",
+		},
+	},
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+example_server_resource = example.ExampleServer("exampleServerResource", properties_collection=[example.ServerPropertiesForReplicaArgs(
+    create_mode="Replica",
+    version="string",
+)])
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const exampleServerResource = new example.ExampleServer("exampleServerResource", {propertiesCollection: [{
+    createMode: "Replica",
+    version: "string",
+}]});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of ExampleServer {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/tests/testdata/codegen/unions-inside-arrays/docs/provider/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/urn-id-properties/docs/provider/_index.md
+++ b/tests/testdata/codegen/urn-id-properties/docs/provider/_index.md
@@ -15,6 +15,7 @@ no_edit_this_page: true
 
 
 
+
 ## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>

--- a/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
+++ b/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
@@ -17,7 +17,91 @@ It's fine to use urn and id as input properties
 
 
 
-## Create Res Resource {#create}
+## Create Res Resource
+<div>
+<pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+var resResource = new Urnid.Res("resResource", new()
+{
+    Id = "string",
+    Urn = "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+example, err := urnid.NewRes(ctx, "resResource", &urnid.ResArgs{
+	Id:  pulumi.String("string"),
+	Urn: pulumi.String("string"),
+})
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+res_resource = urnid.Res("resResource",
+    id="string",
+    urn="string")
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+const resResource = new urnid.Res("resResource", {
+    id: "string",
+    urn: "string",
+});
+```
+
+</pulumi-choosable>
+</div>
+
+
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+Coming soon!
+```
+
+</pulumi-choosable>
+</div>
+
+
+## Definition of Res {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>


### PR DESCRIPTION
# Description

This PR is an initial implementation of emitting constructor syntax of resources into the docs for typescript, python, go and csharp. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
