### PR TITLE
Run integration tests with race detection

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -40,6 +40,11 @@ on:
         default: false
         required: false
         type: boolean
+      enable-race-detection:
+        description: "Build binaries with race detection"
+        default: false
+        required: false
+        type: boolean
 
 defaults:
   run:
@@ -117,6 +122,7 @@ jobs:
           GORELEASER_CURRENT_TAG: v${{ inputs.version }}
           PULUMI_VERSION: ${{ inputs.dev-version || inputs.version }}
           PULUMI_BUILD_MODE: ${{ inputs.enable-coverage && 'coverage' || 'normal' }}
+          PULUMI_ENABLE_RACE_DETECTION: ${{ inputs.enable-race-detection && 'true' || 'false' }}
         run: |
           set -euxo pipefail
           # Spurious, this command requires piping via stdin

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -88,6 +88,8 @@ jobs:
       build-platform: ${{ matrix.build-platform }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: false
+      # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
+      enable-race-detection: ${{ matrix.os == 'darwin' || (matrix.os == 'linux' && matrix.arch == 'amd64') }}
     secrets: inherit
 
   build-sdks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,8 @@ jobs:
       build-platform: ${{ matrix.target.build-platform }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: ${{ inputs.enable-coverage }}
+      # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
+      enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
     secrets: inherit
 
   build-sdks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
   main: ./cmd/pulumi
   gobinary: ../scripts/go-wrapper.sh
   env:
-  - CGO_ENABLED=0
   - GO111MODULE=on
   goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']

--- a/changelog/pending/20240409--cli--dev-cli-is-now-built-with-race-detection-turned-on.yaml
+++ b/changelog/pending/20240409--cli--dev-cli-is-now-built-with-race-detection-turned-on.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Dev CLI is now built with race detection turned on.

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -325,7 +325,6 @@ func persistEngineEvents(
 	batchesToTransmit := make(chan engineEventBatch)
 
 	transmitBatchLoop := func() {
-		wg.Add(1)
 		defer wg.Done()
 
 		for eventBatch := range batchesToTransmit {
@@ -338,6 +337,7 @@ func persistEngineEvents(
 	// Start N different go-routines which will all pull from the batchesToTransmit channel
 	// and persist those engine events until the channel is closed.
 	for i := 0; i < maxConcurrentRequests; i++ {
+		wg.Add(1)
 		go transmitBatchLoop()
 	}
 

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -500,9 +500,9 @@ func generateImportedDefinitions(ctx *plugin.Context,
 		urn := resource.NewURN(stackName.Q(), projectName, parentType, i.Type, i.Name)
 		if state, ok := resourceTable[urn]; ok {
 			// Copy the state and override the protect bit.
-			s := *state
+			s := state.Copy()
 			s.Protect = protectResources
-			resources = append(resources, &s)
+			resources = append(resources, s)
 		}
 	}
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -152,11 +152,11 @@ func (i *importer) registerExistingResources(ctx context.Context) bool {
 			}
 
 			// Clear the ID because Same asserts that the new state has no ID.
-			new := *r
+			new := r.Copy()
 			new.ID = ""
 			// Set a dummy goal so the resource is tracked as managed.
 			i.deployment.goals.Store(r.URN, &resource.Goal{})
-			if !i.executeSerial(ctx, NewSameStep(i.deployment, noopEvent(0), r, &new)) {
+			if !i.executeSerial(ctx, NewSameStep(i.deployment, noopEvent(0), r, new)) {
 				return false
 			}
 		}
@@ -348,11 +348,11 @@ func (i *importer) importResources(ctx context.Context) error {
 			}
 			if oldID == imp.ID {
 				// Clear the ID because Same asserts that the new state has no ID.
-				new := *old
+				new := old.Copy()
 				new.ID = ""
 				// Set a dummy goal so the resource is tracked as managed.
 				i.deployment.goals.Store(old.URN, &resource.Goal{})
-				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, &new))
+				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, new))
 				continue
 			}
 		}
@@ -366,11 +366,11 @@ func (i *importer) importResources(ctx context.Context) error {
 			}
 			if oldID == imp.ID {
 				// Clear the ID because Same asserts that the new state has no ID.
-				new := *old
+				new := old.Copy()
 				new.ID = ""
 				// Set a dummy goal so the resource is tracked as managed.
 				i.deployment.goals.Store(old.URN, &resource.Goal{})
-				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, &new))
+				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, new))
 				continue
 			}
 		}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -103,6 +103,9 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 	}
 
 	fixResource := func(old *resource.State) *resource.State {
+		old.Lock.Lock()
+		defer old.Lock.Unlock()
+
 		return newStateBuilder(old).
 			withUpdatedURN(fixUrn).
 			withUpdatedParent(fixUrn).

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -56,9 +56,9 @@ func TestSnapshotWithUpdatedResources(t *testing.T) {
 	assert.Same(t, s, s1)
 
 	s = s1.withUpdatedResources(func(r *resource.State) *resource.State {
-		out := *r
+		out := r.Copy()
 		out.URN += "!"
-		return &out
+		return out
 	})
 	assert.NotSame(t, s, s1)
 	assert.Equal(t, s1.Resources[0].URN+"!", s.Resources[0].URN)

--- a/pkg/resource/deploy/state_builder.go
+++ b/pkg/resource/deploy/state_builder.go
@@ -26,7 +26,7 @@ type stateBuilder struct {
 }
 
 func newStateBuilder(state *resource.State) *stateBuilder {
-	return &stateBuilder{*state, state, false}
+	return &stateBuilder{*(state.Copy()), state, false}
 }
 
 func (sb *stateBuilder) withUpdatedURN(update func(resource.URN) resource.URN) *stateBuilder {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -306,6 +306,9 @@ func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bo
 	contract.Requiref(res != nil, "res", "must not be nil")
 	contract.Requiref(res.URN != "", "res", "must have a URN")
 
+	res.Lock.Lock()
+	defer res.Lock.Unlock()
+
 	// Serialize all input and output properties recursively, and add them if non-empty.
 	var inputs map[string]interface{}
 	if inp := res.Inputs; inp != nil {

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -36,13 +36,26 @@ case "$1" in
             fi
         fi
 
+        RACE=
+        CGO_ENABLED=0
+        if [ "$PULUMI_ENABLE_RACE_DETECTION" = "true" ]; then
+            RACE='-race'
+
+            if [ "$(go env GOOS)" != "darwin" ]; then
+                # On macOS, we don't need CGO but windows and linux still do.
+                CGO_ENABLED=1
+            fi
+        fi
+        export CGO_ENABLED
+
         case "$MODE" in
             normal)
-                go "$@"
+                shift
+                go build ${RACE} "$@"
                 ;;
             coverage)
                 shift
-                go build -cover -coverpkg "$COVERPKG" "$@"
+                go build ${RACE} -cover -coverpkg "$COVERPKG" "$@"
                 ;;
             *)
                 echo "unknown build mode: $MODE"

--- a/sdk/go/common/resource/resource_state.go
+++ b/sdk/go/common/resource/resource_state.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"sync"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -27,6 +28,11 @@ import (
 //
 //nolint:lll
 type State struct {
+	// Currently the engine implements RegisterResourceOutputs by directly mutating the state to change the `Outputs`. This
+	// triggers a race between the snapshot serialization code and the engine. Ideally we'd do a more principled fix, but
+	// just locking in these two places is sufficient to stop the race detector from firing on integration tests.
+	Lock sync.Mutex
+
 	Type                    tokens.Type           // the resource's type.
 	URN                     URN                   // the resource's object urn, a human-friendly, unique name for the resource.
 	Custom                  bool                  // true if the resource is custom, managed by a plugin.
@@ -51,6 +57,36 @@ type State struct {
 	Created                 *time.Time            // If set, the time when the state was initially added to the state file. (i.e. Create, Import)
 	Modified                *time.Time            // If set, the time when the state was last modified in the state file.
 	SourcePosition          string                // If set, the source location of the resource registration
+}
+
+// Copy creates a deep copy of the resource state, except without copying the lock.
+func (s *State) Copy() *State {
+	return &State{
+		Type:                    s.Type,
+		URN:                     s.URN,
+		Custom:                  s.Custom,
+		Delete:                  s.Delete,
+		ID:                      s.ID,
+		Inputs:                  s.Inputs,
+		Outputs:                 s.Outputs,
+		Parent:                  s.Parent,
+		Protect:                 s.Protect,
+		External:                s.External,
+		Dependencies:            s.Dependencies,
+		InitErrors:              s.InitErrors,
+		Provider:                s.Provider,
+		PropertyDependencies:    s.PropertyDependencies,
+		PendingReplacement:      s.PendingReplacement,
+		AdditionalSecretOutputs: s.AdditionalSecretOutputs,
+		Aliases:                 s.Aliases,
+		CustomTimeouts:          s.CustomTimeouts,
+		ImportID:                s.ImportID,
+		RetainOnDelete:          s.RetainOnDelete,
+		DeletedWith:             s.DeletedWith,
+		Created:                 s.Created,
+		Modified:                s.Modified,
+		SourcePosition:          s.SourcePosition,
+	}
 }
 
 func (s *State) GetAliasURNs() []URN {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Combining #15120 and #15124 and including fixes to allow tests to pass.

Enable race detection in the binary we're using for integration tests. This will allow us to catch more data races before they get into any release. This does mean the binary we're using for integration tests is slightly different from the binary we're releasing, however that's already the case as we're running a binary with coverage enabled for them. Later we rebuild the binary we're actually releasing.

This requires us to fix the race between snapshot code, display code, and the step executor. I've done that by adding a lock to the State struct. This does not feel great, but it's a quick way to fix this and get race detection running (and unblocks #15871 which was also hitting the race detector because it started pulling snapshot code into unit tests as well). There's probably a more principled overhaul that doesn't require locking at this level.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
