### PR TITLE
[auto/go] Support for remote deployment executor image

### DIFF
--- a/changelog/pending/20240315--auto-go--support-for-remote-deployment-executor-image.yaml
+++ b/changelog/pending/20240315--auto-go--support-for-remote-deployment-executor-image.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Support for remote deployment executor image

--- a/changelog/pending/20240315--auto-go--support-for-remote-deployment-executor-image.yaml
+++ b/changelog/pending/20240315--auto-go--support-for-remote-deployment-executor-image.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go
-  description: Support for remote deployment executor image
+  description: Support remote deployment executor image

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -229,7 +229,6 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(
 		&r.executorImagePassword, "remote-executor-image-password", "",
 		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor")
-
 }
 
 // runDeployment kicks off a remote deployment.

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -165,6 +165,9 @@ type RemoteArgs struct {
 	gitAuthSSHPrivateKeyPath string
 	gitAuthPassword          string
 	gitAuthUsername          string
+	executorImage            string
+	executorImageUsername    string
+	executorImagePassword    string
 }
 
 // Add flags to support remote operations
@@ -217,6 +220,16 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(
 		&r.gitAuthUsername, "remote-git-auth-username", "",
 		"[EXPERIMENTAL] Git username")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImage, "remote-executor-image", "",
+		"[EXPERIMENTAL] The Docker image to use for the executor")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImageUsername, "remote-executor-image-username", "",
+		"[EXPERIMENTAL] The username for the credentials with access to the Docker image to use for the executor")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImagePassword, "remote-executor-image-password", "",
+		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor")
+
 }
 
 // runDeployment kicks off a remote deployment.
@@ -236,6 +249,15 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 	if args.gitAuthSSHPrivateKey != "" && args.gitAuthSSHPrivateKeyPath != "" {
 		return result.FromError(errors.New("`--remote-git-auth-ssh-private-key` and " +
 			"`--remote-git-auth-ssh-private-key-path` cannot both be specified"))
+	}
+	if args.executorImage == "" && (args.executorImageUsername != "" || args.executorImagePassword != "") {
+		return result.FromError(errors.New("`--remote-executor-image-username` and `--remote-executor-image-password` " +
+			"cannot be specified without `--remote-executor-image`"))
+	}
+	if (args.executorImagePassword != "" && args.executorImageUsername == "") ||
+		(args.executorImageUsername != "" && args.executorImagePassword == "") {
+		return result.FromError(errors.New("`--remote-executor-image-username` and `--remote-executor-image-password` " +
+			"must both be specified"))
 	}
 
 	// Parse and validate the environment args.
@@ -312,6 +334,20 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 		}
 	}
 
+	var executorImage *apitype.DockerImage
+	if args.executorImage != "" {
+		executorImage = &apitype.DockerImage{
+			Reference: args.executorImage,
+		}
+	}
+	if args.executorImageUsername != "" && args.executorImagePassword != "" {
+		if executorImage.Credentials == nil {
+			executorImage.Credentials = &apitype.DockerImageCredentials{}
+		}
+		executorImage.Credentials.Username = args.executorImageUsername
+		executorImage.Credentials.Password = apitype.SecretValue{Value: args.executorImagePassword, Secret: true}
+	}
+
 	var operationOptions *apitype.OperationContextOptions
 	if args.skipInstallDependencies {
 		operationOptions = &apitype.OperationContextOptions{
@@ -320,6 +356,9 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 	}
 
 	req := apitype.CreateDeploymentRequest{
+		Executor: &apitype.ExecutorContext{
+			ExecutorImage: executorImage,
+		},
 		Source: &apitype.SourceContext{
 			Git: &apitype.SourceContextGit{
 				RepoURL: url,

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -57,6 +57,7 @@ type LocalWorkspace struct {
 	preRunCommands                []string
 	remoteSkipInstallDependencies bool
 	pulumiCommand                 PulumiCommand
+	remoteExecutorImage           *ExecutorImage
 }
 
 var settingsExtensions = []string{".yaml", ".yml", ".json"}
@@ -964,6 +965,8 @@ type localWorkspaceOptions struct {
 	PreRunCommands []string
 	// RemoteSkipInstallDependencies sets whether to skip the default dependency installation step
 	RemoteSkipInstallDependencies bool
+	// RemoteExecutorImage is the image to use for the remote Pulumi operation.
+	RemoteExecutorImage *ExecutorImage
 }
 
 // LocalWorkspaceOption is used to customize and configure a LocalWorkspace at initialization time.
@@ -1120,6 +1123,12 @@ func preRunCommands(commands ...string) LocalWorkspaceOption {
 func remoteSkipInstallDependencies(skipInstallDependencies bool) LocalWorkspaceOption {
 	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
 		lo.RemoteSkipInstallDependencies = skipInstallDependencies
+	})
+}
+
+func remoteExecutorImage(image *ExecutorImage) LocalWorkspaceOption {
+	return localWorkspaceOption(func(lo *localWorkspaceOptions) {
+		lo.RemoteExecutorImage = image
 	})
 }
 

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -871,6 +871,7 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 		remote:                        lwOpts.Remote,
 		remoteEnvVars:                 lwOpts.RemoteEnvVars,
 		remoteSkipInstallDependencies: lwOpts.RemoteSkipInstallDependencies,
+		remoteExecutorImage:           lwOpts.RemoteExecutorImage,
 		repo:                          lwOpts.Repo,
 		pulumiCommand:                 pulumiCommand,
 	}

--- a/sdk/go/auto/remote_workspace.go
+++ b/sdk/go/auto/remote_workspace.go
@@ -142,6 +142,20 @@ func remoteToLocalOptions(repo GitRepo, opts ...RemoteWorkspaceOption) ([]LocalW
 		}
 	}
 
+	if remoteOpts.ExecutorImage != nil {
+		if remoteOpts.ExecutorImage.Image == "" {
+			return nil, errors.New("executorImage.Image cannot be empty")
+		}
+		if remoteOpts.ExecutorImage.Credentials != nil {
+			if remoteOpts.ExecutorImage.Credentials.Username == "" {
+				return nil, errors.New("executorImage.Credentials.Username cannot be empty")
+			}
+			if remoteOpts.ExecutorImage.Credentials.Password == "" {
+				return nil, errors.New("executorImage.Credentials.Password cannot be empty")
+			}
+		}
+	}
+
 	localOpts := []LocalWorkspaceOption{
 		remote(true),
 		remoteEnvVars(remoteOpts.EnvVars),
@@ -206,6 +220,13 @@ func RemotePreRunCommands(commands ...string) RemoteWorkspaceOption {
 func RemoteSkipInstallDependencies(skipInstallDependencies bool) RemoteWorkspaceOption {
 	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
 		opts.SkipInstallDependencies = skipInstallDependencies
+	})
+}
+
+// RemoteExecutorImage sets the image to use for the remote executor.
+func RemoteExecutorImage(image *ExecutorImage) RemoteWorkspaceOption {
+	return remoteWorkspaceOption(func(opts *remoteWorkspaceOptions) {
+		opts.ExecutorImage = image
 	})
 }
 

--- a/sdk/go/auto/remote_workspace.go
+++ b/sdk/go/auto/remote_workspace.go
@@ -148,6 +148,7 @@ func remoteToLocalOptions(repo GitRepo, opts ...RemoteWorkspaceOption) ([]LocalW
 		preRunCommands(remoteOpts.PreRunCommands...),
 		remoteSkipInstallDependencies(remoteOpts.SkipInstallDependencies),
 		Repo(repo),
+		remoteExecutorImage(remoteOpts.ExecutorImage),
 	}
 	return localOpts, nil
 }
