### PR TITLE
add support for --import-file when using the Automation API

### DIFF
--- a/changelog/pending/20240426--auto-go-nodejs-python--add-support-for-import-file-option-on-preview-with-automation-api.yaml
+++ b/changelog/pending/20240426--auto-go-nodejs-python--add-support-for-import-file-option-on-preview-with-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add support for --import-file option on Preview with Automation API

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -539,7 +539,7 @@ func newPreviewCmd() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",
-		"Save any creates seen during the preview into an import file to use with pulumi import")
+		"Save any creates seen during the preview into an import file to use with 'pulumi import'")
 
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false, "Emit secrets in plaintext in the plan file. Defaults to `false`")

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -539,7 +539,7 @@ func newPreviewCmd() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(
 		&importFilePath, "import-file", "",
-		"Save any creates seen during the preview into an import file to use with `pulumi import`")
+		"Save any creates seen during the preview into an import file to use with pulumi import")
 
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false, "Emit secrets in plaintext in the plan file. Defaults to `false`")

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -137,9 +137,9 @@ func SuppressOutputs() Option {
 }
 
 // ImportFile save any creates seen during the preview into an import file to use with pulumi import
-func ImportFile() Option {
+func ImportFile(path string) Option {
 	return optionFunc(func(opts *Options) {
-		opts.ImportFile = true
+		opts.ImportFile = path
 	})
 }
 
@@ -192,7 +192,7 @@ type Options struct {
 	// Suppress display of stack outputs (in case they contain sensitive values)
 	SuppressOutputs bool
 	// Save any creates seen during the preview into an import file to use with pulumi import
-	ImportFile bool
+	ImportFile string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -136,6 +136,13 @@ func SuppressOutputs() Option {
 	})
 }
 
+// ImportFile save any creates seen during the preview into an import file to use with pulumi import
+func ImportFile() Option {
+	return optionFunc(func(opts *Options) {
+		opts.ImportFile = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Preview() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -184,6 +191,8 @@ type Options struct {
 	SuppressProgress bool
 	// Suppress display of stack outputs (in case they contain sensitive values)
 	SuppressOutputs bool
+	// Save any creates seen during the preview into an import file to use with pulumi import
+	ImportFile bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -275,6 +275,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.SuppressProgress {
 		sharedArgs = append(sharedArgs, "--suppress-progress")
 	}
+	if preOpts.ImportFile {
+		sharedArgs = append(sharedArgs, "--import-file")
+	}
 
 	// Apply the remote args, if needed.
 	sharedArgs = append(sharedArgs, s.remoteArgs()...)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -276,7 +276,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, "--suppress-progress")
 	}
 	if preOpts.ImportFile {
-		sharedArgs = append(sharedArgs, "--import-file")
+		sharedArgs = append(sharedArgs, "--import-file="+preOpts.ImportFile)
 	}
 
 	// Apply the remote args, if needed.

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -275,7 +275,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.SuppressProgress {
 		sharedArgs = append(sharedArgs, "--suppress-progress")
 	}
-	if preOpts.ImportFile {
+	if preOpts.ImportFile != "" {
 		sharedArgs = append(sharedArgs, "--import-file="+preOpts.ImportFile)
 	}
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -336,6 +336,9 @@ Event: ${line}\n${e.toString()}`);
             if (opts.plan) {
                 args.push("--save-plan", opts.plan);
             }
+            if (opts.importFile) {
+              args.push("--import-file");
+            } 
             applyGlobalOpts(opts, args);
         }
 
@@ -914,6 +917,10 @@ export interface GlobalOpts {
      * Suppress display of periodic progress dots
      */
     suppressProgress?: boolean;
+    /**
+     * Save any creates seen during the preview into an import file to use with pulumi import
+     */
+    importFile?: boolean;
 }
 
 /**

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -337,7 +337,7 @@ Event: ${line}\n${e.toString()}`);
                 args.push("--save-plan", opts.plan);
             }
             if (opts.importFile) {
-              args.push("--import-file");
+              args.push("--import-file", opts.importFile);
             }
             applyGlobalOpts(opts, args);
         }
@@ -920,7 +920,7 @@ export interface GlobalOpts {
     /**
      * Save any creates seen during the preview into an import file to use with pulumi import
      */
-    importFile?: boolean;
+    importFile?: string;
 }
 
 /**

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -337,7 +337,7 @@ Event: ${line}\n${e.toString()}`);
                 args.push("--save-plan", opts.plan);
             }
             if (opts.importFile) {
-              args.push("--import-file", opts.importFile);
+                args.push("--import-file", opts.importFile);
             }
             applyGlobalOpts(opts, args);
         }

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -338,7 +338,7 @@ Event: ${line}\n${e.toString()}`);
             }
             if (opts.importFile) {
               args.push("--import-file");
-            } 
+            }
             applyGlobalOpts(opts, args);
         }
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -391,7 +391,7 @@ class Stack:
         if import_file is not None:
             args.append("--import-file")
             args.append(import_file)
-                
+
         if plan is not None:
             args.append("--save-plan")
             args.append(plan)

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -350,6 +350,7 @@ class Stack:
         debug: Optional[bool] = None,
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
+        import_file: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -377,6 +378,7 @@ class Stack:
         :param debug: Print detailed debugging output during resource operations
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
+        :param import_file: Save any creates seen during the preview into an import file to use with pulumi import
         :returns: PreviewResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -386,6 +388,9 @@ class Stack:
         args = ["preview"]
         args.extend(extra_args)
 
+        if import_file is not None:
+            args.append("--import-file")
+                
         if plan is not None:
             args.append("--save-plan")
             args.append(plan)

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -350,7 +350,7 @@ class Stack:
         debug: Optional[bool] = None,
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
-        import_file: Optional[bool] = None,
+        import_file: Optional[str] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run update to a stack, returning pending changes.
@@ -390,6 +390,7 @@ class Stack:
 
         if import_file is not None:
             args.append("--import-file")
+            args.append(import_file)
                 
         if plan is not None:
             args.append("--save-plan")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
