### PR TITLE
Make sure TestCall test doesn't flake

### DIFF
--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2557,15 +2557,14 @@ func TestCall(t *testing.T) {
 							"test": resource.NewStringProperty("test-value"),
 						},
 						args)
-					assert.Equal(t,
-						map[resource.PropertyKey][]resource.URN{
-							"test": {
-								"urn:pulumi:stack::project::type::dep1",
-								"urn:pulumi:stack::project::type::dep2",
-								"urn:pulumi:stack::project::type::dep3",
-							},
+					require.Equal(t, 1, len(options.ArgDependencies))
+					assert.ElementsMatch(t,
+						[]resource.URN{
+							"urn:pulumi:stack::project::type::dep1",
+							"urn:pulumi:stack::project::type::dep2",
+							"urn:pulumi:stack::project::type::dep3",
 						},
-						options.ArgDependencies)
+						options.ArgDependencies["test"])
 					called = true
 					return plugin.CallResult{}, expectedErr
 				},


### PR DESCRIPTION
The ordering of this array isn't guaranteed, so use ElementsMatch instead of Equal to compare to avoid the flakyness.

I noticed this test being flaky while working on bazel, but also noticed it in CI logs, here: https://github.com/pulumi/pulumi/actions/runs/8646652290/job/23706586759?pr=15906