### PR TITLE
ci: Use the latest version of actions/setup-go

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"
         run: echo "$CACHE_KEY" > .gocache.tmp
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
           cache: true

--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
           ./.github/scripts/set-output version "${PULUMI_VERSION}"
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.0' # decoupled from version sets, used by changelog tool
           cache: true

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
           # golangci-lint-action handles all the caching for Go.
@@ -58,7 +58,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
       - name: Run go mod tidy
@@ -79,7 +79,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
       - name: Run make gen
@@ -111,7 +111,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
       - name: Set up Python ${{ fromJson(inputs.version-set).python }}
@@ -160,7 +160,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
       - run: |

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(needs.matrix.outputs.version-set).go }}
       - name: Install Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           CACHE_KEY: "matrix-setup"
         run: echo "$CACHE_KEY" > .gocache.tmp
       - name: Setup Go Caching
-        uses: actions/setup-go@v3 # only used by gotestsum
+        uses: actions/setup-go@v5 # only used by gotestsum
         with:
           go-version: '>=1.19.0' # decoupled from version sets, only used by gotestsum
           cache: true

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
       - name: Build
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
       - name: Build

--- a/.github/workflows/on-pr-changelog.yml
+++ b/.github/workflows/on-pr-changelog.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.0' # decoupled from version sets, only used by changelog tool
       - name: Changelog

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -86,7 +86,7 @@ jobs:
             role-session-name: awsx@githubActions
             role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
         - name: Setup Go
-          uses: actions/setup-go@v2
+          uses: actions/setup-go@v5
           with:
             go-version: ${{ env.GOVERSION }}
             check-latest: true

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.0' # decoupled from version sets, only used by changelog tool
       - name: Create PR


### PR DESCRIPTION
Upgrade all workflows to the latest version of actions/setup-go (which uses node 20 runtime).