### PR TITLE
properly check if the cache is primed

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -170,7 +170,7 @@ jobs:
             pkg/go.sum
             .gocache.tmp
       - name: Prime Go cache
-        if: ${{ steps.setup-go.outputs.cache-hit != 'true' }}
+        if: ${{ ! steps.setup-go.outputs.cache-hit }}
         # Compile every test to ensure we populate a good cache entry.
         run: |
           ( cd sdk && go test -run "_________" ./... )


### PR DESCRIPTION
Before every CI job we currently check whether the Go cache is primed, and if not compile all the tests to prime it.  However that check is currently wrong.  `steps.setup-go.outputs.cache-hit` is a boolean variable, however we compare it against a string 'true'.   Since we are comparing for inequality, this check is always true, so we are always priming the cache, even if it is already primed.  

Fix this check, so we can only prime the cache when it needs to be and don't waste extra CI time to prime the cache when it already might be.

h/t again to @iamricard for noticing that we are taking a long time to prime the cache in some cases.