### PR TITLE
Don't bail at preview when a protected resource needs replacement

### DIFF
--- a/changelog/pending/20240417--engine--dont-bail-at-preview-when-a-protected-resource-needs-replacement.yaml
+++ b/changelog/pending/20240417--engine--dont-bail-at-preview-when-a-protected-resource-needs-replacement.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Don't bail at preview when a protected resource needs replacement

--- a/changelog/pending/20240417--engine--dont-bail-at-preview-when-a-protected-resource-needs-replacement.yaml
+++ b/changelog/pending/20240417--engine--dont-bail-at-preview-when-a-protected-resource-needs-replacement.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: Don't bail at preview when a protected resource needs replacement
+  description: Display the entire preview with diff when a protected resource needs replacement

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -3190,7 +3190,7 @@ func TestProtect(t *testing.T) {
 		"foo": "baz",
 	})
 	_, err = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient, validate)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "step generator errored")
 
 	// Run an update which will cause a replace, we should get an error.
 	// Contrary to the preview, the error is a bail, so no resources are created.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1034,6 +1034,9 @@ func (sg *stepGenerator) generateStepsFromDiff(
 					"program and run `pulumi up`", urn)
 				sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
 				sg.sawError = true
+				// In Update mode, we bail to stop any further actions immediately.
+				// In Preview, we mark the deployment as Error but continue to next steps,
+				// so that the preview is shown to the user and they can see the diff causing it.
 				if !sg.deployment.preview {
 					return nil, result.BailErrorf(message)
 				}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1034,7 +1034,9 @@ func (sg *stepGenerator) generateStepsFromDiff(
 					"program and run `pulumi up`", urn)
 				sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
 				sg.sawError = true
-				return nil, result.BailErrorf(message)
+				if !sg.deployment.preview {
+					return nil, result.BailErrorf(message)
+				}
 			}
 
 			// If the goal state specified an ID, issue an error: the replacement will change the ID, and is

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1034,9 +1034,11 @@ func (sg *stepGenerator) generateStepsFromDiff(
 					"program and run `pulumi up`", urn)
 				sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
 				sg.sawError = true
-				// In Update mode, we bail to stop any further actions immediately.
 				// In Preview, we mark the deployment as Error but continue to next steps,
 				// so that the preview is shown to the user and they can see the diff causing it.
+				// In Update mode, we bail to stop any further actions immediately. If we don't bail and
+				// we're doing a create before delete replacement we'll execute the create before getting
+				// to the delete error.
 				if !sg.deployment.preview {
 					return nil, result.BailErrorf(message)
 				}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Don't bail at preview when a protected resource needs replacement, just error. This makes sure that users can see the actual diff that causes the replacement.

Fixes #5027

Before:

```
$ pulumi preview
Type                                     Name                  Plan     Info
     pulumi:pulumi:Stack                      azure-native-ts-dev2           
     └─ azure-native:resources:ResourceGroup  rg                             1 error

Diagnostics:
  azure-native:resources:ResourceGroup (rg):
    error: unable to replace resource "urn:pulumi:dev2::azure-native-ts::azure-native:resources:ResourceGroup::rg"
    as it is currently marked for protection. To unprotect the resource, remove the `protect` flag from the resource in your Pulumi program and run `pulumi up`


$ pulumi preview --diff
pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:dev2::azure-native-ts::pulumi:pulumi:Stack::azure-native-ts-dev2]
error: unable to replace resource "urn:pulumi:dev2::azure-native-ts::azure-native:resources:ResourceGroup::rg"
as it is currently marked for protection. To unprotect the resource, remove the `protect` flag from the resource in your Pulumi program and run `pulumi up`
Resources:
    1 unchanged
```

After:

```
$ pulumi preview
Type                                     Name                  Plan        Info
     pulumi:pulumi:Stack                      azure-native-ts-dev2              1 error; 2 warnings
 +-  └─ azure-native:resources:ResourceGroup  rg                    replace     [diff: ~location]; 1 error

Diagnostics:
  azure-native:resources:ResourceGroup (rg):
    error: unable to replace resource "urn:pulumi:dev2::azure-native-ts::azure-native:resources:ResourceGroup::rg"
    as it is currently marked for protection. To unprotect the resource, remove the `protect` flag from the resource in your Pulumi program and run `pulumi up`

  pulumi:pulumi:Stack (azure-native-ts-dev2):
    error: preview failed


$ pulumi preview --diff
pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:dev2::azure-native-ts::pulumi:pulumi:Stack::azure-native-ts-dev2]
error: unable to replace resource "urn:pulumi:dev2::azure-native-ts::azure-native:resources:ResourceGroup::rg"
as it is currently marked for protection. To unprotect the resource, remove the `protect` flag from the resource in your Pulumi program and run `pulumi up`
    +-azure-native:resources:ResourceGroup: (replace) 🔒
        [id=/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/rg5f8e30e4]
        [urn=urn:pulumi:dev2::azure-native-ts::azure-native:resources:ResourceGroup::rg]
        [provider=urn:pulumi:dev2::azure-native-ts::pulumi:providers:azure-native::default_2_30_0::3c957b2a-4852-439c-b211-22a115bbe89a]
      ~ location: "westeurope" => "westus2"
error: preview failed
Resources:
    +-1 to replace
    1 unchanged
```

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
