### PR TITLE
Return error in RPC response instead of exiting in the language runtime

### DIFF
--- a/changelog/pending/20240510--sdk-nodejs--return-error-in-rpc-response-instead-of-exiting-in-the-language-runtime.yaml
+++ b/changelog/pending/20240510--sdk-nodejs--return-error-in-rpc-response-instead-of-exiting-in-the-language-runtime.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Return error in RPC response instead of exiting in the language runtime

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -577,7 +577,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 
 	nodeBin, err := exec.LookPath("node")
 	if err != nil {
-		cmdutil.Exit(fmt.Errorf("could not find node on the $PATH: %w", err))
+		return &pulumirpc.RunResponse{Error: "could not find node on the $PATH: " + err.Error()}, nil
 	}
 
 	runPath := os.Getenv("PULUMI_LANGUAGE_NODEJS_RUN_PATH")
@@ -593,7 +593,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 
 	runPath, err = locateModule(ctx, runPath, programDirectory, nodeBin)
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		return &pulumirpc.RunResponse{Error: err.Error()}, nil
 	}
 
 	// Channel producing the final response we want to issue to our caller. Will get the result of


### PR DESCRIPTION
# Description

If we can't start the node process for some reason, report back the error via RPC instead of exiting immediately.

Fixes https://github.com/pulumi/pulumi/issues/11706

Instead of:
<img width="1018" alt="Screenshot 2024-05-10 at 15 05 37" src="https://github.com/pulumi/pulumi/assets/387068/c418e890-34a3-473d-bbb5-6d45679f8bb6">
we get
<img width="1294" alt="Screenshot 2024-05-10 at 15 06 19" src="https://github.com/pulumi/pulumi/assets/387068/2ef1b0af-159d-4e99-9a6c-9c6b21375ea8">

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
