### PR TITLE
Make TestConstructComponentConfigureProviderPython less flaky

### DIFF
--- a/tests/integration/construct_component_configure_provider/python/requirements.txt
+++ b/tests/integration/construct_component_configure_provider/python/requirements.txt
@@ -1,4 +1,4 @@
-pulumi_tls==4.10.0
+pulumi_tls==5.0.1
 
 # TODO[pulumi/pulumi#12414]: Remove our implicit dependency on setuptools.
 # Python 3.12 doesn't include setuptools in virtual environments created by

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -19,7 +19,6 @@ package ints
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -222,11 +221,10 @@ func optsForConstructPython(
 	}
 }
 
+//nolint:paralleltest // Sets env vars
 func TestConstructComponentConfigureProviderPython(t *testing.T) {
-	t.Parallel()
-
-	err := exec.Command("pulumi", "plugin", "install", "resource", "tls", "v4.10.0").Run()
-	assert.NoError(t, err)
+	// This uses the tls plugin so needs to be able to download it
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 	const testDir = "construct_component_configure_provider"
 	runComponentSetup(t, testDir)


### PR DESCRIPTION
Update TLS library to a more recent version that doesn't have the old "install the plugin as part of setup.py" logic.

Then enable the engine to do the plugin download for this test by disabling `PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION`. Should make the test less flaky as the engine is managing the download and can retry, but at least makes the error much more clear if it does fail.