### PR TITLE
Allow missing stack config and bookkeeping files

### DIFF
--- a/changelog/pending/20240404--auto--tolerate-missing-stack-and-bookkeeping-files-in-programtest.yaml
+++ b/changelog/pending/20240404--auto--tolerate-missing-stack-and-bookkeeping-files-in-programtest.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto
+  description: Tolerate missing stack and bookkeeping files in ProgramTest.

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1742,11 +1742,22 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 		if err := fsutil.CopyFile(newProjectYaml, oldProjectYaml, nil); err != nil {
 			return fmt.Errorf("Couldn't copy Pulumi.yaml: %w", err)
 		}
-		if err := fsutil.CopyFile(newConfigYaml, oldConfigYaml, nil); err != nil {
-			return fmt.Errorf("Couldn't copy Pulumi.%s.yaml: %w", pt.opts.StackName, err)
+
+		// Copy the config file over if it exists.
+		//
+		// Pulumi is not required to write a config file if there is no config, so
+		// it might not.
+		if _, err := os.Stat(oldConfigYaml); !os.IsNotExist(err) {
+			if err := fsutil.CopyFile(newConfigYaml, oldConfigYaml, nil); err != nil {
+				return fmt.Errorf("Couldn't copy Pulumi.%s.yaml: %w", pt.opts.StackName, err)
+			}
 		}
-		if err := fsutil.CopyFile(newProjectDir, oldProjectDir, nil); err != nil {
-			return fmt.Errorf("Couldn't copy .pulumi: %w", err)
+
+		// Likewise, pulumi is not required to write a book-keeping (.pulumi) file.
+		if _, err := os.Stat(oldProjectDir); !os.IsNotExist(err) {
+			if err := fsutil.CopyFile(newProjectDir, oldProjectDir, nil); err != nil {
+				return fmt.Errorf("Couldn't copy .pulumi: %w", err)
+			}
 		}
 
 		// Finally, replace our current temp directory with the new one.


### PR DESCRIPTION
Pulumi isn't required to write out these files, so valid tests fail when it doesn't. Previously this behavior wasn't a problem because the return values from fsutil.CopyFile were not checked. This regression was changed in https://github.com/pulumi/pulumi/pull/14695.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [X] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
