### PR TITLE
Move resource.URN to urn.URN

### DIFF
--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -4230,6 +4230,7 @@ func TestTimestampTracking(t *testing.T) {
 		assert.Equal(t, creationTimes[resource.URN], *resource.Created,
 			"created time changed: %v", resource.URN)
 
+		//exhaustive:ignore
 		switch resource.Type {
 		case "pkgA:m:typA":
 			tz, _ := resource.Modified.Zone()

--- a/pkg/operations/operations_aws.go
+++ b/pkg/operations/operations_aws.go
@@ -120,6 +120,7 @@ const (
 func (ops *awsOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	state := ops.component.State
 	logging.V(6).Infof("GetLogs[%v]", state.URN)
+	//exhaustive:ignore
 	switch state.Type {
 	case awsFunctionType:
 		functionName := state.Outputs["name"].StringValue()

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -60,6 +60,7 @@ const (
 func (ops *cloudOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	state := ops.component.State
 	logging.V(6).Infof("GetLogs[%v]", state.URN)
+	//exhaustive:ignore
 	switch state.Type {
 	case cloudFunctionType:
 		// We get the aws:lambda/function:Function child and request it's logs, parsing out the

--- a/pkg/operations/operations_gcp.go
+++ b/pkg/operations/operations_gcp.go
@@ -72,6 +72,7 @@ const (
 func (ops *gcpOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	state := ops.component.State
 	logging.V(6).Infof("GetLogs[%v]", state.URN)
+	//exhaustive:ignore
 	switch state.Type {
 	case gcpFunctionType:
 		return ops.getFunctionLogs(state, query)

--- a/sdk/go/common/resource/urn/urn.go
+++ b/sdk/go/common/resource/urn/urn.go
@@ -1,0 +1,200 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package urn
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// URN is a friendly, but unique, URN for a resource, most often auto-assigned by Pulumi.  These are
+// used as unique IDs for objects, and help us to perform graph diffing and resolution of resource
+// objects.
+//
+// In theory, we could support manually assigned URIs in the future.  For the time being, however,
+// we have opted to simplify developers' lives by mostly automating the generation of them
+// algorithmically.  The one caveat where it isn't truly automatic is that a developer -- or
+// resource provider -- must provide a semi-unique name part.
+//
+// Each resource URN is of the form:
+//
+//	urn:pulumi:<Stack>::<Project>::<Qualified$Type$Name>::<Name>
+//
+// wherein each element is the following:
+//
+//	<Stack>                 The stack being deployed into
+//	<Project>               The project being evaluated
+//	<Qualified$Type$Name>   The object type's qualified type token (including the parent type)
+//	<Name>                  The human-friendly name identifier assigned by the developer or provider
+//
+// In the future, we may add elements to the URN; it is more important that it is unique than it is
+// human-typable.
+type URN string
+
+const (
+	Prefix        = "urn:" + NamespaceID + ":" // the standard URN prefix
+	NamespaceID   = "pulumi"                   // the URN namespace
+	NameDelimiter = "::"                       // the delimiter between URN name elements
+	TypeDelimiter = "$"                        // the delimiter between URN type elements
+)
+
+// Parse attempts to parse a string into a URN returning an error if it's not valid.
+func Parse(s string) (URN, error) {
+	if s == "" {
+		return "", errors.New("missing required URN")
+	}
+
+	urn := URN(s)
+	if !urn.IsValid() {
+		return "", fmt.Errorf("invalid URN %q", s)
+	}
+	return urn, nil
+}
+
+// ParseOptional is the same as Parse except it will allow the empty string.
+func ParseOptional(s string) (URN, error) {
+	if s == "" {
+		return "", nil
+	}
+	return Parse(s)
+}
+
+// New creates a unique resource URN for the given resource object.
+func New(stack tokens.QName, proj tokens.PackageName, parentType, baseType tokens.Type, name string) URN {
+	typ := string(baseType)
+	if parentType != "" && parentType != tokens.RootStackType {
+		typ = string(parentType) + TypeDelimiter + typ
+	}
+
+	return URN(
+		Prefix +
+			string(stack) +
+			NameDelimiter + string(proj) +
+			NameDelimiter + typ +
+			NameDelimiter + name,
+	)
+}
+
+// Quote returns the quoted form of the URN appropriate for use as a command line argument for the current OS.
+func (urn URN) Quote() string {
+	quote := `'`
+	if runtime.GOOS == "windows" {
+		// Windows uses double-quotes instead of single-quotes.
+		quote = `"`
+	}
+	return quote + string(urn) + quote
+}
+
+// IsValid returns true if the URN is well-formed.
+func (urn URN) IsValid() bool {
+	if !strings.HasPrefix(string(urn), Prefix) {
+		return false
+	}
+
+	return strings.Count(string(urn), NameDelimiter) >= 3
+	// TODO: We should validate the stack, project and type tokens here, but currently those fields might not
+	// actually be "valid" (e.g. spaces in project names, custom component types, etc).
+}
+
+// URNName returns the URN name part of a URN (i.e., strips off the prefix).
+func (urn URN) URNName() string {
+	s := string(urn)
+	contract.Assertf(strings.HasPrefix(s, Prefix), "Urn is: '%s'", string(urn))
+	return s[len(Prefix):]
+}
+
+// Stack returns the resource stack part of a URN.
+func (urn URN) Stack() tokens.QName {
+	return tokens.QName(getComponent(urn.URNName(), NameDelimiter, 0))
+}
+
+// Project returns the project name part of a URN.
+func (urn URN) Project() tokens.PackageName {
+	return tokens.PackageName(getComponent(urn.URNName(), NameDelimiter, 1))
+}
+
+// QualifiedType returns the resource type part of a URN including the parent type
+func (urn URN) QualifiedType() tokens.Type {
+	return tokens.Type(getComponent(urn.URNName(), NameDelimiter, 2))
+}
+
+// Gets the n'th delimited component of a string.
+//
+// This is used instead of the `strings.Split(string, delimiter)[index]` pattern which
+// is inefficient.
+func getComponent(input string, delimiter string, index int) string {
+	return getComponentN(input, delimiter, index, false)
+}
+
+// This gets the n'th delimited compnent of a string, and optionally the rest of the string
+//
+// If the *open* parameter is true, then this will return everything after the n-1th delimiter
+func getComponentN(input string, delimiter string, index int, open bool) string {
+	if open && index == 0 {
+		return input
+	}
+	nameDelimiters := 0
+	partStart := 0
+	for i := 0; i < len(input); i++ {
+		if strings.HasPrefix(input[i:], delimiter) {
+			nameDelimiters++
+			if nameDelimiters == index {
+				i += len(delimiter)
+				partStart = i
+				if open {
+					return input[partStart:]
+				}
+				i--
+			} else if nameDelimiters > index {
+				return input[partStart:i]
+			} else {
+				i += len(delimiter) - 1
+			}
+		}
+	}
+	return input[partStart:]
+}
+
+// Type returns the resource type part of a URN
+func (urn URN) Type() tokens.Type {
+	name := urn.URNName()
+	qualifiedType := getComponent(name, NameDelimiter, 2)
+
+	lastTypeDelimiter := strings.LastIndex(qualifiedType, TypeDelimiter)
+	return tokens.Type(qualifiedType[lastTypeDelimiter+1:])
+}
+
+// Name returns the resource name part of a URN.
+func (urn URN) Name() string {
+	return getComponentN(urn.URNName(), NameDelimiter, 3, true)
+}
+
+// Returns a new URN with an updated name part
+func (urn URN) Rename(newName string) URN {
+	return New(
+		urn.Stack(),
+		urn.Project(),
+		// parent type is empty because
+		// assuming the qualified type already includes it
+		"",
+		urn.QualifiedType(),
+		newName,
+	)
+}

--- a/sdk/go/common/resource/urn/urn_test.go
+++ b/sdk/go/common/resource/urn/urn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package resource
+package urn_test
 
 import (
 	"runtime"
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
@@ -32,7 +33,7 @@ func TestURNRoundTripping(t *testing.T) {
 	parentType := tokens.Type("")
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
 	name := "a-swell-resource"
-	urn := NewURN(stack, proj, parentType, typ, name)
+	urn := urn.New(stack, proj, parentType, typ, name)
 	assert.Equal(t, stack, urn.Stack())
 	assert.Equal(t, proj, urn.Project())
 	assert.Equal(t, typ, urn.QualifiedType())
@@ -48,7 +49,7 @@ func TestURNRoundTripping2(t *testing.T) {
 	parentType := tokens.Type("parent$type")
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
 	name := "a-swell-resource"
-	urn := NewURN(stack, proj, parentType, typ, name)
+	urn := urn.New(stack, proj, parentType, typ, name)
 	assert.Equal(t, stack, urn.Stack())
 	assert.Equal(t, proj, urn.Project())
 	assert.Equal(t, tokens.Type("parent$type$bang:boom/fizzle:MajorResource"), urn.QualifiedType())
@@ -64,7 +65,7 @@ func TestURNRoundTripping3(t *testing.T) {
 	parentType := tokens.Type("parent$type")
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
 	name := "a-swell-resource::with_awkward$names"
-	urn := NewURN(stack, proj, parentType, typ, name)
+	urn := urn.New(stack, proj, parentType, typ, name)
 	assert.Equal(t, stack, urn.Stack())
 	assert.Equal(t, proj, urn.Project())
 	assert.Equal(t, tokens.Type("parent$type$bang:boom/fizzle:MajorResource"), urn.QualifiedType())
@@ -83,7 +84,7 @@ func TestIsValid(t *testing.T) {
 		"urn:pulumi:stack::project with whitespace::type::some name",
 	}
 	for _, str := range goodUrns {
-		urn := URN(str)
+		urn := urn.URN(str)
 		assert.True(t, urn.IsValid(), "IsValid expected to be true: %v", urn)
 	}
 }
@@ -107,7 +108,7 @@ func TestComponentAccess(t *testing.T) {
 		}
 
 		for _, test := range cases {
-			urn, err := ParseURN(test.urn)
+			urn, err := urn.Parse(test.urn)
 			require.NoError(t, err)
 			require.Equal(t, test.urn, string(urn))
 
@@ -127,7 +128,7 @@ func TestComponentAccess(t *testing.T) {
 		}
 
 		for _, test := range cases {
-			urn, err := ParseURN(test.urn)
+			urn, err := urn.Parse(test.urn)
 			require.NoError(t, err)
 			require.Equal(t, test.urn, string(urn))
 
@@ -147,7 +148,7 @@ func TestComponentAccess(t *testing.T) {
 		}
 
 		for _, test := range cases {
-			urn, err := ParseURN(test.urn)
+			urn, err := urn.Parse(test.urn)
 			require.NoError(t, err)
 			require.Equal(t, test.urn, string(urn))
 
@@ -171,7 +172,7 @@ func TestComponentAccess(t *testing.T) {
 		}
 
 		for _, test := range cases {
-			urn, err := ParseURN(test.urn)
+			urn, err := urn.Parse(test.urn)
 			require.NoError(t, err)
 			require.Equal(t, test.urn, string(urn))
 
@@ -207,7 +208,7 @@ func TestComponentAccess(t *testing.T) {
 		}
 
 		for _, test := range cases {
-			urn, err := ParseURN(test.urn)
+			urn, err := urn.Parse(test.urn)
 			require.NoError(t, err)
 			require.Equal(t, test.urn, string(urn))
 
@@ -217,7 +218,7 @@ func TestComponentAccess(t *testing.T) {
 	})
 }
 
-func TestParseURN(t *testing.T) {
+func TestURNParse(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Positive Tests", func(t *testing.T) {
@@ -231,7 +232,7 @@ func TestParseURN(t *testing.T) {
 			"urn:pulumi:stack::project with whitespace::type::some name",
 		}
 		for _, str := range goodUrns {
-			urn, err := ParseURN(str)
+			urn, err := urn.Parse(str)
 			assert.NoErrorf(t, err, "Expecting %v to parse as a good urn", str)
 			assert.Equal(t, str, string(urn), "A parsed URN should be the same as the string that it was parsed from")
 		}
@@ -243,7 +244,7 @@ func TestParseURN(t *testing.T) {
 		t.Run("Empty String", func(t *testing.T) {
 			t.Parallel()
 
-			urn, err := ParseURN("")
+			urn, err := urn.Parse("")
 			assert.ErrorContains(t, err, "missing required URN")
 			assert.Empty(t, urn)
 		})
@@ -258,7 +259,7 @@ func TestParseURN(t *testing.T) {
 				"urn:pulumi:stack::too-few-elements",
 			}
 			for _, str := range invalidUrns {
-				urn, err := ParseURN(str)
+				urn, err := urn.Parse(str)
 				assert.ErrorContainsf(t, err, "invalid URN", "Expecting %v to parse as an invalid urn")
 				assert.Empty(t, urn)
 			}
@@ -281,7 +282,7 @@ func TestParseOptionalURN(t *testing.T) {
 			"",
 		}
 		for _, str := range goodUrns {
-			urn, err := ParseOptionalURN(str)
+			urn, err := urn.ParseOptional(str)
 			assert.NoErrorf(t, err, "Expecting '%v' to parse as a good urn", str)
 			assert.Equal(t, str, string(urn))
 		}
@@ -297,7 +298,7 @@ func TestParseOptionalURN(t *testing.T) {
 			"urn:pulumi:stack::too-few-elements",
 		}
 		for _, str := range invalidUrns {
-			urn, err := ParseOptionalURN(str)
+			urn, err := urn.ParseOptional(str)
 			assert.ErrorContainsf(t, err, "invalid URN", "Expecting %v to parse as an invalid urn")
 			assert.Empty(t, urn)
 		}
@@ -307,7 +308,7 @@ func TestParseOptionalURN(t *testing.T) {
 func TestQuote(t *testing.T) {
 	t.Parallel()
 
-	urn, err := ParseURN("urn:pulumi:test::test::pulumi:pulumi:Stack::test-test")
+	urn, err := urn.Parse("urn:pulumi:test::test::pulumi:pulumi:Stack::test-test")
 	require.NoError(t, err)
 	require.NotEmpty(t, urn)
 
@@ -328,11 +329,11 @@ func TestRename(t *testing.T) {
 	typ := tokens.Type("bang:boom/fizzle:MajorResource")
 	name := "a-swell-resource"
 
-	urn := NewURN(stack, proj, parentType, typ, name)
-	renamed := urn.Rename("a-better-resource")
+	oldURN := urn.New(stack, proj, parentType, typ, name)
+	renamed := oldURN.Rename("a-better-resource")
 
-	assert.NotEqual(t, urn, renamed)
+	assert.NotEqual(t, oldURN, renamed)
 	assert.Equal(t,
-		NewURN(stack, proj, parentType, typ, "a-better-resource"),
+		urn.New(stack, proj, parentType, typ, "a-better-resource"),
 		renamed)
 }

--- a/sdk/go/common/tokens/stack_type.go
+++ b/sdk/go/common/tokens/stack_type.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package resource
-
-import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-)
+package tokens
 
 // RootStackType is the type name that will be used for the root component in the Pulumi resource tree.
-const RootStackType tokens.Type = tokens.RootStackType
-
-// DefaultRootStackURN constructs a default root stack URN for the given stack and project.
-func DefaultRootStackURN(stack tokens.QName, proj tokens.PackageName) URN {
-	return NewURN(stack, proj, "", RootStackType, string(proj)+"-"+string(stack))
-}
+const RootStackType Type = "pulumi:pulumi:Stack"


### PR DESCRIPTION
This change follows on https://github.com/pulumi/pulumi/pull/15157, to allow https://github.com/pulumi/pulumi/pull/15145 to be imported by `resource`. This is the last module import cycle change necessary for `resource` to import `property` (as in https://github.com/pulumi/pulumi/pull/15145).

Like https://github.com/pulumi/pulumi/pull/15157, this change is *100% backwards* compatible.