### PR TITLE
Decouple persist and display events

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -65,15 +66,19 @@ type DiagInfo struct {
 type progressRenderer interface {
 	io.Closer
 
-	tick(display *ProgressDisplay)
-	rowUpdated(display *ProgressDisplay, row Row)
-	systemMessage(display *ProgressDisplay, payload engine.StdoutEventPayload)
-	done(display *ProgressDisplay)
-	println(display *ProgressDisplay, line string)
+	initializeDisplay(display *ProgressDisplay)
+	tick()
+	rowUpdated(row Row)
+	systemMessage(payload engine.StdoutEventPayload)
+	done()
+	println(line string)
 }
 
 // ProgressDisplay organizes all the information needed for a dynamically updated "progress" view of an update.
 type ProgressDisplay struct {
+	// mutex is used to synchronize access to eventUrnToResourceRow, which is accessed by the treeRenderer
+	m sync.RWMutex
+
 	opts Options
 
 	renderer progressRenderer
@@ -133,9 +138,6 @@ type ProgressDisplay struct {
 
 	// the list of suffixes to rotate through
 	suffixesArray []string
-
-	// Maps used so we can generate short IDs for resource urns.
-	urnToID map[resource.URN]string
 
 	// Structure that tracks the time taken to perform an action on a resource.
 	opStopwatch opStopwatch
@@ -235,10 +237,10 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 		eventUrnToResourceRow: make(map[resource.URN]ResourceRow),
 		suffixColumn:          int(statusColumn),
 		suffixesArray:         []string{"", ".", "..", "..."},
-		urnToID:               make(map[resource.URN]string),
 		displayOrderCounter:   1,
 		opStopwatch:           newOpStopwatch(),
 	}
+	renderer.initializeDisplay(display)
 
 	ticker := time.NewTicker(1 * time.Second)
 	if opts.deterministicOutput {
@@ -253,7 +255,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Stack
 }
 
 func (display *ProgressDisplay) println(line string) {
-	display.renderer.println(display, line)
+	display.renderer.println(line)
 }
 
 type treeNode struct {
@@ -310,6 +312,11 @@ func (display *ProgressDisplay) getOrCreateTreeNode(
 }
 
 func (display *ProgressDisplay) generateTreeNodes() []*treeNode {
+	// We take the reader lock here because this is called from the renderer and reads from
+	// the eventUrnToResourceRow map
+	display.m.RLock()
+	defer display.m.RUnlock()
+
 	result := []*treeNode{}
 
 	result = append(result, &treeNode{
@@ -440,6 +447,10 @@ func removeInfoColumnIfUnneeded(rows [][]string) {
 // Specifically, this will update the status messages for any resources, and will also then
 // print out all final diagnostics. and finally will print out the summary.
 func (display *ProgressDisplay) processEndSteps() {
+	// Take the read lock here because we are reading from the eventUrnToResourceRow map
+	display.m.RLock()
+	defer display.m.RUnlock()
+
 	// Figure out the rows that are currently in progress.
 	var inProgressRows []ResourceRow
 	if !display.isTerminal {
@@ -458,7 +469,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	// since the display was marked 'done'.
 	if !display.isTerminal {
 		for _, v := range inProgressRows {
-			display.renderer.rowUpdated(display, v)
+			display.renderer.rowUpdated(v)
 		}
 	}
 
@@ -466,7 +477,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	// messages from a status message (since we're going to print them all) below.  Note, this will
 	// only do something in a terminal.  This is what we want, because if we're not in a terminal we
 	// don't really want to reprint any finished items we've already printed.
-	display.renderer.done(display)
+	display.renderer.done()
 
 	// Render the policies section; this will print all policy packs that ran plus any specific
 	// policies that led to violations or remediations. This comes before diagnostics since policy
@@ -807,10 +818,14 @@ func (display *ProgressDisplay) processTick() {
 	// often timeout a process if output is not seen in a while.
 	display.currentTick++
 
-	display.renderer.tick(display)
+	display.renderer.tick()
 }
 
 func (display *ProgressDisplay) getRowForURN(urn resource.URN, metadata *engine.StepEventMetadata) ResourceRow {
+	// Take the write lock here because this can write the the eventUrnToResourceRow map
+	display.m.Lock()
+	defer display.m.Unlock()
+
 	// If there's already a row for this URN, return it.
 	row, has := display.eventUrnToResourceRow[urn]
 	if has {
@@ -993,19 +1008,26 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		contract.Failf("Unhandled event type '%s'", event.Type)
 	}
 
-	display.renderer.rowUpdated(display, row)
+	display.renderer.rowUpdated(row)
 }
 
 func (display *ProgressDisplay) handleSystemEvent(payload engine.StdoutEventPayload) {
+	// We need too take the writer lock here because ensureHeaderAndStackRows expects to be
+	// called under the write lock
+	display.m.Lock()
+	defer display.m.Unlock()
+
 	// Make sure we have a header to display
 	display.ensureHeaderAndStackRows()
 
 	display.systemEventPayloads = append(display.systemEventPayloads, payload)
 
-	display.renderer.systemMessage(display, payload)
+	display.renderer.systemMessage(payload)
 }
 
 func (display *ProgressDisplay) ensureHeaderAndStackRows() {
+	contract.Assertf(!display.m.TryLock(), "ProgressDisplay.ensureHeaderAndStackRows MUST be called "+
+		"under the write lock")
 	if display.headerRow == nil {
 		// about to make our first status message.  make sure we present the header line first.
 		display.headerRow = &headerRowData{display: display}

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -35,7 +35,8 @@ type treeRenderer struct {
 
 	opts Options
 
-	term terminal.Terminal
+	display *ProgressDisplay
+	term    terminal.Terminal
 
 	permalink string
 
@@ -84,20 +85,24 @@ func (r *treeRenderer) Close() error {
 	return r.term.Close()
 }
 
-func (r *treeRenderer) tick(display *ProgressDisplay) {
-	r.render(display)
+func (r *treeRenderer) initializeDisplay(display *ProgressDisplay) {
+	r.display = display
 }
 
-func (r *treeRenderer) rowUpdated(display *ProgressDisplay, _ Row) {
-	r.render(display)
+func (r *treeRenderer) tick() {
+	r.markDirty()
 }
 
-func (r *treeRenderer) systemMessage(display *ProgressDisplay, _ engine.StdoutEventPayload) {
-	r.render(display)
+func (r *treeRenderer) rowUpdated(_ Row) {
+	r.markDirty()
 }
 
-func (r *treeRenderer) done(display *ProgressDisplay) {
-	r.render(display)
+func (r *treeRenderer) systemMessage(_ engine.StdoutEventPayload) {
+	r.markDirty()
+}
+
+func (r *treeRenderer) done() {
+	r.markDirty()
 
 	r.ticker.Stop()
 	r.closed <- true
@@ -118,7 +123,7 @@ func (r *treeRenderer) print(text string) {
 	contract.IgnoreError(err)
 }
 
-func (r *treeRenderer) println(display *ProgressDisplay, text string) {
+func (r *treeRenderer) println(text string) {
 	r.print(text)
 	r.print("\n")
 }
@@ -133,22 +138,21 @@ func (r *treeRenderer) overln(text string) {
 	r.print("\n")
 }
 
-func (r *treeRenderer) render(display *ProgressDisplay) {
-	r.m.Lock()
-	defer r.m.Unlock()
+func (r *treeRenderer) render() {
+	contract.Assertf(!r.m.TryLock(), "treeRenderer.render() MUST be called from within a locked context")
 
-	if display.headerRow == nil {
+	if r.display.headerRow == nil {
 		return
 	}
 
 	// Render the resource tree table into rows.
-	rootNodes := display.generateTreeNodes()
-	rootNodes = display.filterOutUnnecessaryNodesAndSetDisplayTimes(rootNodes)
+	rootNodes := r.display.generateTreeNodes()
+	rootNodes = r.display.filterOutUnnecessaryNodesAndSetDisplayTimes(rootNodes)
 	sortNodes(rootNodes)
-	display.addIndentations(rootNodes, true /*isRoot*/, "")
+	r.display.addIndentations(rootNodes, true /*isRoot*/, "")
 
 	maxSuffixLength := 0
-	for _, v := range display.suffixesArray {
+	for _, v := range r.display.suffixesArray {
 		runeCount := utf8.RuneCountInString(v)
 		if runeCount > maxSuffixLength {
 			maxSuffixLength = runeCount
@@ -157,7 +161,7 @@ func (r *treeRenderer) render(display *ProgressDisplay) {
 
 	var treeTableRows [][]string
 	var maxColumnLengths []int
-	display.convertNodesToRows(rootNodes, maxSuffixLength, &treeTableRows, &maxColumnLengths)
+	r.display.convertNodesToRows(rootNodes, maxSuffixLength, &treeTableRows, &maxColumnLengths)
 	removeInfoColumnIfUnneeded(treeTableRows)
 
 	r.treeTableRows = r.treeTableRows[:0]
@@ -168,14 +172,9 @@ func (r *treeRenderer) render(display *ProgressDisplay) {
 
 	// Convert system events into lines.
 	r.systemMessages = r.systemMessages[:0]
-	for _, payload := range display.systemEventPayloads {
+	for _, payload := range r.display.systemEventPayloads {
 		msg := payload.Color.Colorize(payload.Message)
 		r.systemMessages = append(r.systemMessages, splitIntoDisplayableLines(msg)...)
-	}
-
-	r.dirty = true
-	if r.opts.deterministicOutput {
-		r.frame(true, false)
 	}
 }
 
@@ -184,6 +183,9 @@ func (r *treeRenderer) markDirty() {
 	defer r.m.Unlock()
 
 	r.dirty = true
+	if r.opts.deterministicOutput {
+		r.frame(true, false)
+	}
 }
 
 // +--------------------------------------------+
@@ -204,6 +206,9 @@ func (r *treeRenderer) frame(locked, done bool) {
 		return
 	}
 	r.dirty = false
+
+	contract.Assertf(r.display != nil, "treeRender.initializeDisplay MUST be called before rendering")
+	r.render()
 
 	termWidth, termHeight, err := r.term.Size()
 	contract.IgnoreError(err)
@@ -260,7 +265,14 @@ func (r *treeRenderer) frame(locked, done bool) {
 
 		treeTableHeight = termHeight - systemMessagesHeight - statusMessageHeight - 1
 		r.maxTreeTableOffset = len(treeTableRows) - treeTableHeight + 1
+		if r.maxTreeTableOffset < 0 {
+			r.maxTreeTableOffset = 0
+		}
 		scrollable := r.maxTreeTableOffset != 0
+
+		if r.treeTableOffset > r.maxTreeTableOffset {
+			r.treeTableOffset = r.maxTreeTableOffset
+		}
 
 		if autoscroll {
 			r.treeTableOffset = r.maxTreeTableOffset
@@ -270,7 +282,11 @@ func (r *treeRenderer) frame(locked, done bool) {
 			// Ensure that the treeTableHeight is at least 1 to avoid going out of bounds.
 			treeTableHeight = 1
 		}
-		treeTableRows = treeTableRows[r.treeTableOffset : r.treeTableOffset+treeTableHeight-1]
+		if r.treeTableOffset+treeTableHeight-1 < len(treeTableRows) {
+			treeTableRows = treeTableRows[r.treeTableOffset : r.treeTableOffset+treeTableHeight-1]
+		} else if r.treeTableOffset < len(treeTableRows) {
+			treeTableRows = treeTableRows[r.treeTableOffset:]
+		}
 
 		totalHeight = treeTableHeight + systemMessagesHeight + statusMessageHeight + 1
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Retry #15529 with fix for the issue that required the revert in #15705 

This removes a scenario where events could not be persisted to the cloud because they were waiting on the same event being displayed

Instead of rendering the tree every time a row is updated, instead, this renders when the display actually happens in the the `frame` call. The renderer instead simply marks itself as dirty in the `rowUpdated`, `tick`, `systemMessage` and `done` methods and relies on the frame being redrawn on a 60Hz timer (the `done` method calls `frame` explicitly). This makes the rowUpdated call exceedingly cheap (it simply marks the treeRenderer as dirty) which allows the ProgressDisplay instance to service the display events faster, which prevents it from blocking the persist events.

This requires a minor refactor to ensure that the display object is available in the frame method

Because the treeRenderer is calling back into the ProgressDisplay object in a goroutine, the ProgressDisplay object needs to be thread safe, so a read-write mutex is added to protect the `eventUrnToResourceRow` map. The unused `urnToID` map was removed in passing.

## Impact

There are scenarios where the total time taken for an operation was dominated by servicing the events.

This reduces the time for a complex (~2000 resources) `pulumi preview` from 1m45s to 45s

For a `pulumi up` with `-v=11` on a the same stack, where all the register resource spans were completing in 1h6m and the postEngineEventBatch events were taking 3h45m, this PR removes the time impact of reporting the events (greatly inflated by the high verbosity setting) and the operation takes the anticipated 1h6m


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #15668 

This was happening because the renderer was being marked dirty once per second in a tick event, which caused frame to redraw. There is a check in the render method that `display.headerRow` is not nil that was previously used to prevent rendering when no events had been added. This check is now part of the `markDirty` logic

Some of the tests needed to be updated to make this work and have also been refactored

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
