### PR TITLE
Add --yes to state upgrade

### DIFF
--- a/changelog/pending/20240312--cli-state--add-yes-to-state-upgrade.yaml
+++ b/changelog/pending/20240312--cli-state--add-yes-to-state-upgrade.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Add `--yes` to `state upgrade`

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -51,6 +51,7 @@ This only has an effect on DIY backends.
 			return nil
 		}),
 	}
+	cmd.Flags().BoolVarP(&sucmd.yes, "yes", "y", false, "Automatically approve and perform the upgrade")
 	return cmd
 }
 
@@ -59,6 +60,8 @@ type stateUpgradeCmd struct {
 	Stdin  io.Reader // defaults to os.Stdin
 	Stdout io.Writer // defaults to os.Stdout
 	Stderr io.Writer // defaults to os.Stderr
+
+	yes bool
 
 	// Used to mock out the currentBackend function for testing.
 	// Defaults to currentBackend function.
@@ -104,7 +107,7 @@ func (cmd *stateUpgradeCmd) Run(ctx context.Context) error {
 	prompt := "This will upgrade the current backend to the latest supported version.\n" +
 		"Older versions of Pulumi will not be able to read the new format.\n" +
 		"Are you sure you want to proceed?"
-	if !confirmPrompt(prompt, "yes", dopts) {
+	if !cmd.yes && !confirmPrompt(prompt, "yes", dopts) {
 		fmt.Fprintln(cmd.Stdout, "Upgrade cancelled")
 		return nil
 	}

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -111,6 +111,30 @@ func TestStateUpgradeCommand_Run_upgrade(t *testing.T) {
 	assert.True(t, called, "Upgrade was never called")
 }
 
+func TestStateUpgradeCommand_Run_upgrade_yes_flag(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	cmd := stateUpgradeCmd{
+		currentBackend: func(context.Context, *workspace.Project, display.Options) (backend.Backend, error) {
+			return &stubDIYBackend{
+				UpgradeF: func(context.Context, *diy.UpgradeOptions) error {
+					called = true
+					return nil
+				},
+			}, nil
+		},
+		Stdin:  strings.NewReader(""),
+		Stdout: io.Discard,
+	}
+
+	cmd.yes = true
+	err := cmd.Run(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, called, "Upgrade was never called")
+}
+
 func TestStateUpgradeCommand_Run_upgradeRejected(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15646

Small change to add `--yes` to `state upgrade` allowing it to be used in non-interactive environments.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
