### PR TITLE
Type functions decorated by `@pulumi.getter`

### DIFF
--- a/changelog/pending/20240405--sdk-python--improve-types-of-getters-in-python-sdk.yaml
+++ b/changelog/pending/20240405--sdk-python--improve-types-of-getters-in-python-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Improve types of getters in Python SDK

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -283,11 +283,13 @@ from typing import (
     Union,
     cast,
     get_type_hints,
+    overload,
 )
 
 from . import _utils
 
 T = TypeVar("T")
+C = TypeVar("C", bound=Callable)
 
 
 _PULUMI_NAME = "_pulumi_name"
@@ -581,6 +583,10 @@ def output_type_from_dict(cls: Type[T], output: Dict[str, Any]) -> T:
     return cls(**args)  # type: ignore
 
 
+@overload
+def getter(*, name: Optional[str] = None) -> Callable[[C], C]: ...
+@overload
+def getter(_fn: C) -> C: ...
 def getter(_fn=None, *, name: Optional[str] = None):
     """
     Decorator to indicate a function is a Pulumi property getter.


### PR DESCRIPTION
This commit strengthens the type of the `@pulumi.getter` decorator so that tools like Pyright infer the type of the decorated function correctly. Prior to this, decorated properties could be inferred as having the type `Any`. This is particularly troublesome when using methods such as `apply`:

```python
x = random.RandomString("x", ...)

y = x.result.apply(lambda value: f"y-{value}")
```

Here, `x.result` having the type `Any` means that `value` will end up being `Unknown`, providing no useful type information inside the lambda. With this commit, `result` will correctly be inferred as having the type `Output[str]`, and thus `value` will be typed as `str`. Fixes #12557.
