### PR TITLE
Fix marshalling Provider and Providers options from Go transforms

### DIFF
--- a/changelog/pending/20240409--sdk-go--fix-provider-and-providers-options-in-go-transform-functions.yaml
+++ b/changelog/pending/20240409--sdk-go--fix-provider-and-providers-options-in-go-transform-functions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix Provider and Providers options in Go transform functions

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -469,8 +469,9 @@ func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback
 			rpcRes.Options.IgnoreChanges = opts.IgnoreChanges
 			rpcRes.Options.PluginDownloadUrl = opts.PluginDownloadURL
 			rpcRes.Options.Protect = opts.Protect
+
 			if opts.Provider != nil {
-				rpcRes.Options.Provider, err = marshalToUrn(opts.Provider)
+				rpcRes.Options.Provider, err = ctx.resolveProviderReference(opts.Provider)
 				if err != nil {
 					return nil, fmt.Errorf("marshaling provider: %w", err)
 				}
@@ -478,12 +479,12 @@ func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback
 			if opts.Providers != nil {
 				rpcRes.Options.Providers = make(map[string]string)
 				for _, p := range opts.Providers {
-					urn, err := marshalToUrn(p)
+					ref, err := ctx.resolveProviderReference(p)
 					if err != nil {
 						return nil, fmt.Errorf("marshaling providers: %w", err)
 					}
 
-					rpcRes.Options.Providers[p.getPackage()] = urn
+					rpcRes.Options.Providers[p.getPackage()] = ref
 				}
 			}
 			rpcRes.Options.ReplaceOnChanges = opts.ReplaceOnChanges


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15881.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
