### PR TITLE
Report snapshot write errors as actual errors

### DIFF
--- a/changelog/pending/20240430--backend-diy-service--promote-snapshot-closure-errors-from-diagnostics-to-actual-errors.yaml
+++ b/changelog/pending/20240430--backend-diy-service--promote-snapshot-closure-errors-from-diagnostics-to-actual-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy,service
+  description: Promote snapshot closure errors from diagnostics to actual errors

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1127,10 +1127,14 @@ func (b *diyBackend) apply(
 	close(engineEvents)
 	if manager != nil {
 		err = manager.Close()
-		// Historically we ignored this error (using IgnoreClose so it would log to the V11 log).
-		// To minimize the immediate blast radius of this to start with we're just going to write an error to the user.
+		// If the snapshot manager failed to close, we should return that error.
+		// Even though all the parts of the operation have potentially succeeded, a
+		// snapshotting failure is likely to rear its head on the next
+		// operation/invocation (e.g. an invalid snapshot that fails integrity
+		// checks, or a failure to write that means the snapshot is incomplete).
+		// Reporting now should make debugging and reporting easier.
 		if err != nil {
-			cmdutil.Diag().Errorf(diag.Message("", "Snapshot write failed: %v"), err)
+			return plan, changes, result.FromError(fmt.Errorf("writing snapshot: %w", err))
 		}
 	}
 


### PR DESCRIPTION
When we finish an operation and close the snapshot manager, the snapshot manager may perform a final write if there are unflushed changes (e.g. refresh changes whose writes were elided at the time). Things may go wrong at this point -- if something is wrong with the snapshot, the integrity check following this write could fail; if a write error occurs, pieces of the snapshot may be missing. In these cases, we really don't want to swallow the error or report it as "just" a diagnostic, because it's a real problem that will almost certainly rear its head on the next Pulumi invocation when we attempt (and fail) to read the snapshot (or worse, operate with an incomplete one). This commit changes the existing flow to report all snapshot close errors as bonafide failures, even if the actual operation has succeeded and been applied.