### PR TITLE
add .cov files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 **/.DS_Store
 coverage.cov
 *.coverprofile
+*.cov
 **/obj/
 coverage/
 venv/


### PR DESCRIPTION
These are being produced e.g. when running `make` in sdk/nodejs. Probably in other places as well, but that's where I noticed them.  We never want them in version control, so let's add them to the `.gitignore`.