### PR TITLE
ci: Use latest version of peter-evans/create-or-update-comment

### DIFF
--- a/.github/workflows/on-pr-changelog.yml
+++ b/.github/workflows/on-pr-changelog.yml
@@ -64,7 +64,7 @@ jobs:
           issue-number: ${{ inputs.pr-number }}
           body-includes: "# Changelog"
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32 # v2.0.0
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update with Result
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/pr-test-docs-generation-on-dispatch.yml
+++ b/.github/workflows/pr-test-docs-generation-on-dispatch.yml
@@ -22,7 +22,7 @@ jobs:
         id: vars
         run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${GITHUB_OUTPUT}"
       - name: Update with Result
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}


### PR DESCRIPTION
Upgrade all workflows to the latest version of peter-evans/create-or-update-comment (which uses node 20 runtime).