### PR TITLE
upgrade to latest version of golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -38,12 +38,12 @@ jobs:
       # and maintain the cache,
       # but we want to run the command ourselves.
       # The action doesn't have an install-only mode,
-      # so we'll ask it to print its version only.
+      # so we'll ask it to print its help output instead.
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --version
+          args: --help
 
       - name: Run golangci-lint
         # Print GitHub Actions-friendly output so that errors get marked

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.55.2
+  GOLANGCI_LINT_VERSION: v1.57.2
 
 jobs:
   golangci:

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	b64 "encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -234,7 +235,7 @@ func (h *testHost) ListAnalyzers() []plugin.Analyzer {
 func (h *testHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
 	// Look in the providers map for this provider
 	if version == nil {
-		return nil, fmt.Errorf("unexpected provider request with no version")
+		return nil, errors.New("unexpected provider request with no version")
 	}
 
 	key := fmt.Sprintf("%s@%s", pkg, version)
@@ -335,16 +336,16 @@ func (eng *languageTestServer) PrepareLanguageTests(
 	req *testingrpc.PrepareLanguageTestsRequest,
 ) (*testingrpc.PrepareLanguageTestsResponse, error) {
 	if req.LanguagePluginName == "" {
-		return nil, fmt.Errorf("language plugin name must be specified")
+		return nil, errors.New("language plugin name must be specified")
 	}
 	if req.LanguagePluginTarget == "" {
-		return nil, fmt.Errorf("language plugin target must be specified")
+		return nil, errors.New("language plugin target must be specified")
 	}
 	if req.SnapshotDirectory == "" {
-		return nil, fmt.Errorf("snapshot directory must be specified")
+		return nil, errors.New("snapshot directory must be specified")
 	}
 	if req.TemporaryDirectory == "" {
-		return nil, fmt.Errorf("temporary directory must be specified")
+		return nil, errors.New("temporary directory must be specified")
 	}
 
 	err := os.MkdirAll(req.SnapshotDirectory, 0o755)
@@ -775,7 +776,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			return nil, fmt.Errorf("program snapshot validation: %w", err)
 		}
 		if len(validations) > 0 {
-			return makeTestResponse(fmt.Sprintf("program snapshot validation failed:\n%s", strings.Join(validations, "\n"))), nil
+			return makeTestResponse("program snapshot validation failed:\n" + strings.Join(validations, "\n")), nil
 		}
 		// If we made a snapshot edit we can clean it up now
 		if projectDirSnapshot != projectDir {
@@ -854,7 +855,7 @@ func (eng *languageTestServer) RunLanguageTest(
 			}
 
 			if found == nil {
-				return makeTestResponse(fmt.Sprintf("missing expected dependency %s", expectedDependency.Name)), nil
+				return makeTestResponse("missing expected dependency " + expectedDependency.Name), nil
 			} else if expectedDependency.Version != *found {
 				return makeTestResponse(fmt.Sprintf("dependency %s has unexpected version %s, expected %s",
 					expectedDependency.Name, *found, expectedDependency.Version)), nil

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +56,7 @@ func (h *L1EmptyLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReque
 	}
 
 	if h.failPack {
-		return nil, fmt.Errorf("boom")
+		return nil, errors.New("boom")
 	}
 
 	return &pulumirpc.PackResponse{
@@ -70,7 +71,7 @@ func (h *L1EmptyLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
 	}
 	if !req.Strict {
-		return nil, fmt.Errorf("expected strict to be true")
+		return nil, errors.New("expected strict to be true")
 	}
 	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
 		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)

--- a/cmd/pulumi-test-language/l1main_test.go
+++ b/cmd/pulumi-test-language/l1main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -63,7 +64,7 @@ func (h *L1MainLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
 	}
 	if !req.Strict {
-		return nil, fmt.Errorf("expected strict to be true")
+		return nil, errors.New("expected strict to be true")
 	}
 	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-main") {
 		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)

--- a/cmd/pulumi-test-language/l2destroy_test.go
+++ b/cmd/pulumi-test-language/l2destroy_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,7 +79,7 @@ func (h *L2DestroyLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("unexpected simple sdk %s", req.LocalDependencies["simple"])
 	}
 	if !req.Strict {
-		return nil, fmt.Errorf("expected strict to be true")
+		return nil, errors.New("expected strict to be true")
 	}
 	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l2-destroy", strconv.Itoa(h.currentRun)) {
 		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,7 +76,7 @@ func (h *L2ResourceSimpleLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("unexpected simple sdk %s", req.LocalDependencies["simple"])
 	}
 	if !req.Strict {
-		return nil, fmt.Errorf("expected strict to be true")
+		return nil, errors.New("expected strict to be true")
 	}
 	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l2-resource-simple") {
 		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func (h *RuntimeOptionsLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("unexpected core sdk %s", req.LocalDependencies["pulumi"])
 	}
 	if !req.Strict {
-		return nil, fmt.Errorf("expected strict to be true")
+		return nil, errors.New("expected strict to be true")
 	}
 	if req.TargetDirectory != filepath.Join(h.tempDir, "projects", "l1-empty") {
 		return nil, fmt.Errorf("unexpected target directory %s", req.TargetDirectory)

--- a/pkg/cmd/pulumi/new_ai.go
+++ b/pkg/cmd/pulumi/new_ai.go
@@ -153,7 +153,7 @@ func sendPromptToPulumiAI(
 	}
 	conversationID = res.Header.Get("x-conversation-id")
 	connectionID = res.Header.Get("x-connection-id")
-	projectURL := parsedURL.JoinPath("api", "project", url.PathEscape(fmt.Sprintf("%s.zip", conversationID))).String()
+	projectURL := parsedURL.JoinPath("api", "project", url.PathEscape(conversationID+".zip")).String()
 	conversationURL := parsedURL.JoinPath("conversations", conversationID).String()
 	fmt.Println("View this conversation at: ", conversationURL)
 	return projectURL, connectionID, conversationID, nil

--- a/pkg/cmd/pulumi/state_edit.go
+++ b/pkg/cmd/pulumi/state_edit.go
@@ -208,7 +208,7 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 	}
 }
 
-var errNoStateChange = fmt.Errorf("No state change")
+var errNoStateChange = errors.New("No state change")
 
 func (cmd *stateEditCmd) validateAndPrintState(ctx context.Context, f *snapshotBuffer) (*deploy.Snapshot, error) {
 	contract.Requiref(ctx != nil, "ctx", "must not be nil")

--- a/pkg/codegen/docs/constructor_syntax_extractor.go
+++ b/pkg/codegen/docs/constructor_syntax_extractor.go
@@ -15,7 +15,6 @@
 package docs
 
 import (
-	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -36,7 +35,7 @@ func extractConstructorSyntaxExamples(
 
 	for _, line := range strings.Split(program, "\n") {
 		line = strings.TrimPrefix(line, indentToTrim)
-		if strings.HasPrefix(line, fmt.Sprintf("%s Resource", commentDelimiter)) {
+		if strings.HasPrefix(line, commentDelimiter+" Resource") {
 			currentExample = ""
 			readingResource = true
 			readingInvoke = false
@@ -45,7 +44,7 @@ func extractConstructorSyntaxExamples(
 			continue
 		}
 
-		if strings.HasPrefix(line, fmt.Sprintf("%s Invoke", commentDelimiter)) {
+		if strings.HasPrefix(line, commentDelimiter+" Invoke") {
 			currentExample = ""
 			readingInvoke = true
 			readingResource = false

--- a/pkg/codegen/docs/constructor_syntax_generator.go
+++ b/pkg/codegen/docs/constructor_syntax_generator.go
@@ -302,7 +302,7 @@ func (g *constructorSyntaxGenerator) generateAll(schema *schema.Package, opts ge
 
 			resourceCode := g.exampleResourceWithName(r, func(resourceToken string) string {
 				pkg, modName, memberName, _ := pcl.DecomposeToken(resourceToken, hcl.Range{})
-				resourceName := fmt.Sprintf("%sResource", camelCase(memberName))
+				resourceName := camelCase(memberName) + "Resource"
 				if !seenNames.Has(resourceName) {
 					seenNames.Add(resourceName)
 					return resourceName
@@ -320,7 +320,7 @@ func (g *constructorSyntaxGenerator) generateAll(schema *schema.Package, opts ge
 				return resourceNameWithModule
 			})
 
-			buffer.WriteString(fmt.Sprintf("// Resource %s", r.Token))
+			buffer.WriteString("// Resource " + r.Token)
 			buffer.WriteString("\n")
 			buffer.WriteString(resourceCode)
 			buffer.WriteString("\n")
@@ -340,7 +340,7 @@ func (g *constructorSyntaxGenerator) generateAll(schema *schema.Package, opts ge
 					return memberName
 				}
 
-				functionName := fmt.Sprintf("%sResult", memberName)
+				functionName := memberName + "Result"
 				if !seenNames.Has(functionName) {
 					seenNames.Add(functionName)
 					return functionName
@@ -360,7 +360,7 @@ func (g *constructorSyntaxGenerator) generateAll(schema *schema.Package, opts ge
 				return functionNameWithMod
 			})
 
-			buffer.WriteString(fmt.Sprintf("// Invoking %s", f.Token))
+			buffer.WriteString("// Invoking " + f.Token)
 			buffer.WriteString("\n")
 			buffer.WriteString(functionCode)
 			buffer.WriteString("\n")

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1202,7 +1202,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(properties []*schema.
 		// in another package and link there.
 		if isExt := isExternalType(codegen.UnwrapType(prop.Type), mod.pkg); isExt {
 			packageName := tokenToPackageName(fmt.Sprintf("%v", codegen.UnwrapType(prop.Type)))
-			extPkgLink := fmt.Sprintf("/registry/packages/%s", packageName)
+			extPkgLink := "/registry/packages/" + packageName
 			comment += fmt.Sprintf("\nThis type is defined in the [%s](%s) package.", getPackageDisplayName(packageName), extPkgLink)
 		}
 

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1148,7 +1148,7 @@ func (pkg *pkgContext) genEnumInputInterface(w io.Writer, name string, enumType 
 			// skip deprecated enum cases
 			continue
 		}
-		enumCases = append(enumCases, fmt.Sprintf("\t\t%s", enumCase.Name))
+		enumCases = append(enumCases, "\t\t"+enumCase.Name)
 	}
 
 	enumUsage := strings.Join([]string{

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -2,7 +2,6 @@ package gen
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -223,7 +222,7 @@ func TestNotYetImplementedEmittedWhenGeneratingFunctions(t *testing.T) {
 			Name: fn,
 		})
 
-		assert.Contains(t, content.String(), fmt.Sprintf("call %s", fn))
+		assert.Contains(t, content.String(), "call "+fn)
 	}
 }
 

--- a/pkg/engine/lifecycletest/test_plan.go
+++ b/pkg/engine/lifecycletest/test_plan.go
@@ -38,16 +38,16 @@ func snapshotEqual(journal, manager *deploy.Snapshot) error {
 		return nil
 	}
 	if journal == nil {
-		return fmt.Errorf("journal snapshot is nil")
+		return errors.New("journal snapshot is nil")
 	}
 	if manager == nil {
-		return fmt.Errorf("manager snapshot is nil")
+		return errors.New("manager snapshot is nil")
 	}
 
 	// Manifests and SecretsManagers are known to differ because we don't thread them through for the Journal code.
 
 	if len(journal.PendingOperations) != len(manager.PendingOperations) {
-		return fmt.Errorf("journal and manager pending operations differ")
+		return errors.New("journal and manager pending operations differ")
 	}
 
 	for _, jop := range journal.PendingOperations {
@@ -64,7 +64,7 @@ func snapshotEqual(journal, manager *deploy.Snapshot) error {
 	}
 
 	if len(journal.Resources) != len(manager.Resources) {
-		return fmt.Errorf("journal and manager resources differ")
+		return errors.New("journal and manager resources differ")
 	}
 
 	for _, jr := range journal.Resources {

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -16,7 +16,7 @@ package deploytest
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
@@ -230,7 +230,7 @@ func (prov *Provider) StreamInvoke(
 	onNext func(resource.PropertyMap) error,
 ) ([]plugin.CheckFailure, error) {
 	if prov.StreamInvokeF == nil {
-		return []plugin.CheckFailure{}, fmt.Errorf("StreamInvoke unimplemented")
+		return []plugin.CheckFailure{}, errors.New("StreamInvoke unimplemented")
 	}
 	return prov.StreamInvokeF(tok, args, onNext)
 }

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -17,7 +17,6 @@ package deploy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/blang/semver"
@@ -55,7 +54,7 @@ func TestImportDeployment(t *testing.T) {
 				Decrypter: &decrypterMock{
 					DecryptValueF: func(ctx context.Context, ciphertext string) (string, error) {
 						decrypterCalled = true
-						return "", fmt.Errorf("expected fail")
+						return "", errors.New("expected fail")
 					},
 				},
 			}, "projectName", nil, true)

--- a/pkg/resource/deploy/target_test.go
+++ b/pkg/resource/deploy/target_test.go
@@ -16,7 +16,7 @@ package deploy
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -32,7 +32,7 @@ func TestTarget(t *testing.T) {
 			t.Parallel()
 			t.Run("secret in namespace", func(t *testing.T) {
 				t.Parallel()
-				expectedErr := fmt.Errorf("expected error")
+				expectedErr := errors.New("expected error")
 				target := &Target{
 					Config: config.Map{
 						config.MustMakeKey("test", "secret"):  config.NewSecureValue("secret-value"),
@@ -62,7 +62,7 @@ func TestTarget(t *testing.T) {
 			})
 		})
 		t.Run("ok", func(t *testing.T) {
-			expectedErr := fmt.Errorf("expected error")
+			expectedErr := errors.New("expected error")
 			target := &Target{
 				Config: config.Map{
 					config.MustMakeKey("a", "val"):        config.NewValue("a-value"),

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -53,7 +53,7 @@ func RunCommandPulumiHome(
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
 	if pulumiHome != "" {
-		env = append(env, fmt.Sprintf("PULUMI_HOME=%s", pulumiHome))
+		env = append(env, "PULUMI_HOME="+pulumiHome)
 	}
 
 	cmd := exec.Cmd{

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -332,9 +332,9 @@ func fixupPath(env []string, pulumiBin string) []string {
 		if oldPath != "" {
 			pathEntry = pulumiBin + string(os.PathListSeparator) + oldPath
 		}
-		newEnv[pathIndex] = fmt.Sprintf("PATH=%s", pathEntry)
+		newEnv[pathIndex] = "PATH=" + pathEntry
 	} else {
-		newEnv = append(newEnv, fmt.Sprintf("PATH=%s", pulumiBin))
+		newEnv = append(newEnv, "PATH="+pulumiBin)
 	}
 	return newEnv
 }

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -139,7 +139,7 @@ func (l *LocalWorkspace) PostCommandCallback(ctx context.Context, stackName stri
 func (l *LocalWorkspace) AddEnvironments(ctx context.Context, stackName string, envs ...string) error {
 	// 3.95 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.95.0)
 	if l.pulumiCommand.Version().LT(semver.Version{Major: 3, Minor: 95}) {
-		return fmt.Errorf("AddEnvironments requires Pulumi CLI version >= 3.95.0")
+		return errors.New("AddEnvironments requires Pulumi CLI version >= 3.95.0")
 	}
 	args := []string{"config", "env", "add"}
 	args = append(args, envs...)
@@ -155,7 +155,7 @@ func (l *LocalWorkspace) AddEnvironments(ctx context.Context, stackName string, 
 func (l *LocalWorkspace) ListEnvironments(ctx context.Context, stackName string) ([]string, error) {
 	// 3.99 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.99.0)
 	if l.pulumiCommand.Version().LT(semver.Version{Major: 3, Minor: 99}) {
-		return nil, fmt.Errorf("ListEnvironments requires Pulumi CLI version >= 3.99.0")
+		return nil, errors.New("ListEnvironments requires Pulumi CLI version >= 3.99.0")
 	}
 	args := []string{"config", "env", "ls", "--stack", stackName, "--json"}
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -174,7 +174,7 @@ func (l *LocalWorkspace) ListEnvironments(ctx context.Context, stackName string)
 func (l *LocalWorkspace) RemoveEnvironment(ctx context.Context, stackName string, env string) error {
 	// 3.95 added this command (https://github.com/pulumi/pulumi/releases/tag/v3.95.0)
 	if l.pulumiCommand.Version().LT(semver.Version{Major: 3, Minor: 95}) {
-		return fmt.Errorf("RemoveEnvironments requires Pulumi CLI version >= 3.95.0")
+		return errors.New("RemoveEnvironments requires Pulumi CLI version >= 3.95.0")
 	}
 	args := []string{"config", "env", "rm", env, "--yes", "--stack", stackName}
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
@@ -527,7 +527,7 @@ func (l *LocalWorkspace) ChangeStackSecretsProvider(
 	var reader io.Reader
 	if newSecretsProvider == "passphrase" {
 		if opts == nil || opts.NewPassphrase == nil {
-			return fmt.Errorf("new passphrase must be provided")
+			return errors.New("new passphrase must be provided")
 		}
 		reader = strings.NewReader(*opts.NewPassphrase)
 	}

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -475,7 +475,7 @@ func (s *Stack) PreviewRefresh(ctx context.Context, opts ...optrefresh.Option) (
 
 	// 3.105.0 added this flag (https://github.com/pulumi/pulumi/releases/tag/v3.105.0)
 	if s.Workspace().PulumiCommand().Version().LT(semver.Version{Major: 3, Minor: 105}) {
-		return res, fmt.Errorf("PreviewRefresh requires Pulumi CLI version >= 3.105.0")
+		return res, errors.New("PreviewRefresh requires Pulumi CLI version >= 3.105.0")
 	}
 
 	refreshOpts := &optrefresh.Options{}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -408,7 +408,7 @@ func goListModules(ctx context.Context, gobin, dir string, modulePaths []string)
 	args = append(args, modulePaths...)
 
 	span, ctx := opentracing.StartSpanFromContext(ctx,
-		fmt.Sprintf("%s list -m json", gobin),
+		gobin+" list -m json",
 		opentracing.Tag{Key: "component", Value: "exec.Command"},
 		opentracing.Tag{Key: "command", Value: gobin},
 		opentracing.Tag{Key: "args", Value: args})
@@ -451,7 +451,7 @@ func goModDownload(ctx context.Context, gobin, dir string, modulePaths []string)
 	args = append(args, modulePaths...)
 
 	span, ctx := opentracing.StartSpanFromContext(ctx,
-		fmt.Sprintf("%s mod download -json", gobin),
+		gobin+" mod download -json",
 		opentracing.Tag{Key: "component", Value: "exec.Command"},
 		opentracing.Tag{Key: "command", Value: gobin},
 		opentracing.Tag{Key: "args", Value: args})
@@ -1060,7 +1060,7 @@ func (host *goLanguageHost) GenerateProject(
 		}, nil
 	}
 	if program == nil {
-		return nil, fmt.Errorf("internal error: program was nil")
+		return nil, errors.New("internal error: program was nil")
 	}
 
 	var project workspace.Project
@@ -1111,7 +1111,7 @@ func (host *goLanguageHost) GenerateProgram(
 		}, nil
 	}
 	if program == nil {
-		return nil, fmt.Errorf("internal error: program was nil")
+		return nil, errors.New("internal error: program was nil")
 	}
 
 	files, diags, err := codegen.GenerateProgram(program)

--- a/sdk/go/pulumi/callback.go
+++ b/sdk/go/pulumi/callback.go
@@ -15,6 +15,7 @@
 package pulumi
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -76,7 +77,7 @@ func (s *callbackServer) Invoke(
 ) (*pulumirpc.CallbackInvokeResponse, error) {
 	function, ok := s.functions[req.Token]
 	if !ok {
-		return nil, fmt.Errorf("callback function not found")
+		return nil, errors.New("callback function not found")
 	}
 
 	resp, err := function(ctx, req.Request)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -296,7 +296,7 @@ func (ctx *Context) IsConfigSecret(key string) bool {
 // registerTransform starts up a callback server if not already running and registers the given transform.
 func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback, error) {
 	if !ctx.state.supportsTransforms {
-		return nil, fmt.Errorf("the Pulumi CLI does not support transforms. Please update the Pulumi CLI")
+		return nil, errors.New("the Pulumi CLI does not support transforms. Please update the Pulumi CLI")
 	}
 
 	// Wrap the transform in a callback function.
@@ -434,7 +434,7 @@ func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback
 			// It's an error to try and change the parent and the engine doesn't even let you send it back so
 			// sanity check that here.
 			if opts.Parent != parent {
-				return nil, fmt.Errorf("cannot change parent in transform")
+				return nil, errors.New("cannot change parent in transform")
 			}
 
 			rpcRes.Options = &pulumirpc.TransformResourceOptions{

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -193,7 +193,7 @@ func TestLanguage(t *testing.T) {
 				},
 				{
 					Path:        "package\\.json",
-					Pattern:     fmt.Sprintf("%s/artifacts", rootDir),
+					Pattern:     rootDir + "/artifacts",
 					Replacement: "ROOT/artifacts",
 				},
 			},

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -487,7 +487,7 @@ func getPluginVersion(info packageJSON) (string, error) {
 		}
 	}
 	if strings.IndexRune(version, 'v') != 0 {
-		return fmt.Sprintf("v%s", version), nil
+		return "v" + version, nil
 	}
 	return version, nil
 }
@@ -1163,7 +1163,7 @@ func (host *nodeLanguageHost) GenerateProgram(
 		}, nil
 	}
 	if program == nil {
-		return nil, fmt.Errorf("internal error program was nil")
+		return nil, errors.New("internal error program was nil")
 	}
 
 	files, diags, err := codegen.GenerateProgram(program)

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -195,7 +195,7 @@ func TestLanguage(t *testing.T) {
 				},
 				{
 					Path:        "requirements\\.txt",
-					Pattern:     fmt.Sprintf("%s/artifacts", rootDir),
+					Pattern:     rootDir + "/artifacts",
 					Replacement: "ROOT/artifacts",
 				},
 			},

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -594,7 +594,7 @@ func determinePluginDependency(
 	}
 	if !strings.HasPrefix(version, "v") {
 		// Add "v" prefix if not already present.
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	result := &pulumirpc.PluginDependency{
@@ -632,7 +632,7 @@ func determinePluginDependency(
 // Reference on PEP440: https://www.python.org/dev/peps/pep-0440/
 func determinePluginVersion(packageVersion string) (string, error) {
 	if len(packageVersion) == 0 {
-		return "", fmt.Errorf("cannot parse empty string")
+		return "", errors.New("cannot parse empty string")
 	}
 	// Verify ASCII
 	for i := 0; i < len(packageVersion); i++ {
@@ -655,7 +655,7 @@ func determinePluginVersion(packageVersion string) (string, error) {
 
 	// Explicitly err on epochs
 	if num, maybeEpoch := parseNumber(packageVersion); num != "" && strings.HasPrefix(maybeEpoch, "!") {
-		return "", fmt.Errorf("epochs are not supported")
+		return "", errors.New("epochs are not supported")
 	}
 
 	segments := []string{}
@@ -1251,7 +1251,7 @@ func (host *pythonLanguageHost) GenerateProgram(
 		}, nil
 	}
 	if program == nil {
-		return nil, fmt.Errorf("internal error program was nil")
+		return nil, errors.New("internal error program was nil")
 	}
 
 	files, diags, err := codegen.GenerateProgram(program)

--- a/tests/integration/integration_go_acceptance_test.go
+++ b/tests/integration/integration_go_acceptance_test.go
@@ -191,7 +191,7 @@ func TestConstructComponentConfigureProviderGo(t *testing.T) {
 	opts = opts.With(integration.ProgramTestOptions{
 		Dir: filepath.Join(testDir, "go"),
 		Dependencies: []string{
-			fmt.Sprintf("github.com/pulumi/pulumi/sdk/v3=%s", pulumiGoSDK),
+			"github.com/pulumi/pulumi/sdk/v3=" + pulumiGoSDK,
 			fmt.Sprintf("%s=%s", sdkPkg, componentSDK),
 		},
 		NoParallel: true,

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -19,7 +19,6 @@ package ints
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -859,7 +858,7 @@ func TestTracePropagationGo(t *testing.T) {
 		SkipExportImport:       true,
 		SkipEmptyPreviewUpdate: true,
 		Quick:                  false,
-		Tracing:                fmt.Sprintf("file:%s", filepath.Join(dir, "{command}.trace")),
+		Tracing:                "file:" + filepath.Join(dir, "{command}.trace"),
 		RequireService:         true,
 		NoParallel:             true,
 	}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -878,7 +878,7 @@ func TestCloudSecretProvider(t *testing.T) {
 	testOptions := integration.ProgramTestOptions{
 		Dir:             "cloud_secrets_provider",
 		Dependencies:    []string{"@pulumi/pulumi"},
-		SecretsProvider: fmt.Sprintf("awskms://alias/%s", awsKmsKeyAlias),
+		SecretsProvider: "awskms://alias/" + awsKmsKeyAlias,
 		Secrets: map[string]string{
 			"mysecret": "THISISASECRET",
 		},
@@ -903,11 +903,11 @@ func TestCloudSecretProvider(t *testing.T) {
 	})
 
 	azureTestOptions := testOptions.With(integration.ProgramTestOptions{
-		SecretsProvider: fmt.Sprintf("azurekeyvault://%s", azureKeyVault),
+		SecretsProvider: "azurekeyvault://" + azureKeyVault,
 	})
 
 	gcpTestOptions := testOptions.With(integration.ProgramTestOptions{
-		SecretsProvider: fmt.Sprintf("gcpkms://projects/%s", gcpKmsKey),
+		SecretsProvider: "gcpkms://projects/" + gcpKmsKey,
 	})
 
 	// Run with default Pulumi service backend

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -17,7 +17,6 @@
 package ints
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -247,7 +246,7 @@ func TestAutomaticVenvCreation(t *testing.T) {
 		}
 		newYaml := []byte(strings.ReplaceAll(string(oldYaml),
 			"virtualenv: venv",
-			fmt.Sprintf("virtualenv: >-\n      %s", venvPath)))
+			"virtualenv: >-\n      "+venvPath))
 
 		if err := os.WriteFile(pulumiYaml, newYaml, 0o600); err != nil {
 			t.Error(err)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -459,7 +459,7 @@ func TestPython3NotInstalled(t *testing.T) {
 			// Note: we use PULUMI_PYTHON_CMD to override the default behavior of searching
 			// for Python 3, since anyone running tests surely already has Python 3 installed on their
 			// machine. The code paths are functionally the same.
-			fmt.Sprintf("PULUMI_PYTHON_CMD=%s", badPython),
+			"PULUMI_PYTHON_CMD=" + badPython,
 		},
 		ExpectFailure: true,
 		Stderr:        stderr,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -459,7 +459,7 @@ func TestConfigPaths(t *testing.T) {
 			args = append(args, "--path")
 		}
 		stdout, stderr := e.RunCommand("pulumi", args...)
-		assert.Equal(t, fmt.Sprintf("%s\n", value), stdout)
+		assert.Equal(t, value+"\n", stdout)
 		assert.Equal(t, "", stderr)
 	}
 

--- a/tests/roundtrip_test.go
+++ b/tests/roundtrip_test.go
@@ -16,7 +16,6 @@
 package tests
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,7 +65,7 @@ resources:
 `
 
 	integration.CreatePulumiRepo(e, pulumiProject)
-	projFilename := filepath.Join(e.CWD, fmt.Sprintf("%s.yaml", workspace.ProjectFile))
+	projFilename := filepath.Join(e.CWD, workspace.ProjectFile+".yaml")
 	// TODO: Replace this with config set --project after implemented.
 	proj, err := workspace.LoadProject(projFilename)
 	require.NoError(t, err)
@@ -131,7 +130,7 @@ runtime: yaml
 	e.SetBackend(e.LocalURL())
 	e.RunCommand("pulumi", "stack", "init", "test")
 	e.Passphrase = "TestConfigRoundtripComments"
-	configFilename := filepath.Join(e.CWD, fmt.Sprintf("%s.test.yaml", workspace.ProjectFile))
+	configFilename := filepath.Join(e.CWD, workspace.ProjectFile+".test.yaml")
 
 	err := os.WriteFile(configFilename, []byte(`
 encryptionsalt: v1:ThS5UPxP9qc=:v1:UZYAXF+ylaJ0rGhv:9OTvBnOEDFgxs7btjzSu+LZ470vLpg==

--- a/tests/testprovider/echo.go
+++ b/tests/testprovider/echo.go
@@ -18,7 +18,8 @@ package main
 
 import (
 	"context"
-	"fmt"
+
+	"strconv"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -107,7 +108,7 @@ func (p *echoResourceProvider) Create(ctx context.Context, req *rpc.CreateReques
 
 	p.id++
 	return &rpc.CreateResponse{
-		Id:         fmt.Sprintf("%v", p.id),
+		Id:         strconv.Itoa(p.id),
 		Properties: outputProperties,
 	}, nil
 }

--- a/tests/testprovider/fails_on_delete.go
+++ b/tests/testprovider/fails_on_delete.go
@@ -19,7 +19,8 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
+
+	"strconv"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -57,7 +58,7 @@ func (p *failsOnDeleteResourceProvider) Create(
 ) (*rpc.CreateResponse, error) {
 	p.id++
 	return &rpc.CreateResponse{
-		Id: fmt.Sprintf("%v", p.id),
+		Id: strconv.Itoa(p.id),
 	}, nil
 }
 


### PR DESCRIPTION
The version we currently have doesn't support Go 1.22 properly, so it throws a bunch of warnings locally when trying to run it with the latest Go version installed.  Just running the latest version locally also doesn't quite work, since it throws a bunch of errors from the perfsprint linter, which seems to have gotten stricter.

Upgrade to the latest version of golangci-lint, and fix all the errors we're getting from it.  Mostly done via `perfsprint -fix`, with some manual changes that `perfsprint -fix` wouldn't touch.

