### PR TITLE
be consistent in the way we round seconds

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -302,9 +302,9 @@ func renderSummaryEvent(event engine.SummaryEventPayload, hasError bool, diffSty
 
 	// For actual deploys, we print some additional summary information
 	if !event.IsPreview {
-		// Round to the nearest second.  It's not useful to spit out time with 9 digits of
+		// Round up to the nearest second.  It's not useful to spit out time with 9 digits of
 		// precision.
-		roundedSeconds := int64(math.Round(event.Duration.Seconds()))
+		roundedSeconds := int64(math.Ceil(event.Duration.Seconds()))
 		roundedDuration := time.Duration(roundedSeconds) * time.Second
 
 		fprintIgnoreError(out, opts.Color.Colorize(fmt.Sprintf("\n%sDuration:%s %s\n",

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -302,9 +302,9 @@ func renderSummaryEvent(event engine.SummaryEventPayload, hasError bool, diffSty
 
 	// For actual deploys, we print some additional summary information
 	if !event.IsPreview {
-		// Round up to the nearest second.  It's not useful to spit out time with 9 digits of
+		// Round to the nearest second.  It's not useful to spit out time with 9 digits of
 		// precision.
-		roundedSeconds := int64(math.Ceil(event.Duration.Seconds()))
+		roundedSeconds := int64(math.Round(event.Duration.Seconds()))
 		roundedDuration := time.Duration(roundedSeconds) * time.Second
 
 		fprintIgnoreError(out, opts.Color.Colorize(fmt.Sprintf("\n%sDuration:%s %s\n",

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"time"
 
@@ -134,7 +135,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		}
 		apiEvent.SummaryEvent = &apitype.SummaryEvent{
 			MaybeCorrupt:    p.MaybeCorrupt,
-			DurationSeconds: int(p.Duration.Seconds()),
+			DurationSeconds: int(math.Round(p.Duration.Seconds())),
 			ResourceChanges: changes,
 			PolicyPacks:     p.PolicyPacks,
 		}

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -135,7 +135,7 @@ func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, 
 		}
 		apiEvent.SummaryEvent = &apitype.SummaryEvent{
 			MaybeCorrupt:    p.MaybeCorrupt,
-			DurationSeconds: int(math.Round(p.Duration.Seconds())),
+			DurationSeconds: int(math.Ceil(p.Duration.Seconds())),
 			ResourceChanges: changes,
 			PolicyPacks:     p.PolicyPacks,
 		}


### PR DESCRIPTION
In some cases we only display full seconds, particularly when rendering the summary event, and when converting the engine event for use in the API.  However we are currently not consistent with that, rounding up in the display code and rounding down when converting the engine event.

It probably doesn't matter what exactly we are doing here, but for writing display snapshot tests it does.  Let's split the difference here, and always round up, so we never give the impression that the operation took no time.

It doesn't look like Pulumi Cloud shows this at all, so it probably doesn't matter for users, and we could just round up for everyone as well.  I don't have strong opinions about that.