### PR TITLE
[sdkgen/python] Replace-on-changes values should be camelCased

### DIFF
--- a/changelog/pending/20240313--sdkgen-python--replace-on-changes-values-should-be-camelcased-not-kebab_cased.yaml
+++ b/changelog/pending/20240313--sdkgen-python--replace-on-changes-values-should-be-camelcased-not-kebab_cased.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Replace-on-changes values should be camelCased not kebab_cased

--- a/changelog/pending/20240313--sdkgen-python--replace-on-changes-values-should-be-camelcased-not-kebab_cased.yaml
+++ b/changelog/pending/20240313--sdkgen-python--replace-on-changes-values-should-be-camelcased-not-kebab_cased.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdkgen/python
-  description: Replace-on-changes values should be camelCased not kebab_cased
+  description: Make replace-on-changes values camelCased not kebab_cased

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1435,7 +1435,8 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		cmdutil.Diag().Warningf(&diag.Diag{Message: err.Error()})
 	}
 	if len(replaceOnChangesProps) > 0 {
-		replaceOnChangesStrings := schema.PropertyListJoinToString(replaceOnChangesProps, PyName)
+		replaceOnChangesStrings := schema.PropertyListJoinToString(replaceOnChangesProps,
+			func(x string) string { return x })
 		fmt.Fprintf(w, `        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["%s"])`, strings.Join(replaceOnChangesStrings, `", "`))
 		fmt.Fprintf(w, "\n        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)\n")
 	}

--- a/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
@@ -279,8 +279,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_csharp">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_csharp" style="color: inherit; text-decoration: inherit;">Replace</a>
+        <span id="replaceme_csharp">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replaceme_csharp" style="color: inherit; text-decoration: inherit;">Replace<wbr>Me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -309,8 +309,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_go">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_go" style="color: inherit; text-decoration: inherit;">Replace</a>
+        <span id="replaceme_go">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replaceme_go" style="color: inherit; text-decoration: inherit;">Replace<wbr>Me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -339,8 +339,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_java">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_java" style="color: inherit; text-decoration: inherit;">replace</a>
+        <span id="replaceme_java">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replaceme_java" style="color: inherit; text-decoration: inherit;">replace<wbr>Me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>
@@ -369,8 +369,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_nodejs">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_nodejs" style="color: inherit; text-decoration: inherit;">replace</a>
+        <span id="replaceme_nodejs">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replaceme_nodejs" style="color: inherit; text-decoration: inherit;">replace<wbr>Me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -399,8 +399,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_python">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_python" style="color: inherit; text-decoration: inherit;">replace</a>
+        <span id="replace_me_python">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_me_python" style="color: inherit; text-decoration: inherit;">replace_<wbr>me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -429,8 +429,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd></dd><dt class="property- property-replacement"
             title="">
-        <span id="replace_yaml">
-<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_yaml" style="color: inherit; text-decoration: inherit;">replace</a>
+        <span id="replaceme_yaml">
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replaceme_yaml" style="color: inherit; text-decoration: inherit;">replace<wbr>Me</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">String</span>

--- a/tests/testdata/codegen/replace-on-change/dotnet/NoRecursive.cs
+++ b/tests/testdata/codegen/replace-on-change/dotnet/NoRecursive.cs
@@ -15,8 +15,8 @@ namespace Pulumi.Example
         [Output("rec")]
         public Output<Outputs.Rec?> Rec { get; private set; } = null!;
 
-        [Output("replace")]
-        public Output<string?> Replace { get; private set; } = null!;
+        [Output("replaceMe")]
+        public Output<string?> ReplaceMe { get; private set; } = null!;
 
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Pulumi.Example
                 Version = Utilities.Version,
                 ReplaceOnChanges =
                 {
-                    "replace",
+                    "replaceMe",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);

--- a/tests/testdata/codegen/replace-on-change/go/example/noRecursive.go
+++ b/tests/testdata/codegen/replace-on-change/go/example/noRecursive.go
@@ -14,8 +14,8 @@ import (
 type NoRecursive struct {
 	pulumi.CustomResourceState
 
-	Rec     RecPtrOutput           `pulumi:"rec"`
-	Replace pulumi.StringPtrOutput `pulumi:"replace"`
+	Rec       RecPtrOutput           `pulumi:"rec"`
+	ReplaceMe pulumi.StringPtrOutput `pulumi:"replaceMe"`
 }
 
 // NewNoRecursive registers a new resource with the given unique name, arguments, and options.
@@ -26,7 +26,7 @@ func NewNoRecursive(ctx *pulumi.Context,
 	}
 
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
-		"replace",
+		"replaceMe",
 	})
 	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
