### PR TITLE
ci: Use latest version of actions/checkout

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -71,7 +71,7 @@ jobs:
           echo "$TOOL_BIN" | tee -a "$GITHUB_PATH"
           command -v tar
           tar --version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Configure Go Cache Key

--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -42,7 +42,7 @@ jobs:
     name: python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Setup versioning env vars
@@ -79,7 +79,7 @@ jobs:
     name: nodejs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Setup versioning env vars

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -23,7 +23,7 @@ jobs:
     name: gather-info
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
@@ -46,7 +46,7 @@ jobs:
   matrix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: build matrix

--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -40,7 +40,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
@@ -54,7 +54,7 @@ jobs:
     name: go mod tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
@@ -75,7 +75,7 @@ jobs:
     name: Generate Go SDK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
@@ -96,7 +96,7 @@ jobs:
     name: Lint Protobufs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Check Protobufs
@@ -107,7 +107,7 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
@@ -136,7 +136,7 @@ jobs:
       - name: Update path
         run: |
           echo "$RUNNER_TEMP/opt/pulumi/bin" >> "$GITHUB_PATH"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set Go Dep path
@@ -156,7 +156,7 @@ jobs:
     name: Lint GHA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [sign]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Get commit hash

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -140,7 +140,7 @@ jobs:
           echo "/usr/local/opt/coreutils/libexec/gnubin" | tee -a "$GITHUB_PATH"
           command -v bash
           bash --version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Setup versioning env vars

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -27,7 +27,7 @@ jobs:
   matrix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: build matrix
@@ -81,25 +81,25 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: pulumi
           ref: ${{ inputs.ref }}
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out pulumi-aws
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: pulumi/pulumi-aws
           path: pulumi-aws
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out pulumi-kubernetes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: pulumi/pulumi-kubernetes
           path: pulumi-kubernetes
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check out docs
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Use the PAT and not the default GITHUB_TOKEN since we want to create a branch
           # in this workflow and push it to a remote that is NOT the current repo, i.e. pulumi/pulumi.
@@ -107,7 +107,7 @@ jobs:
           repository: pulumi/docs
           path: docs
       - name: Check out registry
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: pulumi/registry
           path: registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
   matrix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Configure Go Cache Key
@@ -95,7 +95,7 @@ jobs:
           cache-dependency-path: |
             pkg/go.sum
             .gocache.tmp
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: dnephin/gotestsum
           ref: d09768c81065b404caed0855eb3ab8f11a2a4431
@@ -443,7 +443,7 @@ jobs:
               exit 1
           fi
       # Checkout repository to upload coverage results.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Retrieve code coverage reports

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -9,7 +9,7 @@ jobs:
   pkg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
@@ -19,7 +19,7 @@ jobs:
   sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"

--- a/.github/workflows/on-pr-changelog.yml
+++ b/.github/workflows/on-pr-changelog.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [dev-release, info]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - name: Install Pulumictl

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       version: "${{ fromJSON(steps.version.outputs.version) }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Uses release ref (tag)
       - name: Info
         id: version

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -116,7 +116,7 @@ jobs:
           with:
             repo: pulumi/pulumictl
         - name: Check out source code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             ref: ${{ github.event.pull_request.head.sha }}
             token: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,7 +15,7 @@ jobs:
       )
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo

--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           path: pulumi
       - name: Checkout tap repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: pulumi/homebrew-tap
           path: homebrew-tap

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,7 +35,7 @@ jobs:
     name: version bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         language: ["nodejs", "python", "go"]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Python ${{ fromJson(inputs.version-set).python }}
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Configure AWS Credentials
@@ -165,7 +165,7 @@ jobs:
             run-command: pulumictl dispatch -r pulumi/pulumi-docker-containers -c release-build "${PULUMI_VERSION}"
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
       - name: Install Pulumictl

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/trigger-release-docs-event.yml
+++ b/.github/workflows/trigger-release-docs-event.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ci-scripts
           repository: pulumi/scripts


### PR DESCRIPTION
Upgrade all workflows to the latest version of actions/checkout (which uses node 20 runtime).