### PR TITLE
mark snapshot tests as non-parallel

### DIFF
--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -548,13 +548,19 @@ func BenchmarkDiffStackRecorded(b *testing.B) {
 	testOrBenchmarkDiffStack(b, benchmarkDiffStack, recordedCases)
 }
 
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func TestDiffStackRecorded(t *testing.T) {
-	t.Parallel()
 	testOrBenchmarkDiffStack(t, testDiffStack, recordedCases)
 }
 
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func TestMarshalDeployment(t *testing.T) {
-	t.Parallel()
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, dynamicCases)
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, recordedCases)
 }


### PR DESCRIPTION
These tests are currently flaky when run in parallel.  Since the proper fix is a bit more involved, and we really want to turn of rerunning tests on failures, make them not run in parallel for the time being.  We'll keep https://github.com/pulumi/pulumi/issues/15461 open to remind us to fix this properly and get them running in parallel again.