### PR TITLE
Add some missing checks for DisableIntegrityChecking

### DIFF
--- a/changelog/pending/20240411--cli--fix-some-commands-that-didnt-respect-disable-integrity-checking.yaml
+++ b/changelog/pending/20240411--cli--fix-some-commands-that-didnt-respect-disable-integrity-checking.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix some commands that didn't respect `--disable-integrity-checking`

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -663,8 +663,10 @@ func (sm *SnapshotManager) saveSnapshot() error {
 	if err := sm.persister.Save(snap); err != nil {
 		return fmt.Errorf("failed to save snapshot: %w", err)
 	}
-	if err := snap.VerifyIntegrity(); err != nil {
-		return fmt.Errorf("failed to verify snapshot: %w", err)
+	if !DisableIntegrityChecking {
+		if err := snap.VerifyIntegrity(); err != nil {
+			return fmt.Errorf("failed to verify snapshot: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -122,12 +122,14 @@ func saveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 		}
 	}
 	// Validate the stack. If --force was passed, issue an error if validation fails. Otherwise, issue a warning.
-	if err := snapshot.VerifyIntegrity(); err != nil {
-		msg := fmt.Sprintf("state file contains errors: %v", err)
-		if force {
-			cmdutil.Diag().Warningf(diag.Message("", msg))
-		} else {
-			result = multierror.Append(result, errors.New(msg))
+	if !backend.DisableIntegrityChecking {
+		if err := snapshot.VerifyIntegrity(); err != nil {
+			msg := fmt.Sprintf("state file contains errors: %v", err)
+			if force {
+				cmdutil.Diag().Warningf(diag.Message("", msg))
+			} else {
+				result = multierror.Append(result, errors.New(msg))
+			}
 		}
 	}
 	if result != nil {

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -177,7 +177,7 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 	}
 
 	// If the stack is already broken, don't bother verifying the integrity here.
-	if !stackIsAlreadyHosed {
+	if !stackIsAlreadyHosed && !backend.DisableIntegrityChecking {
 		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
 	}
 

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -218,9 +218,11 @@ func (cmd *stateEditCmd) validateAndPrintState(ctx context.Context, f *snapshotB
 		return nil, err
 	}
 
-	err = news.VerifyIntegrity()
-	if err != nil {
-		return nil, err
+	if !backend.DisableIntegrityChecking {
+		err = news.VerifyIntegrity()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Display state in JSON to match JSON-like diffs in the update display.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This would have helped with https://github.com/pulumi/pulumi/issues/15831 as the `destroy` would have been able to run instead of err'ing on the first save because of the already broken snapshot.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
