### PR TITLE
fix deprecation warnings in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,6 @@
 run:
   timeout: 10m
   # Enable checking the by default skipped "examples" dirs
-  skip-dirs:
-    - Godeps$
-    - builtin$
-    - node_modules
-    - testdata$
-    - third_party$
-    - vendor$
-  skip-dirs-use-default: false
   build-tags:
   - all
 linters:
@@ -102,3 +94,12 @@ issues:
 
     # https://github.com/pulumi/pulumi/issues/12328
     - 'deprecated: Please use types in:? cloud.google.com/go/logging/apiv2/loggingpb'
+
+  exclude-dirs:
+    - Godeps$
+    - builtin$
+    - node_modules
+    - testdata$
+    - third_party$
+    - vendor$
+  exclude-dirs-use-default: false


### PR DESCRIPTION
Since we upgraded golangci-lint to 1.57.2, we started getting a couple of deprecation warnings about `run.skip-dirs` and `run.skip-dirs-use-default`. Both of these moved to the issues: section and changed names slightly.  Make that move to avoid the deprecation warnings.
