### PR TITLE
Emit imports for input types from external packages

### DIFF
--- a/changelog/pending/20240417--programgen-python--emit-imports-for-input-types-from-external-packages.yaml
+++ b/changelog/pending/20240417--programgen-python--emit-imports-for-input-types-from-external-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Emit imports for input types from external packages

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -422,6 +422,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Tests whether using inline invoke expressions works",
 		SkipCompile: codegen.NewStringSet("go"),
 	},
+	{
+		Directory:   "python-import-external-type",
+		Description: "Tests importing external types in python",
+		Skip:        allProgLanguages.Except("python"),
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -95,5 +95,6 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"plain-properties", "1.0.0"},
 		SchemaProvider{"recursive", "1.0.0"},
 		SchemaProvider{"aws-static-website", "0.4.0"},
+		SchemaProvider{"external-type-ref", "1.0.0"},
 	)
 }

--- a/tests/testdata/codegen/aws-static-website-pp/python/aws-static-website.py
+++ b/tests/testdata/codegen/aws-static-website-pp/python/aws-static-website.py
@@ -1,4 +1,5 @@
 import pulumi
+import pulumi_aws as aws
 import pulumi_aws_static_website as aws_static_website
 
 website_resource = aws_static_website.Website("websiteResource",

--- a/tests/testdata/codegen/external-type-ref-1.0.0.json
+++ b/tests/testdata/codegen/external-type-ref-1.0.0.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "external-type-ref",
+  "version": "1.0.0",
+  "resources": {
+    "external-type-ref:index:ExampleComponent": {
+      "isComponent": true,
+      "inputProperties": {
+        "externalInput": {
+          "type": "object",
+          "$ref": "/aws/v5.4.0/schema.json#/types/aws:s3/BucketWebsite:BucketWebsite"
+        }
+      }
+    }
+  },
+  "language": {
+    "python": {
+      "requires": {
+        "pulumi": ">=3.0.0,<4.0.0",
+        "pulumi-aws": ">=5.3.0,<6.0.0"
+      }
+    }
+  }
+}

--- a/tests/testdata/codegen/python-import-external-type-pp/python-import-external-type.pp
+++ b/tests/testdata/codegen/python-import-external-type-pp/python-import-external-type.pp
@@ -1,0 +1,5 @@
+resource "main" "external-type-ref:index:ExampleComponent" {
+    externalInput = {
+		indexDocument = "index.html"
+	}
+}

--- a/tests/testdata/codegen/python-import-external-type-pp/python/python-import-external-type.py
+++ b/tests/testdata/codegen/python-import-external-type-pp/python/python-import-external-type.py
@@ -1,0 +1,7 @@
+import pulumi
+import pulumi_aws as aws
+import pulumi_external_type_ref as external_type_ref
+
+main = external_type_ref.ExampleComponent("main", external_input=aws.s3.BucketWebsiteArgs(
+    index_document="index.html",
+))

--- a/tests/testdata/codegen/transpiled_examples/aws-eks-pp/python/aws-eks.py
+++ b/tests/testdata/codegen/transpiled_examples/aws-eks-pp/python/aws-eks.py
@@ -1,6 +1,7 @@
 import pulumi
 import pulumi_aws as aws
 import pulumi_eks as eks
+import pulumi_kubernetes as kubernetes
 
 vpc_id = aws.ec2.get_vpc(default=True).id
 subnet_ids = aws.ec2.get_subnet_ids(vpc_id=vpc_id).ids

--- a/tests/testdata/codegen/transpiled_examples/cue-eks-pp/python/cue-eks.py
+++ b/tests/testdata/codegen/transpiled_examples/cue-eks-pp/python/cue-eks.py
@@ -1,5 +1,7 @@
 import pulumi
+import pulumi_aws as aws
 import pulumi_eks as eks
+import pulumi_kubernetes as kubernetes
 
 rawkode = eks.Cluster("rawkode",
     instance_type="t2.medium",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

In program gen, we need to add imports for external packages that are used as input types.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
