### PR TITLE
ci: Use latest version of jaxxstorm/action-install-gh-release

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -222,7 +222,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname "$(pwd)")" | tee -a "${GITHUB_ENV}"
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
@@ -230,7 +230,7 @@ jobs:
           tag: v0.0.42
           cache: enable
       - name: Install gotestsum
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
@@ -238,7 +238,7 @@ jobs:
           tag: v1.8.1
           cache: enable
       - name: Install goteststats
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
       - name: Install Pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -108,11 +108,11 @@ jobs:
             distribution: temurin
             java-version: ${{ env.JAVAVERSION }}
         - name: Install gotestfmt
-          uses: jaxxstorm/action-install-gh-release@v1.7.1
+          uses: jaxxstorm/action-install-gh-release@v1.11.0
           with:
             repo: gotesttools/gotestfmt
         - name: Install pulumictl
-          uses: jaxxstorm/action-install-gh-release@v1.1.0
+          uses: jaxxstorm/action-install-gh-release@v1.11.0
           with:
             repo: pulumi/pulumictl
         - name: Check out source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Install Pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:


### PR DESCRIPTION
Upgrade all workflows to the latest version of jaxxstorm/action-install-gh-release (which uses node 20 runtime).