### PR TITLE
Revert "Lock access when writing event timings in display"

### DIFF
--- a/changelog/pending/20240506--cli-display--revert-a-change-that-caused-the-display-to-lock-on-pulumi-up-and-pulumi-refresh.yaml
+++ b/changelog/pending/20240506--cli-display--revert-a-change-that-caused-the-display-to-lock-on-pulumi-up-and-pulumi-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Revert a change that caused the display to lock on pulumi up and pulumi refresh


### PR DESCRIPTION
Reverts pulumi/pulumi#16101

Fixes https://github.com/pulumi/pulumi/issues/16127