### PR TITLE
Add --no-plugins and --no-dependencies to `pulumi install`

### DIFF
--- a/changelog/pending/20240411--cli--add-no-plugins-and-no-dependencies-to-pulumi-install.yaml
+++ b/changelog/pending/20240411--cli--add-no-plugins-and-no-dependencies-to-pulumi-install.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli
-  description: Add --no-plugins and --no-dependencies to `pulumi install`.
+  description: Add --no-plugins and --no-dependencies to `pulumi install`

--- a/changelog/pending/20240411--cli--add-no-plugins-and-no-dependencies-to-pulumi-install.yaml
+++ b/changelog/pending/20240411--cli--add-no-plugins-and-no-dependencies-to-pulumi-install.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add --no-plugins and --no-dependencies to `pulumi install`.

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -35,6 +35,7 @@ import (
 
 func newInstallCmd() *cobra.Command {
 	var reinstall bool
+	var noPlugins, noDependencies bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -81,64 +82,68 @@ func newInstallCmd() *cobra.Command {
 				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
 			}
 
-			if err = lang.InstallDependencies(programInfo); err != nil {
-				return fmt.Errorf("installing dependencies: %w", err)
+			if !noDependencies {
+				if err = lang.InstallDependencies(programInfo); err != nil {
+					return fmt.Errorf("installing dependencies: %w", err)
+				}
 			}
 
-			// Compute the set of plugins the current project needs.
-			installs, err := lang.GetRequiredPlugins(programInfo)
-			if err != nil {
-				return err
-			}
-
-			// Now for each kind, name, version pair, download it from the release website, and install it.
-			for _, install := range installs {
-				// PluginSpec.String() just returns the name and version, we want the kind too.
-				label := fmt.Sprintf("%s plugin %s", install.Kind, install)
-
-				// If the plugin already exists, don't download it unless --reinstall was passed.
-				if !reinstall {
-					if install.Version != nil {
-						if workspace.HasPlugin(install) {
-							logging.V(1).Infof("%s skipping install (existing == match)", label)
-							continue
-						}
-					} else {
-						if has, _ := workspace.HasPluginGTE(install); has {
-							logging.V(1).Infof("%s skipping install (existing >= match)", label)
-							continue
-						}
-					}
-				}
-
-				pctx.Diag.Infoerrf(diag.Message("", "%s installing"), label)
-
-				// If we got here, actually try to do the download.
-				withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
-					return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
-				}
-				retry := func(err error, attempt int, limit int, delay time.Duration) {
-					pctx.Diag.Warningf(
-						diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
-				}
-
-				r, err := workspace.DownloadToFile(install, withProgress, retry)
+			if !noPlugins {
+				// Compute the set of plugins the current project needs.
+				installs, err := lang.GetRequiredPlugins(programInfo)
 				if err != nil {
-					return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
+					return err
 				}
-				defer func() {
-					err := os.Remove(r.Name())
-					if err != nil {
-						pctx.Diag.Warningf(
-							diag.Message("", "Error removing temporary file %s: %s"), r.Name(), err)
+
+				// Now for each kind, name, version pair, download it from the release website, and install it.
+				for _, install := range installs {
+					// PluginSpec.String() just returns the name and version, we want the kind too.
+					label := fmt.Sprintf("%s plugin %s", install.Kind, install)
+
+					// If the plugin already exists, don't download it unless --reinstall was passed.
+					if !reinstall {
+						if install.Version != nil {
+							if workspace.HasPlugin(install) {
+								logging.V(1).Infof("%s skipping install (existing == match)", label)
+								continue
+							}
+						} else {
+							if has, _ := workspace.HasPluginGTE(install); has {
+								logging.V(1).Infof("%s skipping install (existing >= match)", label)
+								continue
+							}
+						}
 					}
-				}()
 
-				payload := workspace.TarPlugin(r)
+					pctx.Diag.Infoerrf(diag.Message("", "%s installing"), label)
 
-				logging.V(1).Infof("%s installing tarball ...", label)
-				if err = install.InstallWithContext(ctx, payload, reinstall); err != nil {
-					return fmt.Errorf("installing %s: %w", label, err)
+					// If we got here, actually try to do the download.
+					withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
+						return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
+					}
+					retry := func(err error, attempt int, limit int, delay time.Duration) {
+						pctx.Diag.Warningf(
+							diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
+					}
+
+					r, err := workspace.DownloadToFile(install, withProgress, retry)
+					if err != nil {
+						return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
+					}
+					defer func() {
+						err := os.Remove(r.Name())
+						if err != nil {
+							pctx.Diag.Warningf(
+								diag.Message("", "Error removing temporary file %s: %s"), r.Name(), err)
+						}
+					}()
+
+					payload := workspace.TarPlugin(r)
+
+					logging.V(1).Infof("%s installing tarball ...", label)
+					if err = install.InstallWithContext(ctx, payload, reinstall); err != nil {
+						return fmt.Errorf("installing %s: %w", label, err)
+					}
 				}
 			}
 
@@ -148,6 +153,10 @@ func newInstallCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&reinstall,
 		"reinstall", false, "Reinstall a plugin even if it already exists")
+	cmd.PersistentFlags().BoolVar(&noPlugins,
+		"no-plugins", false, "Skip installing plugins")
+	cmd.PersistentFlags().BoolVar(&noDependencies,
+		"no-dependencies", false, "Skip installing dependencies")
 
 	return cmd
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Raised on Slack. User would like to be able to use `pulumi install` but just for dependency installation, skipping the plugins. Makes sense to also support the opposite while here, i.e. just plugins.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
