### PR TITLE
Updating python dynamic provider types for inputs to Dict[str, Any]

### DIFF
--- a/changelog/pending/20240502--sdk--updating-python-dynamic-provider-types.yaml
+++ b/changelog/pending/20240502--sdk--updating-python-dynamic-provider-types.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
-  scope: sdk
-  description: Updating python dynamic provider types for inputs to Dict[str, Any], from Any. I also added a Union so it was backward compatible, and doesn't immediately throw type errors for users.
+  scope: sdk/python
+  description: Update python dynamic provider types for inputs to Dict[str, Any], from Any

--- a/changelog/pending/20240502--sdk--updating-python-dynamic-provider-types.yaml
+++ b/changelog/pending/20240502--sdk--updating-python-dynamic-provider-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Updating python dynamic provider types for inputs to Dict[str, Any], from Any. I also added a Union so it was backward compatible, and doesn't immediately throw type errors for users.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -22,7 +22,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Union,
     cast,
     no_type_check,
 )
@@ -44,7 +43,7 @@ class CheckResult:
     CheckResult represents the results of a call to `ResourceProvider.check`.
     """
 
-    inputs: Union[Any, Dict[str, Any]]
+    inputs: Dict[str, Any]
     """
     The inputs to use, if any.
     """
@@ -54,9 +53,7 @@ class CheckResult:
     Any validation failures that occurred.
     """
 
-    def __init__(
-        self, inputs: Union[Any, Dict[str, Any]], failures: List["CheckFailure"]
-    ) -> None:
+    def __init__(self, inputs: Dict[str, Any], failures: List["CheckFailure"]) -> None:
         self.inputs = inputs
         self.failures = failures
 
@@ -130,14 +127,12 @@ class CreateResult:
     The ID of the created resource.
     """
 
-    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
+    outs: Optional[Dict[str, Any]]
     """
     Any properties that were computed during creation.
     """
 
-    def __init__(
-        self, id_: str, outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None
-    ) -> None:
+    def __init__(self, id_: str, outs: Optional[Dict[str, Any]] = None) -> None:
         self.id = id_
         self.outs = outs
 
@@ -152,7 +147,7 @@ class ReadResult:
     The ID of the resource ready back (or blank if missing).
     """
 
-    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
+    outs: Optional[Dict[str, Any]]
     """
     The current property state read from the live environment.
     """
@@ -160,7 +155,7 @@ class ReadResult:
     def __init__(
         self,
         id_: Optional[str] = None,
-        outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None,
+        outs: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.id = id_
         self.outs = outs
@@ -171,14 +166,12 @@ class UpdateResult:
     UpdateResult represents the results of a call to `ResourceProvider.update`.
     """
 
-    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
+    outs: Optional[Dict[str, Any]]
     """
     Any properties that were computed during updating.
     """
 
-    def __init__(
-        self, outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None
-    ) -> None:
+    def __init__(self, outs: Optional[Dict[str, Any]] = None) -> None:
         self.outs = outs
 
 
@@ -188,9 +181,7 @@ class ResourceProvider:
     whose CRUD operations are implemented inside your Python program.
     """
 
-    def check(
-        self, _olds: Union[Any, Dict[str, Any]], news: Union[Any, Dict[str, Any]]
-    ) -> CheckResult:
+    def check(self, _olds: Dict[str, Any], news: Dict[str, Any]) -> CheckResult:
         """
         Check validates that the given property bag is valid for a resource of the given type.
         """
@@ -199,15 +190,15 @@ class ResourceProvider:
     def diff(
         self,
         _id: str,
-        _olds: Union[Any, Dict[str, Any]],
-        _news: Union[Any, Dict[str, Any]],
+        _olds: Dict[str, Any],
+        _news: Dict[str, Any],
     ) -> DiffResult:
         """
         Diff checks what impacts a hypothetical update will have on the resource's properties.
         """
         return DiffResult()
 
-    def create(self, props: Union[Any, Dict[str, Any]]) -> CreateResult:
+    def create(self, props: Dict[str, Any]) -> CreateResult:
         """
         Create allocates a new instance of the provided resource and returns its unique ID
         afterwards. If this call fails, the resource must not have been created (i.e., it is
@@ -215,7 +206,7 @@ class ResourceProvider:
         """
         raise Exception("Subclass of ResourceProvider must implement 'create'")
 
-    def read(self, id_: str, props: Union[Any, Dict[str, Any]]) -> ReadResult:
+    def read(self, id_: str, props: Dict[str, Any]) -> ReadResult:
         """
         Reads the current live state associated with a resource.  Enough state must be included in
         the inputs to uniquely identify the resource; this is typically just the resource ID, but it
@@ -226,15 +217,15 @@ class ResourceProvider:
     def update(
         self,
         _id: str,
-        _olds: Union[Any, Dict[str, Any]],
-        _news: Union[Any, Dict[str, Any]],
+        _olds: Dict[str, Any],
+        _news: Dict[str, Any],
     ) -> UpdateResult:
         """
         Update updates an existing resource with new values.
         """
         return UpdateResult()
 
-    def delete(self, _id: str, _props: Union[Any, Dict[str, Any]]) -> None:
+    def delete(self, _id: str, _props: Dict[str, Any]) -> None:
         """
         Delete tears down an existing resource with the given ID.  If it fails, the resource is
         assumed to still exist.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -15,7 +15,17 @@
 import asyncio
 import base64
 import pickle
-from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, cast, no_type_check
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+    no_type_check,
+)
 
 import dill
 
