### PR TITLE
More descriptive exception in serialize_property

### DIFF
--- a/changelog/pending/20240501--sdk-python--provide-more-descriptive-exception.yaml
+++ b/changelog/pending/20240501--sdk-python--provide-more-descriptive-exception.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Provide more descriptive exception

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -199,6 +199,7 @@ async def prepare_resource(
         translate,
         typ,
         keep_output_values=remote,
+        resource_obj=res,
     )
 
     # Wait for our parent to resolve

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -196,10 +196,10 @@ async def prepare_resource(
     serialized_props = await rpc.serialize_properties(
         props,
         property_dependencies_resources,
+        res,
         translate,
         typ,
         keep_output_values=remote,
-        resource_obj=res,
     )
 
     # Wait for our parent to resolve
@@ -746,7 +746,7 @@ def read_resource(
             # because a "read" resource does not actually have any dependencies at all in the cloud
             # provider sense, because a read resource already exists. We do not need to track this
             # dependency.
-            resolved_id = await rpc.serialize_property(opts.id, [])
+            resolved_id = await rpc.serialize_property(opts.id, [], None)
             log.debug(f"read prepared: ty={ty}, name={name}, id={opts.id}")
 
             # These inputs will end up in the snapshot, so if there are any additional secret

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -174,6 +174,7 @@ async def serialize_properties(
     input_transformer: Optional[Callable[[str], str]] = None,
     typ: Optional[type] = None,
     keep_output_values: Optional[bool] = None,
+    resource_obj=None,
 ) -> struct_pb2.Struct:
     """
     Serializes an arbitrary Input bag into a Protobuf structure, keeping track of the list
@@ -213,7 +214,7 @@ async def serialize_properties(
         v = inputs[k]
         deps: List["Resource"] = []
         result = await serialize_property(
-            v, deps, input_transformer, get_type(k), keep_output_values
+            v, deps, input_transformer, get_type(k), keep_output_values, resource_obj, k
         )
         # We treat properties that serialize to None as if they don't exist.
         if result is not None:
@@ -328,6 +329,8 @@ async def serialize_property(
     input_transformer: Optional[Callable[[str], str]] = None,
     typ: Optional[type] = None,
     keep_output_values: Optional[bool] = None,
+    resource_obj=None,
+    property_key=None,
 ) -> Any:
     """
     Serializes a single Input into a form suitable for remoting to the engine, awaiting
@@ -581,7 +584,9 @@ async def serialize_property(
 
     # Ensure that we have a value that Protobuf understands.
     if not isLegalProtobufValue(value):
-        raise ValueError(f"unexpected input of type {type(value).__name__}")
+        raise ValueError(
+            f"unexpected input of type {type(value).__name__} for {property_key} in {type(resource_obj).__name__}"
+        )
 
     return value
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -659,9 +659,19 @@ async def serialize_property(
 
     # Ensure that we have a value that Protobuf understands.
     if not isLegalProtobufValue(value):
-        raise ValueError(
-            f"unexpected input of type {type(value).__name__} for {property_key} in {type(resource_obj).__name__}"
-        )
+        if property_key is not None and resource_obj is not None:
+            raise ValueError(
+                f"unexpected input of type {type(value).__name__} for {property_key} in {type(resource_obj).__name__}"
+            )
+        if property_key is not None:
+            raise ValueError(
+                f"unexpected input of type {type(value).__name__} for {property_key}"
+            )
+        if resource_obj is not None:
+            raise ValueError(
+                f"unexpected input of type {type(value).__name__} in {type(resource_obj).__name__}"
+            )
+        raise ValueError(f"unexpected input of type {type(value).__name__}")
 
     return value
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -171,10 +171,10 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
 async def serialize_properties(
     inputs: "Inputs",
     property_deps: Dict[str, List["Resource"]],
+    resource_obj: Optional["Resource"] = None,
     input_transformer: Optional[Callable[[str], str]] = None,
     typ: Optional[type] = None,
     keep_output_values: Optional[bool] = None,
-    resource_obj=None,
 ) -> struct_pb2.Struct:
     """
     Serializes an arbitrary Input bag into a Protobuf structure, keeping track of the list
@@ -214,7 +214,13 @@ async def serialize_properties(
         v = inputs[k]
         deps: List["Resource"] = []
         result = await serialize_property(
-            v, deps, input_transformer, get_type(k), keep_output_values, resource_obj, k
+            v,
+            deps,
+            k,
+            resource_obj,
+            input_transformer,
+            get_type(k),
+            keep_output_values,
         )
         # We treat properties that serialize to None as if they don't exist.
         if result is not None:
@@ -326,11 +332,11 @@ async def _expand_dependencies(
 async def serialize_property(
     value: "Input[Any]",
     deps: List["Resource"],
+    property_key: Optional[str],
+    resource_obj: Optional["Resource"] = None,
     input_transformer: Optional[Callable[[str], str]] = None,
     typ: Optional[type] = None,
     keep_output_values: Optional[bool] = None,
-    resource_obj=None,
-    property_key=None,
 ) -> Any:
     """
     Serializes a single Input into a form suitable for remoting to the engine, awaiting
@@ -360,7 +366,13 @@ async def serialize_property(
         for elem in value:
             props.append(
                 await serialize_property(
-                    elem, deps, input_transformer, element_type, keep_output_values
+                    elem,
+                    deps,
+                    property_key,
+                    resource_obj,
+                    input_transformer,
+                    element_type,
+                    keep_output_values,
                 )
             )
 
@@ -380,12 +392,22 @@ async def serialize_property(
             res = {
                 _special_sig_key: _special_resource_sig,
                 "urn": await serialize_property(
-                    resource.urn, deps, input_transformer, keep_output_values=False
+                    resource.urn,
+                    deps,
+                    property_key,
+                    resource_obj,
+                    input_transformer,
+                    keep_output_values=False,
                 ),
             }
             if is_custom:
                 res["id"] = await serialize_property(
-                    resource_id, deps, input_transformer, keep_output_values=False
+                    resource_id,
+                    deps,
+                    property_key,
+                    resource_obj,
+                    input_transformer,
+                    keep_output_values=False,
                 )
             return res
 
@@ -393,6 +415,8 @@ async def serialize_property(
         return await serialize_property(
             resource_id if is_custom else resource.urn,
             deps,
+            property_key,
+            resource_obj,
             input_transformer,
             keep_output_values=False,
         )
@@ -406,17 +430,32 @@ async def serialize_property(
         if hasattr(value, "path"):
             file_asset = cast("FileAsset", value)
             obj["path"] = await serialize_property(
-                file_asset.path, deps, input_transformer, keep_output_values=False
+                file_asset.path,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         elif hasattr(value, "text"):
             str_asset = cast("StringAsset", value)
             obj["text"] = await serialize_property(
-                str_asset.text, deps, input_transformer, keep_output_values=False
+                str_asset.text,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         elif hasattr(value, "uri"):
             remote_asset = cast("RemoteAsset", value)
             obj["uri"] = await serialize_property(
-                remote_asset.uri, deps, input_transformer, keep_output_values=False
+                remote_asset.uri,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         else:
             raise AssertionError(f"unknown asset type: {value!r}")
@@ -432,17 +471,32 @@ async def serialize_property(
         if hasattr(value, "assets"):
             asset_archive = cast("AssetArchive", value)
             obj["assets"] = await serialize_property(
-                asset_archive.assets, deps, input_transformer, keep_output_values=False
+                asset_archive.assets,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         elif hasattr(value, "path"):
             file_archive = cast("FileArchive", value)
             obj["path"] = await serialize_property(
-                file_archive.path, deps, input_transformer, keep_output_values=False
+                file_archive.path,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         elif hasattr(value, "uri"):
             remote_archive = cast("RemoteArchive", value)
             obj["uri"] = await serialize_property(
-                remote_archive.uri, deps, input_transformer, keep_output_values=False
+                remote_archive.uri,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                keep_output_values=False,
             )
         else:
             raise AssertionError(f"unknown archive type: {value!r}")
@@ -459,7 +513,13 @@ async def serialize_property(
         awaitable = cast("Any", value)
         future_return = await asyncio.ensure_future(awaitable)
         return await serialize_property(
-            future_return, deps, input_transformer, typ, keep_output_values
+            future_return,
+            deps,
+            property_key,
+            resource_obj,
+            input_transformer,
+            typ,
+            keep_output_values,
         )
 
     if known_types.is_output(value):
@@ -477,6 +537,8 @@ async def serialize_property(
         value = await serialize_property(
             output.future(),
             promise_deps,
+            property_key,
+            resource_obj,
             input_transformer,
             typ,
             keep_output_values=False,
@@ -488,7 +550,12 @@ async def serialize_property(
             urn_deps: List["Resource"] = []
             for resource in value_resources:
                 await serialize_property(
-                    resource.urn, urn_deps, input_transformer, keep_output_values=False
+                    resource.urn,
+                    urn_deps,
+                    property_key,
+                    resource_obj,
+                    input_transformer,
+                    keep_output_values=False,
                 )
             promise_deps.extend(set(urn_deps))
             value_resources.update(urn_deps)
@@ -522,7 +589,13 @@ async def serialize_property(
 
         return {
             k: await serialize_property(
-                v, deps, input_transformer, types.get(k), keep_output_values
+                v,
+                deps,
+                property_key,
+                resource_obj,
+                input_transformer,
+                types.get(k),
+                keep_output_values,
             )
             for k, v in value.items()
         }
@@ -575,6 +648,8 @@ async def serialize_property(
             obj[transformed_key] = await serialize_property(
                 value[k],
                 deps,
+                k,
+                resource_obj,
                 input_transformer,
                 get_type(transformed_key),
                 keep_output_values,

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -486,7 +486,9 @@ class NextSerializationTests(unittest.TestCase):
             error = err
 
         self.assertIsNotNone(error)
-        self.assertEqual("unexpected input of type MyClass", str(error))
+        self.assertEqual(
+            "unexpected input of type MyClass for None in NoneType", str(error)
+        )
 
     @pulumi_test
     async def test_string(self):

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -156,20 +156,20 @@ class NextSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_list(self):
         test_list = [1, 2, 3]
-        props = await rpc.serialize_property(test_list, [])
+        props = await rpc.serialize_property(test_list, [], None)
         self.assertEqual(test_list, props)
 
     @pulumi_test
     async def test_tuple(self):
         test_tuple = tuple([1, 2, 3])
-        props = await rpc.serialize_property(test_tuple, [])
+        props = await rpc.serialize_property(test_tuple, [], None)
         self.assertEqual([1, 2, 3], props)
 
     @pulumi_test
     async def test_future(self):
         fut = asyncio.Future()
         fut.set_result(42)
-        prop = await rpc.serialize_property(fut, [])
+        prop = await rpc.serialize_property(fut, [], None)
         self.assertEqual(42, prop)
 
     @pulumi_test
@@ -178,7 +178,7 @@ class NextSerializationTests(unittest.TestCase):
             await asyncio.sleep(0.1)
             return 42
 
-        prop = await rpc.serialize_property(fun(), [])
+        prop = await rpc.serialize_property(fun(), [], None)
         self.assertEqual(42, prop)
 
     @pulumi_test
@@ -186,7 +186,7 @@ class NextSerializationTests(unittest.TestCase):
         fut = asyncio.Future()
         fut.set_result(99)
         test_dict = {"a": 42, "b": fut}
-        prop = await rpc.serialize_property(test_dict, [])
+        prop = await rpc.serialize_property(test_dict, [], None)
         self.assertDictEqual({"a": 42, "b": 99}, prop)
 
     @pulumi_test
@@ -201,13 +201,13 @@ class NextSerializationTests(unittest.TestCase):
 
         settings.SETTINGS.feature_support["resourceReferences"] = False
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(id, prop)
 
         settings.SETTINGS.feature_support["resourceReferences"] = True
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res, res], deps)
         self.assertEqual(rpc._special_resource_sig, prop[rpc._special_sig_key])
         self.assertEqual(urn, prop["urn"])
@@ -231,13 +231,13 @@ class NextSerializationTests(unittest.TestCase):
 
         settings.SETTINGS.feature_support["resourceReferences"] = False
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(id, prop)
 
         settings.SETTINGS.feature_support["resourceReferences"] = True
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res, res], deps)
         self.assertEqual(rpc._special_resource_sig, prop[rpc._special_sig_key])
         self.assertEqual(urn, prop["urn"])
@@ -260,13 +260,13 @@ class NextSerializationTests(unittest.TestCase):
 
         settings.SETTINGS.feature_support["resourceReferences"] = False
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(urn, prop)
 
         settings.SETTINGS.feature_support["resourceReferences"] = True
         deps = []
-        prop = await rpc.serialize_property(res, deps)
+        prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(rpc._special_resource_sig, prop[rpc._special_sig_key])
         self.assertEqual(urn, prop["urn"])
@@ -281,21 +281,21 @@ class NextSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_string_asset(self):
         asset = StringAsset("Python 3 is cool")
-        prop = await rpc.serialize_property(asset, [])
+        prop = await rpc.serialize_property(asset, [], None)
         self.assertEqual(rpc._special_asset_sig, prop[rpc._special_sig_key])
         self.assertEqual("Python 3 is cool", prop["text"])
 
     @pulumi_test
     async def test_file_asset(self):
         asset = FileAsset("hello.txt")
-        prop = await rpc.serialize_property(asset, [])
+        prop = await rpc.serialize_property(asset, [], None)
         self.assertEqual(rpc._special_asset_sig, prop[rpc._special_sig_key])
         self.assertEqual("hello.txt", prop["path"])
 
     @pulumi_test
     async def test_remote_asset(self):
         asset = RemoteAsset("https://pulumi.com")
-        prop = await rpc.serialize_property(asset, [])
+        prop = await rpc.serialize_property(asset, [], None)
         self.assertEqual(rpc._special_asset_sig, prop[rpc._special_sig_key])
         self.assertEqual("https://pulumi.com", prop["uri"])
 
@@ -310,7 +310,7 @@ class NextSerializationTests(unittest.TestCase):
         out = Output({res}, fut, known_fut)
 
         deps = [existing]
-        prop = await rpc.serialize_property(out, deps)
+        prop = await rpc.serialize_property(out, deps, None)
         self.assertListEqual(deps, [existing, res])
         self.assertEqual(42, prop)
 
@@ -349,8 +349,8 @@ class NextSerializationTests(unittest.TestCase):
         combined = Output.all(out, other)
         combined_dict = Output.all(out=out, other=other)
         deps = []
-        prop = await rpc.serialize_property(combined, deps)
-        prop_dict = await rpc.serialize_property(combined_dict, deps)
+        prop = await rpc.serialize_property(combined, deps, None)
+        prop_dict = await rpc.serialize_property(combined_dict, deps, None)
         self.assertSetEqual(set(deps), {res})
         self.assertEqual([42, 99], prop)
         self.assertEqual({"out": 42, "other": 99}, prop_dict)
@@ -359,7 +359,7 @@ class NextSerializationTests(unittest.TestCase):
     async def test_output_all_no_inputs(self):
         empty_all = Output.all()
         deps = []
-        prop = await rpc.serialize_property(empty_all, deps)
+        prop = await rpc.serialize_property(empty_all, deps, None)
         self.assertEqual([], prop)
 
     @pulumi_test
@@ -396,8 +396,8 @@ class NextSerializationTests(unittest.TestCase):
         combined = Output.all(out, other_out)
         combined_dict = Output.all(out=out, other_out=other_out)
         deps = []
-        prop = await rpc.serialize_property(combined, deps)
-        prop_dict = await rpc.serialize_property(combined_dict, deps)
+        prop = await rpc.serialize_property(combined, deps, None)
+        prop_dict = await rpc.serialize_property(combined_dict, deps, None)
         self.assertSetEqual(set(deps), {res, other})
         self.assertEqual([42, 99], prop)
         self.assertEqual({"out": 42, "other_out": 99}, prop_dict)
@@ -421,8 +421,8 @@ class NextSerializationTests(unittest.TestCase):
         combined = Output.all(out, other_out)
         combined_dict = Output.all(out=out, other_out=other_out)
         deps = []
-        prop = await rpc.serialize_property(combined, deps)
-        prop_dict = await rpc.serialize_property(combined_dict, deps)
+        prop = await rpc.serialize_property(combined, deps, None)
+        prop_dict = await rpc.serialize_property(combined_dict, deps, None)
         self.assertSetEqual(set(deps), {res, other})
 
         # The contents of the list are unknown if any of the Outputs used to
@@ -439,7 +439,7 @@ class NextSerializationTests(unittest.TestCase):
         known_fut.set_result(False)
         out = Output({res}, fut, known_fut)
         deps = []
-        prop = await rpc.serialize_property(out, deps)
+        prop = await rpc.serialize_property(out, deps, None)
         self.assertListEqual(deps, [res])
         self.assertEqual(rpc.UNKNOWN, prop)
 
@@ -448,7 +448,7 @@ class NextSerializationTests(unittest.TestCase):
         archive = AssetArchive({"foo": StringAsset("bar")})
 
         deps = []
-        prop = await rpc.serialize_property(archive, deps)
+        prop = await rpc.serialize_property(archive, deps, None)
         self.assertDictEqual(
             {
                 rpc._special_sig_key: rpc._special_archive_sig,
@@ -462,14 +462,14 @@ class NextSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_remote_archive(self):
         asset = RemoteArchive("https://pulumi.com")
-        prop = await rpc.serialize_property(asset, [])
+        prop = await rpc.serialize_property(asset, [], None)
         self.assertEqual(rpc._special_archive_sig, prop[rpc._special_sig_key])
         self.assertEqual("https://pulumi.com", prop["uri"])
 
     @pulumi_test
     async def test_file_archive(self):
         asset = FileArchive("foo.tar.gz")
-        prop = await rpc.serialize_property(asset, [])
+        prop = await rpc.serialize_property(asset, [], None)
         self.assertEqual(rpc._special_archive_sig, prop[rpc._special_sig_key])
         self.assertEqual("foo.tar.gz", prop["path"])
 
@@ -481,7 +481,7 @@ class NextSerializationTests(unittest.TestCase):
 
         error = None
         try:
-            prop = await rpc.serialize_property(MyClass(), [])
+            prop = await rpc.serialize_property(MyClass(), [], None)
         except ValueError as err:
             error = err
 
@@ -493,7 +493,7 @@ class NextSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_string(self):
         # Ensure strings are serialized as strings (and not sequences).
-        prop = await rpc.serialize_property("hello world", [])
+        prop = await rpc.serialize_property("hello world", [], None)
         self.assertEqual("hello world", prop)
 
     @pulumi_test
@@ -507,7 +507,7 @@ class NextSerializationTests(unittest.TestCase):
 
         for case in cases:
             with self.assertRaises(ValueError):
-                await rpc.serialize_property(case, [])
+                await rpc.serialize_property(case, [], None)
 
     @pulumi_test
     async def test_distinguished_unknown_output(self):
@@ -1013,7 +1013,7 @@ class NextSerializationTests(unittest.TestCase):
             ),
             is_known=True,
         )
-        prop = await rpc.serialize_property(out, [])
+        prop = await rpc.serialize_property(out, [], None)
 
         self.assertTrue(await out.is_known())
         self.assertEqual(prop["values"], ["foo", "bar"])
@@ -1271,7 +1271,7 @@ class InputTypeSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_simple_input_type(self):
         it = FooArgs(first_arg="hello", second_arg=42)
-        prop = await rpc.serialize_property(it, [])
+        prop = await rpc.serialize_property(it, [], None)
         self.assertEqual({"firstArg": "hello", "secondArg": 42}, prop)
 
     @pulumi_test
@@ -1279,7 +1279,7 @@ class InputTypeSerializationTests(unittest.TestCase):
         it = ListDictInputArgs(
             a=["hi"], b=["there"], c={"hello": "world"}, d={"foo": "bar"}
         )
-        prop = await rpc.serialize_property(it, [])
+        prop = await rpc.serialize_property(it, [], None)
         self.assertEqual(
             {"a": ["hi"], "b": ["there"], "c": {"hello": "world"}, "d": {"foo": "bar"}},
             prop,
@@ -1295,7 +1295,7 @@ class InputTypeSerializationTests(unittest.TestCase):
             }.get(prop) or prop
 
         it = BarArgs({"foo_bar": "hello", "foo_baz": "world"})
-        prop = await rpc.serialize_property(it, [], transformer)
+        prop = await rpc.serialize_property(it, [], None, None, transformer)
         # Input type keys are not transformed, but keys of nested
         # dicts are still transformed.
         self.assertEqual(
@@ -1328,19 +1328,19 @@ class EnumSerializationTests(unittest.TestCase):
     @pulumi_test
     async def test_string_enum(self):
         one = StrEnum.ONE
-        prop = await rpc.serialize_property(one, [])
+        prop = await rpc.serialize_property(one, [], None)
         self.assertEqual(StrEnum.ONE, prop)
 
     @pulumi_test
     async def test_int_enum(self):
         one = IntEnum.ONE
-        prop = await rpc.serialize_property(one, [])
+        prop = await rpc.serialize_property(one, [], None)
         self.assertEqual(IntEnum.ONE, prop)
 
     @pulumi_test
     async def test_float_enum(self):
         one = FloatEnum.ZERO_POINT_ONE
-        prop = await rpc.serialize_property(one, [])
+        prop = await rpc.serialize_property(one, [], None)
         self.assertEqual(FloatEnum.ZERO_POINT_ONE, prop)
 
 
@@ -1462,7 +1462,7 @@ class TypeMetaDataSerializationTests(unittest.TestCase):
 
         for props in tests:
             result = await rpc.serialize_properties(
-                props, {}, transformer, SerializationArgs
+                props, {}, None, transformer, SerializationArgs
             )
 
             self.assertEqual("hello", result["someValue"])

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -486,9 +486,7 @@ class NextSerializationTests(unittest.TestCase):
             error = err
 
         self.assertIsNotNone(error)
-        self.assertEqual(
-            "unexpected input of type MyClass for None in NoneType", str(error)
-        )
+        self.assertEqual("unexpected input of type MyClass", str(error))
 
     @pulumi_test
     async def test_string(self):


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #15156 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
