### PR TITLE
Run pulumi-test-language tests in parallel

### DIFF
--- a/cmd/pulumi-test-language/internal_test.go
+++ b/cmd/pulumi-test-language/internal_test.go
@@ -28,11 +28,9 @@ import (
 )
 
 // Check that an invalid schema triggers an error
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestInvalidSchema(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l1empty_test.go
+++ b/cmd/pulumi-test-language/l1empty_test.go
@@ -170,11 +170,9 @@ func (h *L1EmptyLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 }
 
 // Run a simple successful test with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -296,11 +294,9 @@ func TestL1Empty_FailPrepare(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty_BadSnapshot(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
@@ -338,11 +334,9 @@ func TestL1Empty_BadSnapshot(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Empty_MissingStack(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l1main_test.go
+++ b/cmd/pulumi-test-language/l1main_test.go
@@ -185,11 +185,9 @@ func (h *L1MainLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest)
 }
 
 // Run a simple successful test
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL1Main(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l2continue_on_error_test.go
+++ b/cmd/pulumi-test-language/l2continue_on_error_test.go
@@ -267,11 +267,9 @@ func (h *L2ContinueOnErrorHost) Run(
 }
 
 // Run a simple successful test with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2ContinueOnError(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l2destroy_test.go
+++ b/cmd/pulumi-test-language/l2destroy_test.go
@@ -245,11 +245,9 @@ func (h *L2DestroyLanguageHost) Run(
 }
 
 // Run a simple successful test with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2Destroy(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/l2resourcesimple_test.go
+++ b/cmd/pulumi-test-language/l2resourcesimple_test.go
@@ -232,11 +232,9 @@ func (h *L2ResourceSimpleLanguageHost) Run(
 }
 
 // Run a simple successful test with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2ResourceSimple(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -272,11 +270,9 @@ func TestL2ResourceSimple(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad sdk snapshot with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_BadSnapshot(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{DisableSnapshotWriting: true}
@@ -314,11 +310,9 @@ func TestL2SimpleResource_BadSnapshot(t *testing.T) {
 }
 
 // Run a simple failing test because of a bad project snapshot with a mocked runtime.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_MissingResource(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -359,11 +353,9 @@ func TestL2SimpleResource_MissingResource(t *testing.T) {
 }
 
 // Run a simple failing test because GetRequiredPlugins doesn't return the right plugins.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}
@@ -406,11 +398,9 @@ func TestL2SimpleResource_MissingRequiredPlugins(t *testing.T) {
 }
 
 // Run a simple successful test with a mocked runtime that edits the snapshot files.
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
 func TestL2ResourceSnapshotEdit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}

--- a/cmd/pulumi-test-language/runtime_options_test.go
+++ b/cmd/pulumi-test-language/runtime_options_test.go
@@ -207,12 +207,10 @@ func (h *RuntimeOptionsLanguageHost) Run(
 	return &pulumirpc.RunResponse{}, nil
 }
 
-// Run a simple test with a mocked runtime that uses runtime options
-//
-// TODO(https://github.com/pulumi/pulumi/issues/13945): enable parallel tests
-//
-//nolint:paralleltest // These aren't yet safe to run in parallel
+// Run a simple test with a mocked runtime that uses runtime options.
 func TestRuntimeOptions(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	engine := &languageTestServer{}


### PR DESCRIPTION
Thanks to @tgummerer merging https://github.com/pulumi/pulumi/pull/15607 it looks like these tests are now safe to run in parallel.