### PR TITLE
Update builtin module list for function serialization

### DIFF
--- a/changelog/pending/20240329--sdk-nodejs--update-builtin-module-list-for-function-serialization.yaml
+++ b/changelog/pending/20240329--sdk-nodejs--update-builtin-module-list-for-function-serialization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Update builtin module list for function serialization

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -15,6 +15,7 @@
 /* eslint-disable max-len */
 
 import * as upath from "upath";
+import { builtinModules as nodeBuiltinModules } from "node:module";
 import { ResourceError } from "../../errors";
 import { Input, isSecretOutput, Output } from "../../output";
 import * as resource from "../../resource";
@@ -1335,43 +1336,16 @@ function getBuiltInModules(): Promise<Map<any, string>> {
     async function computeBuiltInModules() {
         // These modules are built-in to Node.js, and are available via `require(...)`
         // but are not stored in the `require.cache`.  They are guaranteed to be
-        // available at the unqualified names listed below. _Note_: This list is derived
-        // based on Node.js 6.x tree at: https://github.com/nodejs/node/tree/v6.x/lib
-        const builtInModuleNames = [
-            "assert",
-            "buffer",
-            "child_process",
-            "cluster",
-            "console",
-            "constants",
-            "crypto",
-            "dgram",
-            "dns",
-            "domain",
-            "events",
-            "fs",
-            "http",
-            "https",
-            "module",
-            "net",
-            "os",
-            "path",
-            "process",
-            "punycode",
-            "querystring",
-            "readline",
-            "repl",
-            "stream",
-            "string_decoder",
-            /* "sys" deprecated ,*/ "timers",
-            "tls",
-            "tty",
-            "url",
-            "util",
-            "v8",
-            "vm",
-            "zlib",
+        // available at the unqualified names listed below.
+
+        const excludes = [
+            "sys", // deprecated since 1.0
+            "wasi", // experimental
         ];
+
+        const builtInModuleNames = nodeBuiltinModules.filter(
+            (name) => !name.startsWith("_") && !excludes.includes(name),
+        );
 
         const map = new Map<any, string>();
         for (const name of builtInModuleNames) {

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/index.ts
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const description = "fsPromises";
+
+import { readdir } from "fs/promises";
+
+export const func = async () => {
+    const files = await readdir(".");
+    return files;
+}

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/snapshot.txt
@@ -1,0 +1,33 @@
+exports.handler = __f0;
+
+function __f1(__0, __1, __2, __3) {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+const promises_1 = require("fs/promises");
+
+function __f0() {
+  return (function() {
+    with({ __awaiter: __f1, this: undefined, arguments: undefined }) {
+
+return () => __awaiter(void 0, void 0, void 0, function* () {
+    const files = yield (0, promises_1.readdir)(".");
+    return files;
+});
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/snapshot.~3.8.3.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/171-fs-promises/snapshot.~3.8.3.txt
@@ -1,0 +1,33 @@
+exports.handler = __f0;
+
+function __f1(__0, __1, __2, __3) {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+const promises_1 = require("fs/promises");
+
+function __f0() {
+  return (function() {
+    with({ __awaiter: __f1, this: undefined, arguments: undefined }) {
+
+return () => __awaiter(void 0, void 0, void 0, function* () {
+    const files = yield promises_1.readdir(".");
+    return files;
+});
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Update the list of node modules detected as builtin during function serialisation.

This helps with some of the cases in https://github.com/pulumi/pulumi/issues/5294 (notably trying to use `fs/promises`).

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