@@ -160,6 +161,18 @@ type remoteWorkspaceOptions struct {
 	PreRunCommands []string
 	// SkipInstallDependencies sets whether to skip the default dependency installation step. Defaults to false.
 	SkipInstallDependencies bool
+	// ExecutorImage is the image to use for the remote executor.
+	ExecutorImage *ExecutorImage
+}
+
+type ExecutorImage struct {
+	Image       string
+	Credentials *DockerImageCredentials
+}
+
+type DockerImageCredentials struct {
+	Username string
+	Password string
 }
 
 // LocalWorkspaceOption is used to customize and configure a LocalWorkspace at initialization time.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1140,12 +1140,14 @@ func (s *Stack) remoteArgs() []string {
 	var preRunCommands []string
 	var envvars map[string]EnvVarValue
 	var skipInstallDependencies bool
+	var executorImage *ExecutorImage
 	if lws, isLocalWorkspace := s.Workspace().(*LocalWorkspace); isLocalWorkspace {
 		remote = lws.remote
 		repo = lws.repo
 		preRunCommands = lws.preRunCommands
 		envvars = lws.remoteEnvVars
 		skipInstallDependencies = lws.remoteSkipInstallDependencies
+		executorImage = lws.remoteExecutorImage
 	}
 	if !remote {
 		return nil
@@ -1200,6 +1202,18 @@ func (s *Stack) remoteArgs() []string {
 
 	if skipInstallDependencies {
 		args = append(args, "--remote-skip-install-dependencies")
+	}
+
+	if executorImage != nil {
+		args = append(args, "--remote-executor-image="+executorImage.Image)
+		if executorImage.Credentials != nil {
+			if executorImage.Credentials.Username != "" {
+				args = append(args, "--remote-executor-image-username="+executorImage.Credentials.Username)
+			}
+			if executorImage.Credentials.Password != "" {
+				args = append(args, "--remote-executor-image-password="+executorImage.Credentials.Password)
+			}
+		}
 	}
 
 	return args

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -51,7 +51,19 @@ type ExecutorContext struct {
 	WorkingDirectory string `json:"workingDirectory"`
 
 	// Defines the image that the pulumi operations should run in.
-	ExecutorImage string `json:"executorImage,omitempty"`
+	ExecutorImage *DockerImage `json:"executorImage,omitempty"`
+}
+
+// A DockerImage describes a Docker image reference + optional credentials for use with a job definition.
+type DockerImage struct {
+	Reference   string                  `json:"reference"`
+	Credentials *DockerImageCredentials `json:"credentials,omitempty"`
+}
+
+// DockerImageCredentials describes the credentials needed to access a Docker repository.
+type DockerImageCredentials struct {
+	Username string      `json:"username"`
+	Password SecretValue `json:"password"`
 }
 
 // SourceContext describes some source code, and how to obtain it.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds Go Automation API support for specifying custom executor images for remote deployments.

Part of: https://github.com/pulumi/pulumi/issues/15693

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
