### PR TITLE
Support always qualifying stack names (#11081)

### DIFF
--- a/changelog/pending/20240403--cli--support-always-fully-qualifying-stack-names-in-cli-output.yaml
+++ b/changelog/pending/20240403--cli--support-always-fully-qualifying-stack-names-in-cli-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Support always fully qualifying stack names in CLI output

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -141,6 +141,12 @@ func (r *diyBackendReference) String() string {
 		return r.name.String()
 	}
 
+	// If the user has asked us to fully qualify names, we won't elide any
+	// information.
+	if cmdutil.FullyQualifyStackNames {
+		return fmt.Sprintf("organization/%s/%s", r.project, r.name)
+	}
+
 	if r.currentProject != nil {
 		proj := r.currentProject()
 		// For project scoped references when stringifying backend references,

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -26,10 +26,81 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+//nolint:paralleltest // mutates global configuration
+func TestEnabledFullyQualifiedStackNames(t *testing.T) {
+	// Arrange
+	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
+	}
+
+	ctx := context.Background()
+
+	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	require.NoError(t, err)
+
+	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	require.NoError(t, err)
+
+	stackName := ptesting.RandomStackName()
+	ref, err := b.ParseStackReference(stackName)
+	require.NoError(t, err)
+
+	s, err := b.CreateStack(ctx, ref, "", nil)
+	require.NoError(t, err)
+
+	previous := cmdutil.FullyQualifyStackNames
+	expected := s.Ref().FullyQualifiedName().String()
+
+	// Act
+	cmdutil.FullyQualifyStackNames = true
+	defer func() { cmdutil.FullyQualifyStackNames = previous }()
+
+	actual := s.Ref().String()
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
+
+//nolint:paralleltest // mutates global configuration
+func TestDisabledFullyQualifiedStackNames(t *testing.T) {
+	// Arrange
+	if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
+	}
+
+	ctx := context.Background()
+
+	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	require.NoError(t, err)
+
+	b, err := New(diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	require.NoError(t, err)
+
+	stackName := ptesting.RandomStackName()
+	ref, err := b.ParseStackReference(stackName)
+	require.NoError(t, err)
+
+	s, err := b.CreateStack(ctx, ref, "", nil)
+	require.NoError(t, err)
+
+	previous := cmdutil.FullyQualifyStackNames
+	expected := s.Ref().Name().String()
+
+	// Act
+	cmdutil.FullyQualifyStackNames = false
+	defer func() { cmdutil.FullyQualifyStackNames = previous }()
+
+	actual := s.Ref().String()
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
 
 //nolint:paralleltest // mutates environment variables
 func TestValueOrDefaultURL(t *testing.T) {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -51,6 +52,12 @@ type cloudBackendReference struct {
 }
 
 func (c cloudBackendReference) String() string {
+	// If the user has asked us to fully qualify names, we won't elide any
+	// information.
+	if cmdutil.FullyQualifyStackNames {
+		return fmt.Sprintf("%s/%s/%s", c.owner, c.project, c.name)
+	}
+
 	// When stringifying backend references, we take the current project (if present) into account.
 	currentProject := c.b.currentProject
 

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -286,6 +286,8 @@ func NewPulumiCmd() *cobra.Command {
 		"Run pulumi as if it had been started in another directory")
 	cmd.PersistentFlags().BoolVarP(&cmdutil.Emoji, "emoji", "e", runtime.GOOS == "darwin",
 		"Enable emojis in the output")
+	cmd.PersistentFlags().BoolVarP(&cmdutil.FullyQualifyStackNames, "fully-qualify-stack-names", "Q", false,
+		"Show fully-qualified stack names")
 	cmd.PersistentFlags().BoolVar(&backend.DisableIntegrityChecking, "disable-integrity-checking", false,
 		"Disable integrity checking of checkpoint files")
 	cmd.PersistentFlags().BoolVar(&logFlow, "logflow", false,

--- a/sdk/go/common/util/cmdutil/stack.go
+++ b/sdk/go/common/util/cmdutil/stack.go
@@ -1,0 +1,20 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+// If true, we'll always print fully-qualified stack names (of the form
+// organisation/project/stack. Defaults to false. Can be set by passing
+// --fully-qualify-stack-names or -Q at the command line.
+var FullyQualifyStackNames bool


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This commit adds the `--fully-qualify-stack-names` (or `-Q` for short) global command-line argument, which when supplied will always print stack names in the fully-qualified form of `organization/project/stack`. Fixes #11081.

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
