### PR TITLE
Lock access when writing event timings in display

### DIFF
--- a/changelog/pending/20240502--backend--fix-concurrent-reads-from-and-writes-to-display-resource-timer-maps.yaml
+++ b/changelog/pending/20240502--backend--fix-concurrent-reads-from-and-writes-to-display-resource-timer-maps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend
+  description: Fix concurrent reads from and writes to display resource timer maps


### PR DESCRIPTION
This should fix #16085, in which we are getting concurrent reads and writes to the `opStopwatch` maps.