### PR TITLE
Always use the snapshot secret manager

### DIFF
--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -294,7 +294,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
+	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	data, err := encoding.JSON.Marshal(sdep)

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -171,7 +171,7 @@ func makeUntypedDeploymentTimestamp(
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
+	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func TestHtmlEscaping(t *testing.T) {
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
+	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	data, err := encoding.JSON.Marshal(sdep)

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -296,7 +296,7 @@ func (b *diyBackend) saveStack(
 	sm secrets.Manager,
 ) (string, error) {
 	contract.Requiref(ref != nil, "ref", "ref was nil")
-	chk, err := stack.SerializeCheckpoint(ref.FullyQualifiedName(), snap, sm, false /* showSecrets */)
+	chk, err := stack.SerializeCheckpoint(ref.FullyQualifiedName(), snap, false /* showSecrets */)
 	if err != nil {
 		return "", fmt.Errorf("serializaing checkpoint: %w", err)
 	}

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -38,7 +38,7 @@ type cloudSnapshotPersister struct {
 func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	ctx := persister.context
 
-	deploymentV3, err := stack.SerializeDeployment(snapshot, nil, false /* showSecrets */)
+	deploymentV3, err := stack.SerializeDeployment(snapshot, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -326,7 +326,7 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 	for i := range journalEntries {
 		snap, err := journalEntries[:i].Snap(nil)
 		require.NoError(t, err)
-		deployment, err := stack.SerializeDeployment(snap, nil, true)
+		deployment, err := stack.SerializeDeployment(snap, true)
 		require.NoError(t, err)
 		snaps[i] = deployment
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -196,7 +196,8 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(ctx context.Context,
 	}
 
 	// Reserialize the Snapshopshot with the NewSecrets Manager
-	reserializedDeployment, err := stack.SerializeDeployment(snap, newSecretsManager, false /*showSecrets*/)
+	snap.SecretsManager = newSecretsManager
+	reserializedDeployment, err := stack.SerializeDeployment(snap, false /*showSecrets*/)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -106,7 +106,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			return snapshot, nil
 		},
 		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(snapshot, nil, false)
+			chk, err := stack.SerializeDeployment(snapshot, false)
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +207,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			return snapshot, nil
 		},
 		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(snapshot, nil, false)
+			chk, err := stack.SerializeDeployment(snapshot, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -95,7 +95,7 @@ func newStackExportCmd() *cobra.Command {
 					return checkDeploymentVersionError(err, stackName)
 				}
 
-				serializedDeployment, err := stack.SerializeDeployment(snap, snap.SecretsManager, true)
+				serializedDeployment, err := stack.SerializeDeployment(snap, true)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -145,7 +145,7 @@ func saveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 
 		snapshot.PendingOperations = nil
 	}
-	sdp, err := stack.SerializeDeployment(snapshot, snapshot.SecretsManager, false /* showSecrets */)
+	sdp, err := stack.SerializeDeployment(snapshot, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("constructing deployment for upload: %w", err)
 	}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -181,7 +181,7 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
 	}
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrets */)
+	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}

--- a/pkg/cmd/pulumi/state_edit_encoder.go
+++ b/pkg/cmd/pulumi/state_edit_encoder.go
@@ -39,7 +39,7 @@ type jsonSnapshotEncoder struct{}
 var _ snapshotEncoder = &jsonSnapshotEncoder{}
 
 func (se *jsonSnapshotEncoder) SnapshotToText(snap *deploy.Snapshot) (snapshotText, error) {
-	dep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false)
+	dep, err := stack.SerializeDeployment(snap, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -30,7 +30,7 @@ import (
 // or apply an infrastructure deployment plan in order to make reality match the snapshot state.
 type Snapshot struct {
 	Manifest          Manifest             // a deployment manifest of versions, checksums, and so on.
-	SecretsManager    secrets.Manager      // the manager to use use when seralizing this snapshot.
+	SecretsManager    secrets.Manager      // the manager to use use when serializing this snapshot.
 	Resources         []*resource.State    // fetches all resources and their associated states.
 	PendingOperations []resource.Operation // all currently pending resource operations.
 }

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -103,12 +103,12 @@ func MarshalUntypedDeploymentToVersionedCheckpoint(
 
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
 func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
-	sm secrets.Manager, showSecrets bool,
+	showSecrets bool,
 ) (*apitype.VersionedCheckpoint, error) {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
 	var latest *apitype.DeploymentV3
 	if snap != nil {
-		dep, err := SerializeDeployment(snap, sm, showSecrets)
+		dep, err := SerializeDeployment(snap, showSecrets)
 		if err != nil {
 			return nil, fmt.Errorf("serializing deployment: %w", err)
 		}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -101,17 +101,13 @@ func ValidateUntypedDeployment(deployment *apitype.UntypedDeployment) error {
 }
 
 // SerializeDeployment serializes an entire snapshot as a deploy record.
-func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets bool) (*apitype.DeploymentV3, error) {
+func SerializeDeployment(snap *deploy.Snapshot, showSecrets bool) (*apitype.DeploymentV3, error) {
 	contract.Requiref(snap != nil, "snap", "must not be nil")
 
 	// Capture the version information into a manifest.
 	manifest := snap.Manifest.Serialize()
 
-	// If a specific secrets manager was not provided, use the one in the snapshot, if present.
-	if sm == nil {
-		sm = snap.SecretsManager
-	}
-
+	sm := snap.SecretsManager
 	var enc config.Encrypter
 	if sm != nil {
 		e, err := sm.Encrypter()

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -325,7 +325,7 @@ func TestStackCommands(t *testing.T) {
 			Resource: res,
 			Type:     resource.OperationTypeDeleting,
 		})
-		v3deployment, err := stack.SerializeDeployment(snap, nil, false /* showSecrets */)
+		v3deployment, err := stack.SerializeDeployment(snap, false /* showSecrets */)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

There were a number of places where we passed a `Snapshot` and a `secret.Manager` as arguments to a method, where if the `Manger` was nil we'd fall back to the `Snapshot.SecretManager` (which could also be nil).

Turns out in all but one place this was always passed as nil or just as directly the snapshot's `SecretManager` field.
The one place it differed was in `pkg/cmd/pulumi/stack_change_secrets_provider.go` where we're changing the secret manager, but it's fine to just set the snapshot's `SecretManager` field to the new manager.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