@@ -34,7 +44,7 @@ class CheckResult:
     CheckResult represents the results of a call to `ResourceProvider.check`.
     """
 
-    inputs: Any
+    inputs: Union[Any, Dict[str, Any]]
     """
     The inputs to use, if any.
     """
@@ -44,7 +54,9 @@ class CheckResult:
     Any validation failures that occurred.
     """
 
-    def __init__(self, inputs: Any, failures: List["CheckFailure"]) -> None:
+    def __init__(
+        self, inputs: Union[Any, Dict[str, Any]], failures: List["CheckFailure"]
+    ) -> None:
         self.inputs = inputs
         self.failures = failures
 
@@ -118,12 +130,14 @@ class CreateResult:
     The ID of the created resource.
     """
 
-    outs: Optional[Any]
+    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
     """
     Any properties that were computed during creation.
     """
 
-    def __init__(self, id_: str, outs: Optional[Any] = None) -> None:
+    def __init__(
+        self, id_: str, outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None
+    ) -> None:
         self.id = id_
         self.outs = outs
 
@@ -138,12 +152,16 @@ class ReadResult:
     The ID of the resource ready back (or blank if missing).
     """
 
-    outs: Optional[Any]
+    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
     """
     The current property state read from the live environment.
     """
 
-    def __init__(self, id_: Optional[str] = None, outs: Optional[Any] = None) -> None:
+    def __init__(
+        self,
+        id_: Optional[str] = None,
+        outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None,
+    ) -> None:
         self.id = id_
         self.outs = outs
 
@@ -153,12 +171,14 @@ class UpdateResult:
     UpdateResult represents the results of a call to `ResourceProvider.update`.
     """
 
-    outs: Optional[Any]
+    outs: Union[Optional[Any], Optional[Dict[str, Any]]]
     """
     Any properties that were computed during updating.
     """
 
-    def __init__(self, outs: Optional[Any] = None) -> None:
+    def __init__(
+        self, outs: Union[Optional[Any], Optional[Dict[str, Any]]] = None
+    ) -> None:
         self.outs = outs
 
 
@@ -168,19 +188,26 @@ class ResourceProvider:
     whose CRUD operations are implemented inside your Python program.
     """
 
-    def check(self, _olds: Any, news: Any) -> CheckResult:
+    def check(
+        self, _olds: Union[Any, Dict[str, Any]], news: Union[Any, Dict[str, Any]]
+    ) -> CheckResult:
         """
         Check validates that the given property bag is valid for a resource of the given type.
         """
         return CheckResult(news, [])
 
-    def diff(self, _id: str, _olds: Any, _news: Any) -> DiffResult:
+    def diff(
+        self,
+        _id: str,
+        _olds: Union[Any, Dict[str, Any]],
+        _news: Union[Any, Dict[str, Any]],
+    ) -> DiffResult:
         """
         Diff checks what impacts a hypothetical update will have on the resource's properties.
         """
         return DiffResult()
 
-    def create(self, props: Any) -> CreateResult:
+    def create(self, props: Union[Any, Dict[str, Any]]) -> CreateResult:
         """
         Create allocates a new instance of the provided resource and returns its unique ID
         afterwards. If this call fails, the resource must not have been created (i.e., it is
@@ -188,7 +215,7 @@ class ResourceProvider:
         """
         raise Exception("Subclass of ResourceProvider must implement 'create'")
 
-    def read(self, id_: str, props: Any) -> ReadResult:
+    def read(self, id_: str, props: Union[Any, Dict[str, Any]]) -> ReadResult:
         """
         Reads the current live state associated with a resource.  Enough state must be included in
         the inputs to uniquely identify the resource; this is typically just the resource ID, but it
@@ -196,13 +223,18 @@ class ResourceProvider:
         """
         return ReadResult(id_, props)
 
-    def update(self, _id: str, _olds: Any, _news: Any) -> UpdateResult:
+    def update(
+        self,
+        _id: str,
+        _olds: Union[Any, Dict[str, Any]],
+        _news: Union[Any, Dict[str, Any]],
+    ) -> UpdateResult:
         """
         Update updates an existing resource with new values.
         """
         return UpdateResult()
 
-    def delete(self, _id: str, _props: Any) -> None:
+    def delete(self, _id: str, _props: Union[Any, Dict[str, Any]]) -> None:
         """
         Delete tears down an existing resource with the given ID.  If it fails, the resource is
         assumed to still exist.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Updating python dynamic provider types for inputs to Dict[str, Any], from Any. I also added a Union so it was backward compatible, and doesn't immediately throw type errors for users. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
- [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
