### PR TITLE
The `--expect-no-changes` flag checks for output diffs

### DIFF
--- a/changelog/pending/20240410--cli-engine--fixes-15564-expect-no-changes-now-causes-pulumi-cli-to-fail-if-the-only-changes-are-output-changes.yaml
+++ b/changelog/pending/20240410--cli-engine--fixes-15564-expect-no-changes-now-causes-pulumi-cli-to-fail-if-the-only-changes-are-output-changes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/engine
+  description: "Fixes #15564, --expect-no-changes now causes pulumi cli to fail if the only changes are output changes"

--- a/changelog/pending/20240410--cli-engine--fixes-15564-expect-no-changes-now-causes-pulumi-cli-to-fail-if-the-only-changes-are-output-changes.yaml
+++ b/changelog/pending/20240410--cli-engine--fixes-15564-expect-no-changes-now-causes-pulumi-cli-to-fail-if-the-only-changes-are-output-changes.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/engine
-  description: "Fixes #15564, --expect-no-changes now causes pulumi cli to fail if the only changes are output changes"
+  description: "Make --expect-no-changes fail even if the only changes are output changes"

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1137,6 +1137,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				opText = "discarding failed"
 			case deploy.OpImport, deploy.OpImportReplacement:
 				opText = "importing failed"
+			case deploy.OpOutputChange:
+				opText = "changing output failed"
 			default:
 				contract.Failf("Unrecognized resource step op: %v", op)
 				return ""
@@ -1171,6 +1173,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				opText = "imported"
 			case deploy.OpImportReplacement:
 				opText = "imported replacement"
+			case deploy.OpOutputChange:
+				opText = "output changed"
 			default:
 				contract.Failf("Unrecognized resource step op: %v", op)
 				return ""

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -316,6 +317,7 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 					_ deploy.Target,
 					entries engine.JournalEntries,
 					_ []engine.Event,
