### PR TITLE
fix: close files in PCL binder

### DIFF
--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	syntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // componentVariableType returns the type of the variable of which the value is a component.

--- a/pkg/codegen/pcl/binder_component.go
+++ b/pkg/codegen/pcl/binder_component.go
@@ -161,6 +161,7 @@ func ComponentProgramBinderFromFileSystem() ComponentProgramBinder {
 				}
 
 				err = parser.ParseFile(file, fileName)
+				contract.IgnoreError(file.Close())
 				if err != nil {
 					diagnostics = diagnostics.Append(errorf(nodeRange, err.Error()))
 					return nil, diagnostics, err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Close files in PCL parser after parsing.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
