### PR TITLE
Check for protect in replace chains

### DIFF
--- a/changelog/pending/20240325--engine--fix-the-engine-trying-to-delete-a-protected-resource-caught-in-a-replace-chain.yaml
+++ b/changelog/pending/20240325--engine--fix-the-engine-trying-to-delete-a-protected-resource-caught-in-a-replace-chain.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix the engine trying to delete a protected resource caught in a replace chain

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
@@ -591,4 +592,85 @@ func TestDependencyChangeDBR(t *testing.T) {
 		},
 	}
 	p.Run(t, snap)
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/15763. Check that if a resource gets implicated in a
+// replacement chain that it fails if the resource is protected.
+func TestDBRProtect(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffF: func(urn resource.URN, id resource.ID,
+					oldInputs, oldOutputs, newInputs resource.PropertyMap, ignoreChanges []string,
+				) (plugin.DiffResult, error) {
+					if !oldOutputs["A"].DeepEquals(newInputs["A"]) {
+						return plugin.DiffResult{
+							ReplaceKeys:         []resource.PropertyKey{"A"},
+							DeleteBeforeReplace: true,
+						}, nil
+					}
+					if !oldOutputs["B"].DeepEquals(newInputs["B"]) {
+						return plugin.DiffResult{
+							Changes: plugin.DiffSome,
+						}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool,
+				) (resource.ID, resource.PropertyMap, resource.Status, error) {
+					return "created-id", news, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+
+	const resType = "pkgA:index:typ"
+
+	inputsA := resource.NewPropertyMapFromMap(map[string]interface{}{"A": "foo"})
+	inputsB := resource.NewPropertyMapFromMap(map[string]interface{}{"A": "foo"})
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		urnA, _, _, _, err := monitor.RegisterResource(resType, "resA", true, deploytest.ResourceOptions{
+			Inputs: inputsA,
+		})
+		assert.NoError(t, err)
+
+		inputDepsB := map[resource.PropertyKey][]resource.URN{"A": {urnA}}
+		_, _, _, _, err = monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
+			Inputs:       inputsB,
+			Dependencies: []resource.URN{urnA},
+			PropertyDeps: inputDepsB,
+			Protect:      true,
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	options := TestUpdateOptions{HostF: hostF}
+	p := &TestPlan{}
+
+	project := p.GetProject()
+
+	// First update just create the two resources.
+	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), options, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	assert.Len(t, snap.Resources, 3)
+
+	// Update A to trigger a replace this should error because of the protect flag on B.
+	inputsA["A"] = resource.NewStringProperty("bar")
+	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil)
+	assert.ErrorContains(t, err, "unable to replace resource \"urn:pulumi:test::test::pkgA:index:typ::resB\""+
+		" as part of replacing \"urn:pulumi:test::test::pkgA:index:typ::resA\" as it is currently marked for protection.")
+
+	// Remove the protect flag and try again
+	assert.Equal(t, snap.Resources[2].Protect, true)
+	snap.Resources[2].Protect = false
+	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), options, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	assert.Len(t, snap.Resources, 3)
 }


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15763.

When doing a replace chain we need to check if the resources implicated for deletion in the chain are actually ok to delete (i.e. they don't have `protect` set). This change fixes the step generator to check that when building the delete chain, and adds a test for it as well.

Sadly because of the nature of the system you have to `state unprotect` these resources if you actually want them replaced, you can't just change `protect` in the resource options in the program. This is because at the point we're processing the "to be replaced" resource we've only got the old state for the implicated resource because we won't have got it's new goal state yet because it depends on the resource we're currently processing.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
