### PR TITLE
Test setting and changing providers on component resources via transforms

### DIFF
--- a/changelog/pending/20240422--sdk-python--fix-an-exception-when-setting-providers-resource-option-with-a-dict.yaml
+++ b/changelog/pending/20240422--sdk-python--fix-an-exception-when-setting-providers-resource-option-with-a-dict.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix an exception when setting providers resource option with a dict

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -18,6 +18,7 @@ import asyncio
 import copy
 import warnings
 from typing import (
+    Awaitable,
     Optional,
     List,
     Any,
@@ -318,7 +319,12 @@ class ResourceTransformResult:
         self.opts = opts
 
 
-ResourceTransform = Callable[[ResourceTransformArgs], Optional[ResourceTransformResult]]
+ResourceTransform = Callable[
+    [ResourceTransformArgs],
+    Optional[
+        Union[Awaitable[Optional[ResourceTransformResult]], ResourceTransformResult]
+    ],
+]
 """
 ResourceTransform is the callback signature for the `transforms` resource option.  A
 transform is passed the same set of inputs provided to the `Resource` constructor, and can
@@ -753,7 +759,7 @@ def _collapse_providers(opts: "ResourceOptions"):
                 for prov in providers:
                     opts.providers[prov.package] = prov
             elif isinstance(providers, dict):
-                for key, prov in providers:
+                for key, prov in providers.items():
                     opts.providers[key] = prov
 
 

--- a/tests/integration/transforms/go/simple/main.go
+++ b/tests/integration/transforms/go/simple/main.go
@@ -182,7 +182,7 @@ func main() {
 			return err
 		}
 
-		// Scenario #6 - mutate the provider on the resource
+		// Scenario #6 - mutate the provider on a custom resource
 		provider1, err := NewProvider(ctx, "provider1")
 		if err != nil {
 			return err
@@ -197,6 +197,24 @@ func main() {
 			pulumi.XTransforms([]pulumi.XResourceTransform{
 				func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
 					fmt.Printf("res6 transform\n")
+					rta.Opts.Provider = provider2
+					return &pulumi.XResourceTransformResult{
+						Props: rta.Props,
+						Opts:  rta.Opts,
+					}
+				},
+			}),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Scenario #7 - mutate the provider on a component resource
+		_, err = NewComponent(ctx, "res7", &ComponentArgs{Length: pulumi.Int(10)},
+			pulumi.Provider(provider1),
+			pulumi.XTransforms([]pulumi.XResourceTransform{
+				func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+					fmt.Printf("res7 transform\n")
 					rta.Opts.Provider = provider2
 					return &pulumi.XResourceTransformResult{
 						Props: rta.Props,

--- a/tests/integration/transforms/go/simple/random.go
+++ b/tests/integration/transforms/go/simple/random.go
@@ -48,6 +48,39 @@ func (RandomArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*randomArgs)(nil)).Elem()
 }
 
+type Component struct {
+	pulumi.ResourceState
+
+	Length  pulumi.IntOutput    `pulumi:"length"`
+	ChildID pulumi.StringOutput `pulumi:"childId"`
+}
+
+func NewComponent(ctx *pulumi.Context,
+	name string, args *ComponentArgs, opts ...pulumi.ResourceOption,
+) (*Random, error) {
+	if args == nil || args.Length == nil {
+		return nil, errors.New("missing required argument 'Length'")
+	}
+	var resource Random
+	err := ctx.RegisterRemoteComponentResource("testprovider:index:Component", name, args, &resource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type componentArgs struct {
+	Length int `pulumi:"length"`
+}
+
+type ComponentArgs struct {
+	Length pulumi.IntInput
+}
+
+func (ComponentArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*componentArgs)(nil)).Elem()
+}
+
 type Provider struct {
 	pulumi.ProviderResourceState
 }

--- a/tests/integration/transforms/nodejs/simple/index.ts
+++ b/tests/integration/transforms/nodejs/simple/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
-import { Random, TestProvider} from "./random";
+import { Component, Random, TestProvider} from "./random";
 
 class MyComponent extends pulumi.ComponentResource {
     child: Random;
@@ -102,7 +102,7 @@ const res5 = new Random("res5", { length: 10 }, {
     ],
 });
 
-// Scenario #6 - mutate the provider on the resource
+// Scenario #6 - mutate the provider on a custom resource
 const provider1 = new TestProvider("provider1");
 const provider2 = new TestProvider("provider2");
 
@@ -111,6 +111,20 @@ const res6 = new Random("res6", { length: 10 }, {
     xTransforms: [
         async ({ type, props, opts }) => {
             console.log("res6 transform");
+            return {
+                props: props,
+                opts: pulumi.mergeOptions(opts, { provider: provider2 }),
+            };
+        },
+    ],
+});
+
+// Scenario #7 - mutate the provider on a component resource
+const res7 = new Component("res7", { length: 10 }, {
+    provider: provider1,
+    xTransforms: [
+        async ({ type, props, opts }) => {
+            console.log("res7 transform");
             return {
                 props: props,
                 opts: pulumi.mergeOptions(opts, { provider: provider2 }),

--- a/tests/integration/transforms/nodejs/simple/random.ts
+++ b/tests/integration/transforms/nodejs/simple/random.ts
@@ -15,6 +15,19 @@ export class Random extends pulumi.CustomResource {
     }
 }
 
+
+interface ComponentArgs {
+    length: pulumi.Input<number>;
+}
+
+export class Component extends pulumi.ComponentResource {
+    public readonly length!: pulumi.Output<number>;
+    public readonly childId!: pulumi.Output<string>;
+    constructor(name: string, args: ComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("testprovider:index:Component", name, args, opts, true);
+    }
+}
+
 export class TestProvider extends pulumi.ProviderResource {
     constructor(name: string, opts?: pulumi.ResourceOptions) {
         super("testprovider", name, {}, opts);

--- a/tests/integration/transforms/python/simple/__main__.py
+++ b/tests/integration/transforms/python/simple/__main__.py
@@ -3,7 +3,7 @@
 import asyncio
 from pulumi import Output, ComponentResource, ResourceOptions, ResourceTransformArgs, ResourceTransformResult
 from pulumi.runtime import x_register_stack_transform
-from random_ import Random, Provider
+from random_ import Component, Random, Provider
 
 class MyComponent(ComponentResource):
     child: Random
@@ -99,12 +99,12 @@ res5 = Random(
     None,
     ResourceOptions(x_transforms=[res5_transform]))
 
-# Scenario #6 - mutate the provider on the resource
+# Scenario #6 - mutate the provider on a custom resource
 provider1 = Provider("provider1")
 provider2 = Provider("provider2")
 
-def res6_transform(args: ResourceTransformArgs):
-    print("res6 transform")
+def provider_transform(args: ResourceTransformArgs):
+    print("provider transform")
     return ResourceTransformResult(
         props=args.props,
         opts=ResourceOptions.merge(args.opts, ResourceOptions(
@@ -117,5 +117,14 @@ res6 = Random(
     None,
     ResourceOptions(
         provider=provider1,
-        x_transforms=[res6_transform],
+        x_transforms=[provider_transform],
+    ))
+
+# Scenario #7 - mutate the provider on a component resource
+res7 = Component(
+    "res7",
+    10,
+    ResourceOptions(
+        provider=provider1,
+        x_transforms=[provider_transform],
     ))

--- a/tests/integration/transforms/python/simple/random_.py
+++ b/tests/integration/transforms/python/simple/random_.py
@@ -26,6 +26,28 @@ class Random(pulumi.CustomResource):
     @pulumi.getter
     def result(self) -> pulumi.Output[str]:
         return pulumi.get(self, "result")
+    
+
+class Component(pulumi.ComponentResource):
+    def __init__(self,
+                 resource_name: str,
+                 length: pulumi.Input[int],
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        props = {
+            "length": length,
+            "childId": None,
+        }
+        super().__init__("testprovider:index:Component", resource_name, props, opts, True)
+
+    @property
+    @pulumi.getter
+    def length(self) -> pulumi.Output[int]:
+        return pulumi.get(self, "length")
+
+    @property
+    @pulumi.getter
+    def child_id(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "childId")
 
 class Provider(pulumi.ProviderResource):
     def __init__(__self__,

--- a/tests/integration/transforms/transforms_test.go
+++ b/tests/integration/transforms/transforms_test.go
@@ -26,6 +26,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes4Child := false
 	foundRes5 := false
 	foundRes6 := false
+	foundRes7 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -86,6 +87,12 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			urn := ref.URN()
 			assert.Equal(t, "provider2", urn.Name())
 		}
+		// "res7" should have changed the provider
+		if res.URN.Name() == "res7" {
+			foundRes7 = true
+			// we change the provider but because this is a remote component resource it ends up empty in state.
+			assert.Equal(t, "", res.Provider)
+		}
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
@@ -93,4 +100,5 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	assert.True(t, foundRes4Child)
 	assert.True(t, foundRes5)
 	assert.True(t, foundRes6)
+	assert.True(t, foundRes7)
 }

--- a/tests/testprovider/component.go
+++ b/tests/testprovider/component.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !all
+// +build !all
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Random struct {
+	pulumi.CustomResourceState
+
+	Length pulumi.IntOutput    `pulumi:"length"`
+	Result pulumi.StringOutput `pulumi:"result"`
+}
+
+func NewRandom(ctx *pulumi.Context,
+	name string, args *RandomArgs, opts ...pulumi.ResourceOption,
+) (*Random, error) {
+	if args == nil || args.Length == nil {
+		return nil, errors.New("missing required argument 'Length'")
+	}
+	var resource Random
+	err := ctx.RegisterResource("testprovider:index:Random", name, args, &resource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type randomArgs struct {
+	Length int    `pulumi:"length"`
+	Prefix string `pulumi:"prefix"`
+}
+
+type RandomArgs struct {
+	Length pulumi.IntInput
+	Prefix pulumi.StringInput
+}
+
+func (RandomArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*randomArgs)(nil)).Elem()
+}
+
+type Component struct {
+	pulumi.ResourceState
+
+	ChildID pulumi.IDOutput `pulumi:"childId"`
+}
+
+type ComponentArgs struct {
+	Length int `pulumi:"length"`
+}
+
+func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
+	opts ...pulumi.ResourceOption,
+) (*Component, error) {
+	if args == nil {
+		return nil, errors.New("args is required")
+	}
+
+	component := &Component{}
+	err := ctx.RegisterComponentResource("testprovider:index:Component", name, component, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := NewRandom(ctx, fmt.Sprintf("child-%s", name), &RandomArgs{
+		Length: pulumi.Int(args.Length),
+	}, pulumi.Parent(component))
+	if err != nil {
+		return nil, err
+	}
+
+	component.ChildID = res.ID()
+
+	if err := ctx.RegisterResourceOutputs(component, pulumi.Map{
+		"childId": component.ChildID,
+	}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15984.

The bug was actually caused by a longstanding mistake in `_collapse_providers` that didn't iterate the providers correctly if it was passed as a `dict`. But worth having this test in full to sanity check the other languages as well.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