+					_ display.ResourceChanges,
 					_ error,
 				) error {
 					journalEntries = entries

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -163,6 +163,8 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 			info.EndTime = makeStringRef(time.Unix(update.EndTime, 0).UTC().Format(timeFormat))
 			resourceChanges := make(map[string]int)
 			for k, v := range update.ResourceChanges {
+				// Filter out the the OpOutputChange events because they are pseudo
+				// events that shouldn't be included in the stack history
 				if k != deploy.OpOutputChange {
 					resourceChanges[string(k)] = v
 				}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -162,7 +163,9 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 			info.EndTime = makeStringRef(time.Unix(update.EndTime, 0).UTC().Format(timeFormat))
 			resourceChanges := make(map[string]int)
 			for k, v := range update.ResourceChanges {
-				resourceChanges[string(k)] = v
+				if k != deploy.OpOutputChange {
+					resourceChanges[string(k)] = v
+				}
 			}
 			info.ResourceChanges = &resourceChanges
 		}

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -189,7 +189,7 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 					Op:            Update,
 					ExpectFailure: expectFailure,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						events []Event, err error,
+						events []Event, changes display.ResourceChanges, err error,
 					) error {
 						for _, event := range events {
 							if event.Type == ResourcePreEvent {
@@ -1595,7 +1595,7 @@ func TestParentAlias(t *testing.T) {
 	firstRun = false
 	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(project workspace.Project, target deploy.Target,
-			entries JournalEntries, events []Event, err error,
+			entries JournalEntries, events []Event, changes display.ResourceChanges, err error,
 		) error {
 			for _, entry := range entries {
 				assert.Equal(t, deploy.OpSame, entry.Step.Op())
@@ -1669,7 +1669,7 @@ func TestEmptyParentAlias(t *testing.T) {
 	firstRun = false
 	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(project workspace.Project, target deploy.Target,
-			entries JournalEntries, events []Event, err error,
+			entries JournalEntries, events []Event, changes display.ResourceChanges, err error,
 		) error {
 			for _, entry := range entries {
 				assert.Equal(t, deploy.OpSame, entry.Step.Op())

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -375,7 +376,7 @@ func TestSimpleAnalyzeResourceFailureRemediateDowngradedToMandatory(t *testing.T
 				SkipPreview:   true,
 				ExpectFailure: true,
 				Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-					events []Event, err error,
+					events []Event, changes display.ResourceChanges, err error,
 				) error {
 					violationEvents := []Event{}
 					for _, e := range events {
@@ -439,7 +440,7 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 				SkipPreview:   true,
 				ExpectFailure: true,
 				Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-					events []Event, err error,
+					events []Event, changes display.ResourceChanges, err error,
 				) error {
 					violationEvents := []Event{}
 					for _, e := range events {

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -176,7 +177,7 @@ func TestDeleteBeforeReplace(t *testing.T) {
 		ExpectFailure: false,
 		SkipPreview:   true,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -350,7 +351,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -374,7 +375,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -399,7 +400,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -423,7 +424,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -447,7 +448,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -473,7 +474,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -575,7 +576,7 @@ func TestDependencyChangeDBR(t *testing.T) {
 		{
 			Op: Update,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				assert.NoError(t, err)
 				assert.True(t, len(entries) > 0)

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -160,7 +160,7 @@ func TestIgnoreChangesGolangLifecycle(t *testing.T) {
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						events []Event, err error,
+						events []Event, changes display.ResourceChanges, err error,
 					) error {
 						for _, event := range events {
 							if event.Type == ResourcePreEvent {
@@ -262,7 +262,7 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 
@@ -286,7 +286,7 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 		Op: Update,
 
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			AssertSameSteps(t, []StepSummary{
@@ -349,7 +349,7 @@ func TestReadResourceGolangLifecycle(t *testing.T) {
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						evts []Event, err error,
+						evts []Event, changes display.ResourceChanges, err error,
 					) error {
 						assert.NoError(t, err)
 
@@ -598,7 +598,7 @@ func TestReplaceOnChangesGolangLifecycle(t *testing.T) {
 			{
 				Op: Update,
 				Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-					events []Event, err error,
+					events []Event, changes display.ResourceChanges, err error,
 				) error {
 					collectedOps := make([]display.StepOp, 0)
 					for _, event := range events {

--- a/pkg/engine/lifecycletest/pending_delete_test.go
+++ b/pkg/engine/lifecycletest/pending_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -60,7 +61,7 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(_ workspace.Project, _ deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			// Verify that we see a DeleteReplacement for the resource with ID 0 and a Delete for the resource with
 			// ID 1.
@@ -136,7 +137,7 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Destroy,
 		Validate: func(_ workspace.Project, _ deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			// Verify that we see a DeleteReplacement for the resource with ID 0 and a Delete for the resource with
 			// ID 1.

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -126,7 +126,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 
 	isRefresh := false
 	validate := func(project workspace.Project, target deploy.Target, entries JournalEntries,
-		_ []Event, err error,
+		_ []Event, changes display.ResourceChanges, err error,
 	) error {
 		require.NoError(t, err)
 
@@ -164,7 +164,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Destroy,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			require.NoError(t, err)
 
@@ -240,7 +240,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			provURN := p.NewProviderURN("pkgA", "default", "")
 			resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -336,7 +336,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			provURN := p.NewProviderURN("pkgA", "provA", "")
 			resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -577,7 +577,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			for _, entry := range entries {
 				if entry.Step.Op() != deploy.OpSame {
@@ -594,7 +594,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			provURN := p.NewProviderURN("pkgA", providerName, "")
 			resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -715,7 +715,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			provURN := p.NewProviderURN("pkgA", "provA", "")
 			resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -811,7 +811,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						events []Event, err error,
+						events []Event, changes display.ResourceChanges, err error,
 					) error {
 						for _, entry := range entries {
 							if entry.Kind != JournalEntrySuccess {
@@ -938,7 +938,7 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						events []Event, err error,
+						events []Event, changes display.ResourceChanges, err error,
 					) error {
 						for _, entry := range entries {
 							if entry.Kind != JournalEntrySuccess {
@@ -1226,7 +1226,7 @@ func TestPluginDownloadURLPassthrough(t *testing.T) {
 
 	steps := MakeBasicLifecycleSteps(t, 2)
 	steps[0].ValidateAnd(func(project workspace.Project, target deploy.Target, entries JournalEntries,
-		_ []Event, err error,
+		_ []Event, changes display.ResourceChanges, err error,
 	) error {
 		for _, e := range entries {
 			r := e.Step.New()
@@ -1483,7 +1483,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 
 			update := []TestStep{{Op: Update, Validate: func(
 				project workspace.Project, target deploy.Target, entries JournalEntries,
-				events []Event, err error,
+				events []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -5720,10 +5720,10 @@ func TestOutputChanges(t *testing.T) {
 		"frob": "baz",
 	})
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		urn, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
+		rrResp, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 
-		err = monitor.RegisterResourceOutputs(urn, outs)
+		err = monitor.RegisterResourceOutputs(rrResp.URN, outs)
 		assert.NoError(t, err)
 
 		return nil

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -87,7 +87,7 @@ func ExpectDiagMessage(t *testing.T, messagePattern string) ValidateFunc {
 	validate := func(
 		project workspace.Project, target deploy.Target,
 		entries JournalEntries, events []Event,
-		err error,
+		changes display.ResourceChanges, err error,
 	) error {
 		assert.Error(t, err)
 
@@ -188,7 +188,7 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 	// Now run a preview. Expect a warning because the diff is unavailable.
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
-			events []Event, err error,
+			events []Event, changes display.ResourceChanges, err error,
 		) error {
 			found := false
 			for _, e := range events {
@@ -237,7 +237,7 @@ func TestCheckFailureRecord(t *testing.T) {
 			ExpectFailure: true,
 			SkipPreview:   true,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				sawFailure := false
 				for _, evt := range evts {
@@ -290,7 +290,7 @@ func TestCheckFailureInvalidPropertyRecord(t *testing.T) {
 			ExpectFailure: true,
 			SkipPreview:   true,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				sawFailure := false
 				for _, evt := range evts {
@@ -337,7 +337,7 @@ func TestLanguageHostDiagnostics(t *testing.T) {
 			ExpectFailure: true,
 			SkipPreview:   true,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				assert.Error(t, err)
 				sawExitCode := false
@@ -400,7 +400,7 @@ func TestBrokenDecrypter(t *testing.T) {
 			ExpectFailure: true,
 			SkipPreview:   true,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				assert.Error(t, err)
 				decryptErr := err.(DecryptError)
@@ -861,7 +861,7 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 	validate := func(
 		project workspace.Project, target deploy.Target,
 		entries JournalEntries, events []Event,
-		err error,
+		changes display.ResourceChanges, err error,
 	) error {
 		for i := range events {
 			if events[i].Type == "diag" {
@@ -936,7 +936,7 @@ func TestUpdatePartialFailure(t *testing.T) {
 		ExpectFailure: true,
 		SkipPreview:   true,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.Error(t, err)
 			for _, entry := range entries {
@@ -1046,7 +1046,7 @@ func TestStackReference(t *testing.T) {
 		Op:          Update,
 		SkipPreview: true,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			for _, entry := range entries {
@@ -1124,7 +1124,7 @@ func TestStackReferenceRegister(t *testing.T) {
 	for i := range steps {
 		v := steps[i].Validate
 		steps[i].Validate = func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			// Check if we registered a stack reference resource (i.e. same/update/create). Ideally we'd warn on refresh
 			// as well but that's just a Read so it's hard to tell in the built-in provider if that's a Read for a
@@ -1156,7 +1156,7 @@ func TestStackReferenceRegister(t *testing.T) {
 				assert.True(t, found, "diagnostic warning not found in: %+v", evts)
 			}
 
-			return v(project, target, entries, evts, err)
+			return v(project, target, entries, evts, nil, err)
 		}
 	}
 
@@ -1201,7 +1201,7 @@ func TestStackReferenceRegister(t *testing.T) {
 		Op:          Update,
 		SkipPreview: true,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			for _, entry := range entries {
@@ -1390,7 +1390,7 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 				{
 					Op: Update,
 					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						events []Event, err error,
+						events []Event, changes display.ResourceChanges, err error,
 					) error {
 						for _, event := range events {
 							if event.Type == ResourcePreEvent {
@@ -1648,7 +1648,7 @@ func replaceOnChangesTest(t *testing.T, name string, diffFunc DiffFunc) {
 					{
 						Op: Update,
 						Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-							events []Event, err error,
+							events []Event, changes display.ResourceChanges, err error,
 						) error {
 							for _, event := range events {
 								if event.Type == ResourcePreEvent {
@@ -1797,7 +1797,7 @@ func TestPersistentDiff(t *testing.T) {
 	// provider diffing.
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
-			events []Event, err error,
+			events []Event, changes display.ResourceChanges, err error,
 		) error {
 			found := false
 			for _, e := range events {
@@ -1818,7 +1818,7 @@ func TestPersistentDiff(t *testing.T) {
 	p.Options.UseLegacyDiff = true
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
-			events []Event, err error,
+			events []Event, changes display.ResourceChanges, err error,
 		) error {
 			found := false
 			for _, e := range events {
@@ -1880,7 +1880,7 @@ func TestDetailedDiffReplace(t *testing.T) {
 	// provider diffing.
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
-			events []Event, err error,
+			events []Event, changes display.ResourceChanges, err error,
 		) error {
 			found := false
 			for _, e := range events {
@@ -1999,7 +1999,7 @@ func TestProviderDiffMissingOldOutputs(t *testing.T) {
 	p.Steps = []TestStep{{
 		Op: Update,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			resURN := p.NewURN("pkgA:m:typA", "resA", "")
 
@@ -3066,7 +3066,7 @@ func TestComponentDeleteDependencies(t *testing.T) {
 			Op:          Destroy,
 			SkipPreview: true,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				evts []Event, err error,
+				evts []Event, changes display.ResourceChanges, err error,
 			) error {
 				assert.NoError(t, err)
 
@@ -3182,7 +3182,7 @@ func TestProtect(t *testing.T) {
 	// Both updates below should give a diagnostic event
 	validate := func(project workspace.Project,
 		target deploy.Target, entries JournalEntries,
-		events []Event, err error,
+		events []Event, changes display.ResourceChanges, err error,
 	) error {
 		for _, event := range events {
 			if event.Type == DiagEvent {
@@ -3669,7 +3669,7 @@ func TestEventSecrets(t *testing.T) {
 		})),
 	}
 	p.Steps[0].Validate = func(project workspace.Project, target deploy.Target, entries JournalEntries,
-		evts []Event, err error,
+		evts []Event, changes display.ResourceChanges, err error,
 	) error {
 		for _, e := range evts {
 			var step StepEventMetadata
@@ -3739,7 +3739,7 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 	validate := func(
 		project workspace.Project, target deploy.Target,
 		entries JournalEntries, events []Event,
-		err error,
+		changes display.ResourceChanges, err error,
 	) error {
 		if err != nil {
 			return err
@@ -4791,7 +4791,7 @@ func TestAutomaticDiff(t *testing.T) {
 	}
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
-			events []Event, err error,
+			events []Event, changes display.ResourceChanges, err error,
 		) error {
 			found := false
 			for _, e := range events {
@@ -5698,4 +5698,83 @@ func TestStackOutputsResourceError(t *testing.T) {
 		"first":  resource.NewProperty("step 3"),
 		"second": resource.NewProperty("step 3"),
 	})
+}
+
+func TestOutputChanges(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool,
+				) (resource.ID, resource.PropertyMap, resource.Status, error) {
+					return resource.ID("created-id-" + urn.Name()), news, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+
+	outs := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo":  "bar",
+		"frob": "baz",
+	})
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		urn, _, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
+		assert.NoError(t, err)
+
+		err = monitor.RegisterResourceOutputs(urn, outs)
+		assert.NoError(t, err)
+
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &TestPlan{
+		Options: TestUpdateOptions{
+			HostF:         hostF,
+			UpdateOptions: UpdateOptions{GeneratePlan: true, Experimental: true},
+		},
+	}
+
+	project := p.GetProject()
+
+	snap, err := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries,
+			events []Event, changes display.ResourceChanges, err error,
+		) error {
+			// Adding two outputs
+			assert.Equal(t, 2, changes[deploy.OpOutputChange], "Expecting two output changes")
+			assert.Equal(t, 1, changes[deploy.OpCreate], "Expecting one OpCreate for the new resource")
+			return nil
+		})
+	assert.NotNil(t, snap)
+	assert.NoError(t, err)
+
+	// Without changing outputs, there should be no OpOutputChange
+	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries,
+			events []Event, changes display.ResourceChanges, err error,
+		) error {
+			assert.Equal(t, 0, changes[deploy.OpOutputChange], "Expecting no output changes")
+			assert.Equal(t, 1, changes[deploy.OpSame], "Expecting one OpSame")
+			return nil
+		})
+	assert.NotNil(t, snap)
+	assert.NoError(t, err)
+
+	// Now change the outputs, there should now be one OpOutputChange
+	outs = resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "bar",
+	})
+	snap, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries,
+			events []Event, changes display.ResourceChanges, err error,
+		) error {
+			assert.Equal(t, 1, changes[deploy.OpSame], "Expecting one OpSame")
+			assert.Equal(t, 1, changes[deploy.OpOutputChange], "Expecting one output to have changed")
+			return nil
+		})
+	assert.NotNil(t, snap)
+	assert.NoError(t, err)
 }

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -11,6 +11,7 @@ import (
 	combinations "github.com/mxschmitt/golang-combinations"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
@@ -387,7 +388,7 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 		{
 			Op: Refresh,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				// Should see only refreshes.
 				for _, entry := range entries {
@@ -562,7 +563,7 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 	p.Steps = []TestStep{{
 		Op: Refresh,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			_ []Event, err error,
+			_ []Event, changes display.ResourceChanges, err error,
 		) error {
 			// Should see only refreshes.
 			for _, entry := range entries {
@@ -737,7 +738,7 @@ func TestCanceledRefresh(t *testing.T) {
 	}
 	project, target := p.GetProject(), p.GetTarget(t, old)
 	validate := func(project workspace.Project, target deploy.Target, entries JournalEntries,
-		_ []Event, err error,
+		_ []Event, changes display.ResourceChanges, err error,
 	) error {
 		for _, entry := range entries {
 			assert.Equal(t, deploy.OpRefresh, entry.Step.Op())

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -131,7 +131,7 @@ func destroySpecificTargets(
 		Op:            Destroy,
 		ExpectFailure: !targetDependents,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -240,7 +240,7 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 		Op:            Update,
 		ExpectFailure: false,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -390,7 +390,7 @@ func TestCreateDuringTargetedUpdate_CreateMentionedAsTarget(t *testing.T) {
 		Op:            Update,
 		ExpectFailure: false,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -452,7 +452,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateNotReferenced(t *testing.T) 
 		Op:            Update,
 		ExpectFailure: false,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -614,7 +614,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUntargetedCreate
 		Op:            Update,
 		ExpectFailure: false,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -679,7 +679,7 @@ func TestReplaceSpecificTargets(t *testing.T) {
 		Op:            Update,
 		ExpectFailure: false,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)
@@ -918,7 +918,7 @@ func destroySpecificTargetsWithChildren(
 		Op:            Destroy,
 		ExpectFailure: !targetDependents,
 		Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-			evts []Event, err error,
+			evts []Event, changes display.ResourceChanges, err error,
 		) error {
 			assert.NoError(t, err)
 			assert.True(t, len(entries) > 0)

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -112,7 +112,7 @@ func ImportOp(imports []deploy.Import) TestOp {
 type TestOp func(UpdateInfo, *Context, UpdateOptions, bool) (*deploy.Plan, display.ResourceChanges, error)
 
 type ValidateFunc func(project workspace.Project, target deploy.Target, entries JournalEntries,
-	events []Event, err error) error
+	events []Event, changes display.ResourceChanges, err error) error
 
 func (op TestOp) Plan(project workspace.Project, target deploy.Target, opts TestUpdateOptions,
 	backendClient deploy.BackendClient, validate ValidateFunc,
@@ -189,7 +189,7 @@ func (op TestOp) runWithContext(
 	})
 
 	// Run the step and its validator.
-	plan, _, opErr := op(info, ctx, updateOpts, dryRun)
+	plan, changes, opErr := op(info, ctx, updateOpts, dryRun)
 	close(events)
 	closeErr := combined.Close()
 
@@ -202,7 +202,7 @@ func (op TestOp) runWithContext(
 	}
 
 	if validate != nil {
-		opErr = validate(project, target, journal.Entries(), firedEvents, opErr)
+		opErr = validate(project, target, journal.Entries(), firedEvents, changes, opErr)
 	}
 
 	errs := []error{opErr, closeErr}
@@ -247,13 +247,13 @@ type TestStep struct {
 func (t *TestStep) ValidateAnd(f ValidateFunc) {
 	o := t.Validate
 	t.Validate = func(project workspace.Project, target deploy.Target, entries JournalEntries,
-		events []Event, err error,
+		events []Event, changes display.ResourceChanges, err error,
 	) error {
-		r := o(project, target, entries, events, err)
+		r := o(project, target, entries, events, changes, err)
 		if r != nil {
 			return r
 		}
-		return f(project, target, entries, events, err)
+		return f(project, target, entries, events, changes, err)
 	}
 }
 
@@ -405,7 +405,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Update,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 
@@ -424,7 +424,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Refresh,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 
@@ -443,7 +443,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Update,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 
@@ -462,7 +462,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Refresh,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 
@@ -481,7 +481,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Destroy,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 
@@ -504,7 +504,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 		{
 			Op: Refresh,
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-				_ []Event, err error,
+				_ []Event, changes display.ResourceChanges, err error,
 			) error {
 				require.NoError(t, err)
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -657,9 +657,21 @@ func (acts *updateActions) OnResourceStepPost(
 }
 
 func (acts *updateActions) OnResourceOutputs(step deploy.Step) error {
-	acts.MapLock.Lock()
-	assertSeen(acts.Seen, step)
-	acts.MapLock.Unlock()
+	func() {
+		acts.MapLock.Lock()
+		defer acts.MapLock.Unlock()
+		assertSeen(acts.Seen, step)
+
+		var oldOutputs resource.PropertyMap
+		if step.Old() != nil {
+			oldOutputs = step.Old().Outputs
+		}
+		newOutputs := step.New().Outputs
+		diff := oldOutputs.Diff(newOutputs)
+		if diff.AnyChanges() {
+			acts.Ops[deploy.OpOutputChange] += len(diff.Adds) + len(diff.Deletes) + len(diff.Updates)
+		}
+	}()
 
 	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, false /*planning*/, acts.Opts.Debug, isInternalStep(step))
 
@@ -771,9 +783,21 @@ func (acts *previewActions) OnResourceStepPost(ctx interface{},
 }
 
 func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
-	acts.MapLock.Lock()
-	assertSeen(acts.Seen, step)
-	acts.MapLock.Unlock()
+	func() {
+		acts.MapLock.Lock()
+		defer acts.MapLock.Unlock()
+		assertSeen(acts.Seen, step)
+
+		var oldOutputs resource.PropertyMap
+		if step.Old() != nil {
+			oldOutputs = step.Old().Outputs
+		}
+		newOutputs := step.New().Outputs
+		diff := oldOutputs.Diff(newOutputs)
+		if diff.AnyChanges() {
+			acts.Ops[deploy.OpOutputChange] += len(diff.Adds) + len(diff.Deletes) + len(diff.Updates)
+		}
+	}()
 
 	// Print the resource outputs separately.
 	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, true /*planning*/, acts.Opts.Debug, isInternalStep(step))

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1277,8 +1277,10 @@ const (
 	OpDiscardReplaced      display.StepOp = "discard-replaced"       // discarding a read resource that was replaced.
 	OpRemovePendingReplace display.StepOp = "remove-pending-replace" // removing a pending replace resource.
 	OpImport               display.StepOp = "import"                 // import an existing resource.
-	OpImportReplacement    display.StepOp = "import-replacement"     // replace an existing resource
-	// with an imported resource.
+	OpImportReplacement    display.StepOp = "import-replacement"     // replace an existing resource with an
+	// imported resource.
+	OpOutputChange display.StepOp = "output-change" // A pseudo operation used when aggregating
+	// statistics. This indicates the number of changed outputs
 )
 
 // StepOps contains the full set of step operation types.
@@ -1298,6 +1300,7 @@ var StepOps = []display.StepOp{
 	OpRemovePendingReplace,
 	OpImport,
 	OpImportReplacement,
+	OpOutputChange,
 }
 
 func IsReplacementStep(op display.StepOp) bool {
@@ -1334,6 +1337,8 @@ func Color(op display.StepOp) string {
 		return colors.SpecUpdate
 	case OpReadDiscard, OpDiscardReplaced:
 		return colors.SpecDelete
+	case OpOutputChange:
+		return colors.SpecUpdate
 	default:
 		contract.Failf("Unrecognized resource step op: '%v'", op)
 		return ""
@@ -1388,6 +1393,8 @@ func RawPrefix(op display.StepOp) string {
 		return "= "
 	case OpImportReplacement:
 		return "=>"
+	case OpOutputChange:
+		return "~ "
 	default:
 		contract.Failf("Unrecognized resource step op: %v", op)
 		return ""
@@ -1396,7 +1403,7 @@ func RawPrefix(op display.StepOp) string {
 
 func PastTense(op display.StepOp) string {
 	switch op {
-	case OpSame, OpCreate, OpReplace, OpCreateReplacement, OpUpdate, OpReadReplacement:
+	case OpSame, OpCreate, OpReplace, OpCreateReplacement, OpUpdate, OpReadReplacement, OpOutputChange:
 		return string(op) + "d"
 	case OpRefresh:
 		return "refreshed"

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1164,3 +1164,58 @@ func TestMultiplePolicyPacks(t *testing.T) {
 	assert.Contains(t, stdout, "error: update failed")
 	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: advisory_policy_pack; mandatory_policy_pack)")
 }
+
+func TestRenameExport(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.ImportDirectory("stack_outputs/python")
+
+	stackName, err := resource.NewUniqueHex("re-test-", 8, -1)
+	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
+
+	e.RunCommand("pulumi", "stack", "init", stackName)
+
+	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
+
+	// rename the output "foo" to "bar"
+	//
+	// The export line will go from
+	//
+	// pulumi.export("foo", 42)
+	//
+	// to
+	//
+	// pulumi.export("bar", 42)
+	//
+	mainPy := filepath.Join(e.CWD, "__main__.py")
+	src, err := os.ReadFile(mainPy)
+	require.NoError(e, err, "Reading __main__.py")
+
+	updated := strings.Replace(string(src), "\"foo\"", "\"bar\"", 1)
+	//nolint:gosec
+	err = os.WriteFile(mainPy, []byte(updated), 0o644)
+	require.NoError(e, err, "Writing updated __main__.py")
+
+	// This should fail because the output has changed
+	stdout, stderr := e.RunCommandExpectError("pulumi", "preview", "--expect-no-changes")
+	assert.Contains(e, stdout, "+ bar: 42")
+	assert.Contains(e, stdout, "- foo: 42")
+	assert.Contains(e, stderr,
+		"error: no changes were expected but changes were proposed")
+
+	// This should succeed because we aren't checking the expect-no-changes flag
+	e.RunCommand("pulumi", "preview")
+
+	// This should also fail because the output has changed (although it will make the change anyway)
+	stdout, stderr = e.RunCommandExpectError("pulumi", "up", "--skip-preview", "--yes", "--expect-no-changes")
+	assert.Contains(e, stdout, "+ bar: 42")
+	assert.Contains(e, stdout, "- foo: 42")
+	assert.Contains(e, stderr,
+		"error: no changes were expected but changes occurred")
+
+	// This should now succeed because the up made the change (although it reported the error)
+	e.RunCommand("pulumi", "preview", "--expect-no-changes")
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This adds a pseudo op `OpOutputChange` to the set of changes that are recorded in `display.ResourceChanges` to count the number of output changes, this is then included in the check used to evaluate the `--expect-no-changes` flag

When resource outputs are registered, they are checked against their previous value using existing functionality, the total count of changes is then added

The internal capability is validated with an engine test, the cli is validated using an integration test

This will break user workflows that depend on the previous behavior

Fixes #15564

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
