### PR TITLE
Add 'typechecker' option to python runtime

### DIFF
--- a/changelog/pending/20240326--sdk-python--adds-typechecker-runtime-option-to-the-python-language-host.yaml
+++ b/changelog/pending/20240326--sdk-python--adds-typechecker-runtime-option-to-the-python-language-host.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Adds 'typeChecker' runtime option to the Python language host

--- a/tests/integration/python/mypy/.gitignore
+++ b/tests/integration/python/mypy/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/mypy/Pulumi.yaml
+++ b/tests/integration/python/mypy/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-python-mypy
+description: A simple Python Pulumi program that type checks with mypy.
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+    typechecker: mypy

--- a/tests/integration/python/mypy/__main__.py
+++ b/tests/integration/python/mypy/__main__.py
@@ -1,0 +1,8 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+"""An example program that type checks with mypy"""
+
+import pulumi
+
+# This export won't work because the first argument is a number, not a string
+pulumi.export(42, 'bar')

--- a/tests/integration/python/mypy/requirements.txt
+++ b/tests/integration/python/mypy/requirements.txt
@@ -1,0 +1,2 @@
+pulumi
+mypy

--- a/tests/integration/python/pyright/.gitignore
+++ b/tests/integration/python/pyright/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/pyright/Pulumi.yaml
+++ b/tests/integration/python/pyright/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-python-pyright
+description: A simple Python Pulumi program that type checks with pyright.
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+    typechecker: pyright

--- a/tests/integration/python/pyright/__main__.py
+++ b/tests/integration/python/pyright/__main__.py
@@ -1,0 +1,8 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+"""An example program that type checks with pyright"""
+
+import pulumi
+
+# This export won't work because the first argument is a number, not a string
+pulumi.export(42, 'bar')

--- a/tests/integration/python/pyright/requirements.txt
+++ b/tests/integration/python/pyright/requirements.txt
@@ -1,0 +1,2 @@
+pulumi
+pyright


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15724.

This adds a new runtime option to the python language host `typeChecker` which can be set to either "mypy" or "pyright". If it's set the language host will run the mypy/pyright module before running the program.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
