### PR TITLE
destroy: implement --continue-on-error

### DIFF
--- a/changelog/pending/20240319--engine--add-a-continue-on-error-flag-to-pulumi-destroy.yaml
+++ b/changelog/pending/20240319--engine--add-a-continue-on-error-flag-to-pulumi-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Add a --continue-on-error flag to pulumi destroy

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -299,6 +299,8 @@ type UpdateOptions struct {
 	SkipPreview bool
 	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
 	PreviewOnly bool
+	// ContinueOnError, when true, causes the update to continue even if there are errors.
+	ContinueOnError bool
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -71,6 +71,7 @@ func newDestroyCmd() *cobra.Command {
 	var targets *[]string
 	var targetDependents bool
 	var excludeProtected bool
+	var continueOnError bool
 
 	use, cmdArgs := "destroy", cmdutil.NoArgs
 	if remoteSupported() {
@@ -278,6 +279,7 @@ func newDestroyCmd() *cobra.Command {
 				DisableResourceReferences: disableResourceReferences(),
 				DisableOutputValues:       disableOutputValues(),
 				Experimental:              hasExperimentalCommands(),
+				ContinueOnError:           continueOnError,
 			}
 
 			_, res := s.Destroy(ctx, backend.UpdateOperation{
@@ -387,6 +389,9 @@ func newDestroyCmd() *cobra.Command {
 		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
+	cmd.PersistentFlags().BoolVar(
+		&continueOnError, "continue-on-error", false,
+		"Continue to perform the destroy operation despite the occurrence of errors")
 
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -313,6 +313,7 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 			DisableResourceReferences: deployment.Options.DisableResourceReferences,
 			DisableOutputValues:       deployment.Options.DisableOutputValues,
 			GeneratePlan:              deployment.Options.UpdateOptions.GeneratePlan,
+			ContinueOnError:           deployment.Options.ContinueOnError,
 		}
 		newPlan, walkError = deployment.Deployment.Execute(ctx, opts, preview)
 		close(done)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -5476,3 +5476,76 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 		test(t, deploytest.WithoutGrpc)
 	})
 }
+
+func TestContinueOnError(t *testing.T) {
+	t.Parallel()
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}, deploytest.WithoutGrpc),
+		deploytest.NewProviderLoader("pkgB", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DeleteF: func(urn resource.URN, id resource.ID, oldInputs, oldOutputs resource.PropertyMap,
+					timeout float64,
+				) (resource.Status, error) {
+					return resource.StatusOK, errors.New("intentionally failed delete")
+				},
+			}, nil
+		}, deploytest.WithoutGrpc),
+	}
+
+	createResource := true
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		if createResource {
+			unrelated1, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", "unrelated1", true, deploytest.ResourceOptions{})
+			assert.NoError(t, err)
+			_, _, _, _, err = monitor.RegisterResource("pkgA:m:typA", "unrelated2", true, deploytest.ResourceOptions{
+				Dependencies: []resource.URN{unrelated1},
+			})
+			assert.NoError(t, err)
+
+			dependency, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", "dependency", true, deploytest.ResourceOptions{})
+			assert.NoError(t, err)
+
+			_, _, _, _, err = monitor.RegisterResource("pkgB:m:typB", "failing", true, deploytest.ResourceOptions{
+				Dependencies: []resource.URN{dependency},
+			})
+			assert.NoError(t, err)
+
+			_, _, _, _, err = monitor.RegisterResource("pkgA:m:typA", "anotherUnrelatedRes", true, deploytest.ResourceOptions{})
+			assert.NoError(t, err)
+
+		}
+
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &TestPlan{
+		Options: TestUpdateOptions{
+			UpdateOptions: UpdateOptions{
+				ContinueOnError: true,
+			},
+			HostF: hostF,
+		},
+	}
+
+	project := p.GetProject()
+
+	// Run an update to create the resource
+	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, snap)
+	assert.Len(t, snap.Resources, 7) // We expect 5 resources + 2 providers
+
+	createResource = false
+	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	assert.ErrorContains(t, err, "intentionally failed delete")
+	assert.NotNil(t, snap)
+	assert.Len(t, snap.Resources, 4) // We expect 2 resources + 2 providers
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgA::default"), snap.Resources[0].URN)
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::dependency"), snap.Resources[1].URN)
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::pulumi:providers:pkgB::default"), snap.Resources[2].URN)
+	assert.Equal(t, resource.URN("urn:pulumi:test::test::pkgB:m:typB::failing"), snap.Resources[3].URN)
+}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -164,6 +164,9 @@ type UpdateOptions struct {
 
 	// Experimental is true if the engine is in experimental mode (i.e. PULUMI_EXPERIMENTAL was set)
 	Experimental bool
+
+	// ContinueOnError is true if the engine should continue processing resources after an error is encountered.
+	ContinueOnError bool
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -62,6 +62,8 @@ type Options struct {
 	DisableResourceReferences bool       // true to disable resource reference support.
 	DisableOutputValues       bool       // true to disable output value support.
 	GeneratePlan              bool       // true to enable plan generation.
+	// true if we should continue with the deployment even if a resource operation fails.
+	ContinueOnError bool
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1484,7 +1484,7 @@ func (sg *stepGenerator) ScheduleDeletes(deleteSteps []Step) []antichain {
 			// it can't be deleted this round.
 		}
 
-		// For all reosurces that are to be deleted in this round, remove them from the graph.
+		// For all resources that are to be deleted in this round, remove them from the graph.
 		for _, step := range steps {
 			condemned.Remove(step.Res())
 		}


### PR DESCRIPTION
Implement a `--continue-on-error` flag for `pulumi destroy`.  This makes sure we continue processing destroys even if errors occur.  We will only continue for resources which do not depend on the failed resource, to make sure we always have a valid snapshot available, and to not leave any orphaned resources behind.

Resources that fail to destroy will still continue to be managed by pulumi, and the process ends in an error to indicate to the user that there were problems and the destroy didn't succeed cleanly.

The output will continue to be the same as for failed destroys, except we now may succeed in destroying more resources than before.

/cc https://github.com/pulumi/pulumi/issues/3304