### PR TITLE
Support serialising reserved NodeJS identifiers

### DIFF
--- a/changelog/pending/20240409--sdk-nodejs--correctly-serialise-functions-whose-code-would-make-use-of-reserved-identifiers.yaml
+++ b/changelog/pending/20240409--sdk-nodejs--correctly-serialise-functions-whose-code-would-make-use-of-reserved-identifiers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Correctly serialise functions whose code would make use of reserved identifiers

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/index.js
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/index.js
@@ -1,0 +1,29 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For this case we want a function whose code contains a shadowed
+// reserved identifier. The simplest way to achieve this with the least amount
+// of variability across TypeScript versions is to use vanilla JavaScript with
+// hand-rolled CommonJS modules. Moreover, to trigger the behaviour in question,
+// we want the serializer to think that we are pulling in a dependency from
+// node_modules (since local modules will have their objects inlined);
+// we thus set up that fake file structure in this test case too.
+
+module.exports.description = "Shadowing reserved identifiers";
+
+exports = require("./node_modules/lib")
+
+module.exports.func = async () => {
+    console.log(exports.libFunc.name);
+};

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/node_modules/lib.js
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/node_modules/lib.js
@@ -1,0 +1,17 @@
+// This file is handwritten to trigger the behaviour required for the test case.
+// This is not a legitimate node_modules folder that has been accidentally
+// committed!
+
+exports.libConst = "libConst";
+
+class LibClass {
+  constructor() {
+    this.property = exports.libConst;
+  }
+}
+
+exports.LibClass = LibClass;
+
+exports.libFunc = () => {
+  return new LibClass();
+};

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/175-reserved-identifier-shadowing/snapshot.txt
@@ -1,0 +1,14 @@
+exports.handler = __f0;
+const __pulumi_closure_import_exports = require("lib.js");
+
+function __f0() {
+  return (function() {
+    with({ exports: __pulumi_closure_import_exports, this: undefined, arguments: undefined }) {
+
+return async () => {
+    console.log(exports.libFunc.name);
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}

--- a/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/Pulumi.yaml
+++ b/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nodejs_reserved_identifier_shadowing
+runtime: nodejs
+description: A NodeJS program that uses dynamic providers to trigger serialization of programs containing identifiers that shadow reserved identifiers (in this case, "exports").

--- a/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/index.ts
+++ b/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/index.ts
@@ -1,0 +1,45 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Input, CustomResourceOptions, output } from "@pulumi/pulumi"
+import { ResourceProvider, Resource } from "@pulumi/pulumi/dynamic"
+
+interface ReproResourceInputs {
+  example: Input<string>
+}
+
+interface ReproInputs {
+  example: string
+}
+
+class ReproProvider implements ResourceProvider {
+  async create(inputs: ReproInputs) {
+    return {
+      id: "nothing",
+      outs: {
+        example: `${output.name} ${inputs.example}`,
+      }
+    }
+  }
+}
+
+const p = new ReproProvider()
+
+class Repro extends Resource {
+  constructor(name: string, args: ReproResourceInputs, opts?: CustomResourceOptions) {
+    super(p, name, args, opts)
+  }
+}
+
+new Repro("test", { example: "words"})

--- a/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/package.json
+++ b/tests/integration/dynamic/nodejs-reserved-identifier-shadowing/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nodejs-reserved-identifier-shadowing",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^4.5.4"
+  },
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1996,3 +1996,26 @@ func TestEnvironmentsMergeNodeJS(t *testing.T) {
 		},
 	})
 }
+
+// Tests errors that would occur when generating code that shadows reserved
+// identifiers (e.g. "const exports = ...").
+//
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodeJSReservedIdentifierShadowing(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           filepath.Join("dynamic", "nodejs-reserved-identifier-shadowing"),
+		Dependencies:  []string{"@pulumi/pulumi"},
+		ExpectFailure: false,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			noError := true
+			for _, event := range stack.Events {
+				if event.ResOpFailedEvent != nil {
+					noError = false
+					assert.Equal(t, apitype.OpType("create"), event.ResOpFailedEvent.Metadata.Op)
+				}
+			}
+
+			assert.True(t, noError, "An error occurred when testing shadowing of reserved identifiers")
+		},
+	})
+}


### PR DESCRIPTION
This commit addresses part of #11942, in which we fail to serialise closures whose code would use reserved identifiers like `exports`. This is due to a change we made where module imports are hoisted to avoid importing the same module multiple times. Previously, code adopted a strategy of passing all dependencies using a `with` statement, viz.:

```typescript
function x() {
  return (function () {
    with({ fooBarBaz: require("foo/bar/baz"), ... }) {
      // Use of fooBarBaz
    }
  }).apply(...)
}

function y() {
  return (function () {
    with({ fooBarBaz: require("foo/bar/baz"), ... }) {
      // Use of fooBarBaz
    }
  }).apply(...)
}
```

This was changed to remove the duplicate imports, yielding code like:

```typescript
const fooBarBaz = require("foo/bar/baz")

function x() {
  return (function () {
    with({ ... }) {
      // Use of fooBarBaz
    }
  }).apply(...)
}

function y() {
  return (function () {
    with({ ... }) {
      // Use of fooBarBaz
    }
  }).apply(...)
}
```

However, while the previous approach would work with reserved identifiers such as `exports` (`with({ exports, ... }) { ... }` is perfectly acceptable), the new one does not (`const exports = ...` is not acceptable since NodeJS will not allow redeclaration of the `exports` global).

This commit combines the two approaches. Modules are only imported once, but if an import would use a reserved identifier, we generate a fresh non-conflicting identifier and alias this using a `with` statement. For example:

```typescript
const fooBarBaz = require("foo/bar/baz")

// __pulumi_closure_import_exports is generated to avoid shadowing the reserved "exports"
const __pulumi_closure_import_exports = require("some/other/module")

function x() {
  return (function () {
    with({ exports: __pulumi_closure_import_exports, ... }) {
      // Use of fooBarBaz and exports
    }
  }).apply(...)
}
```

Note that it is not expected that #11942 will be solved in its entirety. While this commit fixes code that introduces identifiers like `exports`, the introduction in question in that issue is caused by the use of `pulumi.output(...)` in the constructor of a dynamic resource provider. Since dynamic resource providers are implemented under the hood by serialising their code, we attempt to serialise `pulumi.output` and its dependency chain. This commit allows us to make more progress in that regard, but other things go wrong thereafter. Fixing the deeper issue that underpins #11942 (and likely other challenges with dynamic providers) is probably a more involved piece of work.