### PR TITLE
Save component resources as parents

### DIFF
--- a/changelog/pending/20240402--engine--resource-transforms-on-component-resources-now-apply-to-children-correctly.yaml
+++ b/changelog/pending/20240402--engine--resource-transforms-on-component-resources-now-apply-to-children-correctly.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Resource transforms on component resources now apply to children correctly


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15843.

This tracks parent information separate from Goal information (as that was only generated and saved for custom, not component, resources).

We also need to keep track of the transform list between the first RegisterResource starting a remote component construction and the remote component _actually_ registering itself. This means we save the transform list correctly once the component is registered inside the remote process allowing other resource registrations in the remote process to see that saved transform list. 
If we just wait till the Construct call is done then none of the inner children pick up the transform list.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
