### PR TITLE
Canonicalize provider version during default provider lookup

### DIFF
--- a/changelog/pending/20240502--engine--normalize-provider-version-during-default-provider-lookup.yaml
+++ b/changelog/pending/20240502--engine--normalize-provider-version-during-default-provider-lookup.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Normalize provider version during default provider lookup

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -313,54 +313,44 @@ func (d *defaultProviders) normalizeProviderRequest(req providers.ProviderReques
 	// especially onerous because the engine selects the "newest" plugin available on the machine, which is generally
 	// problematic for a lot of reasons.
 	if req.Version() != nil {
-		logging.V(5).Infof("handleRequest(%s): using version %s from request", req, req.Version())
+		logging.V(5).Infof("normalizeProviderRequest(%s): using version %s from request", req, req.Version())
 	} else {
-		logging.V(5).Infof(
-			"handleRequest(%s): no version specified, falling back to default version", req)
 		if version := d.defaultProviderInfo[req.Package()].Version; version != nil {
-			logging.V(5).Infof("handleRequest(%s): default version hit on version %s", req, version)
+			logging.V(5).Infof("normalizeProviderRequest(%s): default version hit on version %s", req, version)
 			req = providers.NewProviderRequest(version, req.Package(), req.PluginDownloadURL(), req.PluginChecksums())
 		} else {
 			logging.V(5).Infof(
-				"handleRequest(%s): default provider miss, sending nil version to engine", req)
+				"normalizeProviderRequest(%s): default provider miss, sending nil version to engine", req)
 		}
 	}
 
 	if req.PluginDownloadURL() != "" {
-		logging.V(5).Infof("handleRequest(%s): using pluginDownloadURL %s from request",
+		logging.V(5).Infof("normalizeProviderRequest(%s): using pluginDownloadURL %s from request",
 			req, req.PluginDownloadURL())
 	} else {
-		logging.V(5).Infof(
-			"handleRequest(%s): no pluginDownloadURL specified, falling back to default pluginDownloadURL",
-			req)
 		if pluginDownloadURL := d.defaultProviderInfo[req.Package()].PluginDownloadURL; pluginDownloadURL != "" {
-			logging.V(5).Infof("handleRequest(%s): default pluginDownloadURL hit on %s",
+			logging.V(5).Infof("normalizeProviderRequest(%s): default pluginDownloadURL hit on %s",
 				req, pluginDownloadURL)
 			req = providers.NewProviderRequest(req.Version(), req.Package(), pluginDownloadURL, req.PluginChecksums())
 		} else {
 			logging.V(5).Infof(
-				"handleRequest(%s): default pluginDownloadURL miss, sending empty string to engine", req)
+				"normalizeProviderRequest(%s): default pluginDownloadURL miss, sending empty string to engine", req)
 		}
 	}
 
 	if req.PluginChecksums() != nil {
-		logging.V(5).Infof("handleRequest(%s): using pluginChecksums %v from request",
+		logging.V(5).Infof("normalizeProviderRequest(%s): using pluginChecksums %v from request",
 			req, req.PluginChecksums())
 	} else {
-		logging.V(5).Infof(
-			"handleRequest(%s): no pluginChecksums specified, falling back to default pluginChecksums",
-			req)
 		if pluginChecksums := d.defaultProviderInfo[req.Package()].Checksums; pluginChecksums != nil {
-			logging.V(5).Infof("newRegisterDefaultProviderEvent(%s): default pluginChecksums hit on %v",
+			logging.V(5).Infof("normalizeProviderRequest(%s): default pluginChecksums hit on %v",
 				req, pluginChecksums)
 			req = providers.NewProviderRequest(req.Version(), req.Package(), req.PluginDownloadURL(), pluginChecksums)
 		} else {
 			logging.V(5).Infof(
-				"newRegisterDefaultProviderEvent(%s): default pluginChecksums miss, sending empty map to engine", req)
+				"normalizeProviderRequest(%s): default pluginChecksums miss, sending empty map to engine", req)
 		}
 	}
-
-	logging.V(5).Infof("normalized default provider request to %s", req)
 
 	return req
 }

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2049,7 +2049,7 @@ func TestDefaultProviders(t *testing.T) {
 			v1 := semver.MustParse("0.1.0")
 			d := &defaultProviders{
 				defaultProviderInfo: map[tokens.Package]workspace.PluginSpec{
-					tokens.Package(""): {
+					tokens.Package("pkg"): {
 						Version:           &v1,
 						PluginDownloadURL: "github://owner/repo",
 						Checksums:         map[string][]byte{"key": []byte("expected-checksum-value")},
@@ -2061,7 +2061,7 @@ func TestDefaultProviders(t *testing.T) {
 					},
 				},
 			}
-			req := d.normalizeProviderRequest(providers.ProviderRequest{})
+			req := d.normalizeProviderRequest(providers.NewProviderRequest(nil, tokens.Package("pkg"), "", nil))
 			assert.NotNil(t, req)
 			assert.Equal(t, &v1, req.Version())
 			assert.Equal(t, "github://owner/repo", req.PluginDownloadURL())


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR addresses a problem that leads to two default providers for a given package+version. The problem occurs when given a combination of unversioned and versioned provider requests, as can occur in multi-language programs.

The fix is as follows: given an unversioned provider request, apply the default version before looking into the provider cache.

Fixes #16108 

## Example
Given the example program from #16108 plus this fix, the stack state has one provider as expected:

```jsonl
{
    "urn": "urn:pulumi:dev::issue-1939-nodejs::pulumi:providers:kubernetes::default_4_10_0",
    "custom": true,
    "id": "c19b65b0-dd5a-432f-8c75-d7544de782ec",
    "type": "pulumi:providers:kubernetes",
    "inputs": {
        "version": "4.10.0"
    },
    "outputs": {
        "version": "4.10.0"
    },
    "created": "2024-05-02T21:22:09.72166Z",
    "modified": "2024-05-02T21:22:09.72166Z"
}
{
    "urn": "urn:pulumi:dev::issue-1939-nodejs::kubernetes:yaml/v2:ConfigGroup$kubernetes:core/v1:ConfigMap::example:eron/example",
    "custom": true,
    "id": "eron/example",
    "type": "kubernetes:core/v1:ConfigMap",
    "parent": "urn:pulumi:dev::issue-1939-nodejs::kubernetes:yaml/v2:ConfigGroup::example",
    "provider": "urn:pulumi:dev::issue-1939-nodejs::pulumi:providers:kubernetes::default_4_10_0::c19b65b0-dd5a-432f-8c75-d7544de782ec",
    "propertyDependencies": {
        "apiVersion": [],
        "kind": [],
        "metadata": []
    },
}
```

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
