### PR TITLE
Don't log test results on success

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -214,8 +214,10 @@ func TestLanguage(t *testing.T) {
 				for _, msg := range result.Messages {
 					t.Log(msg)
 				}
-				t.Logf("stdout: %s", result.Stdout)
-				t.Logf("stderr: %s", result.Stderr)
+				if !result.Success {
+					t.Logf("stdout: %s", result.Stdout)
+					t.Logf("stderr: %s", result.Stderr)
+				}
 				assert.True(t, result.Success)
 			})
 		}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -216,8 +216,10 @@ func TestLanguage(t *testing.T) {
 				for _, msg := range result.Messages {
 					t.Log(msg)
 				}
-				t.Logf("stdout: %s", result.Stdout)
-				t.Logf("stderr: %s", result.Stderr)
+				if !result.Success {
+					t.Logf("stdout: %s", result.Stdout)
+					t.Logf("stderr: %s", result.Stderr)
+				}
 				assert.True(t, result.Success)
 			})
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Don't log the test stdout/err unless it failed. These logs are _very_ verbose and printing them all, all of the time is unproductive for seeing how the failed tests failed.
