### PR TITLE
Export automation.tag.TagMap type & @param tag fixes

### DIFF
--- a/changelog/pending/20240325--sdk-nodejs--export-automation-tag-tagmap-type.yaml
+++ b/changelog/pending/20240325--sdk-nodejs--export-automation-tag-tagmap-type.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Export automation.tag.TagMap type

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -47,7 +47,14 @@ export class CommandResult {
 }
 
 export interface PulumiCommandOptions {
+    /**
+     * The version of the CLI to use. Defaults to the CLI version matching the SDK version.
+     */
     version?: semver.SemVer;
+    /**
+     * The directory to install the CLI in or where to look for an existing
+     * installation. Defaults to $HOME/.pulumi/versions/$VERSION.
+     */
     root?: string;
     /**
      * Skips the minimum CLI version check, see `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK`.
@@ -83,10 +90,6 @@ export class PulumiCommand {
 
     /**
      * Installs the Pulumi CLI.
-     *
-     * @param opts.version the version of the CLI. Defaults to the CLI version matching the SDK version.
-     * @param opts.root the directory to install the CLI in. Defaults to $HOME/.pulumi/versions/$VERSION.
-     * @param opts.skipVersionCheck skips the CLI version check.
      */
     static async install(opts?: PulumiCommandOptions): Promise<PulumiCommand> {
         const optsWithDefaults = withDefaults(opts);

--- a/sdk/nodejs/automation/index.ts
+++ b/sdk/nodejs/automation/index.ts
@@ -23,3 +23,4 @@ export * from "./workspace";
 export * from "./events";
 export * from "./remoteStack";
 export * from "./remoteWorkspace";
+export * from "./tag";

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -729,7 +729,6 @@ export class LocalWorkspace implements Workspace {
      *
      * @param name the name of the plugin.
      * @param version the version of the plugin e.g. "v1.0.0".
-     * @param kind the kind of plugin, defaults to "resource"
      * @param server the server to install the plugin from
      */
     async installPluginFromServer(name: string, version: string, server: string): Promise<void> {

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -238,7 +238,7 @@ export interface Workspace {
      *
      * @param name the name of the plugin.
      * @param version the version of the plugin e.g. "v1.0.0".
-     * @param kind the kind of plugin e.g. "resource"
+     * @param server the server to install the plugin into
      */
     installPluginFromServer(name: string, version: string, server: string): Promise<void>;
     /**
@@ -246,7 +246,7 @@ export interface Workspace {
      *
      * @param name the name of the plugin.
      * @param version the version of the plugin e.g. "v1.0.0".
-     * @param server the server to install the plugin into
+     * @param kind the kind of plugin e.g. "resource"
      */
     installPlugin(name: string, version: string, kind?: string): Promise<void>;
     /**

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -1052,7 +1052,7 @@ export class ComponentResource<TData = any> extends Resource {
      * list of other resources that this resource depends on, controlling the order in which we
      * perform resource operations.
      *
-     * @param t The type of the resource.
+     * @param type The type of the resource.
      * @param name The _unique_ name of the resource.
      * @param args Information passed to [initialize] method.
      * @param opts A bag of options that control this resource's behavior.

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -98,14 +98,14 @@ export interface Mocks {
     /**
      * Mocks provider-implemented function calls (e.g. aws.get_availability_zones).
      *
-     * @param args: MockCallArgs
+     * @param args MockCallArgs
      */
     call(args: MockCallArgs): MockCallResult | Promise<MockCallResult>;
     /**
      * Mocks resource construction calls. This function should return the physical identifier and the output properties
      * for the resource being constructed.
      *
-     * @param args: MockResourceArgs
+     * @param args MockResourceArgs
      */
     newResource(args: MockResourceArgs): MockResourceResult | Promise<MockResourceResult>;
 }
@@ -239,11 +239,11 @@ export class MockMonitor {
 /**
  * setMocks configures the Pulumi runtime to use the given mocks for testing.
  *
- * @param mocks: The mocks to use for calls to provider functions and resource construction.
- * @param project: If provided, the name of the Pulumi project. Defaults to "project".
- * @param stack: If provided, the name of the Pulumi stack. Defaults to "stack".
- * @param preview: If provided, indicates whether or not the program is running a preview. Defaults to false.
- * @param organization: If provided, the name of the Pulumi organization. Defaults to nothing.
+ * @param mocks The mocks to use for calls to provider functions and resource construction.
+ * @param project If provided, the name of the Pulumi project. Defaults to "project".
+ * @param stack If provided, the name of the Pulumi stack. Defaults to "stack".
+ * @param preview If provided, indicates whether or not the program is running a preview. Defaults to false.
+ * @param organization If provided, the name of the Pulumi organization. Defaults to nothing.
  */
 export async function setMocks(
     mocks: Mocks,

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -64,7 +64,7 @@ export class Stack extends ComponentResource<Inputs> {
      * runInit invokes the given init callback with this resource set as the root resource. The return value of init is
      * used as the stack's output properties.
      *
-     * @param init The callback to run in the context of this Pulumi stack
+     * @param args.init The callback to run in the context of this Pulumi stack
      */
     async initialize(args: { init: () => Promise<Inputs> }): Promise<Inputs> {
         await setRootResource(this);

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -42,7 +42,7 @@ export class StackReference extends CustomResource {
      *
      * @param name The _unique_ name of the stack reference.
      * @param args The arguments to use to populate this resource's properties.
-     * @Param opts A bag of options that control this resource's behavior.
+     * @param opts A bag of options that control this resource's behavior.
      */
     constructor(name: string, args?: StackReferenceArgs, opts?: CustomResourceOptions) {
         args = args || {};


### PR DESCRIPTION
# Description

Noticed a couple warnings when building the docs using typedoc.

- Fix some typedoc `@param` tags
- Export automation.tag.TagMap type


Ref: https://github.com/pulumi/docs/pull/10964

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
