### PR TITLE
[program-gen/csharp] Fixes generated code for a list of resources used in resource option DependsOn

### DIFF
--- a/changelog/pending/20240324--programgen-dotnet--fixed-generated-code-for-a-list-of-resources-used-in-resource-option-dependson.yaml
+++ b/changelog/pending/20240324--programgen-dotnet--fixed-generated-code-for-a-list-of-resources-used-in-resource-option-dependson.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Fixes generated code for a list of resources used in resource option DependsOn

--- a/changelog/pending/20240324--programgen-dotnet--fixed-generated-code-for-a-list-of-resources-used-in-resource-option-dependson.yaml
+++ b/changelog/pending/20240324--programgen-dotnet--fixed-generated-code-for-a-list-of-resources-used-in-resource-option-dependson.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: programgen/dotnet
-  description: Fixes generated code for a list of resources used in resource option DependsOn
+  description: Fix generated code for a list of resources used in resource option DependsOn

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1120,7 +1120,7 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions, resourceOption
 						g.Fgenf(&result, "\n%s\"%.v\",", g.Indent, v)
 					}
 				})
-				g.Fgenf(&result, "\n%s}", g.Indent)
+				g.Fgenf(&result, "\n%s},", g.Indent)
 			} else {
 				g.Fgenf(&result, "\n%s%s = %v,", g.Indent, name, g.lowerExpression(value, value.Type()))
 			}
@@ -1132,6 +1132,22 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions, resourceOption
 				} else {
 					g.Fgenf(&result, "\n%s%s = %v,", g.Indent, name, g.lowerExpression(value, value.Type()))
 				}
+			} else {
+				g.Fgenf(&result, "\n%s%s = %v,", g.Indent, name, g.lowerExpression(value, value.Type()))
+			}
+		} else if name == "DependsOn" {
+			// depends on need to be special cased
+			// because new [] { resourceA, resourceB } cannot be implicitly casted to InputList<Resource>
+			// use syntax DependsOn = { resourceA, resourceB } instead
+			if resourcesList, isTuple := value.(*model.TupleConsExpression); isTuple {
+				g.Fgenf(&result, "\n%sDependsOn =", g.Indent)
+				g.Fgenf(&result, "\n%s{", g.Indent)
+				g.Indented(func() {
+					for _, resource := range resourcesList.Expressions {
+						g.Fgenf(&result, "\n%s%v, ", g.Indent, resource)
+					}
+				})
+				g.Fgenf(&result, "\n%s},", g.Indent)
 			} else {
 				g.Fgenf(&result, "\n%s%s = %v,", g.Indent, name, g.lowerExpression(value, value.Type()))
 			}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -287,6 +287,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Generate RetainOnDelete option",
 	},
 	{
+		Directory:   "depends-on-array",
+		Description: "Using DependsOn resource option with an array of resources",
+	},
+	{
 		Directory:   "multiline-string",
 		Description: "Multiline string literals",
 	},

--- a/tests/testdata/codegen/aws-fargate-pp/dotnet/aws-fargate.cs
+++ b/tests/testdata/codegen/aws-fargate-pp/dotnet/aws-fargate.cs
@@ -169,9 +169,9 @@ return await Deployment.RunAsync(() =>
         },
     }, new CustomResourceOptions
     {
-        DependsOn = new[]
+        DependsOn =
         {
-            webListener,
+            webListener, 
         },
     });
 

--- a/tests/testdata/codegen/aws-resource-options-4.26-pp/dotnet/aws-resource-options-4.26.cs
+++ b/tests/testdata/codegen/aws-resource-options-4.26-pp/dotnet/aws-resource-options-4.26.cs
@@ -15,16 +15,16 @@ return await Deployment.RunAsync(() =>
     }, new CustomResourceOptions
     {
         Provider = provider,
-        DependsOn = new[]
+        DependsOn =
         {
-            provider,
+            provider, 
         },
         Protect = true,
         IgnoreChanges =
         {
             "bucket",
             "lifecycleRules[0]",
-        }
+        },
     });
 
 });

