### PR TITLE
avoid racyness from the polling library

### DIFF
--- a/changelog/pending/20240403--auto-go--avoid-flakyness-when-reading-the-event-log-from-pulumi-commands.yaml
+++ b/changelog/pending/20240403--auto-go--avoid-flakyness-when-reading-the-event-log-from-pulumi-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Avoid flakyness when reading the event log from pulumi commands

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1465,6 +1465,9 @@ func (fw *fileWatcher) Close() {
 	// the whole file.  On OSs that don't use the poller we still
 	// want to try to avoid the problem so we sleep for a short
 	// amount of time.
+	//
+	// TODO: remove this once https://github.com/nxadm/tail/issues/67
+	// is fixed and we can upgrade nxadm/tail.
 	if runtime.GOOS == "windows" {
 		time.Sleep(300 * time.Millisecond)
 	} else {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -108,6 +108,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/nxadm/tail"
@@ -1454,6 +1455,21 @@ func (fw *fileWatcher) Close() {
 	}
 
 	// Tell the watcher to end on next EoF, wait for the done event, then cleanup.
+
+	// The tail library we're using is racy when shutting down.
+	// If it gets the shutdown signal before reading the data, it
+	// will just shut down before finding the EoF.  This problem
+	// is exacerbated on Windows, where we use the poller, which
+	// polls for changes every 250ms.  Sleep a little bit longer
+	// than that to ensure the tail library had a chance to read
+	// the whole file.  On OSs that don't use the poller we still
+	// want to try to avoid the problem so we sleep for a short
+	// amount of time.
+	if runtime.GOOS == "windows" {
+		time.Sleep(300 * time.Millisecond)
+	} else {
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	//nolint:errcheck
 	fw.tail.StopAtEOF()


### PR DESCRIPTION
The library we're using unfortunately has a race condition that's especially worse when using polling to check for new changes of the file.  Avoid this racyness by sleeping for a bit for now, but really this should be fixed upstream ideally.

I opened a upstream issue for this in https://github.com/nxadm/tail/issues/67.  I think we should merge this in the meantime, as it makes this work, even though it's very hacky. 

I tested this in https://github.com/pulumi/pulumi/pull/15853, where I could no longer reproduce the failure we've seen before.

Fixes https://github.com/pulumi/pulumi/issues/15659
Fixes https://github.com/pulumi/pulumi/issues/15235