### PR TITLE
Remove unused prefixCrypter

### DIFF
--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -201,28 +201,6 @@ func decryptAES256GCM(ciphertext []byte, key []byte, nonce []byte) (string, erro
 	return string(msg), err
 }
 
-// Crypter that just adds a prefix to the plaintext string when encrypting,
-// and removes the prefix from the ciphertext when decrypting, for use in tests.
-type prefixCrypter struct {
-	prefix string
-}
-
-func newPrefixCrypter(prefix string) Crypter {
-	return prefixCrypter{prefix: prefix}
-}
-
-func (c prefixCrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
-	return strings.TrimPrefix(ciphertext, c.prefix), nil
-}
-
-func (c prefixCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
-	return c.prefix + plaintext, nil
-}
-
-func (c prefixCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(ctx, c, ciphertexts)
-}
-
 // DefaultBulkDecrypt decrypts a list of ciphertexts. Each ciphertext is decrypted individually. The returned
 // map maps from ciphertext to plaintext. This should only be used by implementers of Decrypter to implement
 // their BulkDecrypt method in cases where they can't do more efficient than just individual decryptions.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Was looking into secrets code and noticed this was completely unused.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
