### PR TITLE
Revert "Revert "Run integration tests and dev builds with race detection" (#15998)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,8 @@ jobs:
       build-platform: ${{ matrix.target.build-platform }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: ${{ inputs.enable-coverage }}
+      # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
+      enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
     secrets: inherit
 
   build-sdks:

--- a/build/common.mk
+++ b/build/common.mk
@@ -109,7 +109,7 @@ GO_TEST_PARALLELISM     ?= 10   # -parallel, number of parallel tests to run wit
 GO_TEST_PKG_PARALLELISM ?= 2    # -p flag, number of parallel packages to test
 GO_TEST_SHUFFLE         ?= off  # -shuffle flag, randomizes order of tests within a package
 GO_TEST_TAGS            ?= all
-GO_TEST_RACE            ?= false # disable race detector by default until snapshot system doesn't race with the engine
+GO_TEST_RACE            ?= true
 
 GO_TEST_FLAGS = -count=1 -cover -tags="${GO_TEST_TAGS}" -timeout 1h \
 	-parallel=${GO_TEST_PARALLELISM} \

--- a/changelog/pending/20240508--engine--fix-dataraces-between-snapshot-and-deployment-systems.yaml
+++ b/changelog/pending/20240508--engine--fix-dataraces-between-snapshot-and-deployment-systems.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix dataraces between snapshot and deployment systems.

--- a/pkg/backend/inmemoryPersister.go
+++ b/pkg/backend/inmemoryPersister.go
@@ -33,13 +33,19 @@ func (p *InMemoryPersister) Save(snap *deploy.Snapshot) error {
 		PendingOperations: make([]resource.Operation, len(snap.PendingOperations)),
 	}
 
-	copy(result.Resources, snap.Resources)
+	for i, res := range snap.Resources {
+		res.Lock.Lock()
+		result.Resources[i] = res.Copy()
+		res.Lock.Unlock()
+	}
 
 	for i, op := range snap.PendingOperations {
+		op.Resource.Lock.Lock()
 		result.PendingOperations[i] = resource.Operation{
 			Type:     op.Type,
-			Resource: op.Resource,
+			Resource: op.Resource.Copy(),
 		}
+		op.Resource.Lock.Unlock()
 	}
 
 	p.Snap = result

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -501,9 +501,9 @@ func generateImportedDefinitions(ctx *plugin.Context,
 		urn := resource.NewURN(stackName.Q(), projectName, parentType, i.Type, i.Name)
 		if state, ok := resourceTable[urn]; ok {
 			// Copy the state and override the protect bit.
-			s := *state
+			s := state.Copy()
 			s.Protect = protectResources
-			resources = append(resources, &s)
+			resources = append(resources, s)
 		}
 	}
 

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -716,6 +716,9 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 						assert.Equal(t, deploy.OpUpdate, resultOp)
 					}
 
+					old = old.Copy()
+					new = new.Copy()
+
 					// Only the inputs and outputs should have changed (if anything changed).
 					old.Inputs = expected.Inputs
 					old.Outputs = expected.Outputs
@@ -887,6 +890,7 @@ func TestCanceledRefresh(t *testing.T) {
 				}
 
 				// Only the outputs and Modified timestamp should have changed (if anything changed).
+				old = old.Copy()
 				old.Outputs = expected
 				old.Modified = new.Modified
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -152,11 +152,11 @@ func (i *importer) registerExistingResources(ctx context.Context) bool {
 			}
 
 			// Clear the ID because Same asserts that the new state has no ID.
-			new := *r
+			new := r.Copy()
 			new.ID = ""
 			// Set a dummy goal so the resource is tracked as managed.
 			i.deployment.goals.Store(r.URN, &resource.Goal{})
-			if !i.executeSerial(ctx, NewSameStep(i.deployment, noopEvent(0), r, &new)) {
+			if !i.executeSerial(ctx, NewSameStep(i.deployment, noopEvent(0), r, new)) {
 				return false
 			}
 		}
@@ -348,11 +348,11 @@ func (i *importer) importResources(ctx context.Context) error {
 			}
 			if oldID == imp.ID {
 				// Clear the ID because Same asserts that the new state has no ID.
-				new := *old
+				new := old.Copy()
 				new.ID = ""
 				// Set a dummy goal so the resource is tracked as managed.
 				i.deployment.goals.Store(old.URN, &resource.Goal{})
-				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, &new))
+				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, new))
 				continue
 			}
 		}
