### PR TITLE
ci: Use latest version of actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - run: |
           cd vendor/gotestsum
           go install .
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: test-results
           key: read-gotestsum-timing-${{ github.run_number }}
@@ -409,7 +409,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: test-results
           key: gotestsum-timing-${{ github.run_number }}


### PR DESCRIPTION
Upgrade all workflows to the latest version of actions/cache (which uses node 20 runtime).