### PR TITLE
Test SnapshotManager and Journal in engine tests

### DIFF
--- a/pkg/backend/inmemoryPersister.go
+++ b/pkg/backend/inmemoryPersister.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+var _ = SnapshotPersister((*InMemoryPersister)(nil))
+
+type InMemoryPersister struct {
+	Snap *deploy.Snapshot
+}
+
+func (p *InMemoryPersister) Save(snap *deploy.Snapshot) error {
+	result := &deploy.Snapshot{
+		Manifest:          snap.Manifest,
+		SecretsManager:    snap.SecretsManager,
+		Resources:         make([]*resource.State, len(snap.Resources)),
+		PendingOperations: make([]resource.Operation, len(snap.PendingOperations)),
+	}
+
+	for i, res := range snap.Resources {
+		res.Lock.Lock()
+		result.Resources[i] = res.Copy()
+		res.Lock.Unlock()
+	}
+
+	for i, op := range snap.PendingOperations {
+		op.Resource.Lock.Lock()
+		result.PendingOperations[i] = resource.Operation{
+			Type:     op.Type,
+			Resource: op.Resource.Copy(),
+		}
+		op.Resource.Lock.Unlock()
+	}
+
+	p.Snap = result
+	return nil
+}

--- a/pkg/engine/combinedManager.go
+++ b/pkg/engine/combinedManager.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"errors"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+)
+
+var _ = SnapshotManager((*CombinedManager)(nil))
+
+// CombinedManager combines multiple SnapshotManagers into one, it simply forwards on each call to every manager.
+type CombinedManager struct {
+	Managers []SnapshotManager
+}
+
+func (c *CombinedManager) BeginMutation(step deploy.Step) (SnapshotMutation, error) {
+	var errs []error
+	mutations := &CombinedMutation{}
+	for _, m := range c.Managers {
+		mutation, err := m.BeginMutation(step)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			mutations.Mutations = append(mutations.Mutations, mutation)
+		}
+	}
+
+	return mutations, errors.Join(errs...)
+}
+
+func (c *CombinedManager) RegisterResourceOutputs(step deploy.Step) error {
+	errs := make([]error, 0, len(c.Managers))
+	for _, m := range c.Managers {
+		errs = append(errs, m.RegisterResourceOutputs(step))
+	}
+	return errors.Join(errs...)
+}
+
+func (c *CombinedManager) Close() error {
+	errs := make([]error, 0, len(c.Managers))
+	for _, m := range c.Managers {
+		errs = append(errs, m.Close())
+	}
+	return errors.Join(errs...)
+}
+
+type CombinedMutation struct {
+	Mutations []SnapshotMutation
+}
+
+func (c *CombinedMutation) End(step deploy.Step, success bool) error {
+	errs := make([]error, 0, len(c.Mutations))
+	for _, m := range c.Mutations {
+		errs = append(errs, m.End(step, success))
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -86,6 +86,7 @@ func generateComplexTestDependencyGraph(
 				propertyDependencies{"B": []resource.URN{urnF, urnG}}, nil),
 		},
 	}
+	assert.NoError(t, old.VerifyIntegrity())
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		register := func(urn resource.URN, provider string, inputs resource.PropertyMap) resource.ID {

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -596,6 +596,9 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 						assert.Equal(t, deploy.OpUpdate, resultOp)
 					}
 
+					old = old.Copy()
+					new = new.Copy()
+
 					// Only the inputs and outputs should have changed (if anything changed).
 					old.Inputs = expected.Inputs
 					old.Outputs = expected.Outputs
@@ -643,10 +646,12 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 		}
 
 		// If targeted for refresh the new resources should be equal to the old resources + the new inputs and outputs
+		// and timestamp.
 		old := oldResources[int(idx)]
 		if targetedForRefresh {
 			old.Inputs = expected.Inputs
 			old.Outputs = expected.Outputs
+			old.Modified = r.Modified
 		}
 		assert.Equal(t, old, r)
 	}
@@ -765,6 +770,7 @@ func TestCanceledRefresh(t *testing.T) {
 				}
 
 				// Only the outputs and Modified timestamp should have changed (if anything changed).
