### PR TITLE
Revert "Revert "Disable `--rerun-fails` in tests""

### DIFF
--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -89,7 +89,7 @@ if shutil.which('gotestsum') is not None:
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
-    args = ['gotestsum', '--jsonfile', json_file, '--rerun-fails=1', '--packages', pkgs, '--'] + \
+    args = ['gotestsum', '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts
 else:
     args = ['go', 'test'] + args


### PR DESCRIPTION
Reverts pulumi/pulumi#15234 to disable the `--rerun-fails` option again.  We've done quite a bit of work for flaky tests (there's only some rare cases left after https://github.com/pulumi/pulumi/pull/15642 gets merged), so we should be able to disable this option again now, and have it as a forcing function to keep tests non-flaky.