### PR TITLE
Start mypy linting lib/test

### DIFF
--- a/sdk/python/lib/test/langhost/invoke_types/outputs.py
+++ b/sdk/python/lib/test/langhost/invoke_types/outputs.py
@@ -38,11 +38,11 @@ class MyOtherFunctionNestedResult:
 
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str: ...
+    def first_value(self) -> str: ...  # type: ignore
 
     @property
     @pulumi.getter(name="secondValue")
-    def second_value(self) -> float: ...
+    def second_value(self) -> float: ...  # type: ignore
 
 
 @pulumi.output_type

--- a/sdk/python/lib/test/langhost/types/__main__.py
+++ b/sdk/python/lib/test/langhost/types/__main__.py
@@ -183,7 +183,7 @@ class SupplementaryArgs:
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> pulumi.Input[str]: ...
+    def first_value(self) -> pulumi.Input[str]: ...  # type: ignore
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
@@ -203,10 +203,10 @@ class SupplementaryArgs:
     # passed to the getter decorator.
     @property
     @pulumi.getter
-    def third(self) -> Optional[pulumi.Input[str]]: ...
+    def third(self) -> Optional[pulumi.Input[str]]: ...  # type: ignore
 
     @third.setter
-    def third(self, value: Optional[pulumi.Input[str]]): ...
+    def third(self, value: Optional[pulumi.Input[str]]): ...  # type: ignore
 
     # Another single word property name that doesn't require a name to be
     # passed to the getter decorator, this time using the decorator with
@@ -232,7 +232,7 @@ class Supplementary(dict):
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str: ...
+    def first_value(self) -> str: ...  # type: ignore
 
     # Property with explicitly specified getter/setter bodies.
     @property
@@ -244,14 +244,14 @@ class Supplementary(dict):
     # passed to the getter decorator.
     @property
     @pulumi.getter
-    def third(self) -> str: ...
+    def third(self) -> str: ...  # type: ignore
 
     # Another single word property name that doesn't require a name to be
     # passed to the getter decorator, this time using the decorator with
     # parens.
     @property
     @pulumi.getter
-    def fourth(self) -> str: ...
+    def fourth(self) -> str: ...  # type: ignore
 
 
 class SupplementaryResource(pulumi.CustomResource):
@@ -330,7 +330,7 @@ class AncillaryArgs:
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> pulumi.Input[str]: ...
+    def first_value(self) -> pulumi.Input[str]: ...  # type: ignore
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
@@ -350,20 +350,20 @@ class AncillaryArgs:
     # passed to the getter decorator.
     @property
     @pulumi.getter
-    def third(self) -> Optional[pulumi.Input[str]]: ...
+    def third(self) -> Optional[pulumi.Input[str]]: ...  # type: ignore
 
     @third.setter
-    def third(self, value: Optional[pulumi.Input[str]]): ...
+    def third(self, value: Optional[pulumi.Input[str]]): ...  # type: ignore
 
     # Another single word property name that doesn't require a name to be
     # passed to the getter decorator, this time using the decorator with
     # parens.
     @property
     @pulumi.getter()
-    def fourth(self) -> Optional[pulumi.Input[str]]: ...
+    def fourth(self) -> Optional[pulumi.Input[str]]: ...  # type: ignore
 
     @fourth.setter
-    def fourth(self, value: Optional[pulumi.Input[str]]): ...
+    def fourth(self, value: Optional[pulumi.Input[str]]): ...  # type: ignore
 
 
 @pulumi.output_type
@@ -379,7 +379,7 @@ class Ancillary(dict):
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str: ...
+    def first_value(self) -> str: ...  # type: ignore
 
     # Property with explicitly specified getter/setter bodies.
     @property
@@ -391,14 +391,14 @@ class Ancillary(dict):
     # passed to the getter decorator.
     @property
     @pulumi.getter
-    def third(self) -> str: ...
+    def third(self) -> str: ...  # type: ignore
 
     # Another single word property name that doesn't require a name to be
     # passed to the getter decorator, this time using the decorator with
     # parens.
     @property
     @pulumi.getter()
-    def fourth(self) -> str: ...
+    def fourth(self) -> str: ...  # type: ignore
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -120,21 +120,21 @@ class MyOutputTypeDict(dict):
     # Property with empty body.
     @property
     @pulumi.getter
-    def values(self) -> str:
+    def values(self) -> str:  # type: ignore
         """Values docstring."""
         ...
 
     # Property with empty body.
     @property
     @pulumi.getter
-    def items(self) -> str:
+    def items(self) -> str:  # type: ignore
         """Items docstring."""
         ...
 
     # Property with empty body.
     @property
     @pulumi.getter
