### PR TITLE
update dotnet SDK version in codegen tests

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.60.0"
+const PulumiDotnetSDKVersion = "3.61.0"


### PR DESCRIPTION
Since we released a new SDK we should also update the version here. Otherwise tests might end up failing as soon as a provider we're using in the tests depends on the new dotnet SDK version.

Saw https://github.com/pulumi/pulumi/pull/15955 and realized we ran into issues with this last time.