### PR TITLE
[csharp/program-gen] Removes trailing whitespace from emitted DependsOn resource option expressions

### DIFF
--- a/changelog/pending/20240409--programgen-dotnet--removes-trailing-whitespace-from-emitted-dependson-resource-option-expressions.yaml
+++ b/changelog/pending/20240409--programgen-dotnet--removes-trailing-whitespace-from-emitted-dependson-resource-option-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Removes trailing whitespace from emitted DependsOn resource option expressions

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -1144,7 +1144,7 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions, resourceOption
 				g.Fgenf(&result, "\n%s{", g.Indent)
 				g.Indented(func() {
 					for _, resource := range resourcesList.Expressions {
-						g.Fgenf(&result, "\n%s%v, ", g.Indent, resource)
+						g.Fgenf(&result, "\n%s%v,", g.Indent, resource)
 					}
 				})
 				g.Fgenf(&result, "\n%s},", g.Indent)

--- a/tests/testdata/codegen/aws-fargate-pp/dotnet/aws-fargate.cs
+++ b/tests/testdata/codegen/aws-fargate-pp/dotnet/aws-fargate.cs
@@ -171,7 +171,7 @@ return await Deployment.RunAsync(() =>
     {
         DependsOn =
         {
-            webListener, 
+            webListener,
         },
     });
 

--- a/tests/testdata/codegen/aws-resource-options-4.26-pp/dotnet/aws-resource-options-4.26.cs
+++ b/tests/testdata/codegen/aws-resource-options-4.26-pp/dotnet/aws-resource-options-4.26.cs
@@ -17,7 +17,7 @@ return await Deployment.RunAsync(() =>
         Provider = provider,
         DependsOn =
         {
-            provider, 
+            provider,
         },
         Protect = true,
         IgnoreChanges =

--- a/tests/testdata/codegen/aws-resource-options-5.16.2-pp/dotnet/aws-resource-options-5.16.2.cs
+++ b/tests/testdata/codegen/aws-resource-options-5.16.2-pp/dotnet/aws-resource-options-5.16.2.cs
@@ -17,7 +17,7 @@ return await Deployment.RunAsync(() =>
         Provider = provider,
         DependsOn =
         {
-            provider, 
+            provider,
         },
         Protect = true,
         IgnoreChanges =

--- a/tests/testdata/codegen/depends-on-array-pp/dotnet/depends-on-array.cs
+++ b/tests/testdata/codegen/depends-on-array-pp/dotnet/depends-on-array.cs
@@ -38,8 +38,8 @@ return await Deployment.RunAsync(() =>
     {
         DependsOn =
         {
-            publicAccessBlock, 
-            ownershipControls, 
+            publicAccessBlock,
+            ownershipControls,
         },
     });
 


### PR DESCRIPTION
# Description

Fixes #15852 by removing the trailing whitespace from each expression emitted in the `DependsOn` array

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
