### PR TITLE
Fix warning about Snapshot write failed for previews

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1078,8 +1078,12 @@ func (b *diyBackend) apply(
 	}()
 
 	// Create the management machinery.
-	persister := b.newSnapshotPersister(ctx, diyStackRef)
-	manager := backend.NewSnapshotManager(persister, op.SecretsManager, update.GetTarget().Snapshot)
+	// We only need a snapshot manager if we're doing an update.
+	var manager *backend.SnapshotManager
+	if kind != apitype.PreviewUpdate && !opts.DryRun {
+		persister := b.newSnapshotPersister(ctx, diyStackRef)
+		manager = backend.NewSnapshotManager(persister, op.SecretsManager, update.GetTarget().Snapshot)
+	}
 	engineCtx := &engine.Context{
 		Cancel:          scope.Context(),
 		Events:          engineEvents,
@@ -1115,11 +1119,13 @@ func (b *diyBackend) apply(
 	<-displayDone
 	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
-	err = manager.Close()
-	// Historically we ignored this error (using IgnoreClose so it would log to the V11 log).
-	// To minimize the immediate blast radius of this to start with we're just going to write an error to the user.
-	if err != nil {
-		cmdutil.Diag().Errorf(diag.Message("", "Snapshot write failed: %v"), err)
+	if manager != nil {
+		err = manager.Close()
+		// Historically we ignored this error (using IgnoreClose so it would log to the V11 log).
+		// To minimize the immediate blast radius of this to start with we're just going to write an error to the user.
+		if err != nil {
+			cmdutil.Diag().Errorf(diag.Message("", "Snapshot write failed: %v"), err)
+		}
 	}
 
 	// Make sure the goroutine writing to displayEvents and events has exited before proceeding.


### PR DESCRIPTION
This stops the CLI warning about `error: Snapshot write failed: failed to save snapshot: [403] Updating the checkpoint is not permitted for preview operations.` on every preview operation.