### PR TITLE
Add a link to the Import documentation from API docs pages

### DIFF
--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -580,7 +580,7 @@ func newImportCmd() *cobra.Command {
 			"\n" +
 			"    pulumi import 'aws:iam/user:User' name id\n" +
 			"\n" +
-			"The type token and property used for resource lookup are available in the Import section of" +
+			"The type token and property used for resource lookup are available in the Import section of\n" +
 			"the resource's API documentation in the Pulumi Registry (https://www.pulumi.com/registry/)." +
 			"\n" +
 			"To fully specify parent and/or provider, subsitute the <urn> for each into the following:\n" +

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -344,6 +344,8 @@ Only the first 200 types are included in this documentation.
 
 {{ htmlSafe .ImportDocs }}
 
+To learn more about importing existing cloud resources, see [Importing resources](/docs/using-pulumi/adopting-pulumi/import/).
+
 {{ end }}
 
 {{ template "package_details" .PackageDetails }}

--- a/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -1128,6 +1128,8 @@ $ pulumi import azure-native:documentdb:SqlResourceSqlContainer containerName /s
 ```
 
 
+To learn more about importing existing cloud resources, see [Importing resources](/docs/using-pulumi/adopting-pulumi/import/).
+
 
 
 


### PR DESCRIPTION
Adds a link to the Import docs from the API docs (to help answer questions about how import works, where to look for identifiers, etc.) and adds a line break to the `import --help` CLI output. (Sorry, my bad!)

![image](https://github.com/pulumi/pulumi/assets/274700/f7ba2315-e127-43b0-8dd6-041d344bb367)

Fixes https://github.com/pulumi/registry/issues/3039.
 