### PR TITLE
automation: only read complete lines before trying to deserialize

### DIFF
--- a/changelog/pending/20240325--auto-go-nodejs-python--make-sure-to-read-complete-lines-before-trying-to-deserialize-them-as-engine-events.yaml
+++ b/changelog/pending/20240325--auto-go-nodejs-python--make-sure-to-read-complete-lines-before-trying-to-deserialize-them-as-engine-events.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go,nodejs,python
+  description: Make sure to read complete lines before trying to deserialize them as engine events

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/go-ps v1.0.0
-	github.com/nxadm/tail v1.4.8
+	github.com/nxadm/tail v1.4.11
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/uniseg v0.4.4
@@ -87,7 +87,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -56,6 +56,8 @@ github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
@@ -135,6 +137,8 @@ github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1n
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/opentracing/basictracer-go v1.1.0 h1:Oa1fTSBvAl8pa3U+IJYqrKm0NALwH9OsgwOqDv4xJW0=
 github.com/opentracing/basictracer-go v1.1.0/go.mod h1:V2HZueSJEp879yv285Aap1BS69fQMD+MNP1mRs6mBQc=
@@ -269,6 +273,7 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -53,9 +53,6 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
-github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -135,8 +132,6 @@ github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKt
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -260,7 +255,6 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -269,7 +263,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1391,9 +1391,10 @@ type fileWatcher struct {
 
 func watchFile(path string, receivers []chan<- events.EngineEvent) (*fileWatcher, error) {
 	t, err := tail.TailFile(path, tail.Config{
-		Follow: true,
-		Poll:   runtime.GOOS == "windows", // on Windows poll for file changes instead of using the default inotify
-		Logger: tail.DiscardingLogger,
+		Follow:        true,
+		Poll:          runtime.GOOS == "windows", // on Windows poll for file changes instead of using the default inotify
+		Logger:        tail.DiscardingLogger,
+		CompleteLines: true,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -147,11 +147,16 @@ func TestAlwaysReadsCompleteLine(t *testing.T) {
 		f, err := os.Create(tmpFile)
 		require.NoError(t, err)
 		defer f.Close()
-		parts := []string{`{"stdoutEvent": `, ` {"message": "hello", "color": "blue"}}` + "\n", `{"stdoutEvent": {"message":`, ` "world", "color": "red"}}` + "\n"}
+		parts := []string{
+			`{"stdoutEvent": `,
+			` {"message": "hello", "color": "blue"}}` + "\n",
+			`{"stdoutEvent": {"message":`,
+			` "world", "color": "red"}}` + "\n",
+		}
 		for _, part := range parts {
 			_, err = f.WriteString(part)
 			require.NoError(t, err)
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 	engineEvents := make(chan events.EngineEvent, 20)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -123,9 +123,17 @@ export class Stack {
         });
         await eventLogTail.start();
         const lineSplitter = readline.createInterface({ input: eventLogTail });
+        let partialLine = '';
         lineSplitter.on("line", (line) => {
             let event: EngineEvent;
             try {
+                if (!line.endsWith('\n')) {
+                    partialLine += line;
+                    return;
+                } else {
+                    line = partialLine + line;
+                    partialLine = '';
+                }
                 event = JSON.parse(line);
                 callback(event);
             } catch (e) {

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -123,16 +123,16 @@ export class Stack {
         });
         await eventLogTail.start();
         const lineSplitter = readline.createInterface({ input: eventLogTail });
-        let partialLine = '';
+        let partialLine = "";
         lineSplitter.on("line", (line) => {
             let event: EngineEvent;
             try {
-                if (!line.endsWith('\n')) {
+                if (!line.endsWith("\n")) {
                     partialLine += line;
                     return;
                 } else {
                     line = partialLine + line;
-                    partialLine = '';
+                    partialLine = "";
                 }
                 event = JSON.parse(line);
                 callback(event);

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -127,21 +127,13 @@ export class Stack {
         lineSplitter.on("line", (line) => {
             let event: EngineEvent;
             try {
-                if (!line.endsWith("\n")) {
-                    partialLine += line;
-                    return;
-                } else {
-                    line = partialLine + line;
-                    partialLine = "";
-                }
+                line = partialLine + line;
+                partialLine = "";
                 event = JSON.parse(line);
                 callback(event);
             } catch (e) {
-                log.warn(`Failed to parse engine event
-If you're seeing this warning, please comment on https://github.com/pulumi/pulumi/issues/6768 with the event and any
-details about your environment.
-
-Event: ${line}\n${e.toString()}`);
+                partialLine += line;
+                return;
             }
         });
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -951,6 +951,7 @@ def _create_log_file(command: str) -> Tuple[str, tempfile.TemporaryDirectory]:
 
 
 def _watch_logs(filename: str, callback: OnEvent):
+    partial_line = ''
     with open(filename, encoding="utf-8") as f:
         while True:
             line = f.readline()
@@ -959,6 +960,15 @@ def _watch_logs(filename: str, callback: OnEvent):
             if not line:
                 time.sleep(0.1)
                 continue
+
+            # we don't have a complete line yet.  sleep and try again.
+            if line[-1] != '\n':
+                partiall_line += line
+                time.sleep(0.1)
+                continue
+            else:
+                line = partial_line + line
+                partial_line = ''
 
             event = EngineEvent.from_json(json.loads(line))
             callback(event)

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -951,7 +951,7 @@ def _create_log_file(command: str) -> Tuple[str, tempfile.TemporaryDirectory]:
 
 
 def _watch_logs(filename: str, callback: OnEvent):
-    partial_line = ''
+    partial_line = ""
     with open(filename, encoding="utf-8") as f:
         while True:
             line = f.readline()
@@ -962,13 +962,13 @@ def _watch_logs(filename: str, callback: OnEvent):
                 continue
 
             # we don't have a complete line yet.  sleep and try again.
-            if line[-1] != '\n':
-                partiall_line += line
+            if line[-1] != "\n":
+                partial_line += line
                 time.sleep(0.1)
                 continue
-            else:
-                line = partial_line + line
-                partial_line = ''
+
+            line = partial_line + line
+            partial_line = ""
 
             event = EngineEvent.from_json(json.loads(line))
             callback(event)

--- a/sdk/python/lib/test/automation/test_stack.py
+++ b/sdk/python/lib/test/automation/test_stack.py
@@ -1,0 +1,34 @@
+# Copyright 2024-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+
+class TestStack(unittest.TestCase):
+    def test_always_read_complete_lines(self):
+        tempfile = tempfile.NamedTemporaryFile()
+        async def write_lines():
+            with tempfile as f:
+                parts = ['{"stdoutEvent": ', '{"message": "hello", "color": "blue"}', '}\n', '{"stdoutEvent": ', '{"message": "world"', ', "color": "red"}}\n']
+                for part in parts:
+                    f.write(part)
+                    await asyncio.sleep(0.2)
+        write_task = asyncio.create_task(write_lines())
+        event_num = 0
+        def callback(event):
+            if event_num == 0:
+                self.assertEqual(event, {"message": "hello", "color": "blue"})
+            elif event_num == 1:
+                self.assertEqual(event, {"message": "world", "color": "red"})
+
+        _watch_logs(tempfile.name, callback)

--- a/sdk/python/lib/test/automation/test_stack.py
+++ b/sdk/python/lib/test/automation/test_stack.py
@@ -12,23 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import os
 import tempfile
+import time
+import unittest
 
-class TestStack(unittest.TestCase):
-    def test_always_read_complete_lines(self):
-        tempfile = tempfile.NamedTemporaryFile()
-        async def write_lines():
-            with tempfile as f:
-                parts = ['{"stdoutEvent": ', '{"message": "hello", "color": "blue"}', '}\n', '{"stdoutEvent": ', '{"message": "world"', ', "color": "red"}}\n']
+from pulumi.automation._stack import _watch_logs
+from pulumi.automation import EngineEvent, StdoutEngineEvent
+
+class TestStack(unittest.IsolatedAsyncioTestCase):
+    async def test_always_read_complete_lines(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+
+        async def write_lines(tmp):
+            with open(tmp, 'w') as f:
+                parts = ['{"stdoutEvent": ', '{"message": "hello", "color": "blue"}', '}\n', '{"stdoutEvent": ', '{"message": "world"', ', "color": "red"}}\n', '{"cancelEvent": {}}\n']
                 for part in parts:
                     f.write(part)
-                    await asyncio.sleep(0.2)
-        write_task = asyncio.create_task(write_lines())
-        event_num = 0
-        def callback(event):
-            if event_num == 0:
-                self.assertEqual(event, {"message": "hello", "color": "blue"})
-            elif event_num == 1:
-                self.assertEqual(event, {"message": "world", "color": "red"})
+                    f.flush()
+                    time.sleep(0.2)
 
-        _watch_logs(tempfile.name, callback)
+        write_task = asyncio.create_task(write_lines(tmp.name))
+        event_num = 0
+
+        def callback(event):
+            nonlocal event_num
+            if event_num == 0:
+                self.assertTrue(event.stdout_event)
+                self.assertEqual(event.stdout_event.message, "hello")
+                self.assertEqual(event.stdout_event.color, "blue")
+            elif event_num == 1:
+                self.assertTrue(event.stdout_event)
+                self.assertEqual(event.stdout_event.message, "world")
+                self.assertEqual(event.stdout_event.color, "red")
+            event_num += 1
+
+        async def watch_async():
+            _watch_logs(tmp.name, callback)
+        watch_task = asyncio.create_task(watch_async())
+        await asyncio.gather(write_task, watch_task)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2718,8 +2718,9 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
When tailing the event log in automation API we currently have nothing that makes sure we read only complete lines.  This means if the OS happens to flush an incomplete line for whatever reason (or the Go JSON encoder does, which we're using to write these lines), we might read a line that is incompletely written, and thus will fail to JSON decode it.

Since the JSON encoder always writes a newline at the end of each string, we can also make sure that the line we read ends with a newline and otherwise wait for the rest of the line to be written.

The library we use in Go provides a convenient setting for this, while in python and nodejs we need to add some code to do this ourselves.

Fixes https://github.com/pulumi/pulumi/issues/15235
Fixes https://github.com/pulumi/pulumi/issues/15652
Fixes https://github.com/pulumi/pulumi/issues/9269 (This is closed already, but never had a proper resolution afaics)
Fixes https://github.com/pulumi/pulumi/issues/6768

It would be nice to add a typescript test here as well, but I'm not sure how to do that without marking the readLines function non-private.  But I don't know typescript well, so any hints of how to do that would be appreciated!

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works  
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
