### PR TITLE
Allow setting version during generation

### DIFF
--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -84,7 +84,7 @@ func newGenSdkCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&out, "out", "o", "./sdk",
 		"The directory to write the SDK to")
 	cmd.Flags().StringVar(&overlays, "overlays", "", "A folder of extra overlay files to copy to the generated SDK")
-	cmd.Flags().StringVarP(&version, "version", "v", "", "The provider plugin version to generate the SDK for")
+	cmd.Flags().StringVar(&version, "version", "", "The provider plugin version to generate the SDK for")
 	contract.AssertNoErrorf(cmd.Flags().MarkHidden("overlays"), `Could not mark "overlay" as hidden`)
 	return cmd
 }

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -48,6 +49,7 @@ func newGenSdkCommand() *cobra.Command {
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			source := args[0]
 
+			d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
 			pkg, err := schemaFromSchemaSource(source)
 			if err != nil {
 				return err
@@ -56,6 +58,9 @@ func newGenSdkCommand() *cobra.Command {
 				pkgVersion, err := semver.Parse(version)
 				if err != nil {
 					return fmt.Errorf("invalid version %q: %w", version, err)
+				}
+				if pkg.Version != nil {
+					d.Infof(diag.Message("", "overriding package version %s with %s"), pkg.Version, pkgVersion)
 				}
 				pkg.Version = &pkgVersion
 			}

--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 
 	javagen "github.com/pulumi/pulumi-java/pkg/codegen/java"
@@ -36,6 +37,7 @@ func newGenSdkCommand() *cobra.Command {
 	var overlays string
 	var language string
 	var out string
+	var version string
 	cmd := &cobra.Command{
 		Use:   "gen-sdk <schema_source>",
 		Args:  cobra.ExactArgs(1),
@@ -49,6 +51,13 @@ func newGenSdkCommand() *cobra.Command {
 			pkg, err := schemaFromSchemaSource(source)
 			if err != nil {
 				return err
+			}
+			if version != "" {
+				pkgVersion, err := semver.Parse(version)
+				if err != nil {
+					return fmt.Errorf("invalid version %q: %w", version, err)
+				}
+				pkg.Version = &pkgVersion
 			}
 			// Normalize from well known language names the the matching runtime names.
 			switch language {
@@ -75,6 +84,7 @@ func newGenSdkCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&out, "out", "o", "./sdk",
 		"The directory to write the SDK to")
 	cmd.Flags().StringVar(&overlays, "overlays", "", "A folder of extra overlay files to copy to the generated SDK")
+	cmd.Flags().StringVarP(&version, "version", "v", "", "The provider plugin version to generate the SDK for")
 	contract.AssertNoErrorf(cmd.Flags().MarkHidden("overlays"), `Could not mark "overlay" as hidden`)
 	return cmd
 }


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Some schemas can't contain the correct version as they need to be committed. Therefore allow the option to set the version in the schema at the point of generation.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
- [ ] I have added tests that prove my fix is effective or that my feature works
  - There appears to be no existing tests for this command.
- No changelog required as this is still a hidden command for internal use.