### PR TITLE
improve error message when gRPC fails

### DIFF
--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -107,7 +107,17 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
                 }
 
                 if (errorSet.size !== 0 || log.hasErrors()) {
-                    throw new Error("One or more errors occurred");
+                    let errorMessage: string = "";
+                    if (errorSet.size !== 0) {
+                        errorMessage = ": ";
+                        errorSet.forEach((error) => {
+                            errorMessage += `${error.message}, `;
+                        });
+                        errorMessage = errorMessage.slice(0, -2);
+                    } else {
+                        errorMessage = ". Check logs for more details";
+                    }
+                    throw new Error(`One or more errors occurred${errorMessage}`);
                 }
             } catch (e) {
                 const err = e instanceof Error ? e : new Error(`unknown error ${e}`);


### PR DESCRIPTION
Currently when there are errors we just say "one or more errors occurred", without anymore explanation.  Actually print the error which will help when debugging issues here.

This would have helped debug https://github.com/pulumi/pulumi/issues/15239.