### PR TITLE
allow unknowns in apply during update

### DIFF
--- a/changelog/pending/20240410--sdk-nodejs--allow-apply-to-have-unknown-values-during-updates.yaml
+++ b/changelog/pending/20240410--sdk-nodejs--allow-apply-to-have-unknown-values-during-updates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Allow apply to have unknown values during updates

--- a/changelog/pending/20240410--sdk-nodejs--allow-apply-to-have-unknown-values-during-updates.yaml
+++ b/changelog/pending/20240410--sdk-nodejs--allow-apply-to-have-unknown-values-during-updates.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
-  scope: sdk/nodejs
+  scope: sdk/nodejs,python
   description: Allow apply to have unknown values during updates

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -869,8 +869,8 @@ export interface OutputInstance<T> {
      * If you need have multiple Outputs and a single Output is needed that combines both
      * set of resources, then 'pulumi.all' should be used instead.
      *
-     * This function will only be called execution of a 'pulumi up' request.  It will not run
-     * during 'pulumi preview' (as the values of resources are of course not known then). It is not
+     * This function will be called execution of a 'pulumi up' or 'pulumi preview' request, but it
+     * will ont run when the values of the output are unknown. It is not
      * available for functions that end up executing in the cloud during runtime.  To get the value
      * of the Output during cloud runtime execution, use `get()`.
      */

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -378,27 +378,25 @@ async function applyHelperAsync<T, U>(
     func: (t: T) => Input<U>,
     runWithUnknowns: boolean,
 ) {
-    if (settings.isDryRun()) {
-        // During previews only perform the apply if the engine was able to give us an actual value
-        // for this Output.
-        const applyDuringPreview = isKnown || runWithUnknowns;
+    // Only perform the apply if the engine was able to give us an actual value
+    // for this Output.
+    const doApply = isKnown || runWithUnknowns;
 
-        if (!applyDuringPreview) {
-            // We didn't actually run the function, our new Output is definitely **not** known.
-            return {
-                allResources,
-                value: <U>(<any>undefined),
-                isKnown: false,
-                isSecret,
-            };
-        }
+    if (!doApply) {
+        // We didn't actually run the function, our new Output is definitely **not** known.
+        return {
+            allResources,
+            value: <U>(<any>undefined),
+            isKnown: false,
+            isSecret,
+        };
+    }
 
-        // If we are running with unknown values and the value is explicitly unknown but does not actually
-        // contain any unknown values, collapse its value to the unknown value. This ensures that callbacks
-        // that expect to see unknowns during preview in outputs that are not known will always do so.
-        if (!isKnown && runWithUnknowns && !containsUnknowns(value)) {
-            value = <T>(<any>unknown);
-        }
+    // If we are running with unknown values and the value is explicitly unknown but does not actually
+    // contain any unknown values, collapse its value to the unknown value. This ensures that callbacks
+    // that expect to see unknowns during preview in outputs that are not known will always do so.
+    if (!isKnown && runWithUnknowns && !containsUnknowns(value)) {
+        value = <T>(<any>unknown);
     }
 
     const transformed = await func(value);

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -485,34 +485,31 @@ describe("output", () => {
             assert.strictEqual(await r.promise(), "inner");
         });
 
-        it("produces known on unknown", async () => {
+        it("produces unknown on unknown", async () => {
             runtime._setIsDryRun(false);
 
             const out = createOutput(0, false);
             const r = out.apply((v) => v + 1);
 
-            assert.strictEqual(await r.isKnown, true);
-            assert.strictEqual(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, false);
         });
 
-        it("produces known on unknown awaitable", async () => {
+        it("produces unknown on unknown awaitable", async () => {
             runtime._setIsDryRun(false);
 
             const out = createOutput(0, false);
             const r = out.apply((v) => Promise.resolve("inner"));
 
-            assert.strictEqual(await r.isKnown, true);
-            assert.strictEqual(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
         });
 
-        it("produces known on unknown known output", async () => {
+        it("produces unknown on unknown known output", async () => {
             runtime._setIsDryRun(false);
 
             const out = createOutput(0, false);
             const r = out.apply((v) => createOutput("inner", true));
 
-            assert.strictEqual(await r.isKnown, true);
-            assert.strictEqual(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
         });
 
         it("produces unknown on unknown unknown output", async () => {
@@ -522,7 +519,6 @@ describe("output", () => {
             const r = out.apply((v) => createOutput("inner", false));
 
             assert.strictEqual(await r.isKnown, false);
-            assert.strictEqual(await r.promise(), "inner");
         });
 
         it("preserves secret on known", async () => {
@@ -575,9 +571,8 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply((v) => v + 1);
 
-            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isKnown, false);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), 1);
         });
 
         it("preserves secret on unknown awaitable", async () => {
@@ -586,9 +581,8 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply((v) => Promise.resolve("inner"));
 
-            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isKnown, false);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
         });
 
         it("preserves secret on unknown known output", async () => {
@@ -597,9 +591,8 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply((v) => createOutput("inner", true));
 
-            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isKnown, false);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
         });
 
         it("preserves secret on unknown known output", async () => {
@@ -610,7 +603,6 @@ describe("output", () => {
 
             assert.strictEqual(await r.isKnown, false);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
         });
 
         it("propagates secret on known known output", async () => {
@@ -621,7 +613,6 @@ describe("output", () => {
 
             assert.strictEqual(await r.isKnown, true);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
         });
 
         it("propagates secret on known unknown output", async () => {
@@ -632,29 +623,6 @@ describe("output", () => {
 
             assert.strictEqual(await r.isKnown, false);
             assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
-        });
-
-        it("propagates secret on unknown known output", async () => {
-            runtime._setIsDryRun(false);
-
-            const out = createOutput(0, false);
-            const r = out.apply((v) => createOutput("inner", true, true));
-
-            assert.strictEqual(await r.isKnown, true);
-            assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
-        });
-
-        it("propagates secret on unknown uknown output", async () => {
-            runtime._setIsDryRun(false);
-
-            const out = createOutput(0, false);
-            const r = out.apply((v) => createOutput("inner", false, true));
-
-            assert.strictEqual(await r.isKnown, false);
-            assert.strictEqual(await r.isSecret, true);
-            assert.strictEqual(await r.promise(), "inner");
         });
     });
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -180,7 +180,7 @@ class Output(Generic[T_co]):
                 # Only perform the apply if the engine was able to give us an actual value for this
                 # Output or if the caller is able to tolerate unknown values.
                 do_apply = is_known or run_with_unknowns
-                if not do_apply_during_preview:
+                if not do_apply:
                     # We didn't actually run the function, our new Output is definitely
                     # **not** known.
                     result_resources.set_result(resources)
@@ -191,11 +191,7 @@ class Output(Generic[T_co]):
                 # If we are running with unknown values and the value is explicitly unknown but does not actually
                 # contain any unknown values, collapse its value to the unknown value. This ensures that callbacks
                 # that expect to see unknowns during preview in outputs that are not known will always do so.
-                if (
-                        not is_known
-                        and run_with_unknowns
-                        and not contains_unknowns(value)
-                ):
+                if not is_known and run_with_unknowns and not contains_unknowns(value):
                     value = cast(T_co, UNKNOWN)
 
                 transformed: Input[U] = func(value)

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -154,8 +154,8 @@ class Output(Generic[T_co]):
         'func' can return other Outputs.  This can be handy if you have a Output<SomeVal>
         and you want to get a transitive dependency of it.
 
-        This function will be called during execution of a `pulumi up` request.  It may not run
-        during `pulumi preview` (as the values of resources are of course may not be known then).
+        This function will be called during execution of a `pulumi up` or `pulumi preview` request.
+        It may not run when the values of the resource is unknown.
 
         :param Callable[[T_co],Input[U]] func: A function that will, given this Output's value, transform the value to
                an Input of some kind, where an Input is either a prompt value, a Future, or another Output of the given
@@ -177,28 +177,26 @@ class Output(Generic[T_co]):
                 is_secret = await self._is_secret
                 value = await self._future
 
-                if runtime.is_dry_run():
-                    # During previews only perform the apply if the engine was able to give us an actual value for this
-                    # Output or if the caller is able to tolerate unknown values.
-                    apply_during_preview = is_known or run_with_unknowns
+                # Only perform the apply if the engine was able to give us an actual value for this
+                # Output or if the caller is able to tolerate unknown values.
+                do_apply = is_known or run_with_unknowns
+                if not do_apply_during_preview:
+                    # We didn't actually run the function, our new Output is definitely
+                    # **not** known.
+                    result_resources.set_result(resources)
+                    result_is_known.set_result(False)
+                    result_is_secret.set_result(is_secret)
+                    return cast(U, None)
 
-                    if not apply_during_preview:
-                        # We didn't actually run the function, our new Output is definitely
-                        # **not** known.
-                        result_resources.set_result(resources)
-                        result_is_known.set_result(False)
-                        result_is_secret.set_result(is_secret)
-                        return cast(U, None)
-
-                    # If we are running with unknown values and the value is explicitly unknown but does not actually
-                    # contain any unknown values, collapse its value to the unknown value. This ensures that callbacks
-                    # that expect to see unknowns during preview in outputs that are not known will always do so.
-                    if (
+                # If we are running with unknown values and the value is explicitly unknown but does not actually
+                # contain any unknown values, collapse its value to the unknown value. This ensures that callbacks
+                # that expect to see unknowns during preview in outputs that are not known will always do so.
+                if (
                         not is_known
                         and run_with_unknowns
                         and not contains_unknowns(value)
-                    ):
-                        value = cast(T_co, UNKNOWN)
+                ):
+                    value = cast(T_co, UNKNOWN)
 
                 transformed: Input[U] = func(value)
                 # Transformed is an Input, meaning there are three cases:

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -782,17 +782,16 @@ class NextSerializationTests(unittest.TestCase):
         self.assertEqual(await r.future(), "inner")
 
     @pulumi_test
-    async def test_apply_produces_known_on_unknown(self):
+    async def test_apply_produces_unknown_on_unknown(self):
         settings.SETTINGS.dry_run = False
 
         out = self.create_output(0, is_known=False)
         r = out.apply(lambda v: v + 1)
 
-        self.assertTrue(await r.is_known())
-        self.assertEqual(await r.future(), 1)
+        self.assertFalse(await r.is_known())
 
     @pulumi_test
-    async def test_apply_produces_known_on_unknown_awaitable(self):
+    async def test_apply_produces_unknown_on_unknown_awaitable(self):
         settings.SETTINGS.dry_run = False
 
         out = self.create_output(0, is_known=False)
@@ -803,8 +802,7 @@ class NextSerializationTests(unittest.TestCase):
             return fut
         r = out.apply(apply)
 
-        self.assertTrue(await r.is_known())
-        self.assertEqual(await r.future(), "inner")
+        self.assertFalse(await r.is_known())
 
     @pulumi_test
     async def test_apply_produces_known_on_unknown_known_output(self):
@@ -813,8 +811,7 @@ class NextSerializationTests(unittest.TestCase):
         out = self.create_output(0, is_known=False)
         r = out.apply(lambda v: self.create_output("inner", is_known=True))
 
-        self.assertTrue(await r.is_known())
-        self.assertEqual(await r.future(), "inner")
+        self.assertFalse(await r.is_known())
 
     @pulumi_test
     async def test_apply_produces_unknown_on_unknown_unknown_output(self):
@@ -824,7 +821,6 @@ class NextSerializationTests(unittest.TestCase):
         r = out.apply(lambda v: self.create_output("inner", is_known=False))
 
         self.assertFalse(await r.is_known())
-        self.assertEqual(await r.future(), "inner")
 
     @pulumi_test
     async def test_apply_preserves_secret_on_known(self):
@@ -882,9 +878,8 @@ class NextSerializationTests(unittest.TestCase):
         out = self.create_output(0, is_known=False, is_secret=True)
         r = out.apply(lambda v: v + 1)
 
-        self.assertTrue(await r.is_known())
+        self.assertFalse(await r.is_known())
         self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), 1)
 
     @pulumi_test
     async def test_apply_preserves_secret_on_unknown_awaitable(self):
@@ -898,9 +893,8 @@ class NextSerializationTests(unittest.TestCase):
             return fut
         r = out.apply(apply)
 
-        self.assertTrue(await r.is_known())
+        self.assertFalse(await r.is_known())
         self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), "inner")
 
     @pulumi_test
     async def test_apply_preserves_secret_on_unknown_known_output(self):
@@ -909,9 +903,8 @@ class NextSerializationTests(unittest.TestCase):
         out = self.create_output(0, is_known=False, is_secret=True)
         r = out.apply(lambda v: self.create_output("inner", is_known=True))
 
-        self.assertTrue(await r.is_known())
+        self.assertFalse(await r.is_known())
         self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), "inner")
 
     @pulumi_test
     async def test_apply_preserves_secret_on_unknown_unknown_output(self):
@@ -922,7 +915,6 @@ class NextSerializationTests(unittest.TestCase):
 
         self.assertFalse(await r.is_known())
         self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), "inner")
 
     @pulumi_test
     async def test_apply_propagates_secret_on_known_known_output(self):
@@ -940,28 +932,6 @@ class NextSerializationTests(unittest.TestCase):
         settings.SETTINGS.dry_run = False
 
         out = self.create_output(0, is_known=True)
-        r = out.apply(lambda v: self.create_output("inner", is_known=False, is_secret=True))
-
-        self.assertFalse(await r.is_known())
-        self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), "inner")
-
-    @pulumi_test
-    async def test_apply_propagates_secret_on_unknown_known_output(self):
-        settings.SETTINGS.dry_run = False
-
-        out = self.create_output(0, is_known=False)
-        r = out.apply(lambda v: self.create_output("inner", is_known=True, is_secret=True))
-
-        self.assertTrue(await r.is_known())
-        self.assertTrue(await r.is_secret())
-        self.assertEqual(await r.future(), "inner")
-
-    @pulumi_test
-    async def test_apply_propagates_secret_on_unknown_unknown_output(self):
-        settings.SETTINGS.dry_run = False
-
-        out = self.create_output(0, is_known=False)
         r = out.apply(lambda v: self.create_output("inner", is_known=False, is_secret=True))
 
         self.assertFalse(await r.is_known())


### PR DESCRIPTION
Currently during updates we try to make the values known during apply, even if they are marked unknown.  This results in knows that should really still be unknown.

Note that this behaviour is currently encoded in tests, which also needed to change.