### PR TITLE
Add a test and fix that we don't wait for tasks, just outputs

### DIFF
--- a/changelog/pending/20240326--sdk-python--the-python-sdk-only-waits-for-pending-outputs-not-all-pending-asyncio-tasks.yaml
+++ b/changelog/pending/20240326--sdk-python--the-python-sdk-only-waits-for-pending-outputs-not-all-pending-asyncio-tasks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Wait only for pending outputs in the Python SDK, not all pending asyncio tasks

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -39,6 +39,7 @@ from typing import (
 from . import _types, runtime
 from .runtime import rpc
 from .runtime.sync_await import _sync_await
+from .runtime.settings import SETTINGS
 
 if TYPE_CHECKING:
     from .resource import Resource
@@ -99,6 +100,8 @@ class Output(Generic[T_co]):
     ) -> None:
         is_known = asyncio.ensure_future(is_known)
         future = asyncio.ensure_future(future)
+        # keep track of all created outputs so we can check they resolve
+        SETTINGS.outputs.append(future)
 
         async def is_value_known() -> bool:
             return await is_known and not contains_unknowns(await future)

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -51,6 +51,7 @@ def test(fn):
         from .. import Output  # pylint: disable=import-outside-toplevel
 
         SETTINGS.rpc_manager.clear()
+        SETTINGS.outputs.clear()
 
         _sync_await(
             run_pulumi_func(

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections import deque
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -60,6 +61,7 @@ class Settings:
         organization: Optional[str] = None,
     ):
         self.rpc_manager = RPCManager()
+        self.outputs = deque()
 
         # Save the metadata information.
         self.project = project
@@ -103,6 +105,9 @@ class Settings:
     def rpc_manager(self) -> RPCManager:  # type: ignore
         # The contextproperty decorator will fill the body of this method in, but mypy doesn't know that.
         ...
+
+    @contextproperty
+    def outputs(self) -> deque[asyncio.Task]: ...  # type: ignore
 
     @contextproperty
     def monitor(self) -> Optional[resource_pb2_grpc.ResourceMonitorStub]: ...

--- a/tests/integration/python_await/asyncio_tasks/.gitignore
+++ b/tests/integration/python_await/asyncio_tasks/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/
+lib/

--- a/tests/integration/python_await/asyncio_tasks/Pulumi.yaml
+++ b/tests/integration/python_await/asyncio_tasks/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-python-asyncio-tasks
+description: A Python program that tests waiting for outputs and tasks.
+runtime: python

--- a/tests/integration/python_await/asyncio_tasks/__main__.py
+++ b/tests/integration/python_await/asyncio_tasks/__main__.py
@@ -1,0 +1,25 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import asyncio
+import pulumi
+
+a = pulumi.Output.from_input([1, 2])
+# This output has to await an asyncio.task
+async def fn():
+    await asyncio.sleep(1)
+    return 42
+b = pulumi.Output.from_input(asyncio.to_thread(fn))
+
+# this asyncio task will run forever, we shouldn't block the program on that
+async def loop():
+    while True:
+        await asyncio.sleep(1)
+c = asyncio.create_task(loop())
+
+# we should wait for this because it's an output apply, not just an asyncio task.
+def printer(i: int):
+    print("PRINT:", i)
+d = b.apply(printer)
+
+# but we only explicitly await for a
+pulumi.export("export", a)


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/6762.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
