### PR TITLE
Sort `requirements.txt` files when generating Python code

### DIFF
--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -69,7 +69,7 @@ jobs:
       runs-on: ubuntu-latest
       env:
         GOVERSION: ">=1.19.0" # from awsx: decoupled from version sets, track latest for codegen
-        NODEVERSION: "14.x"
+        NODEVERSION: "18.x"
         PYTHONVERSION: "3.9.x"
         DOTNETVERSION: "6.x"
         JAVAVERSION: "11"

--- a/changelog/pending/20240503--programgen-python--sort-generated-requirements-txt-files-when-generating-python-programs.yaml
+++ b/changelog/pending/20240503--programgen-python--sort-generated-requirements-txt-files-when-generating-python-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Sort generated requirements.txt files when generating Python programs

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/requirements.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-failed-create-continue-on-error/requirements.txt
@@ -1,3 +1,3 @@
 ROOT/artifacts/pulumi-CORE.VERSION-py3-none-any.whl
-ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl
 ROOT/artifacts/pulumi_fail_on_create-4.0.0-py3-none-any.whl
+ROOT/artifacts/pulumi_simple-2.0.0-py3-none-any.whl


### PR DESCRIPTION
A couple of our tests now generate multi-line `requirements.txt` whose order is dependent on that in which we enumerate packages when testing. This PR changes this so that we always sort them, meaning we can consistently check against snapshotted results (as opposed to having flaky tests that only pass when the generated order matches the one we happened to snapshot last).

Fixes https://github.com/pulumi/pulumi/issues/16113