### PR TITLE
add issue template for flaky tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.yaml
+++ b/.github/ISSUE_TEMPLATE/flaky_test.yaml
@@ -1,0 +1,18 @@
+name: Flaky Test
+description: Report a test that's flaky
+labels: ["kind/flaky-test", "area/engineering"]
+body:
+  - type: textarea
+    id: test-output
+    attributes:
+      label: Test Output
+      description: Please copy paste the output of the failure of the flaky test here
+    validations:
+      required: true
+  - type: textarea
+    id: CI Link
+    attributes:
+      label: CI Link
+      description: Please provide a link to the CI job that failed
+    validations:
+      required: true


### PR DESCRIPTION
I keep reporting these, but it's kind of annoying to always add the right labels and have them kind of consistent.  Add an issue template to make reporting these flakes a little easier, which hopefully makes people more likely to open issues, and thus track the flakes.