### PR TITLE
Remove trustDependencies option

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -144,10 +144,6 @@ type deploymentOptions struct {
 
 	// true if we're executing a refresh.
 	isRefresh bool
-
-	// true if we should trust the dependency graph reported by the language host. Not all Pulumi-supported languages
-	// correctly report their dependencies, in which case this will be false.
-	trustDependencies bool
 }
 
 // deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
@@ -195,7 +191,6 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 		cancelFunc()
 	}()
 
-	opts.trustDependencies = proj.TrustResourceDependencies()
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,
 	// for example, loading any plugins which will be required to execute a program, among other things.
 	source, err := opts.SourceFunc(
@@ -314,7 +309,6 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 			ReplaceTargets:            deployment.Options.ReplaceTargets,
 			Targets:                   deployment.Options.Targets,
 			TargetDependents:          deployment.Options.TargetDependents,
-			TrustDependencies:         deployment.Options.trustDependencies,
 			UseLegacyDiff:             deployment.Options.UseLegacyDiff,
 			DisableResourceReferences: deployment.Options.DisableResourceReferences,
 			DisableOutputValues:       deployment.Options.DisableOutputValues,

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -58,7 +58,6 @@ type Options struct {
 	Targets                   UrnTargets // If specified, only operate on specified resources.
 	ReplaceTargets            UrnTargets // If specified, mark the specified resources for replacement.
 	TargetDependents          bool       // true if we're allowing things to proceed, even with unspecified targets
-	TrustDependencies         bool       // whether or not to trust the resource dependency graph.
 	UseLegacyDiff             bool       // whether or not to use legacy diffing behavior.
 	DisableResourceReferences bool       // true to disable resource reference support.
 	DisableOutputValues       bool       // true to disable output value support.

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -646,28 +646,6 @@ func TestStepGenerator(t *testing.T) {
 			assert.Empty(t, targets)
 		})
 	})
-	t.Run("ScheduleDeletes", func(t *testing.T) {
-		t.Parallel()
-		t.Run("don't TrustDependencies", func(t *testing.T) {
-			t.Parallel()
-			sg := &stepGenerator{
-				urns: map[resource.URN]bool{},
-				opts: Options{
-					TrustDependencies: false,
-				},
-				deployment: &Deployment{
-					prev: &Snapshot{},
-					olds: map[resource.URN]*resource.State{},
-				},
-			}
-			antichains := sg.ScheduleDeletes([]Step{
-				&DeleteStep{},
-				&CreateStep{},
-				&UpdateStep{},
-			})
-			assert.Len(t, antichains, 3)
-		})
-	})
 	t.Run("providerChanged", func(t *testing.T) {
 		t.Parallel()
 		t.Run("invalid old ProviderReference", func(t *testing.T) {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -519,13 +519,6 @@ func (proj *Project) Validate() error {
 	return nil
 }
 
-// TrustResourceDependencies returns whether this project's runtime can be trusted to accurately report
-// dependencies. All languages supported by Pulumi today do this correctly. This option remains useful when bringing
-// up new Pulumi languages.
-func (proj *Project) TrustResourceDependencies() bool {
-	return true
-}
-
 // Save writes a project definition to a file.
 func (proj *Project) Save(path string) error {
 	contract.Requiref(path != "", "path", "must not be empty")


### PR DESCRIPTION
This option is always true these days, and we don't expect to set it false for anything.  Remove the flag for a bit of code cleanup.
