### PR TITLE
make parallel test more likely to fail when there are problems

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -621,7 +621,7 @@ describe("LocalWorkspace", () => {
             };
         };
         const projectName = "inline_node";
-        const stackNames = Array.from(Array(10).keys()).map((_) =>
+        const stackNames = Array.from(Array(30).keys()).map((_) =>
             fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`),
         );
 
@@ -662,8 +662,10 @@ describe("LocalWorkspace", () => {
 
             await stack.workspace.removeStack(stack.name);
         };
-
-        await Promise.all(stackNames.map(async (stackName) => await testStackLifetime(stackName)));
+        for (let i = 0; i < stackNames.length; i += 10) {
+            const chunk = stackNames.slice(i, i + 10);
+            await Promise.all(chunk.map(async (stackName) => await testStackLifetime(stackName)));
+        }
     });
     it(`handles events`, async () => {
         const program = async () => {


### PR DESCRIPTION
This test was flaky in https://github.com/pulumi/pulumi/issues/15239. However since it only flaked occasionally, we ignored this for a while, even though a test failure here actually indicated a deeper problem in grpc-js, which could even lead to stacks being completely destroyed (https://github.com/pulumi/pulumi/issues/15390).

The flaky test and the stacks being destroyed had different symptoms, but it was the same root cause of a bug in grpc-js.  Unfortunately the latter is hard to reproduce in a test, since it only happens very infrequently.

However this test being flaky indicates deeper problems.  Increase the amount of stacks we run through in parallel here to make it more likely that this test fails when there are actual errors, making it harder for us to ignore, and hopefully making it fail when we introduce any issues.

Fixes https://github.com/pulumi/pulumi/issues/15390