### PR TITLE
Return the underlying error if we can't locate the pulumi SDK

### DIFF
--- a/changelog/pending/20240510--sdk-nodejs--return-the-underlying-error-if-we-cant-locate-the-pulumi-sdk.yaml
+++ b/changelog/pending/20240510--sdk-nodejs--return-the-underlying-error-if-we-cant-locate-the-pulumi-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Return the underlying error if we can't locate the pulumi SDK


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

When locating the pulumi SDK fails with an error other than
MODULE_NOT_FOUND, return the underlying error instead of our default
error message asking to run `pulumi install`. This is helpful when
there's a typo in package.json and it can't be parsed.

Fixes https://github.com/pulumi/pulumi/issues/4973

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
