### PR TITLE
Fix race condition when listing stacks

### DIFF
--- a/changelog/pending/20240415--backend-diy--fix-race-condition-when-listing-stacks.yaml
+++ b/changelog/pending/20240415--backend-diy--fix-race-condition-when-listing-stacks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Fix race condition when listing stacks

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -777,16 +777,11 @@ func (b *diyBackend) ListStacks(
 		if err != nil {
 			// There is a race between listing stacks and getting their checkpoints.  If there's an error getting
 			// the checkpoint, check if the stack still exists before returning an error.
-			stacks, stackErr := b.getStacks(ctx)
-			if stackErr != nil {
-				return nil, nil, stackErr
+			if _, existsErr := b.stackExists(ctx, stackRef); existsErr == errCheckpointNotFound {
+				continue
 			}
-			for _, stack := range stacks {
-				// The stack still exists, but we couldn't get the checkpoint.  Return the error.
-				if stack.Name() == stackRef.Name() {
-					return nil, nil, err
-				}
-			}
+			return nil, nil, err
+
 		}
 		results = append(results, newDIYStackSummary(stackRef, chk))
 	}


### PR DESCRIPTION
When listing stacks, we currently try to get all the stacks from the backend, and then get the checkpoint to for each stack to show the summary.

However there's a race between listing the stacks and getting the checkpoints, so the checkpoint may be missing by the time we get to that part of the code.

Unfortunately the errors we're getting form getCheckpoint are not structured, so we can't tell if we got a 404 from the cloud here, so the next best option we have is re-checking whether the stack still exists.

This is another attempt at fixing https://github.com/pulumi/pulumi/issues/15658.