### PR TITLE
Add support for continue-on-error parameter of the destroy command to the Automation API

### DIFF
--- a/changelog/pending/20240412--auto-go-nodejs-python--add-support-for-continue-on-error-parameter-in-the-automation-api.yaml
+++ b/changelog/pending/20240412--auto-go-nodejs-python--add-support-for-continue-on-error-parameter-in-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add support for continue-on-error parameter of the destroy command to the Automation API

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -115,6 +115,13 @@ func SuppressOutputs() Option {
 	})
 }
 
+// Continue to perform the destroy operation despite the occurrence of errors.
+func ContinueOnError() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ContinueOnError = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -153,6 +160,8 @@ type Options struct {
 	SuppressProgress bool
 	// Suppress display of stack outputs (in case they contain sensitive values)
 	SuppressOutputs bool
+	// Continue to perform the destroy operation despite the occurrence of errors.
+	ContinueOnError bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -688,6 +688,9 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	if destroyOpts.SuppressProgress {
 		args = append(args, "--suppress-progress")
 	}
+	if destroyOpts.ContinueOnError {
+		args = append(args, "--continue-on-error")
+	}
 
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -492,6 +492,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.excludeProtected) {
                 args.push("--exclude-protected");
             }
+            if (opts.continueOnError) {
+                args.push("--continue-on-error");
+            }
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
             }
@@ -1003,6 +1006,8 @@ export interface DestroyOptions extends GlobalOpts {
      * Do not destroy protected resources.
      */
     excludeProtected?: boolean;
+    // Continue to perform the destroy operation despite the occurrence of errors.
+    continueOnError?: boolean;
 }
 
 const execKind = {

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -540,6 +540,7 @@ class Stack:
         debug: Optional[bool] = None,
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
+        continue_on_error: Optional[bool] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -560,6 +561,7 @@ class Stack:
         :param debug: Print detailed debugging output during resource operations
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
+        :param continue_on_error: Continue to perform the destroy operation despite the occurrence of errors
         :returns: DestroyResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -876,6 +878,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     debug: Optional[bool] = kwargs.get("debug")
     suppress_outputs: Optional[bool] = kwargs.get("suppress_outputs")
     suppress_progress: Optional[bool] = kwargs.get("suppress_progress")
+    continue_on_error: Optional[bool] = kwargs.get("continue_on_error")
 
     if message:
         extra_args.extend(["--message", message])
@@ -915,6 +918,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
         extra_args.extend(["--suppress-outputs"])
     if suppress_progress:
         extra_args.extend(["--suppress-progress"])
+    if continue_on_error:
+        extra_args.extend(["--continue-on-error"])
     return extra_args
 
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Automation API Destroy in Node/Python/Go now has `--continue-on-error`

Resolves #15919 (pending .NET)

.NET is interesting because we probably want to add it to `UpdateOptions` once `up` has it and not to `DestroyOptions` (that inherit from `UpdateOptions`). I'll probably skip it for now.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