--- a/tests/testdata/codegen/aws-resource-options-5.16.2-pp/dotnet/aws-resource-options-5.16.2.cs
+++ b/tests/testdata/codegen/aws-resource-options-5.16.2-pp/dotnet/aws-resource-options-5.16.2.cs
@@ -15,16 +15,16 @@ return await Deployment.RunAsync(() =>
     }, new CustomResourceOptions
     {
         Provider = provider,
-        DependsOn = new[]
+        DependsOn =
         {
-            provider,
+            provider, 
         },
         Protect = true,
         IgnoreChanges =
         {
             "bucket",
             "lifecycleRules[0]",
-        }
+        },
     });
 
 });

--- a/tests/testdata/codegen/depends-on-array-pp/depends-on-array.pp
+++ b/tests/testdata/codegen/depends-on-array-pp/depends-on-array.pp
@@ -1,0 +1,40 @@
+resource myBucket "aws:s3/bucket:Bucket" {
+	website = {
+		indexDocument = "index.html"
+	}
+}
+
+resource ownershipControls "aws:s3/bucketOwnershipControls:BucketOwnershipControls" {
+	bucket = myBucket.id
+	rule = {
+		objectOwnership = "ObjectWriter"
+	}
+}
+
+resource publicAccessBlock "aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock" {
+	bucket = myBucket.id
+	blockPublicAcls = false
+}
+
+resource indexHtml "aws:s3/bucketObject:BucketObject" {
+	__logicalName = "index.html"
+	bucket = myBucket.id
+	source = fileAsset("./index.html")
+	contentType = "text/html"
+	acl = "public-read"
+
+	options {
+		dependsOn = [
+			publicAccessBlock,
+			ownershipControls
+		]
+	}
+}
+
+output bucketName {
+	value = myBucket.id
+}
+
+output bucketEndpoint {
+	value = "http://${myBucket.websiteEndpoint}"
+}

--- a/tests/testdata/codegen/depends-on-array-pp/dotnet/depends-on-array.cs
+++ b/tests/testdata/codegen/depends-on-array-pp/dotnet/depends-on-array.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var myBucket = new Aws.S3.Bucket("myBucket", new()
+    {
+        Website = new Aws.S3.Inputs.BucketWebsiteArgs
+        {
+            IndexDocument = "index.html",
+        },
+    });
+
+    var ownershipControls = new Aws.S3.BucketOwnershipControls("ownershipControls", new()
+    {
+        Bucket = myBucket.Id,
+        Rule = new Aws.S3.Inputs.BucketOwnershipControlsRuleArgs
+        {
+            ObjectOwnership = "ObjectWriter",
+        },
+    });
+
+    var publicAccessBlock = new Aws.S3.BucketPublicAccessBlock("publicAccessBlock", new()
+    {
+        Bucket = myBucket.Id,
+        BlockPublicAcls = false,
+    });
+
+    var indexHtml = new Aws.S3.BucketObject("index.html", new()
+    {
+        Bucket = myBucket.Id,
+        Source = new FileAsset("./index.html"),
+        ContentType = "text/html",
+        Acl = "public-read",
+    }, new CustomResourceOptions
+    {
+        DependsOn =
+        {
+            publicAccessBlock, 
+            ownershipControls, 
+        },
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["bucketName"] = myBucket.Id,
+        ["bucketEndpoint"] = myBucket.WebsiteEndpoint.Apply(websiteEndpoint => $"http://{websiteEndpoint}"),
+    };
+});
+

