### PR TITLE
use yarn less in nodejs codegen tests

### DIFF
--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -63,12 +63,7 @@ func TypeCheck(t *testing.T, path string, _ codegen.StringSet, linkLocal bool) {
 }
 
 func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
-	// NOTE: previous attempt used npm. It may be more popular and
-	// better target than yarn, however our build uses yarn in
-	// other places at the moment, and yarn does not run into the
-	// ${VERSION} problem; use yarn for now.
-
-	test.RunCommand(t, "yarn_install", pwd, "yarn", "install")
+	test.RunCommand(t, "npm_install", pwd, "npm", "install")
 	if linkLocal {
 		test.RunCommand(t, "yarn_link", pwd, "yarn", "link", "@pulumi/pulumi")
 	}
@@ -76,7 +71,7 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
 		// Avoid Out of Memory error on CI:
 		Env: []string{"NODE_OPTIONS=--max_old_space_size=4096"},
 	}
-	test.RunCommandWithOptions(t, tscOptions, "tsc", pwd, "yarn", "run", "tsc",
+	test.RunCommandWithOptions(t, tscOptions, "tsc", pwd, filepath.Join(pwd, "node_modules", ".bin", "tsc"),
 		"--noEmit", "--skipLibCheck", "true", "--skipDefaultLibCheck", "true")
 }
 


### PR DESCRIPTION
Whenever yarn runs it holds a global lock, preventing any other yarn process from running.  Since our tests potentially try to run multiple yarn processes in parallel, this reduces the potential for parallelism in the tests dramatically.

By using `npm install` instead of `yarn install`, and runnig `tsc` directly instead of using `yarn run`, the time to run this test goes from >500s to ~90s when trying to run `nodejs/gen_program_test/batch1` locally.

Similar improvements can be expected from the other batches.  This should also help speed up CI, since this is part of the long tail of long running tests.

This is another thing I noticed during the hackathon (running all tests locally with bazel the difference was even more extreme).