### PR TITLE
Add context.Context to transform functions

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -392,7 +392,7 @@ func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback
 			Opts:   opts,
 		}
 
-		res := t(args)
+		res := t(innerCtx, args)
 		rpcRes := &pulumirpc.TransformResponse{
 			Properties: nil,
 			Options:    nil,

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -14,6 +14,8 @@
 
 package pulumi
 
+import "golang.org/x/net/context"
+
 // XResourceTransformArgs is the argument bag passed to a resource transform.
 //
 // Experimental.
@@ -50,4 +52,4 @@ type XResourceTransformResult struct {
 // this indicates that the resource will not be transformed.
 //
 // Experimental.
-type XResourceTransform func(*XResourceTransformArgs) *XResourceTransformResult
+type XResourceTransform func(context.Context, *XResourceTransformArgs) *XResourceTransformResult

--- a/tests/integration/transforms/go/simple/main.go
+++ b/tests/integration/transforms/go/simple/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -69,7 +70,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		// Scenario #1 - apply a transform to a CustomResource
 		_, err := NewRandom(ctx, "res1", &RandomArgs{Length: pulumi.Int(5)}, pulumi.XTransforms([]pulumi.XResourceTransform{
-			func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 				fmt.Printf("res1 transform\n")
 				rta.Opts.AdditionalSecretOutputs = append(rta.Opts.AdditionalSecretOutputs, "result")
 				return &pulumi.XResourceTransformResult{
@@ -84,7 +85,7 @@ func main() {
 
 		// Scenario #2 - apply a transform to a Component to transform it's children
 		_, err = NewMyComponent(ctx, "res2", pulumi.XTransforms([]pulumi.XResourceTransform{
-			func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 				fmt.Printf("res2 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Opts.AdditionalSecretOutputs = append(rta.Opts.AdditionalSecretOutputs, "result")
@@ -101,7 +102,7 @@ func main() {
 		}
 
 		// Scenario #3 - apply a transform to the Stack to transform all (future) resources in the stack
-		err = ctx.XRegisterStackTransform(func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		err = ctx.XRegisterStackTransform(func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 			fmt.Printf("stack transform\n")
 			fmt.Printf("%v %v\n", rta.Type, rta.Props)
 			if rta.Type == "testprovider:index:Random" {
@@ -132,7 +133,7 @@ func main() {
 		// 3. Second parent transform
 		// 4. Stack transform
 		_, err = NewMyComponent(ctx, "res4", pulumi.XTransforms([]pulumi.XResourceTransform{
-			func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 				fmt.Printf("res4 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Props["prefix"] = pulumi.String("default1")
@@ -144,7 +145,7 @@ func main() {
 				}
 				return nil
 			},
-			func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 				fmt.Printf("res4 transform 2\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Props["prefix"] = pulumi.String("default2")
@@ -163,7 +164,7 @@ func main() {
 
 		// Scenario #5 - mutate the properties of a resource
 		_, err = NewRandom(ctx, "res5", &RandomArgs{Length: pulumi.Int(10)}, pulumi.XTransforms([]pulumi.XResourceTransform{
-			func(rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 				fmt.Printf("res5 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					length := rta.Props["length"].(pulumi.Float64)


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Transform functions are async grpc calls. Make that clear by having a `context.Context` on the function parameters. This also allows users to gracefully handle cancellation if wanted, and will probably be useful for tracing/logging.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
