### PR TITLE
add test for authenticating with AUTH_VIA_CLI

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -201,6 +201,13 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
         with:
           gradle-version: "7.6"
+      - name: log in to azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
       - name: Uninstall pre-installed Pulumi (windows)
         if: inputs.platform == 'windows-latest'
         run: |
@@ -339,6 +346,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
+          AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/application_default_credentials.json

--- a/tests/integration/backend/diy/backend_azure_test.go
+++ b/tests/integration/backend/diy/backend_azure_test.go
@@ -71,3 +71,40 @@ func TestAzureLoginAzLogin(t *testing.T) {
 
 	loginAndCreateStack(t, cloudURL)
 }
+
+//nolint:paralleltest // this test uses the global azure login state
+func TestAzureLoginAzLoginUsingCLI(t *testing.T) {
+	err := os.Chdir("project")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Chdir("..")
+		require.NoError(t, err)
+	})
+	cloudURL := "azblob://pulumitesting?storage_account=pulumitesting"
+	_, clientIDSet := os.LookupEnv("AZURE_CLIENT_ID")
+	_, clientSecretSet := os.LookupEnv("AZURE_CLIENT_SECRET")
+	_, tenantIDSet := os.LookupEnv("AZURE_TENANT_ID")
+	if !clientIDSet || !clientSecretSet || !tenantIDSet {
+		t.Skip("AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID not set, skipping test")
+	}
+
+	// Make sure we don't use the SAS token for login here
+	t.Setenv("AZURE_STORAGE_SAS_TOKEN", "")
+	t.Setenv("AZURE_KEYVAULT_AUTH_VIA_CLI", "true")
+
+	//nolint:gosec // this is a test
+	err = exec.Command("az", "login", "--service-principal",
+		"--username", os.Getenv("AZURE_CLIENT_ID"),
+		"--password", os.Getenv("AZURE_CLIENT_SECRET"),
+		"--tenant", os.Getenv("AZURE_TENANT_ID")).Run()
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := exec.Command("az", "logout").Run()
+		assert.NoError(t, err)
+		err = exec.Command("pulumi", "logout").Run()
+		assert.NoError(t, err)
+	})
+
+	loginAndCreateStack(t, cloudURL)
+}

--- a/tests/integration/backend/diy/backend_azure_test.go
+++ b/tests/integration/backend/diy/backend_azure_test.go
@@ -108,3 +108,28 @@ func TestAzureLoginAzLoginUsingCLI(t *testing.T) {
 
 	loginAndCreateStack(t, cloudURL)
 }
+
+//nolint:paralleltest // this test uses the global azure login state
+func TestAzureLoginAzLoginUsingAction(t *testing.T) {
+	err := os.Chdir("project")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Chdir("..")
+		require.NoError(t, err)
+	})
+	cloudURL := "azblob://pulumitesting?storage_account=pulumitesting"
+	t.Setenv("AZURE_CLIENT_ID", "")
+	t.Setenv("AZURE_CLIENT_SECRET", "")
+	t.Setenv("AZURE_TENANT_ID", "")
+
+	// Make sure we don't use the SAS token for login here
+	t.Setenv("AZURE_STORAGE_SAS_TOKEN", "")
+	t.Setenv("AZURE_KEYVAULT_AUTH_VIA_CLI", "\"true\"")
+
+	t.Cleanup(func() {
+		err = exec.Command("pulumi", "logout").Run()
+		assert.NoError(t, err)
+	})
+
+	loginAndCreateStack(t, cloudURL)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
