### PR TITLE
Fixes to pass dotnet conformance

### DIFF
--- a/pkg/cmd/pulumi/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/package_gen_sdk.go
@@ -116,7 +116,9 @@ func genSDK(language, out string, pkg *schema.Package, overlays string) error {
 	var generatePackage func(string, *schema.Package, map[string][]byte) error
 	switch language {
 	case "dotnet":
-		generatePackage = writeWrapper(dotnet.GeneratePackage)
+		generatePackage = writeWrapper(func(t string, p *schema.Package, e map[string][]byte) (map[string][]byte, error) {
+			return dotnet.GeneratePackage(t, p, e, nil)
+		})
 	case "java":
 		generatePackage = writeWrapper(javagen.GeneratePackage)
 	default:

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2171,6 +2171,7 @@ func genPackageMetadata(pkg *schema.Package,
 	packageReferences map[string]string,
 	projectReferences []string,
 	files codegen.Fs,
+	localDependencies map[string]string,
 ) error {
 	version := ""
 	lang, ok := pkg.Language["csharp"].(CSharpPackageInfo)
@@ -2179,7 +2180,7 @@ func genPackageMetadata(pkg *schema.Package,
 		files.Add("version.txt", []byte(version))
 	}
 
-	projectFile, err := genProjectFile(pkg, assemblyName, packageReferences, projectReferences, version)
+	projectFile, err := genProjectFile(pkg, assemblyName, packageReferences, projectReferences, version, localDependencies)
 	if err != nil {
 		return err
 	}
@@ -2212,6 +2213,7 @@ func genProjectFile(pkg *schema.Package,
 	packageReferences map[string]string,
 	projectReferences []string,
 	version string,
+	localDependencies map[string]string,
 ) ([]byte, error) {
 	if packageReferences == nil {
 		packageReferences = map[string]string{}
@@ -2513,7 +2515,9 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 	return resources, nil
 }
 
-func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]byte) (map[string][]byte, error) {
+func GeneratePackage(
+	tool string, pkg *schema.Package, extraFiles map[string][]byte, localDependencies map[string]string,
+) (map[string][]byte, error) {
 	modules, info, err := generateModuleContextMap(tool, pkg)
 	if err != nil {
 		return nil, err
@@ -2537,7 +2541,8 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 		assemblyName,
 		info.PackageReferences,
 		info.ProjectReferences,
-		files); err != nil {
+		files,
+		localDependencies); err != nil {
 		return nil, err
 	}
 	return files, nil

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -20,8 +20,10 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
@@ -256,13 +258,27 @@ func GenerateProject(
 		return diagnostics
 	}
 
+	// Check the project for "main" as that changes where we write out files and some relative paths.
+	rootDirectory := directory
+	if project.Main != "" {
+		directory = filepath.Join(rootDirectory, project.Main)
+		// mkdir -p the subdirectory
+		err = os.MkdirAll(directory, 0o700)
+		if err != nil {
+			return fmt.Errorf("create main directory: %w", err)
+		}
+	}
+
 	// Set the runtime to "dotnet" then marshal to Pulumi.yaml
 	project.Runtime = workspace.NewProjectRuntimeInfo("dotnet", nil)
 	projectBytes, err := encoding.YAML.Marshal(project)
 	if err != nil {
 		return err
 	}
-	files["Pulumi.yaml"] = projectBytes
+	err = os.WriteFile(path.Join(rootDirectory, "Pulumi.yaml"), projectBytes, 0o600)
+	if err != nil {
+		return fmt.Errorf("write Pulumi.yaml: %w", err)
+	}
 
 	// Build a .csproj based on the packages used by program
 	var csproj bytes.Buffer
@@ -273,10 +289,36 @@ func GenerateProject(
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Pulumi" Version="3.*" />
 `)
+
+	// Find all the local dependency folders
+	folders := mapset.NewSet[string]()
+	for _, dep := range localDependencies {
+		folders.Add(path.Dir(dep))
+	}
+	if len(folders.ToSlice()) > 0 {
+		csproj.WriteString(`	<PropertyGroup>
+		<RestoreSources>`)
+		csproj.WriteString(strings.Join(folders.ToSlice(), ";"))
+		csproj.WriteString(`;$(RestoreSources)</RestoreSources>
+	</PropertyGroup>
+`)
+	}
+
+	csproj.WriteString("	<ItemGroup>\n")
+
+	// Add the Pulumi package reference
+	if path, has := localDependencies[pulumiPackage]; has {
+		filename := filepath.Base(path)
+		pkg, rest, _ := strings.Cut(filename, ".")
+		version, _ := strings.CutSuffix(rest, ".nupkg")
+
+		csproj.WriteString(fmt.Sprintf(
+			"		<PackageReference Include=\"%s\" Version=\"%s\" />\n",
+			pkg, version))
+	} else {
+		csproj.WriteString("		<PackageReference Include=\"Pulumi\" Version=\"3.*\" />\n")
+	}
 
 	// For each package add a PackageReference line
 	packages, err := program.CollectNestedPackageSnapshots()

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -17,8 +17,10 @@ func TestGeneratePackage(t *testing.T) {
 	t.Parallel()
 
 	test.TestSDKCodegen(t, &test.SDKCodegenOptions{
-		Language:   "dotnet",
-		GenPackage: GeneratePackage,
+		Language: "dotnet",
+		GenPackage: func(t string, p *schema.Package, e map[string][]byte) (map[string][]byte, error) {
+			return GeneratePackage(t, p, e, nil)
+		},
 		Checks: map[string]test.CodegenCheck{
 			"dotnet/compile": typeCheckGeneratedPackage,
 			"dotnet/test":    testGeneratedPackage,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This isn't quite enough for dotnet conformance to pass on everything yet, but it's a start and gets the L1 programs passing.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
