### PR TITLE
ci: Replace gradle-build-action with actions/setup-gradle

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -198,7 +198,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: "7.6"
       - name: Uninstall pre-installed Pulumi (windows)


### PR DESCRIPTION
As of v3 gradle/gradle-build-action has been superseded by gradle/actions/setup-gradle. Move to the latest version of that, which runs on node 20.

For more details, see https://github.com/gradle/gradle-build-action/blob/main/README.md