### PR TITLE
Adding unmarshaling logic for DockerImage

### DIFF
--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -67,6 +67,36 @@ type DockerImage struct {
 	Credentials *DockerImageCredentials `json:"credentials,omitempty"`
 }
 
+type dockerImageJSON struct {
+	Reference   string                  `json:"reference"`
+	Credentials *DockerImageCredentials `json:"credentials,omitempty"`
+}
+
+func (d *DockerImage) MarshalJSON() ([]byte, error) {
+	if d.Credentials != nil {
+		return json.Marshal(dockerImageJSON{
+			Reference:   d.Reference,
+			Credentials: d.Credentials,
+		})
+	}
+	return json.Marshal(d.Reference)
+}
+
+func (d *DockerImage) UnmarshalJSON(bytes []byte) error {
+	var image dockerImageJSON
+	if err := json.Unmarshal(bytes, &image); err == nil {
+		d.Reference, d.Credentials = image.Reference, image.Credentials
+		return nil
+	}
+
+	var reference string
+	if err := json.Unmarshal(bytes, &reference); err != nil {
+		return err
+	}
+	d.Reference, d.Credentials = reference, nil
+	return nil
+}
+
 // DockerImageCredentials describes the credentials needed to access a Docker repository.
 type DockerImageCredentials struct {
 	Username string      `json:"username"`


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

- Adding marshalling logic to match pulumi service [here](https://github.com/pulumi/pulumi-service/blob/7cb3e4a314cee068b7cc374c0eb01645e225b240/pkg/apitype/workflow.go#L256) for [issue in pulumi cloud provider](https://github.com/pulumi/pulumi-pulumiservice/issues/262)

Fixes # (issue)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
 - Just model logic
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
 - No need for changelog, just internal model bugfix 
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
