### PR TITLE
temporarily skip TestLanguageNewSmoke for java

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -37,6 +37,9 @@ func TestLanguageNewSmoke(t *testing.T) {
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest
+			if runtime == "java" {
+				t.Skip("this test is currently broken for java, see https://github.com/pulumi/pulumi/issues/16086")
+			}
 
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)


### PR DESCRIPTION
This test is currently broken (probably because of an upstream provider change).  Skip it temporarily so we can keep working on pulumi/pulumi.  This should be addressed as part of https://github.com/pulumi/pulumi/issues/16086.

