### PR TITLE
Lock in wait_for_rpcs

### DIFF
--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from collections import deque
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import grpc
 
-from .. import log
 from .._utils import contextproperty
 from ..errors import RunError
 from ..runtime.proto import engine_pb2_grpc, resource_pb2, resource_pb2_grpc
@@ -62,6 +62,7 @@ class Settings:
     ):
         self.rpc_manager = RPCManager()
         self.outputs = deque()
+        self.lock = threading.Lock()
 
         # Save the metadata information.
         self.project = project
@@ -103,6 +104,9 @@ class Settings:
     def rpc_manager(self) -> RPCManager:  # type: ignore
         # The contextproperty decorator will fill the body of this method in, but mypy doesn't know that.
         ...
+
+    @contextproperty
+    def lock(self) -> threading.Lock: ...  # type: ignore
 
     @contextproperty
     def outputs(self) -> deque[asyncio.Task]: ...  # type: ignore

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1135,11 +1135,10 @@ func TestPythonAwaitOutputs(t *testing.T) {
 	//
 	//nolint:paralleltest // ProgramTest calls t.Parallel()
 	t.Run("AsyncioTasks", func(t *testing.T) {
-		// Skip if python is < 3.9
 		version, err := exec.Command("python3", "--version").Output()
 		require.NoError(t, err)
 		if strings.Contains(string(version), "3.8") {
-			t.Skip("Skipping test as Python version is < 3.9")
+			t.Skip("Skipping test as Python version is < 3.9 and asyncio.to_thread is only available in 3.9+")
 		}
 
 		integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
