### PR TITLE
disable parallelism for all snapshot tests

### DIFF
--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -63,8 +63,12 @@ func applyEdits(before, deltas json.RawMessage) (json.RawMessage, error) {
 // Check that cloudSnapshotPersister can talk the diff-based
 // "checkpointverbatim" and "checkpointdelta" protocol when saving
 // snapshots.
+//
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 
 	expectationsFile := "testdata/snapshot_test.json"
@@ -333,9 +337,11 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 	return snaps
 }
 
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func testMarshalDeployment(t *testing.T, snaps []*apitype.DeploymentV3) {
-	t.Parallel()
-
 	dds := newDeploymentDiffState(0)
 	for _, s := range snaps {
 		expected, err := dds.MarshalDeployment(s)
@@ -355,9 +361,11 @@ func testMarshalDeployment(t *testing.T, snaps []*apitype.DeploymentV3) {
 	}
 }
 
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func testDiffStack(t *testing.T, snaps []*apitype.DeploymentV3) {
-	t.Parallel()
-
 	ctx := context.Background()
 
 	dds := newDeploymentDiffState(0)
@@ -498,9 +506,11 @@ func BenchmarkDiffStack(b *testing.B) {
 	testOrBenchmarkDiffStack(b, benchmarkDiffStack, dynamicCases)
 }
 
+// TODO: This test is currently flaky when run in parallel parallelism
+// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
+//
+//nolint:paralleltest
 func TestDiffStack(t *testing.T) {
-	t.Parallel()
-
 	testOrBenchmarkDiffStack(t, testDiffStack, dynamicCases)
 }
 


### PR DESCRIPTION
These tests can all exhibit the same issue as described in https://github.com/pulumi/pulumi/issues/15461.  Temporarily disable parallelism for them.
