### PR TITLE
fix dev release dependencies

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -102,7 +102,7 @@ jobs:
 
   sign:
     name: sign
-    needs: [build-release]
+    needs: [build-release, build-sdks]
     uses: ./.github/workflows/sign.yml
     with:
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
Currently the sign workflow only depends `build-release`.  However it also needs the SDKs being built, so add a dependency on that.

This usually works because the release builds takes longer, so it just works, but we should make the dependencies explicit.

Fixes https://github.com/pulumi/pulumi/issues/16016