### PR TITLE
Lift context parameter to SerializeDeployment/Resource/Operations/Properties

### DIFF
--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -1,6 +1,7 @@
 package display
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -89,10 +90,11 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		}
 
 		// Serialize properties, ignoring errors, as with other event types.
+		ctx := context.TODO()
 		encrypter := config.BlindingCrypter
-		before, err := stack.SerializeProperties(p.Before, encrypter, showSecrets)
+		before, err := stack.SerializeProperties(ctx, p.Before, encrypter, showSecrets)
 		contract.IgnoreError(err)
-		after, err := stack.SerializeProperties(p.After, encrypter, showSecrets)
+		after, err := stack.SerializeProperties(ctx, p.After, encrypter, showSecrets)
 		contract.IgnoreError(err)
 
 		apiEvent.PolicyRemediationEvent = &apitype.PolicyRemediationEvent{
@@ -245,11 +247,12 @@ func convertStepEventStateMetadata(md *engine.StepEventStateMetadata,
 		return nil
 	}
 
+	ctx := context.TODO()
 	encrypter := config.BlindingCrypter
-	inputs, err := stack.SerializeProperties(md.Inputs, encrypter, showSecrets)
+	inputs, err := stack.SerializeProperties(ctx, md.Inputs, encrypter, showSecrets)
 	contract.IgnoreError(err)
 
-	outputs, err := stack.SerializeProperties(md.Outputs, encrypter, showSecrets)
+	outputs, err := stack.SerializeProperties(ctx, md.Outputs, encrypter, showSecrets)
 	contract.IgnoreError(err)
 
 	return &apitype.StepEventStateMetadata{

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -15,6 +15,7 @@
 package display
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -176,9 +177,10 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 					DetailedDiff:   detailedDiff,
 				}
 
+				ctx := context.TODO()
 				if m.Old != nil {
 					oldState := stateForJSONOutput(m.Old.State, opts)
-					res, err := stack.SerializeResource(oldState, config.NewPanicCrypter(), false /* showSecrets */)
+					res, err := stack.SerializeResource(ctx, oldState, config.NewPanicCrypter(), false /* showSecrets */)
 					if err == nil {
 						step.OldState = &res
 					} else {
@@ -187,7 +189,7 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 				}
 				if m.New != nil {
 					newState := stateForJSONOutput(m.New.State, opts)
-					res, err := stack.SerializeResource(newState, config.NewPanicCrypter(), false /* showSecrets */)
+					res, err := stack.SerializeResource(ctx, newState, config.NewPanicCrypter(), false /* showSecrets */)
 					if err == nil {
 						step.NewState = &res
 					} else {

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -293,8 +293,9 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 	}
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	ctx := context.Background()
 
-	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	data, err := encoding.JSON.Marshal(sdep)
@@ -311,7 +312,6 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
-	ctx := context.Background()
 	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -237,8 +237,9 @@ func makeUntypedDeploymentTimestamp(
 	}
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	ctx := context.Background()
 
-	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
 	if err != nil {
 		return nil, err
 	}
@@ -598,8 +599,9 @@ func TestHtmlEscaping(t *testing.T) {
 	}
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	ctx := context.Background()
 
-	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	data, err := encoding.JSON.Marshal(sdep)
@@ -616,7 +618,6 @@ func TestHtmlEscaping(t *testing.T) {
 
 	// Login to a temp dir diy backend
 	tmpDir := t.TempDir()
-	ctx := context.Background()
 	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -38,7 +38,7 @@ type cloudSnapshotPersister struct {
 func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	ctx := persister.context
 
-	deploymentV3, err := stack.SerializeDeployment(snapshot, false /* showSecrets */)
+	deploymentV3, err := stack.SerializeDeployment(ctx, snapshot, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -326,7 +326,7 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 	for i := range journalEntries {
 		snap, err := journalEntries[:i].Snap(nil)
 		require.NoError(t, err)
-		deployment, err := stack.SerializeDeployment(snap, true)
+		deployment, err := stack.SerializeDeployment(context.Background(), snap, true)
 		require.NoError(t, err)
 		snaps[i] = deployment
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -197,7 +197,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(ctx context.Context,
 
 	// Reserialize the Snapshopshot with the NewSecrets Manager
 	snap.SecretsManager = newSecretsManager
-	reserializedDeployment, err := stack.SerializeDeployment(snap, false /*showSecrets*/)
+	reserializedDeployment, err := stack.SerializeDeployment(ctx, snap, false /*showSecrets*/)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider_test.go
@@ -106,7 +106,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			return snapshot, nil
 		},
 		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(snapshot, false)
+			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +207,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			return snapshot, nil
 		},
 		ExportDeploymentF: func(ctx context.Context) (*apitype.UntypedDeployment, error) {
-			chk, err := stack.SerializeDeployment(snapshot, false)
+			chk, err := stack.SerializeDeployment(ctx, snapshot, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -95,7 +95,7 @@ func newStackExportCmd() *cobra.Command {
 					return checkDeploymentVersionError(err, stackName)
 				}
 
-				serializedDeployment, err := stack.SerializeDeployment(snap, true)
+				serializedDeployment, err := stack.SerializeDeployment(ctx, snap, true)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -147,7 +147,7 @@ func saveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 
 		snapshot.PendingOperations = nil
 	}
-	sdp, err := stack.SerializeDeployment(snapshot, false /* showSecrets */)
+	sdp, err := stack.SerializeDeployment(ctx, snapshot, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("constructing deployment for upload: %w", err)
 	}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -273,6 +273,7 @@ func getStackOutputs(snap *deploy.Snapshot, showSecrets bool) (map[string]interf
 	// massageSecrets will remove all the secrets from the property map, so it should be safe to pass a panic
 	// crypter. This also ensure that if for some reason we didn't remove everything, we don't accidentally disclose
 	// secret values!
-	return stack.SerializeProperties(display.MassageSecrets(state.Outputs, showSecrets),
+	ctx := context.TODO()
+	return stack.SerializeProperties(ctx, display.MassageSecrets(state.Outputs, showSecrets),
 		config.NewPanicCrypter(), showSecrets)
 }

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -181,7 +181,7 @@ func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts 
 		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
 	}
 
-	sdep, err := stack.SerializeDeployment(snap, false /* showSecrets */)
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
 	if err != nil {
 		return fmt.Errorf("serializing deployment: %w", err)
 	}

--- a/pkg/cmd/pulumi/state_edit_encoder.go
+++ b/pkg/cmd/pulumi/state_edit_encoder.go
@@ -39,7 +39,8 @@ type jsonSnapshotEncoder struct{}
 var _ snapshotEncoder = &jsonSnapshotEncoder{}
 
 func (se *jsonSnapshotEncoder) SnapshotToText(snap *deploy.Snapshot) (snapshotText, error) {
-	dep, err := stack.SerializeDeployment(snap, false)
+	ctx := context.TODO()
+	dep, err := stack.SerializeDeployment(ctx, snap, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -15,6 +15,7 @@
 package importer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -291,7 +292,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			assert.Equal(t, state.Provider, actualState.Provider)
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				actual, err := stack.SerializeResource(context.Background(), actualState, config.NopEncrypter, false)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -15,6 +15,7 @@
 package importer
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"testing"
@@ -72,7 +73,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 			assert.Equal(t, state.Provider, actualState.Provider)
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				actual, err := stack.SerializeResource(context.Background(), actualState, config.NopEncrypter, false)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -108,7 +108,8 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
 	var latest *apitype.DeploymentV3
 	if snap != nil {
-		dep, err := SerializeDeployment(snap, showSecrets)
+		ctx := context.TODO()
+		dep, err := SerializeDeployment(ctx, snap, showSecrets)
 		if err != nil {
 			return nil, fmt.Errorf("serializing deployment: %w", err)
 		}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -101,7 +101,7 @@ func ValidateUntypedDeployment(deployment *apitype.UntypedDeployment) error {
 }
 
 // SerializeDeployment serializes an entire snapshot as a deploy record.
-func SerializeDeployment(snap *deploy.Snapshot, showSecrets bool) (*apitype.DeploymentV3, error) {
+func SerializeDeployment(ctx context.Context, snap *deploy.Snapshot, showSecrets bool) (*apitype.DeploymentV3, error) {
 	contract.Requiref(snap != nil, "snap", "must not be nil")
 
 	// Capture the version information into a manifest.
@@ -122,7 +122,7 @@ func SerializeDeployment(snap *deploy.Snapshot, showSecrets bool) (*apitype.Depl
 	// Serialize all vertices and only include a vertex section if non-empty.
 	resources := slice.Prealloc[apitype.ResourceV3](len(snap.Resources))
 	for _, res := range snap.Resources {
-		sres, err := SerializeResource(res, enc, showSecrets)
+		sres, err := SerializeResource(ctx, res, enc, showSecrets)
 		if err != nil {
 			return nil, fmt.Errorf("serializing resources: %w", err)
 		}
@@ -131,7 +131,7 @@ func SerializeDeployment(snap *deploy.Snapshot, showSecrets bool) (*apitype.Depl
 
 	operations := slice.Prealloc[apitype.OperationV2](len(snap.PendingOperations))
 	for _, op := range snap.PendingOperations {
-		sop, err := SerializeOperation(op, enc, showSecrets)
+		sop, err := SerializeOperation(ctx, op, enc, showSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +302,9 @@ func DeserializeDeploymentV3(
 }
 
 // SerializeResource turns a resource into a structure suitable for serialization.
-func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bool) (apitype.ResourceV3, error) {
+func SerializeResource(
+	ctx context.Context, res *resource.State, enc config.Encrypter, showSecrets bool,
+) (apitype.ResourceV3, error) {
 	contract.Requiref(res != nil, "res", "must not be nil")
 	contract.Requiref(res.URN != "", "res", "must have a URN")
 
@@ -312,7 +314,7 @@ func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bo
 	// Serialize all input and output properties recursively, and add them if non-empty.
 	var inputs map[string]interface{}
 	if inp := res.Inputs; inp != nil {
-		sinp, err := SerializeProperties(inp, enc, showSecrets)
+		sinp, err := SerializeProperties(ctx, inp, enc, showSecrets)
 		if err != nil {
 			return apitype.ResourceV3{}, err
 		}
@@ -320,7 +322,7 @@ func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bo
 	}
 	var outputs map[string]interface{}
 	if outp := res.Outputs; outp != nil {
-		soutp, err := SerializeProperties(outp, enc, showSecrets)
+		soutp, err := SerializeProperties(ctx, outp, enc, showSecrets)
 		if err != nil {
 			return apitype.ResourceV3{}, err
 		}
@@ -361,8 +363,10 @@ func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bo
 }
 
 // SerializeOperation serializes a resource in a pending state.
-func SerializeOperation(op resource.Operation, enc config.Encrypter, showSecrets bool) (apitype.OperationV2, error) {
-	res, err := SerializeResource(op.Resource, enc, showSecrets)
+func SerializeOperation(
+	ctx context.Context, op resource.Operation, enc config.Encrypter, showSecrets bool,
+) (apitype.OperationV2, error) {
+	res, err := SerializeResource(ctx, op.Resource, enc, showSecrets)
 	if err != nil {
 		return apitype.OperationV2{}, fmt.Errorf("serializing resource: %w", err)
 	}
@@ -373,12 +377,12 @@ func SerializeOperation(op resource.Operation, enc config.Encrypter, showSecrets
 }
 
 // SerializeProperties serializes a resource property bag so that it's suitable for serialization.
-func SerializeProperties(props resource.PropertyMap, enc config.Encrypter,
+func SerializeProperties(ctx context.Context, props resource.PropertyMap, enc config.Encrypter,
 	showSecrets bool,
 ) (map[string]interface{}, error) {
 	dst := make(map[string]interface{})
 	for _, k := range props.StableKeys() {
-		v, err := SerializePropertyValue(props[k], enc, showSecrets)
+		v, err := SerializePropertyValue(ctx, props[k], enc, showSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -388,11 +392,9 @@ func SerializeProperties(props resource.PropertyMap, enc config.Encrypter,
 }
 
 // SerializePropertyValue serializes a resource property value so that it's suitable for serialization.
-func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
+func SerializePropertyValue(ctx context.Context, prop resource.PropertyValue, enc config.Encrypter,
 	showSecrets bool,
 ) (interface{}, error) {
-	ctx := context.TODO()
-
 	// Serialize nulls as nil.
 	if prop.IsNull() {
 		return nil, nil
@@ -410,7 +412,7 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 		srcarr := prop.ArrayValue()
 		dstarr := make([]interface{}, len(srcarr))
 		for i, elem := range prop.ArrayValue() {
-			selem, err := SerializePropertyValue(elem, enc, showSecrets)
+			selem, err := SerializePropertyValue(ctx, elem, enc, showSecrets)
 			if err != nil {
 				return nil, err
 			}
@@ -421,7 +423,7 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 
 	// Also for objects, recurse and use naked properties.
 	if prop.IsObject() {
-		return SerializeProperties(prop.ObjectValue(), enc, showSecrets)
+		return SerializeProperties(ctx, prop.ObjectValue(), enc, showSecrets)
 	}
 
 	// For assets, we need to serialize them a little carefully, so we can recover them afterwards.
@@ -449,7 +451,7 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 		// Since we are going to encrypt property value, we can elide encrypting sub-elements. We'll mark them as
 		// "secret" so we retain that information when deserializing the overall structure, but there is no
 		// need to double encrypt everything.
-		value, err := SerializePropertyValue(prop.SecretValue().Element, config.NopEncrypter, showSecrets)
+		value, err := SerializePropertyValue(ctx, prop.SecretValue().Element, config.NopEncrypter, showSecrets)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -108,7 +108,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		"",
 	)
 
-	dep, err := SerializeResource(res, config.NopEncrypter, false /* showSecrets */)
+	dep, err := SerializeResource(context.Background(), res, config.NopEncrypter, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	// assert some things about the deployment record:
@@ -382,7 +382,7 @@ func TestCustomSerialization(t *testing.T) {
 	t.Run("SerializeProperties", func(t *testing.T) {
 		t.Parallel()
 
-		serializedPropMap, err := SerializeProperties(propMap, config.BlindingCrypter, false /* showSecrets */)
+		serializedPropMap, err := SerializeProperties(context.Background(), propMap, config.BlindingCrypter, false /* showSecrets */)
 		assert.NoError(t, err)
 
 		// Now JSON encode the results?
@@ -549,9 +549,10 @@ func TestDeserializeMissingSecretsManager(t *testing.T) {
 func TestSerializePropertyValue(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	rapid.Check(t, func(t *rapid.T) {
 		v := resource_testing.PropertyValueGenerator(6).Draw(t, "property value")
-		_, err := SerializePropertyValue(v, config.NopEncrypter, false)
+		_, err := SerializePropertyValue(ctx, v, config.NopEncrypter, false)
 		assert.NoError(t, err)
 	})
 }
@@ -560,16 +561,17 @@ func TestSerializePropertyValue(t *testing.T) {
 func TestSerializePropertyValue_ShowSecrets(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	crypter := config.NewPanicCrypter()
 
 	secret := resource.MakeSecret(resource.NewStringProperty("secret"))
-	_, err := SerializePropertyValue(secret, crypter, true)
+	_, err := SerializePropertyValue(ctx, secret, crypter, true)
 	assert.NoError(t, err)
 
 	secret = resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 		resource.MakeSecret(resource.NewStringProperty("secret")),
 	}))
-	_, err = SerializePropertyValue(secret, crypter, true)
+	_, err = SerializePropertyValue(ctx, secret, crypter, true)
 	assert.NoError(t, err)
 }
 
@@ -584,7 +586,7 @@ func TestDeserializePropertyValue(t *testing.T) {
 }
 
 func wireValue(v resource.PropertyValue) (interface{}, error) {
-	object, err := SerializePropertyValue(v, config.NopEncrypter, false)
+	object, err := SerializePropertyValue(context.Background(), v, config.NopEncrypter, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/stack/plan.go
+++ b/pkg/resource/stack/plan.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -13,12 +15,13 @@ func SerializePlanDiff(
 	enc config.Encrypter,
 	showSecrets bool,
 ) (apitype.PlanDiffV1, error) {
-	adds, err := SerializeProperties(diff.Adds, enc, showSecrets)
+	ctx := context.TODO()
+	adds, err := SerializeProperties(ctx, diff.Adds, enc, showSecrets)
 	if err != nil {
 		return apitype.PlanDiffV1{}, err
 	}
 
-	updates, err := SerializeProperties(diff.Updates, enc, showSecrets)
+	updates, err := SerializeProperties(ctx, diff.Updates, enc, showSecrets)
 	if err != nil {
 		return apitype.PlanDiffV1{}, err
 	}
@@ -65,7 +68,8 @@ func SerializeResourcePlan(
 ) (apitype.ResourcePlanV1, error) {
 	var outputs map[string]interface{}
 	if plan.Outputs != nil {
-		outs, err := SerializeProperties(plan.Outputs, enc, showSecrets)
+		ctx := context.TODO()
+		outs, err := SerializeProperties(ctx, plan.Outputs, enc, showSecrets)
 		if err != nil {
 			return apitype.ResourcePlanV1{}, err
 		}

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -73,6 +73,7 @@ func deserializeProperty(v interface{}, dec config.Decrypter) (resource.Property
 func TestCachingCrypter(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	sm := &testSecretsManager{}
 	csm := NewCachingSecretsManager(sm)
 
@@ -84,38 +85,38 @@ func TestCachingCrypter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Serialize the first copy of "foo". Encrypt should be called once, as this value has not yet been encrypted.
-	foo1Ser, err := SerializePropertyValue(foo1, enc, false /* showSecrets */)
+	foo1Ser, err := SerializePropertyValue(ctx, foo1, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, sm.encryptCalls)
 
 	// Serialize the second copy of "foo". Because this is a different secret instance, Encrypt should be called
 	// a second time even though the plaintext is the same as the last value we encrypted.
-	foo2Ser, err := SerializePropertyValue(foo2, enc, false /* showSecrets */)
+	foo2Ser, err := SerializePropertyValue(ctx, foo2, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, sm.encryptCalls)
 	assert.NotEqual(t, foo1Ser, foo2Ser)
 
 	// Serialize "bar". Encrypt should be called once, as this value has not yet been encrypted.
-	barSer, err := SerializePropertyValue(bar, enc, false /* showSecrets */)
+	barSer, err := SerializePropertyValue(ctx, bar, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 
 	// Serialize the first copy of "foo" again. Encrypt should not be called, as this value has already been
 	// encrypted.
-	foo1Ser2, err := SerializePropertyValue(foo1, enc, false /* showSecrets */)
+	foo1Ser2, err := SerializePropertyValue(ctx, foo1, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo1Ser, foo1Ser2)
 
 	// Serialize the second copy of "foo" again. Encrypt should not be called, as this value has already been
 	// encrypted.
-	foo2Ser2, err := SerializePropertyValue(foo2, enc, false /* showSecrets */)
+	foo2Ser2, err := SerializePropertyValue(ctx, foo2, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo2Ser, foo2Ser2)
 
 	// Serialize "bar" again. Encrypt should not be called, as this value has already been encrypted.
-	barSer2, err := SerializePropertyValue(bar, enc, false /* showSecrets */)
+	barSer2, err := SerializePropertyValue(ctx, bar, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)
@@ -171,21 +172,21 @@ func TestCachingCrypter(t *testing.T) {
 
 	// Serialize the first copy of "foo" again. Encrypt should not be called, as this value has already been
 	// cached by the earlier calls to Decrypt.
-	foo1Ser2, err = SerializePropertyValue(foo1Dec, enc, false /* showSecrets */)
+	foo1Ser2, err = SerializePropertyValue(ctx, foo1Dec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo1Ser, foo1Ser2)
 
 	// Serialize the second copy of "foo" again. Encrypt should not be called, as this value has already been
 	// cached by the earlier calls to Decrypt.
-	foo2Ser2, err = SerializePropertyValue(foo2Dec, enc, false /* showSecrets */)
+	foo2Ser2, err = SerializePropertyValue(ctx, foo2Dec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo2Ser, foo2Ser2)
 
 	// Serialize "bar" again. Encrypt should not be called, as this value has already been cached by the
 	// earlier calls to Decrypt.
-	barSer2, err = SerializePropertyValue(barDec, enc, false /* showSecrets */)
+	barSer2, err = SerializePropertyValue(ctx, barDec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -325,7 +325,7 @@ func TestStackCommands(t *testing.T) {
 			Resource: res,
 			Type:     resource.OperationTypeDeleting,
 		})
-		v3deployment, err := stack.SerializeDeployment(snap, false /* showSecrets */)
+		v3deployment, err := stack.SerializeDeployment(context.Background(), snap, false /* showSecrets */)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

SerializePropertyValue needed a `context.Context` object to pass to the `config.Encrypter`. It was using `context.TODO()`, this change instead accepts a context on the parameters and lifts that up to SerializeProperties, SerializeResource, SerializeOperation, and SerializeDeployment.

There were a few call sites for those methods that already had a context on hand, and they now pass that context. The other calls sites now use `context.TODO()`, we should continue to iterate in this area to ensure everywhere that needs a context has one passed in.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
