### PR TITLE
reenable parallelism in httpstate snapshot_test

### DIFF
--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -64,12 +64,9 @@ func applyEdits(before, deltas json.RawMessage) (json.RawMessage, error) {
 // Check that cloudSnapshotPersister can talk the diff-based
 // "checkpointverbatim" and "checkpointdelta" protocol when saving
 // snapshots.
-//
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	expectationsFile := "testdata/snapshot_test.json"
@@ -339,11 +336,9 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 	return snaps
 }
 
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func testMarshalDeployment(t *testing.T, snaps []*apitype.DeploymentV3) {
+	t.Parallel()
+
 	dds := newDeploymentDiffState(0)
 	for _, s := range snaps {
 		expected, err := dds.MarshalDeployment(s)
@@ -363,11 +358,9 @@ func testMarshalDeployment(t *testing.T, snaps []*apitype.DeploymentV3) {
 	}
 }
 
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func testDiffStack(t *testing.T, snaps []*apitype.DeploymentV3) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	dds := newDeploymentDiffState(0)
@@ -508,11 +501,9 @@ func BenchmarkDiffStack(b *testing.B) {
 	testOrBenchmarkDiffStack(b, benchmarkDiffStack, dynamicCases)
 }
 
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func TestDiffStack(t *testing.T) {
+	t.Parallel()
+
 	testOrBenchmarkDiffStack(t, testDiffStack, dynamicCases)
 }
 
@@ -560,19 +551,15 @@ func BenchmarkDiffStackRecorded(b *testing.B) {
 	testOrBenchmarkDiffStack(b, benchmarkDiffStack, recordedCases)
 }
 
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func TestDiffStackRecorded(t *testing.T) {
+	t.Parallel()
+
 	testOrBenchmarkDiffStack(t, testDiffStack, recordedCases)
 }
 
-// TODO: This test is currently flaky when run in parallel parallelism
-// is temporarily disabled.  See also https://github.com/pulumi/pulumi/issues/15461.
-//
-//nolint:paralleltest
 func TestMarshalDeployment(t *testing.T) {
+	t.Parallel()
+
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, dynamicCases)
 	testOrBenchmarkDiffStack(t, testMarshalDeployment, recordedCases)
 }


### PR DESCRIPTION
We had to remove the parallelism here because these tests were flaky because the engine Chdir'd to the plugin directory. (See also https://github.com/pulumi/pulumi/issues/15461).

However we have since removed this Chdir, so these tests should no longer be flaky even when run in parallel.

Fixes https://github.com/pulumi/pulumi/issues/15461