### PR TITLE
Use a fresh context for automation api runs

### DIFF
--- a/changelog/pending/20240426--auto-python--ensure-async-context-is-not-shared-between-multiple-programs.yaml
+++ b/changelog/pending/20240426--auto-python--ensure-async-context-is-not-shared-between-multiple-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/python
+  description: Ensure async context is not shared between multiple programs

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import sys
 import traceback
+import contextvars
 from contextlib import suppress
 
 import grpc
@@ -33,11 +34,6 @@ class LanguageServer(LanguageRuntimeServicer):
     def __init__(self, program: PulumiFn) -> None:
         self.program = program
 
-    @staticmethod
-    def on_pulumi_exit():
-        # Reset globals
-        reset_options()
-
     def GetRequiredPlugins(self, request, context):
         return language_pb2.GetRequiredPluginsResponse()
 
@@ -53,72 +49,80 @@ class LanguageServer(LanguageRuntimeServicer):
     def Run(self, request, context):
         _suppress_unobserved_task_logging()
 
-        # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
-        engine_address = request.args[0] if request.args else ""
-        organization = request.organization if request.organization else "organization"
-        reset_options(
-            project=request.project,
-            monitor_address=request.monitor_address,
-            engine_address=engine_address,
-            stack=request.stack,
-            parallel=request.parallel,
-            preview=request.dryRun,
-            organization=organization,
-        )
+        def run():
+            # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
+            engine_address = request.args[0] if request.args else ""
+            organization = (
+                request.organization if request.organization else "organization"
+            )
+            reset_options(
+                project=request.project,
+                monitor_address=request.monitor_address,
+                engine_address=engine_address,
+                stack=request.stack,
+                parallel=request.parallel,
+                preview=request.dryRun,
+                organization=organization,
+            )
 
-        if request.config:
-            secret_keys = request.configSecretKeys if request.configSecretKeys else None
-            set_all_config(request.config, secret_keys)
+            if request.config:
+                secret_keys = (
+                    request.configSecretKeys if request.configSecretKeys else None
+                )
+                set_all_config(request.config, secret_keys)
 
-        # The strategy here is derived from sdk/python/cmd/pulumi-language-python-exec
-        result = language_pb2.RunResponse()
-        loop = asyncio.new_event_loop()
+            # The strategy here is derived from sdk/python/cmd/pulumi-language-python-exec
+            result = language_pb2.RunResponse()
+            loop = asyncio.new_event_loop()
 
-        loop.set_exception_handler(self._exception_handler)
-        try:
-            loop.run_until_complete(run_in_stack(self.program))
-        except RunError as exn:
-            msg = str(exn)
-            log.error(msg)
-            result.error = str(msg)
-            return result
-        except grpc.RpcError as exn:
-            # If the monitor is unavailable, it is in the process of shutting down or has already
-            # shut down. Don't emit an error if this is the case.
-            # pylint: disable=no-member
-            if exn.code() == grpc.StatusCode.UNAVAILABLE:
-                log.debug("Resource monitor has terminated, shutting down.")
-            else:
-                msg = f"RPC error: {exn.details()}"
+            loop.set_exception_handler(self._exception_handler)
+            try:
+                loop.run_until_complete(run_in_stack(self.program))
+            except RunError as exn:
+                msg = str(exn)
+                log.error(msg)
+                result.error = str(msg)
+                return result
+            except grpc.RpcError as exn:
+                # If the monitor is unavailable, it is in the process of shutting down or has already
+                # shut down. Don't emit an error if this is the case.
+                # pylint: disable=no-member
+                if exn.code() == grpc.StatusCode.UNAVAILABLE:
+                    log.debug("Resource monitor has terminated, shutting down.")
+                else:
+                    msg = f"RPC error: {exn.details()}"
+                    log.error(msg)
+                    result.error = msg
+                    return result
+            except Exception as exn:
+                msg = str(
+                    f"python inline source runtime error: {exn}\n{traceback.format_exc()}"
+                )
                 log.error(msg)
                 result.error = msg
                 return result
-        except Exception as exn:
-            msg = str(
-                f"python inline source runtime error: {exn}\n{traceback.format_exc()}"
-            )
-            log.error(msg)
-            result.error = msg
-            return result
-        finally:
-            # If there's an exception during `run_in_stack`, it may result in pending asyncio tasks remaining unresolved
-            # at the time the loop is closed, which results in a `Task was destroyed but it is pending!` error being
-            # logged to stdout. To avoid this, we collect all the unresolved tasks in the loop and cancel them before
-            # closing the loop.
-            pending = (
-                # lint safety: we use the python version here to track deprecations
-                asyncio.all_tasks(loop)
-            )  # pylint: disable=no-member
-            log.debug(f"Cancelling {len(pending)} tasks.")
-            for task in pending:
-                task.cancel()
-                with suppress(asyncio.CancelledError):
-                    loop.run_until_complete(task)
-            loop.close()
-            sys.stdout.flush()
-            sys.stderr.flush()
+            finally:
+                # If there's an exception during `run_in_stack`, it may result in pending asyncio tasks remaining unresolved
+                # at the time the loop is closed, which results in a `Task was destroyed but it is pending!` error being
+                # logged to stdout. To avoid this, we collect all the unresolved tasks in the loop and cancel them before
+                # closing the loop.
+                pending = (
+                    # lint safety: we use the python version here to track deprecations
+                    asyncio.all_tasks(loop)
+                )  # pylint: disable=no-member
+                log.debug(f"Cancelling {len(pending)} tasks.")
+                for task in pending:
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        loop.run_until_complete(task)
+                loop.close()
+                sys.stdout.flush()
+                sys.stderr.flush()
 
-        return result
+            return result
+
+        ctx = contextvars.copy_context()
+        return ctx.run(run)
 
     def GetPluginInfo(self, request, context):
         return plugin_pb2.PluginInfo()

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -292,7 +292,6 @@ class Stack:
             server.start()
 
             def on_exit_fn():
-                language_server.on_pulumi_exit()
                 server.stop(0)
 
             on_exit = on_exit_fn
@@ -413,7 +412,6 @@ class Stack:
             server.start()
 
             def on_exit_fn():
-                language_server.on_pulumi_exit()
                 server.stop(0)
 
             on_exit = on_exit_fn

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -151,8 +151,9 @@ def configure(settings: Settings):
     """
     if not settings or not isinstance(settings, Settings):
         raise TypeError("Settings is expected to be non-None and of type Settings")
-    global SETTINGS  # pylint: disable=global-statement
-    SETTINGS = settings
+    # The properties of SETTINGS are contextvars but SETTINGS itself isn't.
+    for key, value in settings.__dict__.items():
+        setattr(SETTINGS, key, value)
 
 
 def is_dry_run() -> bool:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Looks like this should help with some async context tracking for python. We make a fresh context for running the Automation API program and so don't need to reset globals on exit.

We also fix `configure` to set the context variables rather than overwriting the `SETTINGS` object itself which is just a plain global.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
