### PR TITLE
Make "pulumi dn" an alias for "pulumi destroy"

### DIFF
--- a/changelog/pending/20240312--cli--make-pulumi-dn-an-alias-for-pulumi-destroy.yaml
+++ b/changelog/pending/20240312--cli--make-pulumi-dn-an-alias-for-pulumi-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Make "pulumi dn" an alias for "pulumi destroy"

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -79,7 +79,7 @@ func newDestroyCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        use,
-		Aliases:    []string{"down"},
+		Aliases:    []string{"down", "dn"},
 		SuggestFor: []string{"delete", "kill", "remove", "rm", "stop"},
 		Short:      "Destroy all existing resources in the stack",
 		Long: "Destroy all existing resources in the stack, but not the stack itself\n" +


### PR DESCRIPTION
We already support "down" as an alias for "destroy", which has nice symmetry of "up" => "down". This change goes further by adding "dn" as another alias for "destroy". "dn" is "up" rotated 180 degrees :-)