### PR TITLE
Replace non-updating filtered template counter

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -928,7 +928,7 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
 	nopts := len(options)
 	pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
-	message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", pageSize, nopts)
+	message := fmt.Sprintf("\rPlease choose a template (%d total):\n", nopts)
 	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 
 	var option string


### PR DESCRIPTION
# Description

When running `pulumi new` and choosing a template, it says _“Please choose a template (51/227 shown)”_ which is probably correct (haven’t counted), but then when I type to narrow it down, the number of shown templates never changes.

<img width="722" alt="Screenshot 2024-04-14 at 08 10 57" src="https://github.com/pulumi/pulumi/assets/12074/dc5d242b-3f48-4ab9-a3f1-c192fb5a5dd5">

This PR removes the number of templates shown from the message so it just says how many there are in total.

<img width="382" alt="Screenshot 2024-04-17 at 07 57 27" src="https://github.com/pulumi/pulumi/assets/12074/2f095374-83e3-4c69-b8ab-0425d2424982">


I did look into making the number of shown templates update correctly but couldn't find a hook in the Survey package that allows this. I also thought it's not worth much effort since [Survey is deprecated in favor of Bubbletea](https://github.com/AlecAivazis/survey?tab=readme-ov-file).

## Checklist

- [ x] I have run `make tidy` to update any new dependencies
- [ x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
_Unfortunately, I couldn't find pre-existing tests for that area of the CLI._

- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
_I'll let the engine team guide me on whether this is changelog-worthy._

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