--- a/tests/testdata/codegen/depends-on-array-pp/go/depends-on-array.go
+++ b/tests/testdata/codegen/depends-on-array-pp/go/depends-on-array.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		myBucket, err := s3.NewBucket(ctx, "myBucket", &s3.BucketArgs{
+			Website: &s3.BucketWebsiteArgs{
+				IndexDocument: pulumi.String("index.html"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ownershipControls, err := s3.NewBucketOwnershipControls(ctx, "ownershipControls", &s3.BucketOwnershipControlsArgs{
+			Bucket: myBucket.ID(),
+			Rule: &s3.BucketOwnershipControlsRuleArgs{
+				ObjectOwnership: pulumi.String("ObjectWriter"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		publicAccessBlock, err := s3.NewBucketPublicAccessBlock(ctx, "publicAccessBlock", &s3.BucketPublicAccessBlockArgs{
+			Bucket:          myBucket.ID(),
+			BlockPublicAcls: pulumi.Bool(false),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+			Bucket:      myBucket.ID(),
+			Source:      pulumi.NewFileAsset("./index.html"),
+			ContentType: pulumi.String("text/html"),
+			Acl:         pulumi.String("public-read"),
+		}, pulumi.DependsOn([]pulumi.Resource{
+			publicAccessBlock,
+			ownershipControls,
+		}))
+		if err != nil {
+			return err
+		}
+		ctx.Export("bucketName", myBucket.ID())
+		ctx.Export("bucketEndpoint", myBucket.WebsiteEndpoint.ApplyT(func(websiteEndpoint string) (string, error) {
+			return fmt.Sprintf("http://%v", websiteEndpoint), nil
+		}).(pulumi.StringOutput))
+		return nil
+	})
+}

--- a/tests/testdata/codegen/depends-on-array-pp/nodejs/depends-on-array.ts
+++ b/tests/testdata/codegen/depends-on-array-pp/nodejs/depends-on-array.ts
@@ -1,0 +1,29 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const myBucket = new aws.s3.Bucket("myBucket", {website: {
+    indexDocument: "index.html",
+}});
+const ownershipControls = new aws.s3.BucketOwnershipControls("ownershipControls", {
+    bucket: myBucket.id,
+    rule: {
+        objectOwnership: "ObjectWriter",
+    },
+});
+const publicAccessBlock = new aws.s3.BucketPublicAccessBlock("publicAccessBlock", {
+    bucket: myBucket.id,
+    blockPublicAcls: false,
+});
+const indexHtml = new aws.s3.BucketObject("index.html", {
+    bucket: myBucket.id,
+    source: new pulumi.asset.FileAsset("./index.html"),
+    contentType: "text/html",
+    acl: "public-read",
+}, {
+    dependsOn: [
+        publicAccessBlock,
+        ownershipControls,
+    ],
+});
+export const bucketName = myBucket.id;
+export const bucketEndpoint = pulumi.interpolate`http://${myBucket.websiteEndpoint}`;

--- a/tests/testdata/codegen/depends-on-array-pp/python/depends-on-array.py
+++ b/tests/testdata/codegen/depends-on-array-pp/python/depends-on-array.py
@@ -1,0 +1,25 @@
+import pulumi
+import pulumi_aws as aws
+
+my_bucket = aws.s3.Bucket("myBucket", website=aws.s3.BucketWebsiteArgs(
+    index_document="index.html",
+))
+ownership_controls = aws.s3.BucketOwnershipControls("ownershipControls",
+    bucket=my_bucket.id,
+    rule=aws.s3.BucketOwnershipControlsRuleArgs(
+        object_ownership="ObjectWriter",
+    ))
+public_access_block = aws.s3.BucketPublicAccessBlock("publicAccessBlock",
+    bucket=my_bucket.id,
+    block_public_acls=False)
+index_html = aws.s3.BucketObject("index.html",
+    bucket=my_bucket.id,
+    source=pulumi.FileAsset("./index.html"),
+    content_type="text/html",
+    acl="public-read",
+    opts=pulumi.ResourceOptions(depends_on=[
+            public_access_block,
+            ownership_controls,
+        ]))
+pulumi.export("bucketName", my_bucket.id)
+pulumi.export("bucketEndpoint", my_bucket.website_endpoint.apply(lambda website_endpoint: f"http://{website_endpoint}"))


### PR DESCRIPTION
# Description

Fixes #14462 by special casing how we handle `dependsOn` and generating `DependsOn = { ... }` instead of `DependsOn = new[] { ... }`

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