+				old = old.Copy()
 				old.Outputs = expected
 				old.Modified = new.Modified
 

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -4,6 +4,7 @@ package lifecycletest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -12,11 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -28,6 +31,57 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+func snapshotEqual(journal, manager *deploy.Snapshot) error {
+	// Just want to check the same operations and resources are counted, but order might be slightly different.
+	if journal == nil && manager == nil {
+		return nil
+	}
+	if journal == nil {
+		return fmt.Errorf("journal snapshot is nil")
+	}
+	if manager == nil {
+		return fmt.Errorf("manager snapshot is nil")
+	}
+
+	// Manifests and SecretsManagers are known to differ because we don't thread them through for the Journal code.
+
+	if len(journal.PendingOperations) != len(manager.PendingOperations) {
+		return fmt.Errorf("journal and manager pending operations differ")
+	}
+
+	for _, jop := range journal.PendingOperations {
+		found := false
+		for _, mop := range manager.PendingOperations {
+			if reflect.DeepEqual(jop, mop) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("journal and manager pending operations differ, %v not found in manager", jop)
+		}
+	}
+
+	if len(journal.Resources) != len(manager.Resources) {
+		return fmt.Errorf("journal and manager resources differ")
+	}
+
+	for _, jr := range journal.Resources {
+		found := false
+		for _, mr := range manager.Resources {
+			if reflect.DeepEqual(jr, mr) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("journal and manager resources differ, %v not found in manager", jr)
+		}
+	}
+
+	return nil
+}
 
 type updateInfo struct {
 	project workspace.Project
@@ -103,11 +157,18 @@ func (op TestOp) runWithContext(
 
 	events := make(chan Event)
 	journal := NewJournal()
+	persister := &backend.InMemoryPersister{}
+	secretsManager := b64.NewBase64SecretsManager()
+	snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot)
+
+	combined := &CombinedManager{
+		Managers: []SnapshotManager{journal, snapshotManager},
+	}
 
 	ctx := &Context{
 		Cancel:          cancelCtx,
 		Events:          events,
-		SnapshotManager: journal,
+		SnapshotManager: combined,
 		BackendClient:   backendClient,
 	}
 
@@ -130,7 +191,7 @@ func (op TestOp) runWithContext(
 	// Run the step and its validator.
 	plan, _, opErr := op(info, ctx, updateOpts, dryRun)
 	close(events)
-	closeErr := journal.Close()
+	closeErr := combined.Close()
 
 	// Wait for the events to finish. You'd think this would cancel with the callerCtx but tests explicitly use that for
 	// the deployment context, not expecting it to have any effect on the test code here. See
@@ -143,6 +204,7 @@ func (op TestOp) runWithContext(
 	if validate != nil {
 		opErr = validate(project, target, journal.Entries(), firedEvents, opErr)
 	}
+
 	errs := []error{opErr, closeErr}
 	if dryRun {
 		return plan, nil, errors.Join(errs...)
@@ -168,6 +230,9 @@ func (op TestOp) runWithContext(
 			break
 		}
 	}
+
+	// Verify the saved snapshot from SnapshotManger is the same(ish) as that from the Journal
+	errs = append(errs, snapshotEqual(snap, persister.Snap))
 
 	return nil, snap, errors.Join(errs...)
 }

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -245,10 +245,6 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 		}
 	}
 
-	reg.New().Lock.Lock()
-	reg.New().Outputs = outs
-	reg.New().Lock.Unlock()
-
 	// If a plan is present check that these outputs match what we recorded before
 	if se.deployment.plan != nil {
 		resourcePlan, ok := se.deployment.plan.ResourcePlans[urn]
@@ -260,6 +256,10 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 			return fmt.Errorf("resource violates plan: %w", err)
 		}
 	}
+
+	reg.New().Lock.Lock()
+	reg.New().Outputs = outs
+	reg.New().Lock.Unlock()
 
 	// If we're generating plans save these new outputs to the plan
 	if se.opts.GeneratePlan {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This tests the production snapshot manager against the journalling snapshot system in engine tests. This should ensure that both systems produce similar (we ignore exact resource ordering, as long as both are valid) results.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
