### PR TITLE
Fix panic when looking up home

### DIFF
--- a/changelog/pending/20240408--cli--fix-a-panic-when-users-home-directory-could-not-be-looked-up.yaml
+++ b/changelog/pending/20240408--cli--fix-a-panic-when-users-home-directory-could-not-be-looked-up.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix a panic when user's home directory could not be looked up

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -254,11 +254,11 @@ func GetPulumiHomeDir() (string, error) {
 		return "", fmt.Errorf("getting current user: %w", err)
 	}
 
-	if user == nil || user.HomeDir == "" {
+	if user == nil || user.User == nil || user.User.HomeDir == "" {
 		return "", fmt.Errorf("could not find user home directory, set %s", PulumiHomeEnvVar)
 	}
 
-	return filepath.Join(user.HomeDir, BookkeepingDir), nil
+	return filepath.Join(user.User.HomeDir, BookkeepingDir), nil
 }
 
 // GetPulumiPath returns the path to a file or directory under the '.pulumi' folder. It joins the path of


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

https://github.com/pulumi/pulumi/pull/15160 tries to fix https://github.com/pulumi/pulumi/issues/15159 by checking that user is nil or user.HomeDir is nil. Given github.com/tweekmonster/luser embeds the builtin Golang User type as pointer, it still possible that user.User is nil and calling user.HomeDir causes a nil pointer access. this PR checks the embedded pointer explicitly

Fixes https://github.com/pulumi/pulumi/issues/15159

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
