### PR TITLE
Revert "temporarily skip TestLanguageNewSmoke for java"

### DIFF
--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -37,9 +37,6 @@ func TestLanguageNewSmoke(t *testing.T) {
 	for _, runtime := range Runtimes {
 		t.Run(runtime, func(t *testing.T) {
 			//nolint:paralleltest
-			if runtime == "java" {
-				t.Skip("this test is currently broken for java, see https://github.com/pulumi/pulumi/issues/16086")
-			}
 
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)


### PR DESCRIPTION
Reverts pulumi/pulumi#16087.  The issue has now been fixed upstream.

Close https://github.com/pulumi/pulumi/issues/16086