### PR TITLE
Fix folder archives in the engine

### DIFF
--- a/changelog/pending/20240503--engine--fix-folder-archive-outside-of-cwd.yaml
+++ b/changelog/pending/20240503--engine--fix-folder-archive-outside-of-cwd.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix folder archive outside of cwd.

--- a/cmd/pulumi-test-language/l2resourceasset_test.go
+++ b/cmd/pulumi-test-language/l2resourceasset_test.go
@@ -238,7 +238,7 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 		Path: "../archive.tar",
 	}, plugin.MarshalOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal asset: %w", err)
+		return nil, fmt.Errorf("could not marshal archive: %w", err)
 	}
 
 	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
@@ -248,6 +248,27 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 		Object: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"value": archive,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register resource: %w", err)
+	}
+
+	folder, err := plugin.MarshalArchive(&resource.Archive{
+		Path: "../folder",
+	}, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal folder: %w", err)
+	}
+
+	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type:   "asset-archive:index:ArchiveResource",
+		Custom: true,
+		Name:   "dir",
+		Object: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"value": folder,
 			},
 		},
 	})

--- a/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/folder/test.txt
+++ b/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
+++ b/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
@@ -5,3 +5,7 @@ resource "ass" "asset-archive:index:AssetResource" {
 resource "arc" "asset-archive:index:ArchiveResource" {
     value = fileArchive("../archive.tar")
 }
+
+resource "dir" "asset-archive:index:ArchiveResource" {
+    value = fileArchive("../folder")
+}

--- a/cmd/pulumi-test-language/testdata/snapshots/projects/l2-resource-asset-archive/folder/test.txt
+++ b/cmd/pulumi-test-language/testdata/snapshots/projects/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/folder/test.txt
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
@@ -3,3 +3,4 @@ import * as asset_archive from "@pulumi/asset-archive";
 
 const ass = new asset_archive.AssetResource("ass", {value: new pulumi.asset.FileAsset("../test.txt")});
 const arc = new asset_archive.ArchiveResource("arc", {value: new pulumi.asset.FileArchive("../archive.tar")});
+const dir = new asset_archive.ArchiveResource("dir", {value: new pulumi.asset.FileArchive("../folder")});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/folder/test.txt
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
@@ -3,3 +3,4 @@ import * as asset_archive from "@pulumi/asset-archive";
 
 const ass = new asset_archive.AssetResource("ass", {value: new pulumi.asset.FileAsset("../test.txt")});
 const arc = new asset_archive.ArchiveResource("arc", {value: new pulumi.asset.FileArchive("../archive.tar")});
+const dir = new asset_archive.ArchiveResource("dir", {value: new pulumi.asset.FileArchive("../folder")});

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/folder/test.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -3,3 +3,4 @@ import pulumi_asset_archive as asset_archive
 
 ass = asset_archive.AssetResource("ass", value=pulumi.FileAsset("../test.txt"))
 arc = asset_archive.ArchiveResource("arc", value=pulumi.FileArchive("../archive.tar"))
+dir = asset_archive.ArchiveResource("dir", value=pulumi.FileArchive("../folder"))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/folder/test.txt
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/folder/test.txt
@@ -1,0 +1,1 @@
+data in a folder

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -3,3 +3,4 @@ import pulumi_asset_archive as asset_archive
 
 ass = asset_archive.AssetResource("ass", value=pulumi.FileAsset("../test.txt"))
 arc = asset_archive.ArchiveResource("arc", value=pulumi.FileArchive("../archive.tar"))
+dir = asset_archive.ArchiveResource("dir", value=pulumi.FileArchive("../folder"))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16092.

Last part of the fix started in https://github.com/pulumi/pulumi/pull/16100. That last PR fixed assets and archive files, but not archive folders.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
