### PR TITLE
Add `context.Context` to `cachingCrypter.encryptSecret`

### DIFF
--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -471,7 +471,7 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 			// *resource.Secret + plaintext in its cache in order to avoid re-encrypting the value.
 			var ciphertext string
 			if cachingCrypter, ok := enc.(*cachingCrypter); ok {
-				ciphertext, err = cachingCrypter.encryptSecret(prop.SecretValue(), plaintext)
+				ciphertext, err = cachingCrypter.encryptSecret(ctx, prop.SecretValue(), plaintext)
 			} else {
 				ciphertext, err = enc.EncryptValue(ctx, plaintext)
 			}

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -126,9 +126,7 @@ func (c *cachingCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) 
 }
 
 // encryptSecret encrypts the plaintext associated with the given secret value.
-func (c *cachingCrypter) encryptSecret(secret *resource.Secret, plaintext string) (string, error) {
-	ctx := context.TODO()
-
+func (c *cachingCrypter) encryptSecret(ctx context.Context, secret *resource.Secret, plaintext string) (string, error) {
 	// If the cache has an entry for this secret and the plaintext has not changed, re-use the ciphertext.
 	//
 	// Otherwise, re-encrypt the plaintext and update the cache.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Was looking at secret code and saw this was an easy fix up of a `context.TODO()` call.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
