### PR TITLE
Provide a better error message during pulumi new if no nodejs package manager is installed

### DIFF
--- a/changelog/pending/20240501--sdk-nodejs--provide-a-better-error-message-during-pulumi-new-if-no-nodejs-package-manager-is-installed.yaml
+++ b/changelog/pending/20240501--sdk-nodejs--provide-a-better-error-message-during-pulumi-new-if-no-nodejs-package-manager-is-installed.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Provide a better error message during pulumi new if no nodejs package manager is installed

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -2,6 +2,7 @@ package npm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -100,8 +101,8 @@ func ResolvePackageManager(pwd string) (PackageManager, error) {
 	// Finally, fall back to npm.
 	node, err := newNPM()
 	if err != nil {
-		return nil, fmt.Errorf("could not find npm on the $PATH; npm is installed with Node.js "+
-			"available at https://nodejs.org/: %w", err)
+		return nil, errors.New("could not find npm on the $PATH; make sure npm is installed and run " +
+			"'pulumi install' to complete the project setup")
 	}
 
 	return node, nil


### PR DESCRIPTION
# Description

Fixes https://github.com/pulumi/pulumi/issues/13542

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
