### PR TITLE
Fix flaky TestPropertyDependenciesAdapter

### DIFF
--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -258,17 +259,15 @@ func TestPropertyDependenciesAdapter(t *testing.T) {
 			assert.Empty(t, res.Dependencies)
 			assert.Empty(t, res.PropertyDependencies)
 		case urnC:
-			assert.Equal(t, []resource.URN{urnA, urnB}, res.Dependencies)
-			assert.EqualValues(t, propertyDependencies{
-				"A": res.Dependencies,
-				"B": res.Dependencies,
-			}, res.PropertyDependencies)
+			assert.ElementsMatch(t, []resource.URN{urnA, urnB}, res.Dependencies)
+			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, maps.Keys(res.PropertyDependencies))
+			assert.ElementsMatch(t, res.Dependencies, res.PropertyDependencies["A"])
+			assert.ElementsMatch(t, res.Dependencies, res.PropertyDependencies["B"])
 		case urnD:
-			assert.Equal(t, []resource.URN{urnA, urnB, urnC}, res.Dependencies)
-			assert.EqualValues(t, propertyDependencies{
-				"A": []resource.URN{urnB},
-				"B": []resource.URN{urnA, urnC},
-			}, res.PropertyDependencies)
+			assert.ElementsMatch(t, []resource.URN{urnA, urnB, urnC}, res.Dependencies)
+			assert.ElementsMatch(t, []resource.PropertyKey{"A", "B"}, maps.Keys(res.PropertyDependencies))
+			assert.ElementsMatch(t, []resource.URN{urnB}, res.PropertyDependencies["A"])
+			assert.ElementsMatch(t, []resource.URN{urnA, urnC}, res.PropertyDependencies["B"])
 		}
 	}
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -102,6 +102,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	go.pennock.tech/tabular v1.1.3
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/mod v0.14.0
 	golang.org/x/term v0.18.0
 	golang.org/x/text v0.14.0
@@ -259,7 +260,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/time v0.4.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15749.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
