### PR TITLE
Lift context parameter for ApplyProjectConfig

### DIFF
--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -913,7 +913,7 @@ func listConfig(
 
 	// when listing configuration values
 	// also show values coming from the project and environment
-	err = workspace.ApplyProjectConfig(stackName, project, pulumiEnv, cfg, envCrypter)
+	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter)
 	if err != nil {
 		return err
 	}
@@ -1080,7 +1080,7 @@ func getConfig(ctx context.Context, stack backend.Stack, key config.Key, path, j
 	}
 
 	// when asking for a configuration value, include values from the project and environment
-	err = workspace.ApplyProjectConfig(stackName, project, pulumiEnv, cfg, envCrypter)
+	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -336,8 +336,9 @@ func TestStackEnvConfig(t *testing.T) {
 
 	project := workspace.Project{Name: tokens.PackageName("project")}
 
+	ctx := context.Background()
 	cfg, err := getStackConfigurationFromProjectStack(
-		context.Background(),
+		ctx,
 		stack,
 		&project,
 		mockSecretsManager,
@@ -348,7 +349,7 @@ func TestStackEnvConfig(t *testing.T) {
 	assert.Nil(t, cfg.Config)
 	cfg.Config = config.Map{}
 
-	err = workspace.ApplyProjectConfig("mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter)
+	err = workspace.ApplyProjectConfig(ctx, "mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter)
 	require.NoError(t, err)
 
 	assert.Equal(t, config.Map{

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -231,6 +231,7 @@ func newDestroyCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configError := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -920,6 +920,7 @@ func newImportCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -87,6 +87,7 @@ func newLogsCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -392,6 +392,7 @@ func newPreviewCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -195,6 +195,7 @@ func newRefreshCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -123,6 +123,7 @@ func newUpCmd() *cobra.Command {
 
 		stackName := s.Ref().Name().String()
 		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+			ctx,
 			stackName,
 			proj,
 			cfg.Environment,
@@ -356,7 +357,9 @@ func newUpCmd() *cobra.Command {
 		}
 
 		stackName := s.Ref().String()
-		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(stackName,
+		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+			ctx,
+			stackName,
 			proj,
 			cfg.Environment,
 			cfg.Config,

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -127,6 +127,7 @@ func newWatchCmd() *cobra.Command {
 
 			stackName := s.Ref().Name().String()
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
 				stackName,
 				proj,
 				cfg.Environment,

--- a/sdk/go/common/workspace/config.go
+++ b/sdk/go/common/workspace/config.go
@@ -173,6 +173,7 @@ func envConfigValue(v esc.Value) config.Plaintext {
 }
 
 func mergeConfig(
+	ctx context.Context,
 	stackName string,
 	project *Project,
 	stackEnv esc.Value,
@@ -198,7 +199,7 @@ func mergeConfig(
 				return err
 			}
 
-			envValue, err := envConfigValue(value).Encrypt(context.TODO(), encrypter)
+			envValue, err := envConfigValue(value).Encrypt(ctx, encrypter)
 			if err != nil {
 				return err
 			}
@@ -290,6 +291,7 @@ func mergeConfig(
 }
 
 func ValidateStackConfigAndApplyProjectConfig(
+	ctx context.Context,
 	stackName string,
 	project *Project,
 	stackEnv esc.Value,
@@ -297,7 +299,7 @@ func ValidateStackConfigAndApplyProjectConfig(
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
 ) error {
-	return mergeConfig(stackName, project, stackEnv, stackConfig, encrypter, decrypter, true)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, true)
 }
 
 // ApplyConfigDefaults applies the default values for the project configuration onto the stack configuration
@@ -305,11 +307,12 @@ func ValidateStackConfigAndApplyProjectConfig(
 // This is because sometimes during pulumi config ls and pulumi config get, if users are
 // using PassphraseDecrypter, we don't want to always prompt for the values when not necessary
 func ApplyProjectConfig(
+	ctx context.Context,
 	stackName string,
 	project *Project,
 	stackEnv esc.Value,
 	stackConfig config.Map,
 	encrypter config.Encrypter,
 ) error {
-	return mergeConfig(stackName, project, stackEnv, stackConfig, encrypter, nil, false)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, nil, false)
 }

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -399,6 +399,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -434,6 +435,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -468,6 +470,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -502,6 +505,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -535,6 +539,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -566,6 +571,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -665,6 +671,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -701,6 +708,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -773,11 +781,13 @@ config:
   test:importantNumber: hello
 `
 
+	ctx := context.Background()
 	project, projectError := loadProjectFromText(t, projectYaml)
 	assert.NoError(t, projectError, "Shold be able to load the project")
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYamlValid)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		ctx,
 		"dev",
 		project,
 		esc.Value{},
@@ -789,6 +799,7 @@ config:
 	invalidStackConfig, stackError := loadProjectStackFromText(t, project, projectStackYamlInvalid)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError = ValidateStackConfigAndApplyProjectConfig(
+		ctx,
 		"dev",
 		project,
 		esc.Value{},
@@ -817,6 +828,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -846,6 +858,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -877,6 +890,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -903,6 +917,7 @@ config:
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYaml)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		esc.Value{},
@@ -938,11 +953,13 @@ config:
   test:importantNumber: 20
 `
 
+	ctx := context.Background()
 	project, projectError := loadProjectFromText(t, projectYaml)
 	assert.NoError(t, projectError, "Shold be able to load the project")
 	stack, stackError := loadProjectStackFromText(t, project, projectStackYamlValid)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		ctx,
 		"dev",
 		project,
 		esc.Value{},
@@ -954,6 +971,7 @@ config:
 	invalidStackConfig, stackError := loadProjectStackFromText(t, project, projectStackYamlInvalid)
 	assert.NoError(t, stackError, "Should be able to read the stack")
 	configError = ValidateStackConfigAndApplyProjectConfig(
+		ctx,
 		"dev",
 		project,
 		esc.Value{},
@@ -1007,6 +1025,7 @@ config:
 	require.NoError(t, stackError, "Should be able to read the stack")
 
 	configError := ValidateStackConfigAndApplyProjectConfig(
+		context.Background(),
 		"dev",
 		project,
 		env,


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

`mergeConfig` uses `Crypter.Encrypt` that needs a context and was using `context.TODO()`. This lifts that to a context parameter and fixes up all call sites.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
