### PR TITLE
Update descriptions for property types defined in an external package

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1141,7 +1141,6 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
 			extPkgLink := fmt.Sprintf("/registry/packages/%s", packageName)
 			comment += fmt.Sprintf("\nThis type is defined in the [%s](%s) package.", getPackageDisplayName(packageName), extPkgLink)
-			link = ""
 		}
 
 		// Default values for Provider inputs correspond to environment variables, so add that info to the docs.

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1140,7 +1140,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg)
 		if isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
-			comment = fmt.Sprintf("This type is defined in the [%s](https://pulumi.com/registry/packages/%s) package.", getPackageDisplayName(packageName), packageName)
+			comment = fmt.Sprintf("This type is defined in the [%s](/registry/packages/%s) package.", getPackageDisplayName(packageName), packageName)
 			link = ""
 		}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1137,7 +1137,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		// Check if type is defined in a package external to the current package. If
 		// it is external, update comment to indicate to user that type is defined
 		// in another package and link there.
-		if isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg); isExt {
+		if isExt := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg); isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
 			extPkgLink := fmt.Sprintf("/registry/packages/%s", packageName)
 			comment += fmt.Sprintf("\nThis type is defined in the [%s](%s) package.", getPackageDisplayName(packageName), extPkgLink)

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1134,12 +1134,13 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		comment := prop.Comment
 		link := "#" + propID
 
-		// Check if type is defined in a package external to the current pacakge. If
+		// Check if type is defined in a package external to the current package. If
 		// it is external, update comment to indicate to user that type is defined
 		// in another package and link there.
 		if isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg); isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
-			comment = fmt.Sprintf("This type is defined in the [%s](/registry/packages/%s) package.", getPackageDisplayName(packageName), packageName)
+			extPkgLink := fmt.Sprintf("/registry/packages/%s", packageName)
+			comment += fmt.Sprintf("\nThis type is defined in the [%s](%s) package.", getPackageDisplayName(packageName), extPkgLink)
 			link = ""
 		}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1030,7 +1030,6 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 				}
 
 				name := strings.Title(tokenToName(typ.Token))
-				// fmt.Printf("isExternal: %v \n\n", isExternalReference(typ, mod.pkg))
 				typs = append(typs, docNestedType{
 					Name:       wbr(name),
 					AnchorID:   strings.ToLower(name),
@@ -1141,7 +1140,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg)
 		if isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
-			comment = fmt.Sprintf("This type is defined in the [%s](https://pulumi.com/registry/packages/%s) package.", strings.Title(packageName), packageName)
+			comment = fmt.Sprintf("This type is defined in the [%s](https://pulumi.com/registry/packages/%s) package.", getPackageDisplayName(packageName), packageName)
 			link = ""
 		}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1137,8 +1137,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		// Check if type is defined in a package external to the current pacakge. If
 		// it is external, update comment to indicate to user that type is defined
 		// in another package and link there.
-		isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg)
-		if isExt {
+		if isExt, _ := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg); isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
 			comment = fmt.Sprintf("This type is defined in the [%s](/registry/packages/%s) package.", getPackageDisplayName(packageName), packageName)
 			link = ""

--- a/pkg/codegen/docs/utils.go
+++ b/pkg/codegen/docs/utils.go
@@ -107,22 +107,14 @@ func getFunctionLink(name string) string {
 }
 
 // isExternalType checks if the type is external to the given package.
