### PR TITLE
Fix lookup module deps with go.work files

### DIFF
--- a/changelog/pending/20240320--sdk-go--fix-lookup-of-plugin-and-program-dependencies-when-using-go-workspaces.yaml
+++ b/changelog/pending/20240320--sdk-go--fix-lookup-of-plugin-and-program-dependencies-when-using-go-workspaces.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix lookup of plugin and program dependencies when using Go workspaces

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -617,6 +617,9 @@ func (host *goLanguageHost) loadGomod(gobin, programDir string) (modDir string, 
 	//
 	// See 'go help list' for the full definition.
 	cmd := exec.Command(gobin, "list", "-m", "-f", "{{.GoMod}}")
+	// Disable GOWORK, we only want the one module found in this (or a parent) directory. Workspaces being
+	// enabled will cause "list -m" to list every module in the workspace.
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 	cmd.Dir = programDir
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -398,6 +398,17 @@ func TestPluginsAndDependencies_subdir(t *testing.T) {
 
 		testPluginsAndDependencies(t, progDir)
 	})
+
+	t.Run("gowork", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		require.NoError(t,
+			fsutil.CopyFile(root, filepath.Join("testdata", "sample"), nil),
+			"copy test data")
+
+		testPluginsAndDependencies(t, filepath.Join(root, "prog-gowork", "prog"))
+	})
 }
 
 func testPluginsAndDependencies(t *testing.T, progDir string) {

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/README
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/README
@@ -1,0 +1,1 @@
+This is a directory with a go.work with a pulumi project below it

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/go.work
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/go.work
@@ -1,0 +1,6 @@
+go 1.18.0
+
+use (
+	./other
+	./prog
+)

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/other/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/other/go.mod
@@ -1,0 +1,3 @@
+module example.com/other/v1
+
+go 1.18

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/other/other.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/other/other.go
@@ -1,0 +1,3 @@
+package other
+
+func Bar() {}

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: prog
+description: A program with a few dependencies.
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.mod
@@ -1,0 +1,16 @@
+module example.com/prog
+
+go 1.18
+
+replace (
+	example.com/dep => ../../dep
+	example.com/indirect-dep/v2 => ../../indirect-dep
+	example.com/plugin => ../../plugin
+)
+
+require (
+	example.com/dep v1.5.0
+	example.com/plugin v1.2.3
+)
+
+require example.com/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"example.com/dep"
+	"example.com/plugin"
+)
+
+func main() {
+	plugin.Foo()
+	dep.Bar()
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15741.

`go list -m` returns all modules in a workspace if inside a Go workspace. We only need the one module found in the Pulumi program directory (or above it). So we set `GOWORK=off` before calling `go list -m`.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
