### PR TITLE
Fix version scripts

### DIFF
--- a/scripts/reversion.js
+++ b/scripts/reversion.js
@@ -13,4 +13,8 @@ var version = process.argv[3];
 if (version && version[0] === "v") {
     version = version.substring(1);
 }
-fs.writeFileSync(file, data.replace(/\${VERSION}/g, version));
+
+var versionPath = __dirname + "/../sdk/.version";
+var versionToReplace = fs.readFileSync(versionPath).toString("utf8").trim();
+var regexp = new RegExp(versionToReplace, "g");
+fs.writeFileSync(file, data.replace(regexp, version));

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -26,6 +26,11 @@ def main():
     with open("sdk/nodejs/package.json", "w") as f:
         f.write("".join(node))
 
+    node = open("sdk/nodejs/version.ts").readlines()
+    replace_line(node, "export const version = ", f'export const version = "{version}";\n')
+    with open("sdk/nodejs/version.ts", "w") as f:
+        f.write("".join(node))
+
     python = open("sdk/python/lib/setup.py").readlines()
     replace_line(python, "VERSION = ", f'VERSION = "{version}"\n')
     with open("sdk/python/lib/setup.py", "w") as f:

--- a/sdk/nodejs/version.ts
+++ b/sdk/nodejs/version.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const version = "${VERSION}";
+export const version = "3.111.2";


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15756.

Fix the set-version script to also set the .ts file with the version correctly.

Fix reversion to replace the currently expected hardcoded version with the given dynamic version.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