-    def keys(self) -> str:
+    def keys(self) -> str:  # type: ignore
         """Keys docstring."""
         ...
 
@@ -1350,11 +1350,11 @@ class SomeFooArgs:
 
     @property
     @pulumi.getter(name="theFirst")
-    def the_first(self) -> str: ...
+    def the_first(self) -> str: ...  # type: ignore
 
     @property
     @pulumi.getter(name="theSecond")
-    def the_second(self) -> Mapping[str, str]: ...
+    def the_second(self) -> Mapping[str, str]: ...  # type: ignore
 
 
 @pulumi.input_type
@@ -1373,15 +1373,15 @@ class SerializationArgs:
 
     @property
     @pulumi.getter(name="someValue")
-    def some_value(self) -> pulumi.Input[str]: ...
+    def some_value(self) -> pulumi.Input[str]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="someFoo")
-    def some_foo(self) -> pulumi.Input[pulumi.InputType[SomeFooArgs]]: ...
+    def some_foo(self) -> pulumi.Input[pulumi.InputType[SomeFooArgs]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="someBar")
-    def some_bar(
+    def some_bar(  # type: ignore
         self,
     ) -> pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType[SomeFooArgs]]]]: ...
 
@@ -1394,11 +1394,11 @@ class SomeFooOutput(dict):
 
     @property
     @pulumi.getter(name="theFirst")
-    def the_first(self) -> str: ...
+    def the_first(self) -> str: ...  # type: ignore
 
     @property
     @pulumi.getter(name="theSecond")
