### PR TITLE
Add missing `typescript` dependency to sxs_ts_test

### DIFF
--- a/sdk/nodejs/tests/sxs_ts_test/package~3.8.3.json
+++ b/sdk/nodejs/tests/sxs_ts_test/package~3.8.3.json
@@ -3,7 +3,8 @@
     "version": "${VERSION}",
     "license": "Apache-2.0",
     "dependencies": {
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "latest",
+        "typescript": "~3.8.3"
     },
     "devDependencies": {
         "@types/node": "^14.0.0"


### PR DESCRIPTION
With the release of v3.113.0, `@pulumi/pulumi` has an optional peer dependency on `typescript`. If trying to use `tsc` directly, you must explicitly add `typescript` as a dependency in your `package.json`. We're calling `tsc` for this test, so we need to add an explicit dependency.

Note: This could be a `devDependency`, but the `package.json` files for the other test cases list the `typescript` dependency as a regular `dependency` (see [this](https://github.com/pulumi/pulumi/blob/master/sdk/nodejs/tests/sxs_ts_test/package%5E3.json) and [this](https://github.com/pulumi/pulumi/blob/master/sdk/nodejs/tests/sxs_ts_test/package%5E4.json)), so doing the same here.

Fixes https://github.com/pulumi/pulumi/issues/15949