### PR TITLE
go: allow unknowns during update

### DIFF
--- a/changelog/pending/20240415--sdk-go--allow-unknowns-during-pulumi-up.yaml
+++ b/changelog/pending/20240415--sdk-go--allow-unknowns-during-pulumi-up.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Allow unknowns during `pulumi up`


### PR DESCRIPTION
Currently we reject all unknowns during `pulumi up`.  However we are soon going to allow them to come through via `up --continue-on-error`, and thus should no longer error out when we have them.

This is a similar preparatory PR to https://github.com/pulumi/pulumi/pull/15898, except that Go deals with the unknowns a little different, so we don't need to treat apply specially, but the marshalling.