### PR TITLE
ci: Use latest version of dorny/paths-filter

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -52,7 +52,7 @@ jobs:
     name: Inspect changed files
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
Upgrade all workflows to the latest version of dorny/paths-filter (which uses node 20 runtime).