### PR TITLE
Refactor: move plugin kind to apitype

### DIFF
--- a/changelog/pending/20240416--cli-plugin--move-pluginkind-type-definition-into-apitype-and-re-export-for-backward-compatibility.yaml
+++ b/changelog/pending/20240416--cli-plugin--move-pluginkind-type-definition-into-apitype-and-re-export-for-backward-compatibility.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/plugin
+  description: Move PluginKind type definition into apitype and re-export for backward compatibility

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -295,7 +295,7 @@ func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Fl
 }
 
 func (h *testHost) ResolvePlugin(
-	kind workspace.PluginKind, name string, version *semver.Version,
+	kind apitype.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
 	panic("not implemented")
 }

--- a/cmd/pulumi-test-language/l2continue_on_error_test.go
+++ b/cmd/pulumi-test-language/l2continue_on_error_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -132,12 +133,12 @@ func (h *L2ContinueOnErrorHost) GetRequiredPlugins(
 		Plugins: []*pulumirpc.PluginDependency{
 			{
 				Name:    "simple",
-				Kind:    string(workspace.ResourcePlugin),
+				Kind:    string(apitype.ResourcePlugin),
 				Version: "2.0.0",
 			},
 			{
 				Name:    "fail_on_create",
-				Kind:    string(workspace.ResourcePlugin),
+				Kind:    string(apitype.ResourcePlugin),
 				Version: "4.0.0",
 			},
 		},

--- a/cmd/pulumi-test-language/l2destroy_test.go
+++ b/cmd/pulumi-test-language/l2destroy_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
@@ -131,7 +132,7 @@ func (h *L2DestroyLanguageHost) GetRequiredPlugins(
 		Plugins: []*pulumirpc.PluginDependency{
 			{
 				Name:    "simple",
-				Kind:    string(workspace.ResourcePlugin),
+				Kind:    string(apitype.ResourcePlugin),
 				Version: "2.0.0",
 			},
 		},

--- a/cmd/pulumi-test-language/l2large_test.go
+++ b/cmd/pulumi-test-language/l2large_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -127,7 +128,7 @@ func (h *L2LargeLanguageHost) GetRequiredPlugins(
 		Plugins: []*pulumirpc.PluginDependency{
 			{
 				Name:    "large",
-				Kind:    string(workspace.ResourcePlugin),
+				Kind:    string(apitype.ResourcePlugin),
 				Version: "4.3.2",
 			},
 		},

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -135,7 +136,7 @@ func (h *L2ResourceSimpleLanguageHost) GetRequiredPlugins(
 		Plugins: []*pulumirpc.PluginDependency{
 			{
 				Name:    "simple",
-				Kind:    string(workspace.ResourcePlugin),
+				Kind:    string(apitype.ResourcePlugin),
 				Version: "2.0.0",
 			},
 		},

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -223,9 +224,9 @@ func (summary *summaryAbout) Print() {
 }
 
 type pluginAbout struct {
-	Name    string               `json:"name"`
-	Version *semver.Version      `json:"version"`
-	Kind    workspace.PluginKind `json:"kind"`
+	Name    string             `json:"name"`
+	Version *semver.Version    `json:"version"`
+	Kind    apitype.PluginKind `json:"kind"`
 }
 
 func getPluginsAbout(ctx *plugin.Context, proj *workspace.Project, pwd, main string) ([]pluginAbout, error) {

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -58,7 +59,7 @@ func loadConverterPlugin(
 	// Default to the known version of the plugin, this ensures we use the version of the yaml-converter
 	// that aligns with the yaml codegen we've linked to for this CLI release.
 	pluginSpec := workspace.PluginSpec{
-		Kind: workspace.ConverterPlugin,
+		Kind: apitype.ConverterPlugin,
 		Name: name,
 	}
 	if versionSet := util.SetKnownPluginVersion(&pluginSpec); versionSet {
@@ -327,7 +328,7 @@ func runConvert(
 
 		pluginSpec := workspace.PluginSpec{
 			Name: string(provider),
-			Kind: workspace.ResourcePlugin,
+			Kind: apitype.ResourcePlugin,
 		}
 		version, err := pkgWorkspace.InstallPlugin(pluginSpec, log)
 		if err != nil {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -698,7 +699,7 @@ func newImportCmd() *cobra.Command {
 
 					pluginSpec := workspace.PluginSpec{
 						Name: string(provider),
-						Kind: workspace.ResourcePlugin,
+						Kind: apitype.ResourcePlugin,
 					}
 					version, err := pkgWorkspace.InstallPlugin(pluginSpec, log)
 					if err != nil {

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -168,7 +169,7 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 			var missingError *workspace.MissingError
 			if errors.As(err, &missingError) {
 				spec := workspace.PluginSpec{
-					Kind:    workspace.ResourcePlugin,
+					Kind:    apitype.ResourcePlugin,
 					Name:    pkg,
 					Version: version,
 				}

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -108,7 +108,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	// Parse the kind, name, and version, if specified.
 	var installs []workspace.PluginSpec
 	if len(args) > 0 {
-		if !workspace.IsPluginKind(args[0]) {
+		if !apitype.IsPluginKind(args[0]) {
 			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
 		} else if len(args) < 2 {
 			return errors.New("missing plugin name argument")

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
@@ -107,7 +108,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	// Parse the kind, name, and version, if specified.
 	var installs []workspace.PluginSpec
 	if len(args) > 0 {
-		if !workspace.IsPluginKind(args[0]) {
+		if !apitype.IsPluginKind(args[0]) {
 			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
 		} else if len(args) < 2 {
 			return errors.New("missing plugin name argument")
@@ -137,7 +138,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		pluginSpec := workspace.PluginSpec{
-			Kind:              workspace.PluginKind(args[0]),
+			Kind:              apitype.PluginKind(args[0]),
 			Name:              args[1],
 			Version:           version,
 			PluginDownloadURL: cmd.serverURL, // If empty, will use default plugin source.
@@ -148,7 +149,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		// distributed with Pulumi itself. But we turn this check off if PULUMI_DEV is set so we can
 		// test installing plugins that are being moved to their own distribution (such as when we move
 		// pulumi-nodejs).
-		if !cmd.env.GetBool(env.Dev) && workspace.IsPluginBundled(pluginSpec.Kind, pluginSpec.Name) {
+		if !cmd.env.GetBool(env.Dev) && apitype.IsPluginBundled(pluginSpec.Kind, pluginSpec.Name) {
 			return fmt.Errorf(
 				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed"+
 					" with this command. If you need to reinstall this plugin, reinstall"+
@@ -190,7 +191,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		for _, plugin := range plugins {
 			// Skip language plugins; by definition, we already have one installed.
 			// TODO[pulumi/pulumi#956]: eventually we will want to honor and install these in the usual way.
-			if plugin.Kind != workspace.LanguagePlugin {
+			if plugin.Kind != apitype.LanguagePlugin {
 				installs = append(installs, plugin)
 			}
 		}

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -108,7 +108,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	// Parse the kind, name, and version, if specified.
 	var installs []workspace.PluginSpec
 	if len(args) > 0 {
-		if !apitype.IsPluginKind(args[0]) {
+		if !workspace.IsPluginKind(args[0]) {
 			return fmt.Errorf("unrecognized plugin kind: %s", args[0])
 		} else if len(args) < 2 {
 			return errors.New("missing plugin name argument")
@@ -149,7 +149,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		// distributed with Pulumi itself. But we turn this check off if PULUMI_DEV is set so we can
 		// test installing plugins that are being moved to their own distribution (such as when we move
 		// pulumi-nodejs).
-		if !cmd.env.GetBool(env.Dev) && apitype.IsPluginBundled(pluginSpec.Kind, pluginSpec.Name) {
+		if !cmd.env.GetBool(env.Dev) && workspace.IsPluginBundled(pluginSpec.Kind, pluginSpec.Name) {
 			return fmt.Errorf(
 				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed"+
 					" with this command. If you need to reinstall this plugin, reinstall"+

--- a/pkg/cmd/pulumi/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin_install_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -49,7 +50,7 @@ func TestBundledDev(t *testing.T) {
 		pluginGetLatestVersion: func(ps workspace.PluginSpec) (*semver.Version, error) {
 			getLatestVersionCalled = true
 			assert.Equal(t, "nodejs", ps.Name)
-			assert.Equal(t, workspace.LanguagePlugin, ps.Kind)
+			assert.Equal(t, apitype.LanguagePlugin, ps.Kind)
 			return nil, errors.New("404 HTTP error fetching plugin")
 		},
 	}

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 
 	"github.com/blang/semver"
@@ -55,14 +56,14 @@ func newPluginRmCmd() *cobra.Command {
 			}
 
 			// Parse the filters.
-			var kind workspace.PluginKind
+			var kind apitype.PluginKind
 			var name string
 			var version *semver.Range
 			if len(args) > 0 {
-				if !workspace.IsPluginKind(args[0]) {
+				if !apitype.IsPluginKind(args[0]) {
 					return fmt.Errorf("unrecognized plugin kind: %s", kind)
 				}
-				kind = workspace.PluginKind(args[0])
+				kind = apitype.PluginKind(args[0])
 			} else if !all {
 				return errors.New("please pass --all if you'd like to remove all plugins")
 			}

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -60,7 +60,7 @@ func newPluginRmCmd() *cobra.Command {
 			var name string
 			var version *semver.Range
 			if len(args) > 0 {
-				if !apitype.IsPluginKind(args[0]) {
+				if !workspace.IsPluginKind(args[0]) {
 					return fmt.Errorf("unrecognized plugin kind: %s", kind)
 				}
 				kind = apitype.PluginKind(args[0])

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -60,7 +60,7 @@ func newPluginRmCmd() *cobra.Command {
 			var name string
 			var version *semver.Range
 			if len(args) > 0 {
-				if !workspace.IsPluginKind(args[0]) {
+				if !apitype.IsPluginKind(args[0]) {
 					return fmt.Errorf("unrecognized plugin kind: %s", kind)
 				}
 				kind = apitype.PluginKind(args[0])

--- a/pkg/cmd/pulumi/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin_run.go
@@ -39,7 +39,7 @@ type pluginRunCmd struct {
 }
 
 func (cmd *pluginRunCmd) run(args []string) error {
-	if !apitype.IsPluginKind(cmd.kind) {
+	if !workspace.IsPluginKind(cmd.kind) {
 		return fmt.Errorf("unrecognized plugin kind: %s", cmd.kind)
 	}
 	kind := apitype.PluginKind(cmd.kind)

--- a/pkg/cmd/pulumi/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin_run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -38,10 +39,10 @@ type pluginRunCmd struct {
 }
 
 func (cmd *pluginRunCmd) run(args []string) error {
-	if !workspace.IsPluginKind(cmd.kind) {
+	if !apitype.IsPluginKind(cmd.kind) {
 		return fmt.Errorf("unrecognized plugin kind: %s", cmd.kind)
 	}
-	kind := workspace.PluginKind(cmd.kind)
+	kind := apitype.PluginKind(cmd.kind)
 
 	// Parse the name and version from the second argument in the form of "NAME[@VERSION]".
 	name := args[0]

--- a/pkg/cmd/pulumi/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin_run.go
@@ -39,7 +39,7 @@ type pluginRunCmd struct {
 }
 
 func (cmd *pluginRunCmd) run(args []string) error {
-	if !workspace.IsPluginKind(cmd.kind) {
+	if !apitype.IsPluginKind(cmd.kind) {
 		return fmt.Errorf("unrecognized plugin kind: %s", cmd.kind)
 	}
 	kind := apitype.PluginKind(cmd.kind)

--- a/pkg/codegen/convert/plugin_mapper.go
+++ b/pkg/codegen/convert/plugin_mapper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blang/semver"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -136,7 +137,7 @@ func NewPluginMapper(ws Workspace,
 	// and so the user can just delete the higher version plugins from their cache.
 	latestVersions := make(map[string]semver.Version)
 	for _, plugin := range allPlugins {
-		if plugin.Kind != workspace.ResourcePlugin {
+		if plugin.Kind != apitype.ResourcePlugin {
 			continue
 		}
 
@@ -153,7 +154,7 @@ func NewPluginMapper(ws Workspace,
 	// iterate all the plugins now because the convert might not even ask for any mappings.
 	plugins := make([]mapperPluginSpec, 0)
 	for _, plugin := range allPlugins {
-		if plugin.Kind != workspace.ResourcePlugin {
+		if plugin.Kind != apitype.ResourcePlugin {
 			continue
 		}
 

--- a/pkg/codegen/convert/plugin_mapper_test.go
+++ b/pkg/codegen/convert/plugin_mapper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -69,7 +70,7 @@ func TestPluginMapper_InstalledPluginMatches(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "provider",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -111,7 +112,7 @@ func TestPluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProvider",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -156,7 +157,7 @@ func TestPluginMapper_NoPluginMatches(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProvider",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -238,12 +239,12 @@ func TestPluginMapper_UseMatchingNameFirst(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "otherProvider",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 			{
 				Name:    "provider",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -285,12 +286,12 @@ func TestPluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProviderAws",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 			{
 				Name:    "pulumiProviderGcp",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -353,12 +354,12 @@ func TestPluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProviderAws",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 			{
 				Name:    "pulumiProviderGcp",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -440,7 +441,7 @@ func TestPluginMapper_GetMappingsIsUsed(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProviderK8s",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -507,12 +508,12 @@ func TestPluginMapper_GetMappingIsntCalledOnValidMappings(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProviderAws",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 			{
 				Name:    "pulumiProviderGcp",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},
@@ -579,7 +580,7 @@ func TestPluginMapper_InfiniteLoopRegression(t *testing.T) {
 		infos: []workspace.PluginInfo{
 			{
 				Name:    "pulumiProviderAws",
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: semverMustParse("1.0.0"),
 			},
 		},

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -30,6 +30,7 @@ import (
 	"github.com/segmentio/encoding/json"
 
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -234,7 +235,7 @@ func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]b
 		return schemaBytes, version, nil
 	}
 
-	pluginInfo, err := l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, version)
+	pluginInfo, err := l.host.ResolvePlugin(apitype.ResourcePlugin, pkg, version)
 	if err != nil {
 		// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
 		if env.DisableAutomaticPluginAcquisition.Value() {
@@ -244,7 +245,7 @@ func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]b
 		var missingError *workspace.MissingError
 		if errors.As(err, &missingError) {
 			spec := workspace.PluginSpec{
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Name:    pkg,
 				Version: version,
 			}
@@ -258,7 +259,7 @@ func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]b
 				return nil, nil, err
 			}
 
-			pluginInfo, err = l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, version)
+			pluginInfo, err = l.host.ResolvePlugin(apitype.ResourcePlugin, pkg, version)
 			if err != nil {
 				return nil, version, err
 			}

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -1412,7 +1413,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 				Name:              "pkgA",
 				Version:           &semver.Version{Major: 1, Minor: 1},
 				PluginDownloadURL: "example.com/default",
-				Kind:              workspace.ResourcePlugin,
+				Kind:              apitype.ResourcePlugin,
 			}},
 			validate: func(t *testing.T, r *resource.State) {
 				if providers.IsProviderType(r.Type) && !providers.IsDefaultProvider(r.URN) {
@@ -1428,7 +1429,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			plugins: []workspace.PluginSpec{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 			}},
 			validate: func(t *testing.T, r *resource.State) {
 				if providers.IsProviderType(r.Type) && !providers.IsDefaultProvider(r.URN) {
@@ -1446,7 +1447,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			plugins: []workspace.PluginSpec{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
-				Kind:    workspace.ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 			}},
 			snapshot: &deploy.Snapshot{
 				Resources: []*resource.State{

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -129,7 +130,7 @@ func gatherPluginsFromProgram(plugctx *plugin.Context, runtime string, prog plug
 	}
 	for _, plug := range langhostPlugins {
 		// Ignore language plugins named "client".
-		if plug.Name == clientRuntimeName && plug.Kind == workspace.LanguagePlugin {
+		if plug.Name == clientRuntimeName && plug.Kind == apitype.LanguagePlugin {
 			continue
 		}
 
@@ -174,7 +175,7 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", pkg, version, urn)
 		set.Add(workspace.PluginSpec{
 			Name:              pkg.String(),
-			Kind:              workspace.ResourcePlugin,
+			Kind:              apitype.ResourcePlugin,
 			Version:           version,
 			PluginDownloadURL: downloadURL,
 			Checksums:         checksums,
@@ -192,7 +193,7 @@ func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
 	logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): beginning")
 	var installTasks errgroup.Group
 	for _, plug := range plugins.Values() {
-		if plug.Name == "pulumi" && plug.Kind == workspace.ResourcePlugin {
+		if plug.Name == "pulumi" && plug.Kind == apitype.ResourcePlugin {
 			logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): pulumi is a builtin plugin")
 			continue
 		}
@@ -204,7 +205,7 @@ func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
 			continue
 		}
 
-		if workspace.IsPluginBundled(plug.Kind, plug.Name) {
+		if apitype.IsPluginBundled(plug.Kind, plug.Name) {
 			return fmt.Errorf(
 				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed."+
 					" Reinstall Pulumi via your package manager or install script",
@@ -310,7 +311,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 	// from the language host does not include any resource providers, fall back to the full set of plugins.
 	languageReportedProviderPlugins := false
 	for _, plug := range languagePlugins.Values() {
-		if plug.Kind == workspace.ResourcePlugin {
+		if plug.Kind == apitype.ResourcePlugin {
 			languageReportedProviderPlugins = true
 		}
 	}
@@ -337,7 +338,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 	sort.Sort(workspace.SortedPluginSpec(sourcePlugins))
 	for _, p := range sourcePlugins {
 		logging.V(preparePluginLog).Infof("computeDefaultProviderPlugins(): considering %s", p)
-		if p.Kind != workspace.ResourcePlugin {
+		if p.Kind != apitype.ResourcePlugin {
 			// Default providers are only relevant for resource plugins.
 			logging.V(preparePluginVerboseLog).Infof(
 				"computeDefaultProviderPlugins(): skipping %s, not a resource provider", p)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -205,7 +205,7 @@ func ensurePluginsAreInstalled(ctx context.Context, d diag.Sink,
 			continue
 		}
 
-		if apitype.IsPluginBundled(plug.Kind, plug.Name) {
+		if workspace.IsPluginBundled(plug.Kind, plug.Name) {
 			return fmt.Errorf(
 				"the %v %v plugin is bundled with Pulumi, and cannot be directly installed."+
 					" Reinstall Pulumi via your package manager or install script",

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -37,12 +38,12 @@ func TestDefaultProvidersSingle(t *testing.T) {
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:              "kubernetes",
 		Version:           mustMakeVersion("0.22.0"),
-		Kind:              workspace.ResourcePlugin,
+		Kind:              apitype.ResourcePlugin,
 		PluginDownloadURL: "com.server.url",
 	})
 
@@ -70,12 +71,12 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: nil,
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 
 	defaultProviders := computeDefaultProviderPlugins(languagePlugins, newPluginSet())
@@ -94,17 +95,17 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.2-dev.1553126336"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 
 	defaultProviders := computeDefaultProviderPlugins(languagePlugins, newPluginSet())
@@ -122,13 +123,13 @@ func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 	languagePlugins := newPluginSet()
 	languagePlugins.Add(workspace.PluginSpec{
 		Name: "python",
-		Kind: workspace.LanguagePlugin,
+		Kind: apitype.LanguagePlugin,
 	})
 	snapshotPlugins := newPluginSet()
 	snapshotPlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	})
 
 	defaultProviders := computeDefaultProviderPlugins(languagePlugins, snapshotPlugins)
@@ -200,13 +201,13 @@ func TestDefaultProviderPluginsSorting(t *testing.T) {
 	p1 := workspace.PluginSpec{
 		Name:    "foo",
 		Version: &v1,
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	}
 	v2 := semver.MustParse("0.0.1-alpha.10+dirty")
 	p2 := workspace.PluginSpec{
 		Name:    "foo",
 		Version: &v2,
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 	}
 	plugins := newPluginSet(p1, p2)
 	result := computeDefaultProviderPlugins(plugins, plugins)

--- a/pkg/resource/deploy/deploytest/analyzer.go
+++ b/pkg/resource/deploy/deploytest/analyzer.go
@@ -15,6 +15,7 @@
 package deploytest
 
 import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -67,7 +68,7 @@ func (a *Analyzer) GetAnalyzerInfo() (plugin.AnalyzerInfo, error) {
 
 func (a *Analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{
-		Kind: workspace.AnalyzerPlugin,
+		Kind: apitype.AnalyzerPlugin,
 		Name: a.Info.Name,
 	}, nil
 }

--- a/pkg/resource/deploy/deploytest/analyzer_test.go
+++ b/pkg/resource/deploy/deploytest/analyzer_test.go
@@ -17,9 +17,9 @@ package deploytest
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -129,7 +129,7 @@ func TestAnalyzer(t *testing.T) {
 		info, err := a.GetPluginInfo()
 		assert.NoError(t, err)
 		assert.Equal(t, "my-analyzer", info.Name)
-		assert.Equal(t, workspace.AnalyzerPlugin, info.Kind)
+		assert.Equal(t, apitype.AnalyzerPlugin, info.Kind)
 	})
 	t.Run("Configure", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -32,7 +32,7 @@ import (
 func TestNewAnalyzerLoaderWithHost(t *testing.T) {
 	t.Parallel()
 	a := NewAnalyzerLoaderWithHost("pkgA", nil)
-	assert.Equal(t, workspace.PluginKind("analyzer"), a.kind)
+	assert.Equal(t, apitype.PluginKind("analyzer"), a.kind)
 	assert.Equal(t, "pkgA", a.name)
 	assert.Equal(t, semver.Version{}, a.version)
 	assert.Equal(t, "", a.path)

--- a/pkg/resource/deploy/manifest_test.go
+++ b/pkg/resource/deploy/manifest_test.go
@@ -33,13 +33,13 @@ func TestManifest(t *testing.T) {
 				{
 					Name:    "plug-1",
 					Path:    "/foo",
-					Kind:    workspace.LanguagePlugin,
+					Kind:    apitype.LanguagePlugin,
 					Version: &ver,
 				},
 				{
 					Name:    "plug-2",
 					Path:    "/bar",
-					Kind:    workspace.ResourcePlugin,
+					Kind:    apitype.ResourcePlugin,
 					Version: &ver,
 				},
 			},

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -24,6 +24,7 @@ import (
 	uuid "github.com/gofrs/uuid"
 
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -171,7 +172,7 @@ func loadProvider(pkg tokens.Package, version *semver.Version, downloadURL strin
 	}
 
 	pluginSpec := workspace.PluginSpec{
-		Kind:              workspace.ResourcePlugin,
+		Kind:              apitype.ResourcePlugin,
 		Name:              string(pkg),
 		Version:           version,
 		PluginDownloadURL: downloadURL,

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -92,7 +92,7 @@ func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds 
 }
 
 func (host *testPluginHost) ResolvePlugin(
-	kind workspace.PluginKind, name string, version *semver.Version,
+	kind apitype.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
 	return nil, nil
 }

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -724,7 +725,7 @@ func TestLoadProvider_missingError(t *testing.T) {
 	loader := newLoader(t, "myplugin", "1.2.3",
 		func(p tokens.Package, v semver.Version) (plugin.Provider, error) {
 			return nil, workspace.NewMissingError(
-				workspace.ResourcePlugin, "myplugin", &version, false /* ambient */)
+				apitype.ResourcePlugin, "myplugin", &version, false /* ambient */)
 		})
 	host := newPluginHost(t, []*providerLoader{loader})
 

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
-	"github.com/pulumi/pulumi/sdk/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -621,7 +622,7 @@ type mockHost struct {
 
 	EnsurePluginsF func(plugins []workspace.PluginSpec, kinds plugin.Flags) error
 
-	ResolvePluginF func(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
+	ResolvePluginF func(kind apitype.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
 
 	GetProjectPluginsF func() []workspace.ProjectPlugin
 
@@ -707,7 +708,7 @@ func (h *mockHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Fl
 }
 
 func (h *mockHost) ResolvePlugin(
-	kind workspace.PluginKind, name string, version *semver.Version,
+	kind apitype.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
 	if h.ResolvePluginF != nil {
 		return h.ResolvePluginF(kind, name, version)

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -31,7 +32,7 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
 	}
 
 	// Zaid's arm and bicep converters so that `pulumi convert --from arm/bicep` just works.
-	if spec.Kind == workspace.ConverterPlugin && (spec.Name == "arm" || spec.Name == "bicep") {
+	if spec.Kind == apitype.ConverterPlugin && (spec.Name == "arm" || spec.Name == "bicep") {
 		spec.PluginDownloadURL = "github://api.github.com/Zaid-Ajaj"
 		return true
 	}
@@ -63,7 +64,7 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
 		"vra",
 		"zitadel",
 	}
-	if spec.Kind == workspace.ResourcePlugin {
+	if spec.Kind == apitype.ResourcePlugin {
 		for _, plugin := range pulumiversePlugins {
 			if spec.Name == plugin {
 				spec.PluginDownloadURL = "github://api.github.com/pulumiverse"
@@ -83,7 +84,7 @@ func SetKnownPluginVersion(spec *workspace.PluginSpec) bool {
 		return false
 	}
 
-	if spec.Kind == workspace.ConverterPlugin && spec.Name == "yaml" {
+	if spec.Kind == apitype.ConverterPlugin && spec.Name == "yaml" {
 		// By default use the version of yaml we've linked to. N.B. This has to be tested manually because
 		// ReadBuildInfo doesn't return anything in test builds (https://github.com/golang/go/issues/33976).
 		info, ok := debug.ReadBuildInfo()

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -27,7 +28,7 @@ func TestUrlAlreadySet(t *testing.T) {
 
 	spec := workspace.PluginSpec{
 		Name:              "acme",
-		Kind:              workspace.ResourcePlugin,
+		Kind:              apitype.ResourcePlugin,
 		PluginDownloadURL: "github://api.github.com/pulumiverse",
 	}
 	res := SetKnownPluginDownloadURL(&spec)
@@ -39,7 +40,7 @@ func TestKnownProvider(t *testing.T) {
 
 	spec := workspace.PluginSpec{
 		Name: "acme",
-		Kind: workspace.ResourcePlugin,
+		Kind: apitype.ResourcePlugin,
 	}
 	res := SetKnownPluginDownloadURL(&spec)
 	assert.True(t, res)

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 				Err: err,
 				Spec: workspace.PluginSpec{
 					Name: "myplugin",
-					Kind: workspace.ResourcePlugin,
+					Kind: apitype.ResourcePlugin,
 				},
 			},
 			ExpectedError: "Could not automatically download and install resource plugin 'pulumi-resource-myplugin'," +
@@ -52,7 +53,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 				Err: err,
 				Spec: workspace.PluginSpec{
 					Name: "myplugin",
-					Kind: workspace.ConverterPlugin,
+					Kind: apitype.ConverterPlugin,
 				},
 			},
 			ExpectedError: "Could not automatically download and install converter plugin 'pulumi-converter-myplugin'," +
@@ -64,7 +65,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 				Err: err,
 				Spec: workspace.PluginSpec{
 					Name:    "myplugin",
-					Kind:    workspace.ResourcePlugin,
+					Kind:    apitype.ResourcePlugin,
 					Version: &v1,
 				},
 			},
@@ -77,7 +78,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 				Err: err,
 				Spec: workspace.PluginSpec{
 					Name:              "myplugin",
-					Kind:              workspace.ResourcePlugin,
+					Kind:              apitype.ResourcePlugin,
 					Version:           &v1,
 					PluginDownloadURL: "github://owner/repo",
 				},
@@ -92,7 +93,7 @@ func TestInstallPluginErrorText(t *testing.T) {
 				Err: err,
 				Spec: workspace.PluginSpec{
 					Name:              "myplugin",
-					Kind:              workspace.ResourcePlugin,
+					Kind:              apitype.ResourcePlugin,
 					PluginDownloadURL: "github://owner/repo",
 				},
 			},

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 //go:embed deployments.json
@@ -351,10 +350,10 @@ type ManifestV1 struct {
 
 // PluginInfoV1 captures the version and information about a plugin.
 type PluginInfoV1 struct {
-	Name    string               `json:"name" yaml:"name"`
-	Path    string               `json:"path" yaml:"path"`
-	Type    workspace.PluginKind `json:"type" yaml:"type"`
-	Version string               `json:"version" yaml:"version"`
+	Name    string     `json:"name" yaml:"name"`
+	Path    string     `json:"path" yaml:"path"`
+	Type    PluginKind `json:"type" yaml:"type"`
+	Version string     `json:"version" yaml:"version"`
 }
 
 // SecretV1 captures the information that a particular value is secret and must be decrypted before use.

--- a/sdk/go/common/apitype/plugins.go
+++ b/sdk/go/common/apitype/plugins.go
@@ -24,8 +24,6 @@
 // In the event that this is not possible, a breaking change is implied.  The preferred approach is to never make
 // breaking changes.  If that isn't possible, the next best approach is to support both the old and new formats
 // side-by-side (for instance, by using a union type for the property in question).
-//
-//nolint:lll
 package apitype
 
 // apitype.PluginKind represents a kind of a plugin that may be dynamically loaded and used by Pulumi.
@@ -43,28 +41,3 @@ const (
 	// ToolPlugin is an arbitrary plugin that can be run as a tool.
 	ToolPlugin PluginKind = "tool"
 )
-
-// IsPluginKind returns true if k is a valid plugin kind, and false otherwise.
-func IsPluginKind(k string) bool {
-	switch PluginKind(k) {
-	case AnalyzerPlugin, LanguagePlugin, ResourcePlugin, ConverterPlugin, ToolPlugin:
-		return true
-	default:
-		return false
-	}
-}
-
-// We currently bundle some plugins with "pulumi" and thus expect them to be next to the pulumi binary.
-// Eventually we want to fix this so new plugins are true plugins in the plugin cache.
-func IsPluginBundled(kind PluginKind, name string) bool {
-	return (kind == LanguagePlugin && name == "nodejs") ||
-		(kind == LanguagePlugin && name == "go") ||
-		(kind == LanguagePlugin && name == "python") ||
-		(kind == LanguagePlugin && name == "dotnet") ||
-		(kind == LanguagePlugin && name == "yaml") ||
-		(kind == LanguagePlugin && name == "java") ||
-		(kind == ResourcePlugin && name == "pulumi-nodejs") ||
-		(kind == ResourcePlugin && name == "pulumi-python") ||
-		(kind == AnalyzerPlugin && name == "policy") ||
-		(kind == AnalyzerPlugin && name == "policy-python")
-}

--- a/sdk/go/common/apitype/plugins.go
+++ b/sdk/go/common/apitype/plugins.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apitype contains the full set of "exchange types" that are serialized and sent across separately versionable
+// boundaries, including service APIs, plugins, and file formats.  As a result, we must consider the versioning impacts
+// for each change we make to types within this package.  In general, this means the following:
+//
+//  1. DO NOT take anything away
+//  2. DO NOT change processing rules
+//  3. DO NOT make optional things required
+//  4. DO make anything new be optional
+//
+// In the event that this is not possible, a breaking change is implied.  The preferred approach is to never make
+// breaking changes.  If that isn't possible, the next best approach is to support both the old and new formats
+// side-by-side (for instance, by using a union type for the property in question).
+//
+//nolint:lll
+package apitype
+
+// apitype.PluginKind represents a kind of a plugin that may be dynamically loaded and used by Pulumi.
+type PluginKind string
+
+const (
+	// AnalyzerPlugin is a plugin that can be used as a resource analyzer.
+	AnalyzerPlugin PluginKind = "analyzer"
+	// LanguagePlugin is a plugin that can be used as a language host.
+	LanguagePlugin PluginKind = "language"
+	// ResourcePlugin is a plugin that can be used as a resource provider for custom CRUD operations.
+	ResourcePlugin PluginKind = "resource"
+	// ConverterPlugin is a plugin that can be used to convert from other ecosystems to Pulumi.
+	ConverterPlugin PluginKind = "converter"
+	// ToolPlugin is an arbitrary plugin that can be run as a tool.
+	ToolPlugin PluginKind = "tool"
+)
+
+// IsPluginKind returns true if k is a valid plugin kind, and false otherwise.
+func IsPluginKind(k string) bool {
+	switch PluginKind(k) {
+	case AnalyzerPlugin, LanguagePlugin, ResourcePlugin, ConverterPlugin, ToolPlugin:
+		return true
+	default:
+		return false
+	}
+}
+
+// We currently bundle some plugins with "pulumi" and thus expect them to be next to the pulumi binary.
+// Eventually we want to fix this so new plugins are true plugins in the plugin cache.
+func IsPluginBundled(kind PluginKind, name string) bool {
+	return (kind == LanguagePlugin && name == "nodejs") ||
+		(kind == LanguagePlugin && name == "go") ||
+		(kind == LanguagePlugin && name == "python") ||
+		(kind == LanguagePlugin && name == "dotnet") ||
+		(kind == LanguagePlugin && name == "yaml") ||
+		(kind == LanguagePlugin && name == "java") ||
+		(kind == ResourcePlugin && name == "pulumi-nodejs") ||
+		(kind == ResourcePlugin && name == "pulumi-python") ||
+		(kind == AnalyzerPlugin && name == "policy") ||
+		(kind == AnalyzerPlugin && name == "policy-python")
+}

--- a/sdk/go/common/apitype/plugins.go
+++ b/sdk/go/common/apitype/plugins.go
@@ -27,6 +27,7 @@
 package apitype
 
 // apitype.PluginKind represents a kind of a plugin that may be dynamically loaded and used by Pulumi.
+// These are being re exported in sdk/go/common/workspace/plugins.go to keep backward compatibility and should be kept in sync
 type PluginKind string
 
 const (

--- a/sdk/go/common/apitype/plugins.go
+++ b/sdk/go/common/apitype/plugins.go
@@ -43,3 +43,14 @@ const (
 	// ToolPlugin is an arbitrary plugin that can be run as a tool.
 	ToolPlugin PluginKind = "tool"
 )
+
+// IsPluginKind returns true if k is a valid plugin kind, and false otherwise.
+func IsPluginKind(k string) bool {
+	switch PluginKind(k) {
+	case AnalyzerPlugin, LanguagePlugin, ResourcePlugin,
+		ConverterPlugin, ToolPlugin:
+		return true
+	default:
+		return false
+	}
+}

--- a/sdk/go/common/apitype/plugins.go
+++ b/sdk/go/common/apitype/plugins.go
@@ -27,7 +27,8 @@
 package apitype
 
 // apitype.PluginKind represents a kind of a plugin that may be dynamically loaded and used by Pulumi.
-// These are being re exported in sdk/go/common/workspace/plugins.go to keep backward compatibility and should be kept in sync
+// These are being re exported in sdk/go/common/workspace/plugins.go to keep backward compatibility and should
+// be kept in sync
 type PluginKind string
 
 const (

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -60,7 +60,7 @@ var _ Analyzer = (*analyzer)(nil)
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(ctx.Diag,
-		workspace.AnalyzerPlugin, strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
+		apitype.AnalyzerPlugin, strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
 		nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)
@@ -70,7 +70,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	dialOpts := rpcutil.OpenTracingInterceptorDialOptions()
 
 	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
-		workspace.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil /*env*/, dialOpts)
+		apitype.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil /*env*/, dialOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func NewPolicyAnalyzer(
 
 	// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
 	pluginPath, err := workspace.GetPluginPath(ctx.Diag,
-		workspace.AnalyzerPlugin, policyAnalyzerName, nil, host.GetProjectPlugins())
+		apitype.AnalyzerPlugin, policyAnalyzerName, nil, host.GetProjectPlugins())
 
 	var e *workspace.MissingError
 	if errors.As(err, &e) {
@@ -136,7 +136,7 @@ func NewPolicyAnalyzer(
 	}
 
 	plug, err := newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
-		workspace.AnalyzerPlugin, args, env, analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)))
+		apitype.AnalyzerPlugin, args, env, analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)))
 	if err != nil {
 		// The original error might have been wrapped before being returned from newPlugin. So we look for
 		// the root cause of the error. This won't work if we switch to Go 1.13's new approach to wrapping.
@@ -443,7 +443,7 @@ func (a *analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{
 		Name:    string(a.name),
 		Path:    a.plug.Bin,
-		Kind:    workspace.AnalyzerPlugin,
+		Kind:    apitype.AnalyzerPlugin,
 		Version: version,
 	}, nil
 }

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
@@ -44,7 +45,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	prefix := fmt.Sprintf("%v (converter)", name)
 
 	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(ctx.Diag, workspace.ConverterPlugin, name, version, ctx.Host.GetProjectPlugins())
+	path, err := workspace.GetPluginPath(ctx.Diag, apitype.ConverterPlugin, name, version, ctx.Host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +53,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	contract.Assertf(path != "", "unexpected empty path for plugin %s", name)
 
 	plug, err := newPlugin(ctx, ctx.Pwd, path, prefix,
-		workspace.ConverterPlugin, []string{}, os.Environ(), converterPluginDialOptions(ctx, name, ""))
+		apitype.ConverterPlugin, []string{}, os.Environ(), converterPluginDialOptions(ctx, name, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -171,7 +171,7 @@ func (h *langhost) GetRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec,
 			}
 			version = &sv
 		}
-		if !apitype.IsPluginKind(info.Kind) {
+		if !workspace.IsPluginKind(info.Kind) {
 			return nil, errors.Errorf("unrecognized plugin kind: %s", info.Kind)
 		}
 		results = append(results, workspace.PluginSpec{

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -171,7 +171,7 @@ func (h *langhost) GetRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec,
 			}
 			version = &sv
 		}
-		if !workspace.IsPluginKind(info.Kind) {
+		if !apitype.IsPluginKind(info.Kind) {
 			return nil, errors.Errorf("unrecognized plugin kind: %s", info.Kind)
 		}
 		results = append(results, workspace.PluginSpec{

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -55,7 +56,7 @@ type langhost struct {
 func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory string, info ProgramInfo,
 ) (LanguageRuntime, error) {
 	path, err := workspace.GetPluginPath(ctx.Diag,
-		workspace.LanguagePlugin, strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"), nil, host.GetProjectPlugins())
+		apitype.LanguagePlugin, strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"), nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +69,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 	}
 
 	plug, err := newPlugin(ctx, workingDirectory, path, runtime,
-		workspace.LanguagePlugin, args, nil /*env*/, langRuntimePluginDialOptions(ctx, runtime))
+		apitype.LanguagePlugin, args, nil /*env*/, langRuntimePluginDialOptions(ctx, runtime))
 	if err != nil {
 		return nil, err
 	}
@@ -170,12 +171,12 @@ func (h *langhost) GetRequiredPlugins(info ProgramInfo) ([]workspace.PluginSpec,
 			}
 			version = &sv
 		}
-		if !workspace.IsPluginKind(info.Kind) {
+		if !apitype.IsPluginKind(info.Kind) {
 			return nil, errors.Errorf("unrecognized plugin kind: %s", info.Kind)
 		}
 		results = append(results, workspace.PluginSpec{
 			Name:              info.Name,
-			Kind:              workspace.PluginKind(info.Kind),
+			Kind:              apitype.PluginKind(info.Kind),
 			Version:           version,
 			PluginDownloadURL: info.Server,
 			Checksums:         info.Checksums,
@@ -249,7 +250,7 @@ func (h *langhost) GetPluginInfo() (workspace.PluginInfo, error) {
 
 	plugInfo := workspace.PluginInfo{
 		Name: h.runtime,
-		Kind: workspace.LanguagePlugin,
+		Kind: apitype.LanguagePlugin,
 	}
 
 	plugInfo.Path = h.plug.Bin

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -171,7 +172,7 @@ func dialPlugin(portNum int, bin, prefix string, dialOptions []grpc.DialOption) 
 	return conn, nil
 }
 
-func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
+func newPlugin(ctx *Context, pwd, bin, prefix string, kind apitype.PluginKind,
 	args, env []string, dialOptions []grpc.DialOption,
 ) (*plugin, error) {
 	if logging.V(9) {
@@ -311,7 +312,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 }
 
 // execPlugin starts the plugin executable.
-func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
+func execPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 	pluginArgs []string, pwd string, env []string,
 ) (*plugin, error) {
 	args := buildPluginArguments(pluginArgumentOptions{
@@ -328,13 +329,13 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 		pluginDir := filepath.Dir(bin)
 
 		var runtimeInfo workspace.ProjectRuntimeInfo
-		if kind == workspace.ResourcePlugin || kind == workspace.ConverterPlugin {
+		if kind == apitype.ResourcePlugin || kind == apitype.ConverterPlugin {
 			proj, err := workspace.LoadPluginProject(filepath.Join(pluginDir, "PulumiPlugin.yaml"))
 			if err != nil {
 				return nil, fmt.Errorf("loading PulumiPlugin.yaml: %w", err)
 			}
 			runtimeInfo = proj.Runtime
-		} else if kind == workspace.AnalyzerPlugin {
+		} else if kind == apitype.AnalyzerPlugin {
 			proj, err := workspace.LoadPluginProject(filepath.Join(pluginDir, "PulumiPolicy.yaml"))
 			if err != nil {
 				return nil, fmt.Errorf("loading PulumiPolicy.yaml: %w", err)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
@@ -147,7 +148,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
 		path, err := workspace.GetPluginPath(ctx.Diag,
-			workspace.ResourcePlugin, strings.ReplaceAll(string(pkg), tokens.QNameDelimiter, "_"),
+			apitype.ResourcePlugin, strings.ReplaceAll(string(pkg), tokens.QNameDelimiter, "_"),
 			version, host.GetProjectPlugins())
 		if err != nil {
 			return nil, err
@@ -165,7 +166,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 			env = append(env, "PULUMI_CONFIG="+jsonConfig)
 		}
 		plug, err = newPlugin(ctx, ctx.Pwd, path, prefix,
-			workspace.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, pkg, ""))
+			apitype.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, pkg, ""))
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +226,7 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 	env := os.Environ()
 
 	plug, err := newPlugin(ctx, ctx.Pwd, path, "",
-		workspace.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, "", path))
+		apitype.ResourcePlugin, []string{host.ServerAddr()}, env, providerPluginDialOptions(ctx, "", path))
 	if err != nil {
 		return nil, err
 	}
@@ -1770,7 +1771,7 @@ func (p *provider) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{
 		Name:    string(p.pkg),
 		Path:    path,
-		Kind:    workspace.ResourcePlugin,
+		Kind:    apitype.ResourcePlugin,
 		Version: version,
 	}, nil
 }

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1498,8 +1498,13 @@ func cleanupTempDirs(finalDir string) error {
 
 // Re exporting PluginKind to keep backward compatibility, this should be kept in sync with
 // the definitions in sdk/go/common/apitype/plugins.go
-type PluginKind apitype.PluginKind
+//
+// Deprecated: PluginKind type was moved to "github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+type PluginKind = apitype.PluginKind
 
+// ProductKind types definition
+//
+// Deprecated: PluginKind type was moved to "github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 const (
 	AnalyzerPlugin  = apitype.AnalyzerPlugin
 	LanguagePlugin  = apitype.LanguagePlugin

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1496,8 +1496,17 @@ func cleanupTempDirs(finalDir string) error {
 	return nil
 }
 
-// Re exporting PluginKind to keep backward compatibility
+// Re exporting PluginKind to keep backward compatibility, this should be kept in sync with
+// the definitions in sdk/go/common/apitype/plugins.go
 type PluginKind apitype.PluginKind
+
+const (
+	AnalyzerPlugin  = apitype.AnalyzerPlugin
+	LanguagePlugin  = apitype.LanguagePlugin
+	ResourcePlugin  = apitype.ResourcePlugin
+	ConverterPlugin = apitype.ConverterPlugin
+	ToolPlugin      = apitype.ToolPlugin
+)
 
 // IsPluginKind returns true if k is a valid plugin kind, and false otherwise.
 func IsPluginKind(k string) bool {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1514,14 +1514,10 @@ const (
 )
 
 // IsPluginKind returns true if k is a valid plugin kind, and false otherwise.
+//
+// Deprecated: IsPluginKind type was moved to "github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 func IsPluginKind(k string) bool {
-	switch apitype.PluginKind(k) {
-	case apitype.AnalyzerPlugin, apitype.LanguagePlugin, apitype.ResourcePlugin,
-		apitype.ConverterPlugin, apitype.ToolPlugin:
-		return true
-	default:
-		return false
-	}
+	return apitype.IsPluginKind(k)
 }
 
 // HasPlugin returns true if the given plugin exists.

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,7 +86,7 @@ func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadClose
 	v1 := semver.MustParse("0.1.0")
 	plugin := PluginSpec{
 		Name:      "test",
-		Kind:      ResourcePlugin,
+		Kind:      apitype.ResourcePlugin,
 		Version:   &v1,
 		PluginDir: dir,
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
@@ -45,32 +46,32 @@ func TestLegacyPluginSelection_Prerelease(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
-	result := LegacySelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", nil)
+	result := LegacySelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", nil)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -85,33 +86,33 @@ func TestLegacyPluginSelection_PrereleaseRequested(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	v := semver.MustParse("0.2.0")
-	result := LegacySelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", &v)
+	result := LegacySelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", &v)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.3.0-alpha", result.Version.String())
@@ -126,33 +127,33 @@ func TestPluginSelection_ExactMatch(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -167,33 +168,33 @@ func TestPluginSelection_ExactMatchNotFound(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
 	assert.Nil(t, result)
 }
 
@@ -207,38 +208,38 @@ func TestPluginSelection_PatchVersionSlide(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v21,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	requested := semver.MustParseRange(">=0.2.0 <0.3.0")
-	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.1", result.Version.String())
@@ -253,38 +254,38 @@ func TestPluginSelection_EmptyVersionNoAlternatives(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: nil,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Nil(t, result.Version)
@@ -299,43 +300,43 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 	candidatePlugins := []PluginInfo{
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v1,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v2,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: nil,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: nil,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "notmyplugin",
-			Kind:    ResourcePlugin,
+			Kind:    apitype.ResourcePlugin,
 			Version: &v3,
 		},
 		{
 			Name:    "myplugin",
-			Kind:    AnalyzerPlugin,
+			Kind:    apitype.AnalyzerPlugin,
 			Version: &v3,
 		},
 	}
 
 	requested := semver.MustParseRange("0.2.0")
-	result := SelectCompatiblePlugin(candidatePlugins, ResourcePlugin, "myplugin", requested)
+	result := SelectCompatiblePlugin(candidatePlugins, apitype.ResourcePlugin, "myplugin", requested)
 	assert.NotNil(t, result)
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
@@ -361,7 +362,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -402,7 +403,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "",
 			Name:              "otherdl",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -429,7 +430,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name/v${VERSION}/${OS}/${ARCH}",
 			Name:              "mockdl",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -454,7 +455,7 @@ func TestPluginDownload(t *testing.T) {
 				"package-name/${NAME}/v${VERSION}/${OS}/${ARCH}/",
 			Name:    "mockdl",
 			Version: &version,
-			Kind:    PluginKind("resource"),
+			Kind:    apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -479,7 +480,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -522,7 +523,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mockdl",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -598,7 +599,7 @@ func TestPluginDownload(t *testing.T) {
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
-				Kind:              PluginKind("resource"),
+				Kind:              apitype.PluginKind("resource"),
 				Checksums: map[string][]byte{
 					"darwin-amd64": {0},
 				},
@@ -621,7 +622,7 @@ func TestPluginDownload(t *testing.T) {
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
-				Kind:              PluginKind("resource"),
+				Kind:              apitype.PluginKind("resource"),
 				Checksums: map[string][]byte{
 					"darwin-amd64": checksum,
 				},
@@ -646,7 +647,7 @@ func TestPluginDownload(t *testing.T) {
 				PluginDownloadURL: "",
 				Name:              "mockdl",
 				Version:           &version,
-				Kind:              PluginKind("resource"),
+				Kind:              apitype.PluginKind("resource"),
 				Checksums: map[string][]byte{
 					"windows-amd64": {0},
 				},
@@ -668,7 +669,7 @@ func TestPluginDownload(t *testing.T) {
 			PluginDownloadURL: "gitlab://gitlab.com/278964",
 			Name:              "mock-gitlab",
 			Version:           &version,
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -698,7 +699,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
 		source, err := spec.GetSource()
@@ -720,7 +721,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "http://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -732,7 +733,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
@@ -745,7 +746,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mock-private",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
 		source, err := spec.GetSource()
@@ -771,7 +772,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mock-private",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
 		source, err := spec.GetSource()
@@ -797,7 +798,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "gitlab://gitlab.com/278964",
 			Name:              "mock-gitlab",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("1.23.0")
 		source, err := spec.GetSource()
@@ -824,7 +825,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
-			Kind:              PluginKind("resource"),
+			Kind:              apitype.PluginKind("resource"),
 		}
 		source, err := spec.GetSource()
 		assert.NoError(t, err)
@@ -1024,7 +1025,7 @@ func TestDownloadToFile_retries(t *testing.T) {
 	version := semver.MustParse("1.0.0")
 	spec := PluginSpec{
 		Name:              "myplugin",
-		Kind:              LanguagePlugin,
+		Kind:              apitype.LanguagePlugin,
 		Version:           &version,
 		PluginDownloadURL: server.URL,
 		PluginDir:         t.TempDir(),
@@ -1087,7 +1088,7 @@ func TestPluginBadSource(t *testing.T) {
 		PluginDownloadURL: "strange-scheme://what.is.this?oh-no",
 		Name:              "mockdl",
 		Version:           &version,
-		Kind:              PluginKind("resource"),
+		Kind:              apitype.PluginKind("resource"),
 	}
 	source, err := spec.GetSource()
 	assert.ErrorContains(t, err, "unknown plugin source scheme: strange-scheme")
@@ -1108,7 +1109,7 @@ func TestMissingErrorText(t *testing.T) {
 			Name: "ResourceWithVersion",
 			Plugin: PluginInfo{
 				Name:    "myplugin",
-				Kind:    ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: &v1,
 			},
 			IncludeAmbient: true,
@@ -1119,7 +1120,7 @@ func TestMissingErrorText(t *testing.T) {
 			Name: "ResourceWithVersion_ExcludeAmbient",
 			Plugin: PluginInfo{
 				Name:    "myplugin",
-				Kind:    ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: &v1,
 			},
 			IncludeAmbient: false,
@@ -1129,7 +1130,7 @@ func TestMissingErrorText(t *testing.T) {
 			Name: "ResourceWithoutVersion",
 			Plugin: PluginInfo{
 				Name:    "myplugin",
-				Kind:    ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: nil,
 			},
 			IncludeAmbient: true,
@@ -1139,7 +1140,7 @@ func TestMissingErrorText(t *testing.T) {
 			Name: "ResourceWithoutVersion_ExcludeAmbient",
 			Plugin: PluginInfo{
 				Name:    "myplugin",
-				Kind:    ResourcePlugin,
+				Kind:    apitype.ResourcePlugin,
 				Version: nil,
 			},
 			IncludeAmbient: false,
@@ -1149,7 +1150,7 @@ func TestMissingErrorText(t *testing.T) {
 			Name: "LanguageWithoutVersion",
 			Plugin: PluginInfo{
 				Name:    "dotnet",
-				Kind:    LanguagePlugin,
+				Kind:    apitype.LanguagePlugin,
 				Version: nil,
 			},
 			IncludeAmbient: true,
@@ -1194,13 +1195,13 @@ func TestBundledPluginSearch(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	path, err := GetPluginPath(d, apitype.LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
 	// Lookup the plugin with ambient search turned off
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
-	path, err = GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	path, err = GetPluginPath(d, apitype.LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 }
@@ -1223,7 +1224,7 @@ func TestAmbientPluginsWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, ResourcePlugin, "mock", nil, nil)
+	path, err := GetPluginPath(d, apitype.ResourcePlugin, "mock", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, ambientPath, path)
 
@@ -1259,7 +1260,7 @@ func TestBundledPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	path, err := GetPluginPath(d, apitype.LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, bundledPath, path)
 
@@ -1300,7 +1301,7 @@ func TestSymlinkPathPluginsDoNotWarn(t *testing.T) {
 
 	// Lookup the plugin with ambient search turned on
 	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "false")
-	path, err := GetPluginPath(d, LanguagePlugin, "nodejs", nil, nil)
+	path, err := GetPluginPath(d, apitype.LanguagePlugin, "nodejs", nil, nil)
 	require.NoError(t, err)
 	// We expect the ambient path to be returned, but not to warn because it resolves to the same file as the
 	// bundled path.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR moves PluginKind to apitype to prevent circular dependencies when adding apitype as a dependency of the workspace module.
It also re-exports PluginKind to keep backward compatibility

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
