### PR TITLE
Ignore .mono directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ venv/
 .envrc
 # Ignore VSCode created solution file
 /pulumi.sln
+.mono
 
 # Ignore user-provided go.work files.
 /go.work


### PR DESCRIPTION
csdevkit seems to really want to make this directory and I will accidentally `git add` eventually if not ignored. 