### PR TITLE
Add an 'instructions' to Pulumi templates to display them at pulumi new

### DIFF
--- a/changelog/pending/20240328--cli-new--add-an-instructions-option-to-pulumi-templates-and-display-the-instuctions-at-pulumi-new.yaml
+++ b/changelog/pending/20240328--cli-new--add-an-instructions-option-to-pulumi-templates-and-display-the-instuctions-at-pulumi-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Add an 'instructions' option to Pulumi templates and display the instuctions at pulumi new

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/url"
 	"os"
@@ -76,11 +77,16 @@ type newArgs struct {
 	aiPrompt          string
 	aiLanguage        httpstate.PulumiAILanguage
 	templateMode      bool
+	stdout            io.Writer
 }
 
 func runNew(ctx context.Context, args newArgs) error {
 	if !args.interactive && !args.yes {
 		return errors.New("--yes must be passed in to proceed when running in non-interactive mode")
+	}
+
+	if args.stdout == nil {
+		args.stdout = os.Stdout
 	}
 
 	// Prepare options.
@@ -254,8 +260,11 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Show instructions, if we're going to show at least one prompt.
 	hasAtLeastOnePrompt := (args.name == "") || (args.description == "") || (!args.generateOnly && args.stack == "")
 	if !args.yes && hasAtLeastOnePrompt {
-		fmt.Println("This command will walk you through creating a new Pulumi project.")
-		fmt.Println()
+		fmt.Fprintln(args.stdout, "This command will walk you through creating a new Pulumi project.")
+		fmt.Fprintln(args.stdout)
+		if template.Instructions != "" {
+			fmt.Fprintln(args.stdout, opts.Color.Colorize(template.Instructions))
+		}
 		fmt.Println(
 			opts.Color.Colorize(
 				colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -1118,4 +1119,34 @@ func TestSanitizeTemplate(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+//nolint:paralleltest // changes directory for process
+func TestPrintingInstructions(t *testing.T) {
+	templatePath, _ := filepath.Abs("./testdata/testtemplate")
+
+	tempdir := tempProjectDir(t)
+	chdir(t, tempdir)
+
+	uniqueProjectName := filepath.Base(tempdir)
+	orgStackName := fmt.Sprintf("%s/%s", currentUser(t), stackName)
+
+	var stdout bytes.Buffer
+	args := newArgs{
+		interactive:       true,
+		generateOnly:      true,
+		prompt:            promptMock(uniqueProjectName, orgStackName),
+		secretsProvider:   "default",
+		templateNameOrURL: templatePath,
+		stdout:            &stdout,
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	// Note that we implicitly test that the coloring symbols are removed correctly.
+	assert.Contains(t, stdout.String(), `This command will walk you through creating a new Pulumi project.
+
+Test instructions
+Line 2.`)
 }

--- a/pkg/cmd/pulumi/testdata/testtemplate/Pulumi.yaml
+++ b/pkg/cmd/pulumi/testdata/testtemplate/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: nodejs
+template:
+  description: Test description
+  instructions: |
+    <{%bold%}>Test instructions<{%reset%}>
+    Line 2.

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -73,6 +73,8 @@ type ProjectTemplate struct {
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	// Description is an optional description of the template.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Instructions to be displayed when a user chooses the template.
+	Instructions string `json:"instructions,omitempty" yaml:"instructions,omitempty"`
 	// Quickstart contains optional text to be displayed after template creation.
 	Quickstart string `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`
 	// Config is an optional template config.

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -163,6 +163,13 @@
                         "null"
                     ]
                 },
+                "instructions":{
+                    "description":"Instructions to be displayed when a user chooses the template.",
+                    "type":[
+                        "string",
+                        "null"
+                    ]
+                },
                 "quickstart":{
                     "description":"Quickstart contains optional text to be displayed after template creation.",
                     "type":[

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -196,13 +196,14 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 
 // Template represents a project template.
 type Template struct {
-	Dir         string                                // The directory containing Pulumi.yaml.
-	Name        string                                // The name of the template.
-	Description string                                // Description of the template.
-	Quickstart  string                                // Optional text to be displayed after template creation.
-	Config      map[string]ProjectTemplateConfigValue // Optional template config.
-	Important   bool                                  // Indicates whether the template should be listed by default.
-	Error       error                                 // Non-nil if the template is broken.
+	Dir          string                                // The directory containing Pulumi.yaml.
+	Name         string                                // The name of the template.
+	Description  string                                // Description of the template.
+	Instructions string                                // Instructions to be displayed when a user chooses the template.
+	Quickstart   string                                // Optional text to be displayed after template creation.
+	Config       map[string]ProjectTemplateConfigValue // Optional template config.
+	Important    bool                                  // Indicates whether the template should be listed by default.
+	Error        error                                 // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.
@@ -470,6 +471,7 @@ func LoadTemplate(path string) (Template, error) {
 	}
 	if proj.Template != nil {
 		template.Description = proj.Template.Description
+		template.Instructions = proj.Template.Instructions
 		template.Quickstart = proj.Template.Quickstart
 		template.Config = proj.Template.Config
 		template.Important = proj.Template.Important


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add an `instructions` option to Pulumi templates, e.g.

```yaml
name: ${PROJECT}
description: ${DESCRIPTION}
runtime: nodejs
template:
  description: A minimal TypeScript Pulumi program
  instructions: |
    <{%bold%}>Hello!<{%reset%}>
    This is your instructions.
    You can do fancy stuff here:
    - <{%fg 14%}>One<{%reset%}>
    - <{%bg 2%}>Two<{%reset%}>
```

They will be displayed after template selection:

```cli
~/go/bin/pulumi new typescript
This command will walk you through creating a new Pulumi project.

Hello!
This is your instructions.
You can do fancy stuff here:
- One
- Two

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.
```

Color codes are supported for better attention grabbing:

<img width="826" alt="image" src="https://github.com/pulumi/pulumi/assets/1454008/ecfd268d-feb4-443f-8db5-2c6dc2fe6f47">

I haven't found any `new` tests inspecting stdout, so I had to thread a new argument to pass to the command. I choose to only change the lines related to this change to use the arguments, let me know if you think it's better to change add `fmt.Println` statements to be consistent. I default to changing as little as needed.

Fixes #15360

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
