### PR TITLE
Type check depends_on is only passed Resource instances

### DIFF
--- a/changelog/pending/20240320--sdk-python--improve-the-error-message-when-depends_on-is-passed-objects-of-the-wrong-type.yaml
+++ b/changelog/pending/20240320--sdk-python--improve-the-error-message-when-depends_on-is-passed-objects-of-the-wrong-type.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Improve the error message when depends_on is passed objects of the wrong type

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -566,7 +566,7 @@ class ResourceOptions:
         if isinstance(deps, list):
             for dep in deps:
                 if _is_prompt(dep) and not isinstance(dep, Resource):
-                    raise Exception(
+                    raise TypeError(
                         f"'depends_on' was passed a value {dep} that was not a Resource."
                     )
 

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -15,6 +15,7 @@
 """
 Mocks for testing.
 """
+import asyncio
 import functools
 import logging
 from abc import ABC, abstractmethod
@@ -25,7 +26,14 @@ from google.protobuf import empty_pb2
 from ..runtime.proto import engine_pb2, provider_pb2, resource_pb2
 from ..runtime.stack import Stack, run_pulumi_func
 from . import rpc, rpc_manager
-from .settings import Settings, configure, get_project, get_root_resource, get_stack
+from .settings import (
+    Settings,
+    configure,
+    get_project,
+    get_root_resource,
+    get_stack,
+    SETTINGS,
+)
 from .sync_await import _ensure_event_loop, _sync_await
 
 if TYPE_CHECKING:
@@ -41,6 +49,8 @@ def test(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         from .. import Output  # pylint: disable=import-outside-toplevel
+
+        SETTINGS.rpc_manager.clear()
 
         _sync_await(
             run_pulumi_func(

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -265,6 +265,12 @@ async def _add_dependency(
     * Comp2 because it is a non-remote component resoruce
     * Comp3 and Cust5 because Comp3 is a child of a remote component resource
     """
+    from ..resource import Resource  # pylint: disable=import-outside-toplevel
+
+    if not isinstance(res, Resource):
+        raise TypeError(
+            f"'depends_on' was passed a value {res} that was not a Resource."
+        )
 
     # Exit early if there are cycles to avoid hangs.
     no_cycles = declare_dependency(from_resource, res) if from_resource else True


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/13917.

Improves the error message for async type errors to match the error message users would get for sync type errors.

This also fixes the mock.test function to clear the RPCManager between tests so an exception in one test doesn't cause other tests to fail.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
