### PR TITLE
Asset and Archive can have missing contents

### DIFF
--- a/changelog/pending/20240320--engine--handle-that-assets-and-archives-can-be-returned-from-providers-without-content.yaml
+++ b/changelog/pending/20240320--engine--handle-that-assets-and-archives-can-be-returned-from-providers-without-content.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Handle that Assets & Archives can be returned from providers without content.

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -596,9 +596,10 @@ func (p *propertyPrinter) printPropertyValue(v resource.PropertyValue) {
 			p.writeWithIndentNoPrefix("}")
 		} else if path, has := a.GetPath(); has {
 			p.write("asset(file:%s) { %s }", shortHash(a.Hash), path)
+		} else if uri, has := a.GetURI(); has {
+			p.write("asset(uri:%s) { %s }", shortHash(a.Hash), uri)
 		} else {
-			contract.Assertf(a.IsURI(), "asset is not a text, file, or URI")
-			p.write("asset(uri:%s) { %s }", shortHash(a.Hash), a.URI)
+			p.write("asset(unknown:%s) { }", shortHash(a.Hash))
 		}
 	case v.IsArchive():
 		a := v.ArchiveValue()
@@ -892,10 +893,7 @@ func (p *propertyPrinter) printArchiveDiff(titleFunc func(*propertyPrinter),
 			p.write("archive(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))
 			return
 		}
-	} else {
-		contract.Assertf(oldArchive.IsAssets(), "old archive is not a path, URI, or a group of assets")
-		oldAssets, _ := oldArchive.GetAssets()
-
+	} else if oldAssets, has := oldArchive.GetAssets(); has {
 		if newAssets, has := newArchive.GetAssets(); has {
 			titleFunc(p)
 			p.write("archive(assets:%s) {\n", hashChange)
@@ -1039,10 +1037,7 @@ func (p *propertyPrinter) printAssetDiff(titleFunc func(*propertyPrinter), oldAs
 			p.write("asset(file:%s) { %s }\n", hashChange, getTextChangeString(oldPath, newPath))
 			return
 		}
-	} else {
-		contract.Assertf(oldAsset.IsURI(), "old asset is not text, path, or URI")
-
-		oldURI, _ := oldAsset.GetURI()
+	} else if oldURI, has := oldAsset.GetURI(); has {
 		if newURI, has := newAsset.GetURI(); has {
 			titleFunc(p)
 			p.write("asset(uri:%s) { %s }\n", hashChange, getTextChangeString(oldURI, newURI))

--- a/sdk/go/common/resource/archive/archive.go
+++ b/sdk/go/common/resource/archive/archive.go
@@ -107,9 +107,24 @@ func FromURI(uri string) (*Archive, error) {
 	return a, err
 }
 
-func (a *Archive) IsAssets() bool { return a.Assets != nil }
-func (a *Archive) IsPath() bool   { return a.Path != "" }
-func (a *Archive) IsURI() bool    { return a.URI != "" }
+func (a *Archive) IsAssets() bool {
+	if a.IsPath() || a.IsURI() {
+		return false
+	}
+	if len(a.Assets) > 0 {
+		return true
+	}
+	// We can't easily tell the difference between an Archive that really is empty and one that has no contents at all.
+	// If we have a hash we can check if that's the "zero hash" and if so then we know the assets is just empty. If the
+	// hash does not equal the empty hash then we know this is a _placeholder_ archive where the contents are just
+	// currently not known. If we don't have a hash then we can't tell the difference and assume it's just empty.
+	if a.Hash == "" || a.Hash == "5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef" {
+		return true
+	}
+	return false
+}
+func (a *Archive) IsPath() bool { return a.Path != "" }
+func (a *Archive) IsURI() bool  { return a.URI != "" }
 
 func (a *Archive) GetAssets() (map[string]interface{}, bool) {
 	if a.IsAssets() {

--- a/sdk/go/common/resource/asset/asset.go
+++ b/sdk/go/common/resource/asset/asset.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 )
 
-// Asset is a serialized asset reference.  It is a union: thus, only one of its fields will be non-nil.  Several helper
+// Asset is a serialized asset reference. It is a union: thus, at most one of its fields will be non-nil. Several helper
 // routines exist as members in order to easily interact with the assets referenced by an instance of this type.
 type Asset struct {
 	// Sig is the unique asset type signature (see properties.go).
@@ -56,6 +56,10 @@ const (
 // FromText produces a new asset and its corresponding SHA256 hash from the given text.
 func FromText(text string) (*Asset, error) {
 	a := &Asset{Sig: AssetSig, Text: text}
+	// Special case the empty string otherwise EnsureHash will fail.
+	if text == "" {
+		a.Hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	}
 	err := a.EnsureHash()
 	return a, err
 }
@@ -74,7 +78,22 @@ func FromURI(uri string) (*Asset, error) {
 	return a, err
 }
 
-func (a *Asset) IsText() bool { return !a.IsPath() && !a.IsURI() }
+func (a *Asset) IsText() bool {
+	if a.IsPath() || a.IsURI() {
+		return false
+	}
+	if a.Text != "" {
+		return true
+	}
+	// We can't easily tell the difference between an Asset that really has the empty string as its text and one that
+	// has no text at all. If we have a hash we can check if that's the "zero hash" and if so then we know the text is
+	// just empty. If the hash does not equal the empty hash then we know this is a _placeholder_ asset where the text is
+	// just currently not known. If we don't have a hash then we can't tell the difference and assume it's just empty.
+	if a.Hash == "" || a.Hash == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		return true
+	}
+	return false
+}
 func (a *Asset) IsPath() bool { return a.Path != "" }
 func (a *Asset) IsURI() bool  { return a.URI != "" }
 

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -80,7 +80,7 @@ func TestAssetSerialize(t *testing.T) {
 		assert.Equal(t, text3, asset3.Text)
 		assert.Equal(t, "9a6ed070e1ff834427105844ffd8a399a634753ce7a60ec5aae541524bbe7036", asset3.Hash)
 
-		// check that an empty asset also works correctly.
+		// check that an empty text asset also works correctly.
 		empty, err := rasset.FromText("")
 		assert.NoError(t, err)
 		assert.Equal(t, "", empty.Text)
@@ -202,6 +202,37 @@ func TestAssetSerialize(t *testing.T) {
 			assert.Equal(t, "d2587a875f82cdf3d3e6cfe9f8c6e6032be5dde8c344466e664e628da15757b0", archDes.Hash)
 		}
 	})
+	t.Run("empty asset", func(t *testing.T) {
+		t.Parallel()
+
+		// Check that a _fully_ empty asset is treated as an empty text asset.
+		empty := &rasset.Asset{}
+		assert.True(t, empty.IsText())
+		assert.Equal(t, "", empty.Text)
+		emptySer := empty.Serialize()
+		emptyDes, isasset, err := rasset.Deserialize(emptySer)
+		assert.NoError(t, err)
+		assert.True(t, isasset)
+		assert.True(t, emptyDes.IsText())
+		assert.Equal(t, "", emptyDes.Text)
+
+		// Check that a text asset with it's text removed shows as "no content".
+		asset, err := rasset.FromText("a very different and special test asset")
+		assert.NoError(t, err)
+		asset.Text = ""
+		assert.False(t, asset.IsText())
+		assert.False(t, asset.HasContents())
+		asset, isasset, err = rasset.Deserialize(asset.Serialize())
+		assert.NoError(t, err)
+		assert.True(t, isasset)
+		assert.False(t, asset.IsText())
+		assert.False(t, asset.HasContents())
+	})
+}
+
+func TestArchiveSerialize(t *testing.T) {
+	t.Parallel()
+
 	t.Run("path archive", func(t *testing.T) {
 		t.Parallel()
 
@@ -282,6 +313,72 @@ func TestAssetSerialize(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, arch4.EnsureHash())
 		assert.False(t, arch2.Equals(arch4))
+	})
+	t.Run("nested archives", func(t *testing.T) {
+		t.Parallel()
+
+		skipWindows(t)
+		file, err := tempArchive("test", true)
+		assert.NoError(t, err)
+		defer func() { contract.IgnoreError(os.Remove(file)) }()
+		arch1, err := rarchive.FromPath(file)
+		assert.NoError(t, err)
+		assert.Nil(t, arch1.EnsureHash())
+		url := "file:///" + file
+		arch2, err := rarchive.FromURI(url)
+		assert.NoError(t, err)
+		assert.Nil(t, arch2.EnsureHash())
+
+		assert.Nil(t, os.Truncate(file, 0))
+		arch3, err := rarchive.FromPath(file)
+		assert.NoError(t, err)
+		assert.Nil(t, arch3.EnsureHash())
+		assert.False(t, arch1.Equals(arch3))
+		arch4, err := rarchive.FromURI(url)
+		assert.NoError(t, err)
+		assert.Nil(t, arch4.EnsureHash())
+		assert.False(t, arch2.Equals(arch4))
+	})
+	t.Run("assets archive", func(t *testing.T) {
+		t.Parallel()
+
+		archive, err := rarchive.FromAssets(map[string]interface{}{})
+		require.NoError(t, err)
+		assert.True(t, archive.IsAssets())
+		assert.Equal(t, "5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef", archive.Hash)
+		archiveSer := archive.Serialize()
+		archiveDes, isarchive, err := rarchive.Deserialize(archiveSer)
+		require.NoError(t, err)
+		assert.True(t, isarchive)
+		assert.True(t, archiveDes.IsAssets())
+		assert.Equal(t, 0, len(archiveDes.Assets))
+	})
+	t.Run("empty archive", func(t *testing.T) {
+		t.Parallel()
+
+		// Check that a fully empty archive is treated as an empty assets archive.
+		empty := &rarchive.Archive{}
+		assert.True(t, empty.IsAssets())
+		assert.Equal(t, 0, len(empty.Assets))
+		emptySer := empty.Serialize()
+		emptyDes, isarchive, err := rarchive.Deserialize(emptySer)
+		require.NoError(t, err)
+		assert.True(t, isarchive)
+		assert.True(t, emptyDes.IsAssets())
+
+		// Check that an assets archive with it's assets removed shows as "no content".
+		asset, err := rasset.FromText("hello world")
+		require.NoError(t, err)
+		archive, err := rarchive.FromAssets(map[string]interface{}{"foo": asset})
+		require.NoError(t, err)
+		archive.Assets = nil
+		assert.False(t, archive.IsAssets())
+		assert.False(t, archive.HasContents())
+		archive, isarchive, err = rarchive.Deserialize(archive.Serialize())
+		require.NoError(t, err)
+		assert.True(t, isarchive)
+		assert.False(t, archive.IsAssets())
+		assert.False(t, archive.HasContents())
 	})
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15729.

This fixes Assets and Archives to allow four states, as opposed to the three that https://github.com/pulumi/pulumi/pull/14007 had enforced.

An asset can either be Text, Path, Uri, or none. That is `IsText`, `IsPath`, and `IsURI` can all return false. Similarly for archives except with Assets instead of Text.
This happens when a provider returns an Assert (or Archive) with a hash value set, but no other contents. 

The Asset and Archive objects have been updated to handle this case, and a number of places in the CLI that asserted that one of IsText/IsPath/IsURI were true have been fixed up to handle the case of all three being false.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
