### PR TITLE
Make function serialization work on typescript 4 and 5

### DIFF
--- a/changelog/pending/20240322--sdk-nodejs--make-function-serialization-work-with-typescript-4-and-5.yaml
+++ b/changelog/pending/20240322--sdk-nodejs--make-function-serialization-work-with-typescript-4-and-5.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Make function serialization work with typescript 4 and 5

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -61,7 +61,7 @@ install:: install_package install_plugin
 unit_tests:: $(TEST_ALL_DEPS)
 	yarn run nyc -s mocha --timeout 120000 \
 		--exclude 'bin/tests/automation/**/*.spec.js' \
-		--exclude 'bin/tests/runtime/closure-integreation-tests.js' \
+		--exclude 'bin/tests/runtime/closure-integration-tests.js' \
 		'bin/tests/**/*.spec.js'
 	yarn run nyc -s mocha 'bin/tests_with_mocks/**/*.spec.js'
 
@@ -69,7 +69,7 @@ test_auto:: $(TEST_ALL_DEPS)
 	yarn run nyc -s mocha --timeout 300000 'bin/tests/automation/**/*.spec.js'
 
 test_closure:: $(TEST_ALL_DEPS)
-	node 'bin/tests/runtime/closure-integreation-tests.js'
+	node 'bin/tests/runtime/closure-integration-tests.js'
 
 TSC_SUPPORTED_VERSIONS = ~3.8.3 ^3 ^4
 

--- a/sdk/nodejs/runtime/closure/rewriteSuper.ts
+++ b/sdk/nodejs/runtime/closure/rewriteSuper.ts
@@ -12,12 +12,99 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as typescript from "typescript";
+import * as semver from "semver";
+import * as ts from "typescript";
 import * as utils from "./utils";
