### PR TITLE
Fix a race condition in python output handling

### DIFF
--- a/changelog/pending/20240509--sdk-python--fix-a-race-condition-in-output-handling.yaml
+++ b/changelog/pending/20240509--sdk-python--fix-a-race-condition-in-output-handling.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix a race condition in output handling.

--- a/changelog/pending/20240509--sdk-python--fix-a-race-condition-in-output-handling.yaml
+++ b/changelog/pending/20240509--sdk-python--fix-a-race-condition-in-output-handling.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/python
-  description: Fix a race condition in output handling.
+  description: Fix a race condition in output handling

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -110,7 +110,11 @@ class Output(Generic[T_co]):
                 return
             # else remove it from the deque
             with SETTINGS.lock:
-                SETTINGS.outputs.remove(fut)
+                try:
+                    SETTINGS.outputs.remove(fut)
+                except ValueError:
+                    # if it's not in the deque then it's already been removed in wait_for_rpcs
+                    pass
 
         future.add_done_callback(cleanup)
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16154.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
