### PR TITLE
codegen testing: use latest pulumi dotnet version

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -377,4 +377,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.59.0"
+const PulumiDotnetSDKVersion = "3.60.0"


### PR DESCRIPTION
We're currently failing tests because of a nuget error.  It looks like Pulumi.Awsx has started depending on the 3.60 dotnet SDK version, but we're still using 3.59 here.  It looks like this ends up in test as nuget complains about "error NU1605: Warning As Error: Detected package downgrade: Pulumi from 3.60.0 to 3.59.0. Reference the package directly from the project to select a different version."

Not sure if this is the actual fix, not knowing much about dotnet, but it looks like it might be the problem.

Right now the merge queue fails consistently because of this error.