### PR TITLE
truncate debug log output in conformance tests

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"testing"
@@ -57,10 +58,18 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 		return nil, fmt.Errorf("Unrecognized logging severity: %v", req.Severity)
 	}
 
+	message := req.Message
+	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
+		// Cut down logs so they don't overwhelm the test output
+		if len(message) > 100 {
+			message = message[:100] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
+		}
+	}
+
 	if req.StreamId != 0 {
-		e.t.Logf("(%d) %s[%s]: %s", req.StreamId, sev, req.Urn, req.Message)
+		e.t.Logf("(%d) %s[%s]: %s", req.StreamId, sev, req.Urn, message)
 	} else {
-		e.t.Logf("%s[%s]: %s", sev, req.Urn, req.Message)
+		e.t.Logf("%s[%s]: %s", sev, req.Urn, message)
 	}
 	return &pbempty.Empty{}, nil
 }


### PR DESCRIPTION
This debug log output can get way too long, and GitHub Actions logs can't even display it anymore when there are test failures.  Cut each individual message short, with an escape hatch in case someone wants to run with the full output locally.

I had a look at the test failure in https://github.com/pulumi/pulumi/pull/16116 and it seems like it's still having the same issue.  Looking again at the test output it's actually this t.Log that includes the registered resource outputs, that contains the large amounts of data.  I arbitrarily decided to make the cutoff 100 chars, but that could be adjusted.