+
+type Factory = {
+    createIdentifier: typeof ts.createIdentifier;
+    createThis: typeof ts.createThis;
+    createPropertyAccessExpression: typeof ts.createPropertyAccess;
+    updatePropertyAccessExpression: typeof ts.updatePropertyAccess;
+    updateFunctionDeclaration: typeof ts.updateFunctionDeclaration;
+    updateElementAccessExpression: typeof ts.updateElementAccess;
+    updateCallExpression: typeof ts.updateCall;
+};
+
+// TypeScript 4.0 moved the factory functions to the transformationContext
+// with deprecation. TypeScript 5.0 removed the deprecated functions.
+// https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-40
+// Use a shim factory that calls the correct function based on the TypeScript version.
+function getFactory(transformationContext: ts.TransformationContext): Factory {
+    const tsVersion = semver.parse(ts.version)!;
+    const tsLessThan4 = semver.satisfies(tsVersion, "<4.0.0");
+    const tsLessThan48 = semver.satisfies(tsVersion, "<4.8.0");
+    const transformationContextFactory = (<any>transformationContext).factory;
+
+    // In 4.8 the signature of updateFunctionDeclaration changed to remove the decorators parameter.
+    function updateFunctionDeclaration(
+        node: ts.FunctionDeclaration,
+        decorators: readonly ts.Decorator[] | undefined,
+        modifiers: readonly ts.Modifier[] | undefined,
+        asteriskToken: ts.AsteriskToken | undefined,
+        name: ts.Identifier | undefined,
+        typeParameters: readonly ts.TypeParameterDeclaration[] | undefined,
+        parameters: readonly ts.ParameterDeclaration[],
+        type: ts.TypeNode | undefined,
+        body: ts.Block | undefined,
+    ): ts.FunctionDeclaration {
+        if (tsLessThan4) {
+            return ts.updateFunctionDeclaration(
+                node,
+                decorators,
+                modifiers,
+                asteriskToken,
+                name,
+                typeParameters,
+                parameters,
+                type,
+                body,
+            );
+        } else if (tsLessThan48) {
+            return transformationContextFactory.updateFunctionDeclaration(
+                node,
+                decorators,
+                modifiers,
+                asteriskToken,
+                name,
+                typeParameters,
+                parameters,
+                type,
+                body,
+            );
+        } else {
+            return transformationContextFactory.updateFunctionDeclaration(
+                node,
+                modifiers,
+                asteriskToken,
+                name,
+                typeParameters,
+                parameters,
+                type,
+                body,
+            );
+        }
+    }
+
+    return {
+        createIdentifier: tsLessThan4 ? ts.createIdentifier : transformationContextFactory.createIdentifier,
+        createThis: tsLessThan4 ? ts.createThis : transformationContextFactory.createThis,
+        createPropertyAccessExpression: tsLessThan4
+            ? ts.createPropertyAccess
+            : transformationContextFactory.createPropertyAccessExpression,
+        updatePropertyAccessExpression: tsLessThan4
+            ? ts.updatePropertyAccess
+            : transformationContextFactory.updatePropertyAccessExpression,
+        updateFunctionDeclaration,
+        updateElementAccessExpression: tsLessThan4
+            ? ts.updateElementAccess
+            : transformationContextFactory.updateElementAccessExpression,
+        updateCallExpression: tsLessThan4 ? ts.updateCall : transformationContextFactory.updateCallExpression,
+    };
+}
 
 /** @internal */
 export function rewriteSuperReferences(code: string, isStatic: boolean): string {
-    const ts: typeof typescript = require("typescript");
     const sourceFile = ts.createSourceFile("", code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 
     // Transform any usages of "super(...)" into "__super.call(this, ...)", any
@@ -29,11 +116,12 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
 
     return output;
 
-    function rewriteSuperCallsWorker(transformationContext: typescript.TransformationContext) {
-        const newNodes = new Set<typescript.Node>();
+    function rewriteSuperCallsWorker(transformationContext: ts.TransformationContext) {
+        const factory = getFactory(transformationContext);
+        const newNodes = new Set<ts.Node>();
         let firstFunctionDeclaration = true;
 
-        function visitor(node: typescript.Node): typescript.Node {
+        function visitor(node: ts.Node): ts.Node {
             // Convert the top level function so it doesn't have a name. We want to convert the user
             // function to an anonymous function so that interior references to the same function
             // bind properly.  i.e. if we start with "function f() { f(); }" then this gets converted to
@@ -48,12 +136,12 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
                 const funcDecl = ts.visitEachChild(node, visitor, transformationContext);
 
                 const text = utils.isLegalMemberName(funcDecl.name!.text) ? "/*" + funcDecl.name!.text + "*/" : "";
-                return ts.updateFunctionDeclaration(
+                return factory.updateFunctionDeclaration(
                     funcDecl,
                     funcDecl.decorators,
                     funcDecl.modifiers,
                     funcDecl.asteriskToken,
-                    ts.createIdentifier(text),
+                    factory.createIdentifier(text),
                     funcDecl.typeParameters,
                     funcDecl.parameters,
                     funcDecl.type,
@@ -62,14 +150,14 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
             }
 
             if (node.kind === ts.SyntaxKind.SuperKeyword) {
-                const newNode = ts.createIdentifier("__super");
+                const newNode = factory.createIdentifier("__super");
                 newNodes.add(newNode);
                 return newNode;
             } else if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.SuperKeyword) {
                 const expr = isStatic
-                    ? ts.createIdentifier("__super")
-                    : ts.createPropertyAccess(ts.createIdentifier("__super"), "prototype");
-                const newNode = ts.updatePropertyAccess(node, expr, node.name);
+                    ? factory.createIdentifier("__super")
+                    : factory.createPropertyAccessExpression(factory.createIdentifier("__super"), "prototype");
+                const newNode = factory.updatePropertyAccessExpression(node, expr, node.name);
                 newNodes.add(newNode);
                 return newNode;
             } else if (
@@ -78,10 +166,9 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
                 node.expression.kind === ts.SyntaxKind.SuperKeyword
             ) {
                 const expr = isStatic
-                    ? ts.createIdentifier("__super")
-                    : ts.createPropertyAccess(ts.createIdentifier("__super"), "prototype");
-
-                const newNode = ts.updateElementAccess(node, expr, node.argumentExpression);
+                    ? factory.createIdentifier("__super")
+                    : factory.createPropertyAccessExpression(factory.createIdentifier("__super"), "prototype");
+                const newNode = factory.updateElementAccessExpression(node, expr, node.argumentExpression);
                 newNodes.add(newNode);
                 return newNode;
             }
@@ -98,11 +185,11 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
                 // to that, we have to add the .call(this, ...) call.
 
                 const argumentsCopy = rewritten.arguments.slice();
-                argumentsCopy.unshift(ts.createThis());
+                argumentsCopy.unshift(factory.createThis());
 
-                return ts.updateCall(
+                return factory.updateCallExpression(
                     rewritten,
-                    ts.createPropertyAccess(rewritten.expression, "call"),
+                    factory.createPropertyAccessExpression(rewritten.expression, "call"),
                     rewritten.typeArguments,
                     argumentsCopy,
                 );
@@ -111,6 +198,6 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
             return rewritten;
         }
 
-        return (node: typescript.Node) => ts.visitNode(node, visitor);
+        return (node: ts.Node) => ts.visitNode(node, visitor);
     }
 }

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -57,7 +57,7 @@ async function writePackageJSON(
             "ts-node": "^7.0.1",
             typescript: typescriptVersion,
         },
-        resolve: {
+        resolutions: {
             typescript: typescriptVersion,
         },
     };
@@ -107,7 +107,13 @@ async function run(typescriptVersion: string, nodeTypesVersion: string) {
 }
 
 async function main() {
-    for (const [ts, typesNode] of [["~3.8.3", "^17"]]) {
+    for (const [ts, typesNode] of [
+        ["~3.8.3", "^17"], // Latest 3.8.x, this is the default version.
+        ["<4.8.0", "^20"], // Before 4.8.0, the typescript API we use has some breaking changes in 4.8.0.
+        ["^4.9.5", "^20"], // Latest 4.x.x
+        ["<5.2.0", "^20"], // Awaiter changed slightly in 5.2.0 https://github.com/microsoft/TypeScript/pull/56296
+        ["^5.2.0", "^20"], // Latest 5.x.x
+    ]) {
         await run(ts, typesNode);
     }
 }

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/151-Capture-config-created-on-the-outside/snapshot.~3.8.3.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/151-Capture-config-created-on-the-outside/snapshot.~3.8.3.txt
@@ -42,7 +42,7 @@ function __f2(__0) {
     with({ runtimeConfig_1: __runtimeConfig_1, this: undefined, arguments: undefined }) {
 
 return function /*get*/(key) {
-        const v = (0, runtimeConfig_1.getConfig)(this.fullKey(key));
+        const v = runtimeConfig_1.getConfig(this.fullKey(key));
         if (v === undefined) {
             return undefined;
         }

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/152-Capture-config-created-on-the-inside/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/152-Capture-config-created-on-the-inside/snapshot.txt
@@ -1,5 +1,6 @@
 exports.handler = __f0;
 
+var __deploymentOnlyModule = {};
 var __f1_prototype = {};
 Object.defineProperty(__f1_prototype, "constructor", { configurable: true, writable: true, value: __f1 });
 var __config = {["test:TestingKey2"]: "TestingValue2"};
@@ -7,7 +8,10 @@ var __runtimeConfig_1 = {getConfig: __getConfig};
 Object.defineProperty(__f1_prototype, "get", { configurable: true, writable: true, value: __f2 });
 Object.defineProperty(__f1_prototype, "fullKey", { configurable: true, writable: true, value: __f3 });
 Object.defineProperty(__f1, "prototype", { value: __f1_prototype });
-var __deploymentOnlyModule = {Config: __f1};
+var __m = {};
+Object.defineProperty(__m, "__esModule", { value: true });
+__m.Config = __f1;
+Object.defineProperty(__deploymentOnlyModule, "Config", { enumerable: true, get: __f4 });
 
 function __f1(__0) {
   return (function() {
@@ -41,7 +45,7 @@ function __f2(__0) {
     with({ runtimeConfig_1: __runtimeConfig_1, this: undefined, arguments: undefined }) {
 
 return function /*get*/(key) {
-        const v = runtimeConfig_1.getConfig(this.fullKey(key));
+        const v = (0, runtimeConfig_1.getConfig)(this.fullKey(key));
         if (v === undefined) {
             return undefined;
         }
@@ -59,6 +63,16 @@ function __f3(__0) {
 return function /*fullKey*/(key) {
         return this.name + ":" + key;
     };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f4() {
+  return (function() {
+    with({ m: __m, k: "Config", this: undefined, arguments: undefined }) {
+
+return function () { return m[k]; };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/152-Capture-config-created-on-the-inside/snapshot.~3.8.3.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/152-Capture-config-created-on-the-inside/snapshot.~3.8.3.txt
@@ -1,14 +1,13 @@
 exports.handler = __f0;
 
-var __testConfig_proto = {};
-Object.defineProperty(__f1, "prototype", { value: __testConfig_proto });
-Object.defineProperty(__testConfig_proto, "constructor", { configurable: true, writable: true, value: __f1 });
-var __config = {["test:TestingKey1"]: "TestingValue1"};
+var __f1_prototype = {};
+Object.defineProperty(__f1_prototype, "constructor", { configurable: true, writable: true, value: __f1 });
+var __config = {["test:TestingKey2"]: "TestingValue2"};
 var __runtimeConfig_1 = {getConfig: __getConfig};
-Object.defineProperty(__testConfig_proto, "get", { configurable: true, writable: true, value: __f2 });
-Object.defineProperty(__testConfig_proto, "fullKey", { configurable: true, writable: true, value: __f3 });
-var __testConfig = Object.create(__testConfig_proto);
-__testConfig.name = "test";
+Object.defineProperty(__f1_prototype, "get", { configurable: true, writable: true, value: __f2 });
+Object.defineProperty(__f1_prototype, "fullKey", { configurable: true, writable: true, value: __f3 });
+Object.defineProperty(__f1, "prototype", { value: __f1_prototype });
+var __deploymentOnlyModule = {Config: __f1};
 
 function __f1(__0) {
   return (function() {
@@ -42,7 +41,7 @@ function __f2(__0) {
     with({ runtimeConfig_1: __runtimeConfig_1, this: undefined, arguments: undefined }) {
 
 return function /*get*/(key) {
-        const v = (0, runtimeConfig_1.getConfig)(this.fullKey(key));
+        const v = runtimeConfig_1.getConfig(this.fullKey(key));
         if (v === undefined) {
             return undefined;
         }
@@ -67,9 +66,9 @@ return function /*fullKey*/(key) {
 
 function __f0() {
   return (function() {
-    with({ testConfig: __testConfig, this: undefined, arguments: undefined }) {
+    with({ deploymentOnlyModule: __deploymentOnlyModule, this: undefined, arguments: undefined }) {
 
-return function () { const v = testConfig.get("TestingKey1"); console.log(v); };
+return function () { const v = new deploymentOnlyModule.Config("test").get("TestingKey2"); console.log(v); };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/156-Deconstructing-async-function/snapshot.^5.2.0.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/156-Deconstructing-async-function/snapshot.^5.2.0.txt
@@ -1,0 +1,31 @@
+exports.handler = __f;
+
+function __f0(__0, __1, __2, __3) {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f(__0) {
+  return (function() {
+    with({ __awaiter: __f0, f: __f, this: undefined, arguments: undefined }) {
+
+return function /*f*/(_a) {
+    return __awaiter(this, arguments, void 0, function* ({ whatever }) { });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/158-Deconstructing-async-arrow-function/snapshot.^5.2.0.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/158-Deconstructing-async-arrow-function/snapshot.^5.2.0.txt
@@ -1,0 +1,29 @@
+exports.handler = __f0;
+
+function __f1(__0, __1, __2, __3) {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0(__0) {
+  return (function() {
+    with({ __awaiter: __f1, this: undefined, arguments: undefined }) {
+
+return (_a) => __awaiter(void 0, [_a], void 0, function* ({ whatever }) { return whatever; });
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -101,7 +101,7 @@
         "tests/runtime/asyncIterableUtil.spec.ts",
         "tests/runtime/findWorkspaceRoot.spec.ts",
         "tests/runtime/registrations.spec.ts",
-        "tests/runtime/closure-integreation-tests.ts",
+        "tests/runtime/closure-integration-tests.ts",
         "tests/runtime/props.spec.ts",
         "tests/runtime/settings.spec.ts",
         "tests/runtime/langhost/run.spec.ts",


### PR DESCRIPTION
# Description

Builds on top of https://github.com/pulumi/pulumi/pull/15753

Fixes https://github.com/pulumi/pulumi/issues/15735

There are a couple breaking changes in the typescript API that we use in `sdk/nodejs/runtime/closure/rewriteSuper.ts`. This PR adds a shim that is used to bridge the differences and versions the snapshots where needed.

This does not make typescript a peer dependency yet. Instead the tests force a specific version to be used via [yarn resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
