### PR TITLE
Send output values to transforms for dependency tracking

### DIFF
--- a/changelog/pending/20240315--engine--transform-functions-are-sent-output-values-with-property-dependency-information.yaml
+++ b/changelog/pending/20240315--engine--transform-functions-are-sent-output-values-with-property-dependency-information.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: engine
-  description: Transform functions are sent output values with property dependency information
+  description: Send output values with property dependency information to transform functions

--- a/changelog/pending/20240315--engine--transform-functions-are-sent-output-values-with-property-dependency-information.yaml
+++ b/changelog/pending/20240315--engine--transform-functions-are-sent-output-values-with-property-dependency-information.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Transform functions are sent output values with property dependency information


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This engine change is necessary for correct dependency tracking of properties through transform functions.

Unlike other parts of the runtime/provider/engine interface transform functions do not have a property dependencies map sent or returned. Transforms rely entirely on the dependency arrays in output values for their dependency tracking.

This change takes the property dependency map and upgrades all the input properties to be output values tracking those same dependencies (if a property doesn't have any dependencies it doesn't need to be upgraded to an output value).
This upgrade is only done if we're using transform functions, there's currently no need to do this unless we're using transforms.

After running the transforms we downgrade the output values back to plain/secret/computed values if we're registering a custom resource. If we're registering a component resource we just leave all the properties upgraded as output values.
We also rebuild the resources dependencies slice and propertyDependency map with the dependencies recorded in the transformed properties. If the transform didn't change the properties this will just be the same data we encoded into the output values in the properties structure.

There are a couple of things to keep in mind with this change. 

Firstly using a transform can cause a property that was being sent to a component provider as just a `resource.NumberProperty` to start being sent as an `OutputProperty` with the `NumberProperty` as its element. Component providers _should_ handle that, but it's feasible that it could break some component code. This is a fairly limited blast radius as it will only happen when that user starts using a transform function.

Secondly, we can't know in the engine if a property dependencies are from a top level output value or a nested output. That is SDKs send both of the following property shapes the same way to the engine for custom resources:
```
A) Output(Array([Number(1)]), ["dep"])
---
B) Array([Output(Number(1), ["dep"])
```
Currently both would get upgraded to `Output(Array([Number(1)]), ["dep"])`. For a component resource the SDK will send output values, and as long as they define a superset of the dependencies in the property map then we don't add the top-level output tracking the same dependency set.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
