### PR TITLE
Fix panic when changing untargetted provider versions

### DIFF
--- a/changelog/pending/20240318--engine--fix-a-panic-when-updating-provider-version-in-a-run-using-target.yaml
+++ b/changelog/pending/20240318--engine--fix-a-panic-when-updating-provider-version-in-a-run-using-target.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic when updating provider version in a run using --target


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15704.

When doing a targeted run the source evaluator isn't aware of targets but it is responsible for registering default providers. As such on getting a resource event with a new provider version (e.g 1.0 -> 2.0) it will send of a registration for the new version it's seen, which as a default provider the step generator will accept and add to state (this is probably ok).
However when the step generator runs for the resource using this provider it will see it's not targetted and ignore its new goal state just reusing its old state. This old state will be referring to the old version of the provider (e.g "default_aws_1_0_0" rather than "default_aws_2_0_0"), which was causing a panic in the step generator when trying to build the overall stack state for StackAnalyze as the old provider had never been registered.

We now catch this situation when generating the same step for a non-targeted resource and error out that this isn't supported.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