-func isExternalType(t schema.Type, pkg schema.PackageReference) (
-	isExternal bool, token string,
-) {
+func isExternalType(t schema.Type, pkg schema.PackageReference) (isExternal bool) {
 	switch typ := t.(type) {
 	case *schema.ObjectType:
-		isExternal = typ.PackageReference != nil && !codegen.PkgEquals(typ.PackageReference, pkg)
-		token = typ.Token
-		return
+		return typ.PackageReference != nil && !codegen.PkgEquals(typ.PackageReference, pkg)
 	case *schema.ResourceType:
-		isExternal = typ.Resource != nil && pkg != nil && !codegen.PkgEquals(typ.Resource.PackageReference, pkg)
-		token = typ.Token
-		return
+		return typ.Resource != nil && pkg != nil && !codegen.PkgEquals(typ.Resource.PackageReference, pkg)
 	case *schema.EnumType:
-		isExternal = pkg != nil && !codegen.PkgEquals(typ.PackageReference, pkg)
-		token = typ.Token
-		return
+		return pkg != nil && !codegen.PkgEquals(typ.PackageReference, pkg)
 	}
 	return
 }

--- a/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
@@ -236,7 +236,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Core.<wbr>V1.<wbr>Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -258,7 +258,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod<wbr>Type<wbr>Args</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -280,7 +280,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -302,7 +302,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">pulumi<wbr>Kubernetestypesinputcorev1Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -324,7 +324,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod<wbr>Args</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -346,7 +346,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Property Map</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
@@ -227,7 +227,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">Pulumi.<wbr>Google<wbr>Native.<wbr>IAM.<wbr>V1.<wbr>Inputs.<wbr>Audit<wbr>Config</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -241,7 +241,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">Audit<wbr>Config<wbr>Args</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -255,7 +255,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">Audit<wbr>Config</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -269,7 +269,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">pulumi<wbr>Google<wbr>Native.types.input.iam.v1.<wbr>Audit<wbr>Config</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -283,7 +283,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">Audit<wbr>Config<wbr>Args</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -297,7 +297,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#auditconfig">Property Map</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/external-enum/docs/component/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/component/_index.md
@@ -236,7 +236,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Pulumi.<wbr>Google<wbr>Native.<wbr>Accesscontextmanager.<wbr>V1.<wbr>Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -258,7 +258,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -280,7 +280,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -302,7 +302,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">pulumi<wbr>Google<wbr>Nativeaccesscontextmanagerv1Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -324,7 +324,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -346,7 +346,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">&#34;MANAGEMENT_UNSPECIFIED&#34; | &#34;NONE&#34; | &#34;BASIC&#34; | &#34;COMPLETE&#34;</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/google-native">Google Cloud Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/external-resource-schema/docs/argfunction/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/argfunction/_index.md
@@ -110,7 +110,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -124,7 +124,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -138,7 +138,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -152,7 +152,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -166,7 +166,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -180,7 +180,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
@@ -513,7 +513,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
@@ -545,7 +545,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
@@ -575,7 +575,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
@@ -607,7 +607,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
@@ -637,7 +637,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_java" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
@@ -669,7 +669,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_java" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
@@ -699,7 +699,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
@@ -731,7 +731,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
@@ -761,7 +761,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="required_name_array_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_name_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>array</a>
@@ -793,7 +793,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="name_array_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_array_python" style="color: inherit; text-decoration: inherit;">name_<wbr>array</a>
@@ -823,7 +823,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
@@ -855,7 +855,7 @@ Pet<pulumi-choosable type="language" values="python,go" class="inline">, Pet<wbr
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_yaml" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>

--- a/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
@@ -232,7 +232,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
@@ -256,7 +256,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
@@ -286,7 +286,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
@@ -310,7 +310,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
@@ -340,7 +340,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_java" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
@@ -364,7 +364,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_java" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
@@ -394,7 +394,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
@@ -418,7 +418,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
@@ -448,7 +448,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="required_metadata_array_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_metadata_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>array</a>
@@ -472,7 +472,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_array_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_array_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>array</a>
@@ -502,7 +502,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Property Map</a></span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_yaml" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
@@ -526,7 +526,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Property Map</a></span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_yaml" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
@@ -571,7 +571,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Aws.<wbr>Ec2.<wbr>Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_csharp" style="color: inherit; text-decoration: inherit;">Provider</a>
@@ -579,7 +579,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Kubernetes.<wbr>Provider</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storageclasses_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_csharp" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
@@ -609,7 +609,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_go" style="color: inherit; text-decoration: inherit;">Provider</a>
@@ -617,7 +617,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storageclasses_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_go" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
@@ -647,7 +647,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_java" style="color: inherit; text-decoration: inherit;">provider</a>
@@ -655,7 +655,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storageclasses_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_java" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>
@@ -685,7 +685,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Awsec2Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
@@ -693,7 +693,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Kubernetes<wbr>Provider</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storageclasses_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_nodejs" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>
@@ -723,7 +723,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_python" style="color: inherit; text-decoration: inherit;">provider</a>
@@ -731,7 +731,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storage_classes_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storage_classes_python" style="color: inherit; text-decoration: inherit;">storage_<wbr>classes</a>
@@ -761,7 +761,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">aws:ec2:Security<wbr>Group</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="provider_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_yaml" style="color: inherit; text-decoration: inherit;">provider</a>
@@ -769,7 +769,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi:providers:kubernetes</span>
     </dt>
-    <dd></dd><dt class="property-"
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd><dt class="property-"
             title="">
         <span id="storageclasses_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_yaml" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>

--- a/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
@@ -277,7 +277,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Outputs.<wbr>Core.<wbr>V1.<wbr>Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -299,7 +299,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod<wbr>Type</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -321,7 +321,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -343,7 +343,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">pulumi<wbr>Kubernetestypesoutputcorev1Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -365,7 +365,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -387,7 +387,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Property Map</a></span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/kubernetes">Kubernetes</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
@@ -227,7 +227,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Resources.<wbr>Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -241,7 +242,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -255,7 +257,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -269,7 +272,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativeresources<wbr>Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -283,7 +287,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -297,7 +302,8 @@ The RegistryGeoReplication resource accepts the following [input](/docs/intro/co
         <span class="property-indicator"></span>
         <span class="property-type">azure-native:resources:Resource<wbr>Group</span>
     </dt>
-    <dd>The resource group that hosts the component resource</dd></dl>
+    <dd>The resource group that hosts the component resource
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -326,7 +332,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Container<wbr>Registry.<wbr>Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_csharp" style="color: inherit; text-decoration: inherit;">Replication</a>
@@ -334,7 +341,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Container<wbr>Registry.<wbr>Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -356,7 +364,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_go" style="color: inherit; text-decoration: inherit;">Replication</a>
@@ -364,7 +373,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -386,7 +396,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_java" style="color: inherit; text-decoration: inherit;">replication</a>
@@ -394,7 +405,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -416,7 +428,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativecontainerregistry<wbr>Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_nodejs" style="color: inherit; text-decoration: inherit;">replication</a>
@@ -424,7 +437,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativecontainerregistry<wbr>Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -446,7 +460,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_python" style="color: inherit; text-decoration: inherit;">replication</a>
@@ -454,7 +469,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -476,7 +492,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">azure-native:containerregistry:Registry</span>
     </dt>
-    <dd>The Registry</dd><dt class="property-"
+    <dd>The Registry
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd><dt class="property-"
             title="">
         <span id="replication_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_yaml" style="color: inherit; text-decoration: inherit;">replication</a>
@@ -484,7 +501,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">azure-native:containerregistry:Replication</span>
     </dt>
-    <dd>The replication policy</dd></dl>
+    <dd>The replication policy
+This type is defined in the <a href="/registry/packages/azure-native">Azure Native</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
@@ -453,7 +453,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Tls.<wbr>Provider</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -475,7 +475,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -497,7 +497,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -519,7 +519,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Tls<wbr>Provider</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -541,7 +541,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 
@@ -563,7 +563,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi:providers:tls</span>
     </dt>
-    <dd></dd></dl>
+    <dd>This type is defined in the <a href="/registry/packages/pulumi">pulumi</a> package.</dd></dl>
 </pulumi-choosable>
 </div>
 

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
@@ -367,7 +367,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Aws.<wbr>S3.<wbr>Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="websiteurl_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_csharp" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
@@ -389,7 +390,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="websiteurl_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_go" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
@@ -411,7 +413,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="websiteurl_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_java" style="color: inherit; text-decoration: inherit;">website<wbr>Url</a>
@@ -433,7 +436,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Awss3Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="websiteurl_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_nodejs" style="color: inherit; text-decoration: inherit;">website<wbr>Url</a>
@@ -455,7 +459,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="website_url_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#website_url_python" style="color: inherit; text-decoration: inherit;">website_<wbr>url</a>
@@ -477,7 +482,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">aws:s3:Bucket</span>
     </dt>
-    <dd>The bucket resource.</dd><dt class="property-"
+    <dd>The bucket resource.
+This type is defined in the <a href="/registry/packages/aws">AWS Classic</a> package.</dd><dt class="property-"
             title="">
         <span id="websiteurl_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_yaml" style="color: inherit; text-decoration: inherit;">website<wbr>Url</a>

--- a/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
@@ -382,7 +382,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
@@ -430,7 +430,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
@@ -438,7 +438,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_csharp">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
@@ -484,7 +484,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
@@ -532,7 +532,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
@@ -540,7 +540,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_go">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
@@ -586,7 +586,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_java" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Required</a>
@@ -634,7 +634,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_java" style="color: inherit; text-decoration: inherit;">name<wbr>Plain</a>
@@ -642,7 +642,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_java">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_java" style="color: inherit; text-decoration: inherit;">string<wbr>Value</a>
@@ -688,7 +688,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Required</a>
@@ -736,7 +736,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Plain</a>
@@ -744,7 +744,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_nodejs">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value</a>
@@ -790,7 +790,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_string_value_required_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_string_value_required_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value_<wbr>required</a>
@@ -838,7 +838,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_plain_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_plain_python" style="color: inherit; text-decoration: inherit;">name_<wbr>plain</a>
@@ -846,7 +846,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_string_value_python">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_string_value_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value</a>
@@ -892,7 +892,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-required"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_yaml" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Required</a>
@@ -940,7 +940,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_yaml" style="color: inherit; text-decoration: inherit;">name<wbr>Plain</a>
@@ -948,7 +948,7 @@ The following arguments are supported:
         <span class="property-indicator"></span>
         <span class="property-type">random:Random<wbr>Pet</span>
     </dt>
-    <dd></dd><dt class="property-optional"
+    <dd>This type is defined in the <a href="/registry/packages/random">random</a> package.</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_yaml">
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_yaml" style="color: inherit; text-decoration: inherit;">string<wbr>Value</a>


### PR DESCRIPTION
intermediary fix for: https://github.com/pulumi/pulumi/issues/12765

For types that are defined in an external package, we do not render a description and its links are broken. This is an intermediary solution until we can render out nested types defined in external packages on the page or derive the resource page in the external package that contains the type definition. This PR identifies if a property type is externally defined and places a message indicating the type is defined externally in the description field.

<img width="764" alt="Screen Shot 2024-03-13 at 10 10 26 AM" src="https://github.com/pulumi/pulumi/assets/16751381/4be9a771-d3a0-4930-8469-d54f3b5e4e54">

<img width="747" alt="Screen Shot 2024-03-13 at 10 03 54 AM" src="https://github.com/pulumi/pulumi/assets/16751381/45312baa-4929-434c-829a-a5e6494afad8">

