### PR TITLE
fix: advise people of the ESLint Plugin for catching interpolation issues

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -202,7 +202,10 @@ To get the value of an Output<T> as an Output<string> consider either:
 1: o.apply(v => \`prefix\${v}suffix\`)
 2: pulumi.interpolate \`prefix\${v}suffix\`
 
-See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.`;
+See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.
+
+Or use ESLint with https://github.com/pulumi/eslint-plugin-pulumi to warn or
+error lint on using Output<T> in template literals.`;
             if (utils.errorOutputString) {
                 throw new Error(message);
             }


### PR DESCRIPTION
Raised by @lunaris in onboarding, we don't advertise the [Pulumi ESLint Plugin](https://github.com/pulumi/eslint-plugin-pulumi). As using an output in a template literal is one of the most common avenues to discovering this issue, perhaps we should advertise the plugin here?

What's lacking from this is documentation, but I imagine that users will see this, create issues, and that will drive improvements either in the base SDK or the ESLint Plugin.