### PR TITLE
Use the full path when running pulumi from a custom CLI install

### DIFF
--- a/changelog/pending/20240327--auto-go-python--use-the-full-path-when-running-pulumi-from-a-custom-cli-install.yaml
+++ b/changelog/pending/20240327--auto-go-python--use-the-full-path-when-running-pulumi-from-a-custom-cli-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go,python
+  description: Use the full path when running pulumi from a custom CLI install

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -265,7 +265,7 @@ func (p pulumiCommand) Run(ctx context.Context,
 	// all commands should be run in non-interactive mode.
 	// this causes commands to fail rather than prompting for input (and thus hanging indefinitely)
 	args = withNonInteractiveArg(args)
-	cmd := exec.CommandContext(ctx, "pulumi", args...)
+	cmd := exec.CommandContext(ctx, p.command, args...) //nolint:gosec
 	cmd.Dir = workdir
 	env := append(os.Environ(), additionalEnv...)
 	if filepath.IsAbs(p.command) {

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -206,7 +206,7 @@ class PulumiCommand:
         env = {**os.environ, **additional_env}
         if os.path.isabs(self.command):
             env = _fixup_path(env, os.path.dirname(self.command))
-        cmd = ["pulumi"]
+        cmd = [self.command]
         cmd.extend(args)
 
         stdout_chunks: List[str] = []


### PR DESCRIPTION

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15796

Turns out nodejs already uses the [full command name](https://github.com/pulumi/pulumi/blob/bc4a9ad59ba23cef43c27355bb2e2b82d664a12a/sdk/nodejs/automation/cmd.ts#L176).

Fixed for python and go.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
