### PR TITLE
Implement --continue-on-error for up in Automation API

### DIFF
--- a/changelog/pending/20240416--auto-go-nodejs-python--add-support-for-the-continue-on-error-parameter-of-the-up-command-to-the-automation-api.yaml
+++ b/changelog/pending/20240416--auto-go-nodejs-python--add-support-for-the-continue-on-error-parameter-of-the-up-command-to-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add support for the continue-on-error parameter of the up command to the Automation API

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -193,7 +193,7 @@ type Options struct {
 	SuppressProgress bool
 	// Suppress display of stack outputs (in case they contain sensitive values)
 	SuppressOutputs bool
-	// ContinueOnError will continue updating resources even if a resource update fails
+	// ContinueOnError will continue to perform the update operation despite the occurrence of errors.
 	ContinueOnError bool
 }
 

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -193,6 +193,8 @@ type Options struct {
 	SuppressProgress bool
 	// Suppress display of stack outputs (in case they contain sensitive values)
 	SuppressOutputs bool
+	// ContinueOnError will continue updating resources even if a resource update fails
+	ContinueOnError bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -406,6 +406,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	if upOpts.SuppressProgress {
 		sharedArgs = append(sharedArgs, "--suppress-progress")
 	}
+	if upOpts.ContinueOnError {
+		sharedArgs = append(sharedArgs, "--continue-on-error")
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -202,9 +202,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.plan) {
                 args.push("--plan", opts.plan);
             }
-	    if (opts.continueOnError) {
-		args.push("--continue-on-error");
-	    }
+            if (opts.continueOnError) {
+                args.push("--continue-on-error");
+            }
             applyGlobalOpts(opts, args);
         }
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -202,6 +202,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.plan) {
                 args.push("--plan", opts.plan);
             }
+	    if (opts.continueOnError) {
+		args.push("--continue-on-error");
+	    }
             applyGlobalOpts(opts, args);
         }
 
@@ -942,6 +945,10 @@ export interface UpOptions extends GlobalOpts {
      * Include secrets in the UpSummary.
      */
     showSecrets?: boolean;
+    /**
+     * Continue to perform the update operation despite the occurrence of errors.
+     */
+    continueOnError?: boolean;
 }
 
 /**

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -227,6 +227,7 @@ class Stack:
         debug: Optional[bool] = None,
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
+        continue_on_error: Optional[bool] = None,
     ) -> UpResult:
         """
         Creates or updates the resources in a stack by executing the program in the Workspace.
@@ -255,6 +256,7 @@ class Stack:
         :param debug: Print detailed debugging output during resource operations
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
+        :param continue_on_error: Continue to perform the update operation despite the occurrence of errors
         :returns: UpResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args


### PR DESCRIPTION
Users are already able to use --continue-on-error for destroy in the automation API.  Implement the same for `up` as well.

This should only be merged after https://github.com/pulumi/pulumi/pull/15740 is.  (Note that this still includes the commits from there, I will rebase once that PR is merged, hence this is only a draft PR for now)