### PR TITLE
Set range in python codegen default SDK version

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3275,6 +3275,9 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 	return nil
 }
 
+// Require the SDK to fall within the same major version.
+var MinimumValidSDKVersion string = ">=3.0.0,<4.0.0"
+
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies
 // as provided in the package schema, and validates whether
@@ -3287,18 +3290,17 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 // validate.
 func ensureValidPulumiVersion(requires map[string]string) (map[string]string, error) {
 	deps := map[string]string{}
-	// Special case: if the map is empty, we return just pulumi with no version constraint.
-	// This is just legacy functionality; there's no obvious reason this should be the case.
+	// Special case: if the map is empty, we return just pulumi with the minimum version constraint.
 	if len(requires) == 0 {
 		result := map[string]string{
-			"pulumi": ">=3.0.0,<4.0.0",
+			"pulumi": MinimumValidSDKVersion,
 		}
 		return result, nil
 	}
 	// If the pulumi dep is missing, we require it to fall within
 	// our major version constraint.
 	if pulumiDep, ok := requires["pulumi"]; !ok {
-		deps["pulumi"] = ">=3.0.0,<4.0.0"
+		deps["pulumi"] = MinimumValidSDKVersion
 	} else {
 		// Since a value was provided, we check to make sure it's
 		// within an acceptable version range.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3276,7 +3276,7 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package) error {
 }
 
 // Require the SDK to fall within the same major version.
-var MinimumValidSDKVersion string = ">=3.0.0,<4.0.0"
+var MinimumValidSDKVersion = ">=3.0.0,<4.0.0"
 
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3291,7 +3291,7 @@ func ensureValidPulumiVersion(requires map[string]string) (map[string]string, er
 	// This is just legacy functionality; there's no obvious reason this should be the case.
 	if len(requires) == 0 {
 		result := map[string]string{
-			"pulumi": "",
+			"pulumi": ">=3.0.0,<4.0.0",
 		}
 		return result, nil
 	}

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -319,7 +319,7 @@ func TestCalculateDeps(t *testing.T) {
 			// with semver and parver formatted differently from Pulumi.
 			// Pulumi should not have a version.
 			{"parver>=0.2.1", ""},
-			{"pulumi", ""},
+			{"pulumi", ">=3.0.0,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
 	}, {

--- a/sdk/python/cmd/pulumi-language-python/testdata/sdks/old-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/sdks/old-1.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_old',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "2.0.0"

--- a/tests/testdata/codegen/assets-and-archives/python/setup.py
+++ b/tests/testdata/codegen/assets-and-archives/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/cyclic-types/python/setup.py
+++ b/tests/testdata/codegen/cyclic-types/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/dash-named-schema/python/setup.py
+++ b/tests/testdata/codegen/dash-named-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo_bar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/dashed-import-schema/python/setup.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/different-enum/python/setup.py
+++ b/tests/testdata/codegen/different-enum/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/external-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/external-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/functions-secrets/python/setup.py
+++ b/tests/testdata/codegen/functions-secrets/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/hyphenated-symbols/python/setup.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_repro',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/legacy-names/python/setup.py
+++ b/tests/testdata/codegen/legacy-names/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_legacy_names',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_metaprovider',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/naming-collisions/python/setup.py
+++ b/tests/testdata/codegen/naming-collisions/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/nested-module/python/setup.py
+++ b/tests/testdata/codegen/nested-module/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myedgeorder',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/output-funcs/python/setup.py
+++ b/tests/testdata/codegen/output-funcs/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/plain-and-default/python/setup.py
+++ b/tests/testdata/codegen/plain-and-default/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foobar',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/plain-object-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/provider-config-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-config-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configstation',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/provider-type-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-type-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_providerType',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/regress-8403/python/setup.py
+++ b/tests/testdata/codegen/regress-8403/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mongodbatlas',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/regress-node-8110/python/setup.py
+++ b/tests/testdata/codegen/regress-node-8110/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_my8110',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/regress-py-12546/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12546/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/regress-py-12980/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12980/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_myPkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/regress-py-14012/python/setup.py
+++ b/tests/testdata/codegen/regress-py-14012/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/replace-on-change/python/setup.py
+++ b/tests/testdata/codegen/replace-on-change/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/resource-args-python/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/resource-property-overlap/python/setup.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/secrets/python/setup.py
+++ b/tests/testdata/codegen/secrets/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-enum-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-methods-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-plain-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -31,7 +31,7 @@ setup(name='custom_py_package',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.8"

--- a/tests/testdata/codegen/simple-yaml-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/unions-inline/python/setup.py
+++ b/tests/testdata/codegen/unions-inline/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/unions-inside-arrays/python/setup.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/urn-id-properties/python/setup.py
+++ b/tests/testdata/codegen/urn-id-properties/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_urnid',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_credentials',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi',
+          'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
If the schema doesn't set any specific dependencies, we should be defaulting to requiring pulumi within the current major version rather than completely unconstrained.

Discussion: https://github.com/pulumi/pulumi-kafka/pull/410/files#r1594324390