-    def the_second(self) -> Mapping[str, str]: ...
+    def the_second(self) -> Mapping[str, str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -1415,15 +1415,15 @@ class DeserializationOutput(dict):
 
     @property
     @pulumi.getter(name="someValue")
-    def some_value(self) -> str: ...
+    def some_value(self) -> str: ...  # type: ignore
 
     @property
     @pulumi.getter(name="someFoo")
-    def some_foo(self) -> SomeFooOutput: ...
+    def some_foo(self) -> SomeFooOutput: ...  # type: ignore
 
     @property
     @pulumi.getter(name="someBar")
-    def some_bar(self) -> Mapping[str, SomeFooOutput]: ...
+    def some_bar(self) -> Mapping[str, SomeFooOutput]: ...  # type: ignore
 
 
 class TypeMetaDataSerializationTests(unittest.TestCase):

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -139,7 +139,7 @@ def test_depends_on_typing_variations(dep_tracker) -> None:
         res = MockResource(name, opts)
         return pulumi.Output.all(dep.urn, res.urn).apply(lambda urns: check(i, urns))
 
-    return pulumi.Output.all(
+    pulumi.Output.all(
         [
             check_opts(i, f"res{i}", opts)
             for i, opts in enumerate(depends_on_variations(dep))

--- a/sdk/python/lib/test/test_translate_output_properties.py
+++ b/sdk/python/lib/test/test_translate_output_properties.py
@@ -170,73 +170,73 @@ class BarDeclared(dict):
 
     @property
     @pulumi.getter(name="thirdArg")
-    def third_arg(self) -> Foo: ...
+    def third_arg(self) -> Foo: ...  # type: ignore
 
     @property
     @pulumi.getter(name="thirdOptionalArg")
-    def third_optional_arg(self) -> Optional[Foo]: ...
+    def third_optional_arg(self) -> Optional[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fourthArg")
-    def fourth_arg(self) -> Dict[str, Foo]: ...
+    def fourth_arg(self) -> Dict[str, Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fourthOptionalArg")
-    def fourth_optional_arg(self) -> Dict[str, Optional[Foo]]: ...
+    def fourth_optional_arg(self) -> Dict[str, Optional[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fifthArg")
-    def fifth_arg(self) -> List[Foo]: ...
+    def fifth_arg(self) -> List[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fifthOptionalArg")
-    def fifth_optional_arg(self) -> List[Optional[Foo]]: ...
+    def fifth_optional_arg(self) -> List[Optional[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthArg")
-    def sixth_arg(self) -> Dict[str, List[Foo]]: ...
+    def sixth_arg(self) -> Dict[str, List[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthOptionalArg")
-    def sixth_optional_arg(self) -> Dict[str, Optional[List[Foo]]]: ...
+    def sixth_optional_arg(self) -> Dict[str, Optional[List[Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthOptionalOptionalArg")
-    def sixth_optional_optional_arg(
+    def sixth_optional_optional_arg(  # type: ignore
         self,
     ) -> Dict[str, Optional[List[Optional[Foo]]]]: ...
 
     @property
     @pulumi.getter(name="seventhArg")
-    def seventh_arg(self) -> List[Dict[str, Foo]]: ...
+    def seventh_arg(self) -> List[Dict[str, Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="seventhOptionalArg")
-    def seventh_optional_arg(self) -> List[Optional[Dict[str, Foo]]]: ...
+    def seventh_optional_arg(self) -> List[Optional[Dict[str, Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="seventhOptionalOptionalArg")
-    def seventh_optional_optional_arg(
+    def seventh_optional_optional_arg(  # type: ignore
         self,
     ) -> List[Optional[Dict[str, Optional[Foo]]]]: ...
 
     @property
     @pulumi.getter(name="eighthArg")
-    def eighth_arg(self) -> List[Dict[str, List[Foo]]]: ...
+    def eighth_arg(self) -> List[Dict[str, List[Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="eighthOptionalArg")
-    def eighth_optional_arg(self) -> List[Optional[Dict[str, List[Foo]]]]: ...
+    def eighth_optional_arg(self) -> List[Optional[Dict[str, List[Foo]]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="eighthOptionalOptionalArg")
-    def eighth_optional_optional_arg(
+    def eighth_optional_optional_arg(  # type: ignore
         self,
     ) -> List[Optional[Dict[str, Optional[List[Foo]]]]]: ...
 
     @property
     @pulumi.getter(name="eighthOptionalOptionalOptionalArg")
-    def eighth_optional_optional_optional_arg(
+    def eighth_optional_optional_optional_arg(  # type: ignore
         self,
     ) -> List[Optional[Dict[str, Optional[List[Optional[Foo]]]]]]: ...
 
@@ -292,75 +292,75 @@ class BarMappingSequenceDeclared(dict):
 
     @property
     @pulumi.getter(name="thirdArg")
-    def third_arg(self) -> Foo: ...
+    def third_arg(self) -> Foo: ...  # type: ignore
 
     @property
     @pulumi.getter(name="thirdOptionalArg")
-    def third_optional_arg(self) -> Optional[Foo]: ...
+    def third_optional_arg(self) -> Optional[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fourthArg")
-    def fourth_arg(self) -> Mapping[str, Foo]: ...
+    def fourth_arg(self) -> Mapping[str, Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fourthOptionalArg")
-    def fourth_optional_arg(self) -> Mapping[str, Optional[Foo]]: ...
+    def fourth_optional_arg(self) -> Mapping[str, Optional[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fifthArg")
-    def fifth_arg(self) -> Sequence[Foo]: ...
+    def fifth_arg(self) -> Sequence[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="fifthOptionalArg")
-    def fifth_optional_arg(self) -> Sequence[Optional[Foo]]: ...
+    def fifth_optional_arg(self) -> Sequence[Optional[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthArg")
-    def sixth_arg(self) -> Mapping[str, Sequence[Foo]]: ...
+    def sixth_arg(self) -> Mapping[str, Sequence[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthOptionalArg")
-    def sixth_optional_arg(self) -> Mapping[str, Optional[Sequence[Foo]]]: ...
+    def sixth_optional_arg(self) -> Mapping[str, Optional[Sequence[Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="sixthOptionalOptionalArg")
-    def sixth_optional_optional_arg(
+    def sixth_optional_optional_arg(  # type: ignore
         self,
     ) -> Mapping[str, Optional[Sequence[Optional[Foo]]]]: ...
 
     @property
     @pulumi.getter(name="seventhArg")
-    def seventh_arg(self) -> Sequence[Mapping[str, Foo]]: ...
+    def seventh_arg(self) -> Sequence[Mapping[str, Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="seventhOptionalArg")
-    def seventh_optional_arg(self) -> Sequence[Optional[Mapping[str, Foo]]]: ...
+    def seventh_optional_arg(self) -> Sequence[Optional[Mapping[str, Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="seventhOptionalOptionalArg")
-    def seventh_optional_optional_arg(
+    def seventh_optional_optional_arg(  # type: ignore
         self,
     ) -> Sequence[Optional[Mapping[str, Optional[Foo]]]]: ...
 
     @property
     @pulumi.getter(name="eighthArg")
-    def eighth_arg(self) -> Sequence[Mapping[str, Sequence[Foo]]]: ...
+    def eighth_arg(self) -> Sequence[Mapping[str, Sequence[Foo]]]: ...  # type: ignore
 
     @property
     @pulumi.getter(name="eighthOptionalArg")
-    def eighth_optional_arg(
+    def eighth_optional_arg(  # type: ignore
         self,
     ) -> Sequence[Optional[Mapping[str, Sequence[Foo]]]]: ...
 
     @property
     @pulumi.getter(name="eighthOptionalOptionalArg")
-    def eighth_optional_optional_arg(
+    def eighth_optional_optional_arg(  # type: ignore
         self,
     ) -> Sequence[Optional[Mapping[str, Optional[Sequence[Foo]]]]]: ...
 
     @property
     @pulumi.getter(name="eighthOptionalOptionalOptionalArg")
-    def eighth_optional_optional_optional_arg(
+    def eighth_optional_optional_optional_arg(  # type: ignore
         self,
     ) -> Sequence[Optional[Mapping[str, Optional[Sequence[Optional[Foo]]]]]]: ...
 
@@ -380,7 +380,7 @@ class InvalidTypeDeclaredStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> str: ...
+    def value(self) -> str: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -395,7 +395,7 @@ class InvalidTypeDeclaredOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Optional[str]: ...
+    def value(self) -> Optional[str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -415,7 +415,7 @@ class InvalidTypeDeclaredDictStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Dict[str, str]: ...
+    def value(self) -> Dict[str, str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -425,7 +425,7 @@ class InvalidTypeDeclaredMappingStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Mapping[str, str]: ...
+    def value(self) -> Mapping[str, str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -445,7 +445,7 @@ class InvalidTypeDeclaredOptionalDictStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Optional[Dict[str, str]]: ...
+    def value(self) -> Optional[Dict[str, str]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -455,7 +455,7 @@ class InvalidTypeDeclaredOptionalMappingStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Optional[Mapping[str, str]]: ...
+    def value(self) -> Optional[Mapping[str, str]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -475,7 +475,7 @@ class InvalidTypeDeclaredDictOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Dict[str, Optional[str]]: ...
+    def value(self) -> Dict[str, Optional[str]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -485,7 +485,7 @@ class InvalidTypeDeclaredMappingOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Mapping[str, Optional[str]]: ...
+    def value(self) -> Mapping[str, Optional[str]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -505,7 +505,7 @@ class InvalidTypeDeclaredOptionalDictOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Optional[Dict[str, Optional[str]]]: ...
+    def value(self) -> Optional[Dict[str, Optional[str]]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -515,7 +515,7 @@ class InvalidTypeDeclaredOptionalMappingOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Optional[Mapping[str, Optional[str]]]: ...
+    def value(self) -> Optional[Mapping[str, Optional[str]]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -535,7 +535,7 @@ class InvalidTypeDeclaredListStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> List[str]: ...
+    def value(self) -> List[str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -545,7 +545,7 @@ class InvalidTypeDeclaredSequenceStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Sequence[str]: ...
+    def value(self) -> Sequence[str]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -595,7 +595,7 @@ class InvalidTypeDeclaredListOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> List[Optional[str]]: ...
+    def value(self) -> List[Optional[str]]: ...  # type: ignore
 
 
 @pulumi.output_type
@@ -605,7 +605,7 @@ class InvalidTypeDeclaredSequenceOptionalStr(dict):
 
     @property
     @pulumi.getter
-    def value(self) -> Sequence[Optional[str]]: ...
+    def value(self) -> Sequence[Optional[str]]: ...  # type: ignore
 
 
 @pulumi.output_type

--- a/sdk/python/lib/test/test_types_input_type.py
+++ b/sdk/python/lib/test/test_types_input_type.py
@@ -54,7 +54,7 @@ class MyDeclaredPropertiesInputType:
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> pulumi.Input[str]:
+    def first_value(self) -> pulumi.Input[str]:  # type: ignore
         """First value docstring."""
         ...
 

--- a/sdk/python/lib/test/test_types_input_type_types.py
+++ b/sdk/python/lib/test/test_types_input_type_types.py
@@ -24,7 +24,7 @@ import pulumi
 class Foo:
     @property
     @pulumi.getter()
-    def bar(self) -> pulumi.Input[str]: ...
+    def bar(self) -> pulumi.Input[str]: ...  # type: ignore
 
 
 @pulumi.input_type
@@ -47,51 +47,51 @@ class MySimpleInputType:
 class MyPropertiesInputType:
     @property
     @pulumi.getter()
-    def a(self) -> str: ...
+    def a(self) -> str: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def b(self) -> Optional[str]: ...
+    def b(self) -> Optional[str]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def c(self) -> pulumi.Input[str]: ...
+    def c(self) -> pulumi.Input[str]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def d(self) -> Optional[pulumi.Input[str]]: ...
+    def d(self) -> Optional[pulumi.Input[str]]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def e(self) -> Foo: ...
+    def e(self) -> Foo: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def f(self) -> Optional[Foo]: ...
+    def f(self) -> Optional[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def g(self) -> pulumi.Input[Foo]: ...
+    def g(self) -> pulumi.Input[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def h(self) -> Optional[pulumi.Input[Foo]]: ...
+    def h(self) -> Optional[pulumi.Input[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def i(self) -> pulumi.InputType[Foo]: ...
+    def i(self) -> pulumi.InputType[Foo]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def j(self) -> Optional[pulumi.InputType[Foo]]: ...
+    def j(self) -> Optional[pulumi.InputType[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def k(self) -> pulumi.Input[pulumi.InputType[Foo]]: ...
+    def k(self) -> pulumi.Input[pulumi.InputType[Foo]]: ...  # type: ignore
 
     @property
     @pulumi.getter()
-    def l(self) -> Optional[pulumi.Input[pulumi.InputType[Foo]]]: ...
+    def l(self) -> Optional[pulumi.Input[pulumi.InputType[Foo]]]: ...  # type: ignore
 
 
 class InputTypeTypesTests(unittest.TestCase):

--- a/sdk/python/lib/test/test_types_output_type.py
+++ b/sdk/python/lib/test/test_types_output_type.py
@@ -65,7 +65,7 @@ class MyDeclaredPropertiesOutputType:
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str:
+    def first_value(self) -> str:  # type: ignore
         """First value docstring."""
         ...
 
@@ -87,7 +87,7 @@ class MyDeclaredPropertiesOutputTypeDict(dict):
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str:
+    def first_value(self) -> str:  # type: ignore
         """First value docstring."""
         ...
 
@@ -109,7 +109,7 @@ class MyDeclaredPropertiesOutputTypeTranslated:
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str:
+    def first_value(self) -> str:  # type: ignore
         """First value docstring."""
         ...
 
@@ -134,7 +134,7 @@ class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
-    def first_value(self) -> str:
+    def first_value(self) -> str:  # type: ignore
         """First value docstring."""
         ...
 

--- a/sdk/python/lib/test/test_types_resource_types.py
+++ b/sdk/python/lib/test/test_types_resource_types.py
@@ -37,19 +37,19 @@ class Resource4(pulumi.Resource):
 class Resource5(pulumi.Resource):
     @property
     @pulumi.getter
-    def foo(self) -> pulumi.Output[str]: ...
+    def foo(self) -> pulumi.Output[str]: ...  # type: ignore
 
 
 class Resource6(pulumi.Resource):
     @property
     @pulumi.getter
-    def nested(self) -> pulumi.Output["Nested"]: ...
+    def nested(self) -> pulumi.Output["Nested"]: ...  # type: ignore
 
 
 class Resource7(pulumi.Resource):
     @property
     @pulumi.getter(name="nestedValue")
-    def nested_value(self) -> pulumi.Output["Nested"]: ...
+    def nested_value(self) -> pulumi.Output["Nested"]: ...  # type: ignore
 
 
 class Resource8(pulumi.Resource):
@@ -59,7 +59,7 @@ class Resource8(pulumi.Resource):
 class Resource9(pulumi.Resource):
     @property
     @pulumi.getter
-    def foo(self) -> pulumi.Output: ...
+    def foo(self) -> pulumi.Output: ...  # type: ignore
 
 
 class Resource10(pulumi.Resource):
@@ -69,13 +69,13 @@ class Resource10(pulumi.Resource):
 class Resource11(pulumi.Resource):
     @property
     @pulumi.getter
-    def foo(self) -> str: ...
+    def foo(self) -> str: ...  # type: ignore
 
 
 class Resource12(pulumi.Resource):
     @property
     @pulumi.getter
-    def foo(self): ...
+    def foo(self): ...  # type: ignore
 
 
 @pulumi.output_type

--- a/sdk/python/lib/test/test_utils.py
+++ b/sdk/python/lib/test/test_utils.py
@@ -27,9 +27,9 @@ def compute(val: int) -> str:
 
 
 class Foo:
-    def empty_a(self) -> str: ...
+    def empty_a(self) -> str: ...  # type: ignore
 
-    def empty_b(self) -> str:
+    def empty_b(self) -> str:  # type: ignore
         """A docstring."""
         ...
 


### PR DESCRIPTION
This fixes up a load of '[un]expected return statement' errors in the tests. Mostly property getters which I've filled in with `pulumi.get` but some of the tests were explictly checking things worked when the getter was an empty method body.