@@ -366,11 +366,11 @@ func (i *importer) importResources(ctx context.Context) error {
 			}
 			if oldID == imp.ID {
 				// Clear the ID because Same asserts that the new state has no ID.
-				new := *old
+				new := old.Copy()
 				new.ID = ""
 				// Set a dummy goal so the resource is tracked as managed.
 				i.deployment.goals.Store(old.URN, &resource.Goal{})
-				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, &new))
+				steps = append(steps, NewSameStep(i.deployment, noopEvent(0), old, new))
 				continue
 			}
 		}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -103,6 +103,9 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 	}
 
 	fixResource := func(old *resource.State) *resource.State {
+		old.Lock.Lock()
+		defer old.Lock.Unlock()
+
 		return newStateBuilder(old).
 			withUpdatedURN(fixUrn).
 			withUpdatedParent(fixUrn).

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -56,9 +56,9 @@ func TestSnapshotWithUpdatedResources(t *testing.T) {
 	assert.Same(t, s, s1)
 
 	s = s1.withUpdatedResources(func(r *resource.State) *resource.State {
-		out := *r
+		out := r.Copy()
 		out.URN += "!"
-		return &out
+		return out
 	})
 	assert.NotSame(t, s, s1)
 	assert.Equal(t, s1.Resources[0].URN+"!", s.Resources[0].URN)

--- a/pkg/resource/deploy/state_builder.go
+++ b/pkg/resource/deploy/state_builder.go
@@ -26,7 +26,7 @@ type stateBuilder struct {
 }
 
 func newStateBuilder(state *resource.State) *stateBuilder {
-	return &stateBuilder{*state, state, false}
+	return &stateBuilder{*(state.Copy()), state, false}
 }
 
 func (sb *stateBuilder) withUpdatedURN(update func(resource.URN) resource.URN) *stateBuilder {

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -257,7 +257,9 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 		}
 	}
 
+	reg.New().Lock.Lock()
 	reg.New().Outputs = outs
+	reg.New().Lock.Unlock()
 
 	// If we're generating plans save these new outputs to the plan
 	if se.opts.GeneratePlan {
@@ -421,6 +423,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 	// https://github.com/pulumi/pulumi/issues/14994).
 	if step.New() != nil && step.Op() != OpReplace {
 		newState := step.New()
+		newState.Lock.Lock()
+
 		for _, k := range newState.AdditionalSecretOutputs {
 			if k == "id" {
 				se.deployment.Diag().Warningf(&diag.Diag{
@@ -464,6 +468,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 				}
 			}
 		}
+
+		newState.Lock.Unlock()
 
 		// If this is not a resource that is managed by Pulumi, then we can ignore it.
 		if _, hasGoal := se.deployment.goals.Load(newState.URN); hasGoal {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -308,6 +308,9 @@ func SerializeResource(
 	contract.Requiref(res != nil, "res", "must not be nil")
 	contract.Requiref(res.URN != "", "res", "must have a URN")
 
+	res.Lock.Lock()
+	defer res.Lock.Unlock()
+
 	// Serialize all input and output properties recursively, and add them if non-empty.
 	var inputs map[string]interface{}
 	if inp := res.Inputs; inp != nil {

--- a/sdk/go/common/resource/resource_state.go
+++ b/sdk/go/common/resource/resource_state.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"sync"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -27,6 +28,11 @@ import (
 //
 //nolint:lll
 type State struct {
+	// Currently the engine implements RegisterResourceOutputs by directly mutating the state to change the `Outputs`. This
+	// triggers a race between the snapshot serialization code and the engine. Ideally we'd do a more principled fix, but
+	// just locking in these two places is sufficient to stop the race detector from firing on integration tests.
+	Lock sync.Mutex
+
 	Type                    tokens.Type           // the resource's type.
 	URN                     URN                   // the resource's object urn, a human-friendly, unique name for the resource.
 	Custom                  bool                  // true if the resource is custom, managed by a plugin.
@@ -51,6 +57,36 @@ type State struct {
 	Created                 *time.Time            // If set, the time when the state was initially added to the state file. (i.e. Create, Import)
 	Modified                *time.Time            // If set, the time when the state was last modified in the state file.
 	SourcePosition          string                // If set, the source location of the resource registration
+}
+
+// Copy creates a deep copy of the resource state, except without copying the lock.
+func (s *State) Copy() *State {
+	return &State{
+		Type:                    s.Type,
+		URN:                     s.URN,
+		Custom:                  s.Custom,
+		Delete:                  s.Delete,
+		ID:                      s.ID,
+		Inputs:                  s.Inputs,
+		Outputs:                 s.Outputs,
+		Parent:                  s.Parent,
+		Protect:                 s.Protect,
+		External:                s.External,
+		Dependencies:            s.Dependencies,
+		InitErrors:              s.InitErrors,
+		Provider:                s.Provider,
+		PropertyDependencies:    s.PropertyDependencies,
+		PendingReplacement:      s.PendingReplacement,
+		AdditionalSecretOutputs: s.AdditionalSecretOutputs,
+		Aliases:                 s.Aliases,
+		CustomTimeouts:          s.CustomTimeouts,
+		ImportID:                s.ImportID,
+		RetainOnDelete:          s.RetainOnDelete,
+		DeletedWith:             s.DeletedWith,
+		Created:                 s.Created,
+		Modified:                s.Modified,
+		SourcePosition:          s.SourcePosition,
+	}
 }
 
 func (s *State) GetAliasURNs() []URN {

--- a/tests/testprovider/echo.go
+++ b/tests/testprovider/echo.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-
 	"strconv"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"

--- a/tests/testprovider/fails_on_delete.go
+++ b/tests/testprovider/fails_on_delete.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"errors"
-
 	"strconv"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This reverts commit 75340dd94203da02e44ca5f8beb55d9063d302ef.

Fixes https://github.com/pulumi/pulumi/issues/16018.

This re-enables the locking and race detection. The locking is more finely scoped to not be held over provider methods like Read/Update.


## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
