### PR TITLE
Make local dependencies absolute or relative paths

### DIFF
--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -200,25 +200,6 @@ func GenerateProject(
 		return fmt.Errorf("write Pulumi.yaml: %w", err)
 	}
 
-	// The local dependencies map is a map of package name to the path to the package, the path could be
-	// absolute or a relative path but we want to ensure we emit relative paths in the package.json.
-	for k, v := range localDependencies {
-		absPath := v
-		if !filepath.IsAbs(v) {
-			absPath, err = filepath.Abs(v)
-			if err != nil {
-				return fmt.Errorf("absolute path of %s: %w", v, err)
-			}
-		}
-
-		relPath, err := filepath.Rel(directory, absPath)
-		if err != nil {
-			return fmt.Errorf("relative path of %s from %s: %w", absPath, directory, err)
-		}
-
-		localDependencies[k] = relPath
-	}
-
 	// Build the package.json
 	var packageJSON bytes.Buffer
 	fmt.Fprintf(&packageJSON, `{

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -334,25 +334,6 @@ func GenerateProject(
 		return err
 	}
 
-	// The local dependencies map is a map of package name to the path to the package, the path could be
-	// absolute or a relative path but we want to ensure we emit relative paths in the requirments.txt.
-	for k, v := range localDependencies {
-		absPath := v
-		if !filepath.IsAbs(v) {
-			absPath, err = filepath.Abs(v)
-			if err != nil {
-				return fmt.Errorf("absolute path of %s: %w", v, err)
-			}
-		}
-
-		relPath, err := filepath.Rel(directory, absPath)
-		if err != nil {
-			return fmt.Errorf("relative path of %s from %s: %w", absPath, directory, err)
-		}
-
-		localDependencies[k] = relPath
-	}
-
 	// Build a requirements.txt based on the packages used by program
 	var requirementsTxt bytes.Buffer
 	if path, ok := localDependencies["pulumi"]; ok {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -174,9 +174,14 @@ func TestLanguage(t *testing.T) {
 		CoreSdkVersion:       sdk.Version.String(),
 		SnapshotEdits: []*testingrpc.PrepareLanguageTestsRequest_Replacement{
 			{
-				Path:        "package.json",
-				Pattern:     fmt.Sprintf("pulumi-pulumi-%s.tgz", sdk.Version.String()),
+				Path:        "package\\.json",
+				Pattern:     fmt.Sprintf("pulumi-pulumi-%s\\.tgz", sdk.Version.String()),
 				Replacement: "pulumi-pulumi-CORE.VERSION.tgz",
+			},
+			{
+				Path:        "package\\.json",
+				Pattern:     fmt.Sprintf("%s/artifacts", rootDir),
+				Replacement: "ROOT/artifacts",
 			},
 		},
 	})

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-empty/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-empty/package.json
@@ -5,6 +5,6 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-main/subdir/package.json
@@ -5,6 +5,6 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-output-bool/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l1-output-bool/package.json
@@ -5,6 +5,6 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-destroy/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-destroy/0/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-destroy/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-destroy/1/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-engine-update-options/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-engine-update-options/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-resource-simple/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-resource-simple/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-target-up-with-new-dependency/0/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-target-up-with-new-dependency/0/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-target-up-with-new-dependency/1/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/projects/l2-target-up-with-new-dependency/1/package.json
@@ -5,7 +5,7 @@
 	},
 	"dependencies": {
 		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "../../../artifacts/pulumi-pulumi-CORE.VERSION.tgz",
-		"@pulumi/simple": "../../../artifacts/pulumi-simple-2.0.0.tgz"
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
 	}
 }

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -189,9 +189,14 @@ func TestLanguage(t *testing.T) {
 			CoreSdkVersion:       sdk.Version.String(),
 			SnapshotEdits: []*testingrpc.PrepareLanguageTestsRequest_Replacement{
 				{
-					Path:        "requirements.txt",
+					Path:        "requirements\\.txt",
 					Pattern:     fmt.Sprintf("pulumi-%s-py3-none-any.whl", sdk.Version.String()),
 					Replacement: "pulumi-CORE.VERSION-py3-none-any.whl",
+				},
+				{
+					Path:        "requirements\\.txt",
+					Pattern:     fmt.Sprintf("%s/artifacts", rootDir),
+					Replacement: "ROOT/artifacts",
 				},
 			},
 		})

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-empty/requirements.txt
@@ -1,1 +1,1 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-main/subdir/requirements.txt
@@ -1,1 +1,1 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l1-output-bool/requirements.txt
@@ -1,1 +1,1 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/0/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-destroy/1/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-engine-update-options/requirements.txt
@@ -1,2 +1,2 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-simple/requirements.txt
@@ -1,2 +1,2 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/0/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-target-up-with-new-dependency/1/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-empty/requirements.txt
@@ -1,1 +1,1 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/subdir/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-main/subdir/requirements.txt
@@ -1,1 +1,1 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l1-output-bool/requirements.txt
@@ -1,1 +1,1 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/0/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-destroy/1/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-engine-update-options/requirements.txt
@@ -1,2 +1,2 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-simple/requirements.txt
@@ -1,2 +1,2 @@
-../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/0/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-target-up-with-new-dependency/1/requirements.txt
@@ -1,2 +1,2 @@
-../../../artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-../../../artifacts/pulumi_simple-2.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We need this for local dependencies in conformance tests for SDKs and programs. Things like NodeJS just record the path as is in the package.json put into the packed tgz, if a program then uses that tgz via a relative path NodeJS doesn't re-resolve the relative relative paths.
Making these absolute for conformance testing fixes that as all the conformance tests do run in a stable folder location. We fix writing that folder path to the snapshots using the new regex replace facility added in https://github.com/pulumi/pulumi/pull/15747.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
