### PR TITLE
ci: Use latest version of actions/setup-java

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -193,7 +193,7 @@ jobs:
           cache: yarn
           cache-dependency-path: sdk/nodejs/yarn.lock
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -103,7 +103,7 @@ jobs:
           with:
             dotnet-version: ${{ env.DOTNETVERSION }}
         - name: Setup Java
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
             distribution: temurin
             java-version: ${{ env.JAVAVERSION }}


### PR DESCRIPTION
Upgrade all workflows to the latest version of actions/setup-java (which uses node 20 runtime).