### PR TITLE
Cleanup output futures list as they complete

### DIFF
--- a/changelog/pending/20240425--sdk-python--fix-a-memory-leak-in-tracking-outputs.yaml
+++ b/changelog/pending/20240425--sdk-python--fix-a-memory-leak-in-tracking-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix a memory leak in tracking outputs.

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from collections import deque
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import grpc
 
-from .. import log
 from .._utils import contextproperty
 from ..errors import RunError
 from ..runtime.proto import engine_pb2_grpc, resource_pb2, resource_pb2_grpc
@@ -62,6 +62,7 @@ class Settings:
     ):
         self.rpc_manager = RPCManager()
         self.outputs = deque()
+        self.lock = threading.Lock()
 
         # Save the metadata information.
         self.project = project
@@ -103,6 +104,9 @@ class Settings:
     def rpc_manager(self) -> RPCManager:  # type: ignore
         # The contextproperty decorator will fill the body of this method in, but mypy doesn't know that.
         ...
+
+    @contextproperty
+    def lock(self) -> threading.Lock: ...  # type: ignore
 
     @contextproperty
     def outputs(self) -> deque[asyncio.Task]: ...  # type: ignore

--- a/tests/integration/python_await/output_leak/.gitignore
+++ b/tests/integration/python_await/output_leak/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/
+lib/

--- a/tests/integration/python_await/output_leak/Pulumi.yaml
+++ b/tests/integration/python_await/output_leak/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-python-output-leak
+description: A Python program that tests waiting for outputs doesn't leak futures.
+runtime: python

--- a/tests/integration/python_await/output_leak/__main__.py
+++ b/tests/integration/python_await/output_leak/__main__.py
@@ -1,0 +1,33 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+import asyncio
+import pulumi
+
+a = pulumi.Output.from_input([1, 2])
+# This output has to await an asyncio.task
+async def fn():
+    await asyncio.sleep(1)
+    return 42
+b = pulumi.Output.from_input(asyncio.to_thread(fn))
+
+# this asyncio task will run forever, we shouldn't block the program on that
+async def loop():
+    while True:
+        await asyncio.sleep(1)
+c = asyncio.create_task(loop())
+
+# we should wait for this because it's an output apply, not just an asyncio task.
+def printer(i: int):
+    print("PRINT:", i)
+d = b.apply(printer)
+
+# but we only explicitly await for a
+pulumi.export("export", a)
+
+# all of the above should eventually resolve leaving the queue empty.
+while True:
+    # need to pump the event loop so the above outputs resolve.
+    pulumi.runtime.sync_await._sync_await(asyncio.sleep(1))
+    with pulumi.runtime.settings.SETTINGS.lock:
+        if len(pulumi.runtime.settings.SETTINGS.outputs) == 0:
+            break


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16055.

https://github.com/pulumi/pulumi/pull/15744 added precise output tracking to the python runtime, so that we can error correctly on any output that raises an exception, and don't wait for all async tasks that are running which could be unrelated to the pulumi program.

Unfortunately that change had a memory leak where it tracked all outputs for the entire run of the program. Not an issue for our small programs in the tests but problematic when a program ends up making thousands of resources with tens of thousands of output values.

This cleans the outputs up from the tracking list as they complete successfully.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
