### PR TITLE
test: schema support for testprovider

### DIFF
--- a/tests/testprovider/.gitignore
+++ b/tests/testprovider/.gitignore
@@ -1,1 +1,2 @@
 pulumi-resource-testprovider
+schema-testprovider.json

--- a/tests/testprovider/echo.go
+++ b/tests/testprovider/echo.go
@@ -20,12 +20,40 @@ import (
 	"context"
 	"fmt"
 
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func init() {
+	providerSchema.Resources["testprovider:index:Echo"] = pschema.ResourceSpec{
+		IsComponent: false,
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			IsOverlay:   false,
+			Description: "A test resource that echoes its input.",
+			Properties: map[string]pschema.PropertySpec{
+				"echo": {
+					TypeSpec: pschema.TypeSpec{
+						Ref: "pulumi.json#/Resource",
+					},
+					Description: "A resource to echo.",
+				},
+			},
+			Type: "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{
+			"echo": {
+				TypeSpec: pschema.TypeSpec{
+					Ref: "pulumi.json#/Resource",
+				},
+				Description: "An echoed resource.",
+			},
+		},
+	}
+}
 
 type echoResourceProvider struct {
 	id int

--- a/tests/testprovider/echo.go
+++ b/tests/testprovider/echo.go
@@ -30,16 +30,14 @@ import (
 
 func init() {
 	providerSchema.Resources["testprovider:index:Echo"] = pschema.ResourceSpec{
-		IsComponent: false,
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			IsOverlay:   false,
 			Description: "A test resource that echoes its input.",
 			Properties: map[string]pschema.PropertySpec{
 				"echo": {
 					TypeSpec: pschema.TypeSpec{
-						Ref: "pulumi.json#/Resource",
+						Ref: "pulumi.json#/Any",
 					},
-					Description: "A resource to echo.",
+					Description: "Input to echo.",
 				},
 			},
 			Type: "object",
@@ -47,9 +45,9 @@ func init() {
 		InputProperties: map[string]pschema.PropertySpec{
 			"echo": {
 				TypeSpec: pschema.TypeSpec{
-					Ref: "pulumi.json#/Resource",
+					Ref: "pulumi.json#/Any",
 				},
-				Description: "An echoed resource.",
+				Description: "An echoed input.",
 			},
 		},
 	}

--- a/tests/testprovider/fails_on_create.go
+++ b/tests/testprovider/fails_on_create.go
@@ -28,9 +28,7 @@ import (
 
 func init() {
 	providerSchema.Resources["testprovider:index:FailsOnCreate"] = pschema.ResourceSpec{
-		IsComponent: false,
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			IsOverlay:   false,
 			Description: "A test resource fails on create.",
 			Properties:  map[string]pschema.PropertySpec{},
 			Type:        "object",

--- a/tests/testprovider/fails_on_create.go
+++ b/tests/testprovider/fails_on_create.go
@@ -20,10 +20,24 @@ import (
 	"context"
 	"errors"
 
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func init() {
+	providerSchema.Resources["testprovider:index:FailsOnCreate"] = pschema.ResourceSpec{
+		IsComponent: false,
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			IsOverlay:   false,
+			Description: "A test resource fails on create.",
+			Properties:  map[string]pschema.PropertySpec{},
+			Type:        "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{},
+	}
+}
 
 type failsOnCreateResourceProvider struct{}
 

--- a/tests/testprovider/fails_on_delete.go
+++ b/tests/testprovider/fails_on_delete.go
@@ -21,10 +21,24 @@ import (
 	"errors"
 	"fmt"
 
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func init() {
+	providerSchema.Resources["testprovider:index:FailsOnDelete"] = pschema.ResourceSpec{
+		IsComponent: false,
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			IsOverlay:   false,
+			Description: "A test resource fails on delete.",
+			Properties:  map[string]pschema.PropertySpec{},
+			Type:        "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{},
+	}
+}
 
 type failsOnDeleteResourceProvider struct {
 	id int

--- a/tests/testprovider/fails_on_delete.go
+++ b/tests/testprovider/fails_on_delete.go
@@ -29,9 +29,7 @@ import (
 
 func init() {
 	providerSchema.Resources["testprovider:index:FailsOnDelete"] = pschema.ResourceSpec{
-		IsComponent: false,
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			IsOverlay:   false,
 			Description: "A test resource fails on delete.",
 			Properties:  map[string]pschema.PropertySpec{},
 			Type:        "object",

--- a/tests/testprovider/random.go
+++ b/tests/testprovider/random.go
@@ -22,12 +22,44 @@ import (
 	"fmt"
 	"math/big"
 
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func init() {
+	providerSchema.Resources["testprovider:index:Random"] = pschema.ResourceSpec{
+		IsComponent: false,
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			IsOverlay:   false,
+			Description: "A test resource that generates a random string of a given length and with an optional prefix.",
+			Properties: map[string]pschema.PropertySpec{
+				"length": {
+					TypeSpec:    pschema.TypeSpec{Type: "integer"},
+					Description: "The length of the random string (not including the prefix, if any).",
+				},
+				"result": {
+					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Description: "A random string.",
+				},
+			},
+			Type: "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{
+			"length": {
+				TypeSpec:    pschema.TypeSpec{Type: "integer"},
+				Description: "The length of the random string (not including the prefix, if any).",
+			},
+			"prefix": {
+				TypeSpec:    pschema.TypeSpec{Type: "string"},
+				Description: "An optional prefix.",
+			},
+		},
+	}
+}
 
 type randomResourceProvider struct{}
 

--- a/tests/testprovider/random.go
+++ b/tests/testprovider/random.go
@@ -32,9 +32,7 @@ import (
 
 func init() {
 	providerSchema.Resources["testprovider:index:Random"] = pschema.ResourceSpec{
-		IsComponent: false,
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			IsOverlay:   false,
 			Description: "A test resource that generates a random string of a given length and with an optional prefix.",
 			Properties: map[string]pschema.PropertySpec{
 				"length": {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR enhances the testprovider to have a Pulumi schema, e.g. to be able to use it with Pulumi YAML.

Related to https://github.com/pulumi/pulumi/issues/15788

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
