### PR TITLE
Don't load punycode module in function serialization code

### DIFF
--- a/changelog/pending/20240508--sdk-nodejs--dont-load-punycode-module-in-function-serialization-code.yaml
+++ b/changelog/pending/20240508--sdk-nodejs--dont-load-punycode-module-in-function-serialization-code.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Don't load punycode module in function serialization code

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1418,6 +1418,7 @@ function getBuiltInModules(): Promise<Map<any, string>> {
         // available at the unqualified names listed below.
 
         const excludes = [
+            "punycode", // deprecated in documentation since 7.0, logs a warning in 21.0
             "sys", // deprecated since 1.0
             "wasi", // experimental
         ];


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/15545

https://nodejs.org/api/deprecations.html#dep0040-nodepunycode-module

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