@@ -159,8 +159,8 @@ func (o NoRecursiveOutput) Rec() RecPtrOutput {
 	return o.ApplyT(func(v *NoRecursive) RecPtrOutput { return v.Rec }).(RecPtrOutput)
 }
 
-func (o NoRecursiveOutput) Replace() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *NoRecursive) pulumi.StringPtrOutput { return v.Replace }).(pulumi.StringPtrOutput)
+func (o NoRecursiveOutput) ReplaceMe() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *NoRecursive) pulumi.StringPtrOutput { return v.ReplaceMe }).(pulumi.StringPtrOutput)
 }
 
 type NoRecursiveArrayOutput struct{ *pulumi.OutputState }

--- a/tests/testdata/codegen/replace-on-change/nodejs/noRecursive.ts
+++ b/tests/testdata/codegen/replace-on-change/nodejs/noRecursive.ts
@@ -34,7 +34,7 @@ export class NoRecursive extends pulumi.CustomResource {
     }
 
     public /*out*/ readonly rec!: pulumi.Output<outputs.Rec | undefined>;
-    public /*out*/ readonly replace!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly replaceMe!: pulumi.Output<string | undefined>;
 
     /**
      * Create a NoRecursive resource with the given unique name, arguments, and options.
@@ -48,13 +48,13 @@ export class NoRecursive extends pulumi.CustomResource {
         opts = opts || {};
         if (!opts.id) {
             resourceInputs["rec"] = undefined /*out*/;
-            resourceInputs["replace"] = undefined /*out*/;
+            resourceInputs["replaceMe"] = undefined /*out*/;
         } else {
             resourceInputs["rec"] = undefined /*out*/;
-            resourceInputs["replace"] = undefined /*out*/;
+            resourceInputs["replaceMe"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const replaceOnChanges = { replaceOnChanges: ["replace"] };
+        const replaceOnChanges = { replaceOnChanges: ["replaceMe"] };
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(NoRecursive.__pulumiType, name, resourceInputs, opts);
     }

--- a/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/tests/testdata/codegen/replace-on-change/python/pulumi_example/no_recursive.py
@@ -65,8 +65,8 @@ class NoRecursive(pulumi.CustomResource):
             __props__ = NoRecursiveArgs.__new__(NoRecursiveArgs)
 
             __props__.__dict__["rec"] = None
-            __props__.__dict__["replace"] = None
-        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["replace"])
+            __props__.__dict__["replace_me"] = None
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["replaceMe"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(NoRecursive, __self__).__init__(
             'example::NoRecursive',
@@ -91,7 +91,7 @@ class NoRecursive(pulumi.CustomResource):
         __props__ = NoRecursiveArgs.__new__(NoRecursiveArgs)
 
         __props__.__dict__["rec"] = None
-        __props__.__dict__["replace"] = None
+        __props__.__dict__["replace_me"] = None
         return NoRecursive(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -100,7 +100,7 @@ class NoRecursive(pulumi.CustomResource):
         return pulumi.get(self, "rec")
 
     @property
-    @pulumi.getter
-    def replace(self) -> pulumi.Output[Optional[str]]:
-        return pulumi.get(self, "replace")
+    @pulumi.getter(name="replaceMe")
+    def replace_me(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "replace_me")
 

--- a/tests/testdata/codegen/replace-on-change/schema.json
+++ b/tests/testdata/codegen/replace-on-change/schema.json
@@ -7,7 +7,7 @@
         "rec": {
           "$ref": "#/types/example::Rec"
         },
-        "replace": {
+        "replaceMe": {
           "type": "string",
           "replaceOnChanges": true
         }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

When replaceOnChanges is set in the schema for a property with a multi-word name, currently, Python SDK generation incorrectly puts its Python name into replace_on_changes.

This is wrong, because these property names are passed to the engine and they should be engine names (i.e. schema names). All other languages (Node.js, .NET, Go) do this correctly.

This PR adds a test case and fixes the Python generation to use the same naming as all other SDKs.

Fixes #15665

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
