### PR TITLE
fix deadlock in stopwatch mutex

### DIFF
--- a/changelog/pending/20240506--cli-display--fix-a-deadlock-in-the-display-code.yaml
+++ b/changelog/pending/20240506--cli-display--fix-a-deadlock-in-the-display-code.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix a deadlock in the display code

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -79,7 +79,7 @@ type ProgressDisplay struct {
 	// eventMutex is used to synchronize access to eventUrnToResourceRow, which is accessed
 	// by the treeRenderer
 	eventMutex sync.RWMutex
-	// stopwatchMutex is used to synchronixe access to o opStopwatch, which is used to track the times
+	// stopwatchMutex is used to synchronixe access to opStopwatch, which is used to track the times
 	// taken to perform actions on resources.
 	stopwatchMutex sync.RWMutex
 

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -242,8 +242,8 @@ func TestTreeRenderDoesntRenderBeforeItHasContent(t *testing.T) {
 	}()
 
 	func() {
-		display.m.Lock()
-		defer display.m.Unlock()
+		display.eventMutex.Lock()
+		defer display.eventMutex.Unlock()
 		display.ensureHeaderAndStackRows()
 	}()
 


### PR DESCRIPTION
The `m` mutex deadlocks in the display code.  Split it up into an event mutex that works as it did before
https://github.com/pulumi/pulumi/pull/16101, and add a separate mutex for the stopwatch, to avoid any deadlocks here.


Fixes https://github.com/pulumi/pulumi/issues/16127