### PR TITLE
avoid showing repeated messages

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -72,11 +72,13 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 	if e.previousMessage == message {
 		e.logRepeat++
 		return &pbempty.Empty{}, nil
-	} else if e.logRepeat > 1 {
-		e.t.Logf("Last message repeated %d times", e.logRepeat)
-		e.logRepeat = 1
-		e.previousMessage = message
 	}
+
+	if e.logRepeat > 1 {
+		e.t.Logf("Last message repeated %d times", e.logRepeat)
+	}
+	e.logRepeat = 1
+	e.previousMessage = message
 
 	if req.StreamId != 0 {
 		e.t.Logf("(%d) %s[%s]: %s", req.StreamId, sev, req.Urn, message)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -41,6 +41,9 @@ import (
 type hostEngine struct {
 	pulumirpc.UnimplementedEngineServer
 	t *testing.T
+
+	logRepeat       int
+	previousMessage string
 }
 
 func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty.Empty, error) {
@@ -64,6 +67,15 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 		if len(message) > 100 {
 			message = message[:100] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
 		}
+	}
+
+	if e.previousMessage == message {
+		e.logRepeat++
+		return &pbempty.Empty{}, nil
+	} else if e.logRepeat > 1 {
+		e.t.Logf("Last message repeated %d times", e.logRepeat)
+		e.logRepeat = 1
+		e.previousMessage = message
 	}
 
 	if req.StreamId != 0 {

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -74,11 +74,13 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 	if e.previousMessage == message {
 		e.logRepeat++
 		return &pbempty.Empty{}, nil
-	} else if e.logRepeat > 1 {
-		e.t.Logf("Last message repeated %d times", e.logRepeat)
-		e.logRepeat = 1
-		e.previousMessage = message
 	}
+
+	if e.logRepeat > 1 {
+		e.t.Logf("Last message repeated %d times", e.logRepeat)
+	}
+	e.logRepeat = 1
+	e.previousMessage = message
 
 	if req.StreamId != 0 {
 		e.t.Logf("(%d) %s[%s]: %s", req.StreamId, sev, req.Urn, message)


### PR DESCRIPTION
Sometimes we show hundreds of repeated messages in the logs, e.g. "waiting for quiescence; 3 outputs outstanding".  This just makes the logs harder to read.  Since we need to wait for the test to finish before any of this is shown anyway, only log each message once and show a little blurb about how often the message has been repeated.

(Note that for simplicity if the last message is repeated we don't show the same blurb, but that should be okay since the last messages we're logging are always different.)

Based on https://github.com/pulumi/pulumi/pull/16117 where I noticed this, and I didn't want to rebase it to avoid conflicts.