### PR TITLE
Ensure NodeJS SDK awaits full logical operations

### DIFF
--- a/changelog/pending/20240419--sdk-nodejs--fix-a-race-condition-that-could-cause-the-nodejs-runtime-to-terminate-before-finishing-all-work.yaml
+++ b/changelog/pending/20240419--sdk-nodejs--fix-a-race-condition-that-could-cause-the-nodejs-runtime-to-terminate-before-finishing-all-work.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix a race condition that could cause the NodeJS runtime to terminate before finishing all work

--- a/tests/integration/transforms/nodejs/single/Pulumi.yaml
+++ b/tests/integration/transforms/nodejs/single/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: transforms_single
+description:
+runtime: nodejs

--- a/tests/integration/transforms/nodejs/single/index.ts
+++ b/tests/integration/transforms/nodejs/single/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import { Random } from "./random";
+
+pulumi.runtime.xRegisterStackTransform(async ({ type, props, opts }) => {
+    console.log("stack transform");
+    return undefined;
+});
+
+new Random("res1", { length: pulumi.secret(5) });

--- a/tests/integration/transforms/nodejs/single/package.json
+++ b/tests/integration/transforms/nodejs/single/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "transforms",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/transforms/nodejs/single/random.ts
+++ b/tests/integration/transforms/nodejs/single/random.ts
@@ -1,0 +1,16 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface RandomArgs {
+    length: pulumi.Input<number>;
+    prefix?: pulumi.Input<string | undefined>;
+}
+
+export class Random extends pulumi.CustomResource {
+    public readonly length!: pulumi.Output<number>;
+    public readonly result!: pulumi.Output<string>;
+    constructor(name: string, args: RandomArgs, opts?: pulumi.CustomResourceOptions) {
+        super("testprovider:index:Random", name, args, opts);
+    }
+}

--- a/tests/integration/transforms/transforms_nodejs_test.go
+++ b/tests/integration/transforms/transforms_nodejs_test.go
@@ -10,22 +10,29 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
-func TestNodejsTransforms(t *testing.T) {
-	t.Parallel()
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodejsSimpleTransforms(t *testing.T) {
+	d := filepath.Join("nodejs", "simple")
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          d,
+		Dependencies: []string{"@pulumi/pulumi"},
+		LocalProviders: []integration.LocalDependency{
+			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+		},
+		Quick:                  true,
+		ExtraRuntimeValidation: Validator,
+	})
+}
 
-	//nolint:paralleltest // ProgramTest calls t.Parallel()
-	for _, dir := range Dirs {
-		d := filepath.Join("nodejs", dir)
-		t.Run(d, func(t *testing.T) {
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Dir:          d,
-				Dependencies: []string{"@pulumi/pulumi"},
-				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
-				},
-				Quick:                  true,
-				ExtraRuntimeValidation: Validator,
-			})
-		})
-	}
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodejsSingleTransforms(t *testing.T) {
+	d := filepath.Join("nodejs", "single")
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          d,
+		Dependencies: []string{"@pulumi/pulumi"},
+		LocalProviders: []integration.LocalDependency{
+			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+		},
+		Quick: true,
+	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15973.

Ensures that the `rpcDone` promise covers the whole async operation atomically.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
