### PR TITLE
only update homebrew tap after pulumi-version is updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
     if: inputs.run-dispatch-commands && !contains(inputs.version, '-')
+    needs: [dispatch]
     uses: ./.github/workflows/release-homebrew-tap.yml
     permissions:
       contents: read


### PR DESCRIPTION
Currently we run update-homebrew-tap in parallel to the other jobs. That means it could complete before we updated the blobs on S3, and before the version number on pulumi.com/pulumi-version is updated.

That in turn can make the CI fail, raising a P1.

Since all this happens within a pretty sort time, the easiest way to work around this is to just do the homebrew tap update last, after pulumi.com/pulumi-version is updated.  This delays the homebrew tap update, but only by a short amount of time.

Fixes https://github.com/pulumi/homebrew-tap/issues/24
