### PR TITLE
Use a separate type variable for static methods on Output

### DIFF
--- a/changelog/pending/20240510--sdk-python--use-a-separate-type-variable-for-static-methods-on-output.yaml
+++ b/changelog/pending/20240510--sdk-python--use-a-separate-type-variable-for-static-methods-on-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Use a separate type variable for static methods on Output

--- a/changelog/pending/20240515--sdk-python--relax-output-all-types-to-better-match-the-implementation.yaml
+++ b/changelog/pending/20240515--sdk-python--relax-output-all-types-to-better-match-the-implementation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Relax Output.all types to better match the implementation

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -437,22 +437,24 @@ class Output(Generic[T_co]):
     # https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants:~:text=considered%20unsafely%20overlapping
     @overload
     @staticmethod
-    def all(*args: "Output[U]") -> "Output[List[U]]": ...  # type: ignore
+    def all(*args: "Output[Any]") -> "Output[List[Any]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(**kwargs: "Output[U]") -> "Output[Dict[str, U]]": ...  # type: ignore
+    def all(**kwargs: "Output[Any]") -> "Output[Dict[str, Any]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(*args: Input[U]) -> "Output[List[U]]": ...  # type: ignore
+    def all(*args: Input[Any]) -> "Output[List[Any]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(**kwargs: Input[U]) -> "Output[Dict[str, U]]": ...  # type: ignore
+    def all(**kwargs: Input[Any]) -> "Output[Dict[str, Any]]": ...  # type: ignore
 
     @staticmethod
-    def all(*args: Input[U], **kwargs: Input[U]) -> "Output[list[U] | dict[str, U]]":
+    def all(
+        *args: Input[Any], **kwargs: Input[Any]
+    ) -> "Output[list[Any] | dict[str, Any]]":
         """
         Produces an Output of a list (if args i.e a list of inputs are supplied)
         or dict (if kwargs i.e. keyworded arguments are supplied).

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -291,21 +291,21 @@ class Output(Generic[T_co]):
 
     @overload
     @staticmethod
-    def from_input(val: "Output[T_co]") -> "Output[T_co]": ...
+    def from_input(val: "Output[U]") -> "Output[U]": ...
 
     @overload
     @staticmethod
-    def from_input(val: Input[T_co]) -> "Output[T_co]": ...
+    def from_input(val: Input[U]) -> "Output[U]": ...
 
     @staticmethod
-    def from_input(val: Input[T_co]) -> "Output[T_co]":
+    def from_input(val: Input[U]) -> "Output[U]":
         """
         Takes an Input value and produces an Output value from it, deeply unwrapping nested Input values through nested
         lists, dicts, and input classes.  Nested objects of other types (including Resources) are not deeply unwrapped.
 
-        :param Input[T_co] val: An Input to be converted to an Output.
+        :param Input[U] val: An Input to be converted to an Output.
         :return: A deeply-unwrapped Output that is guaranteed to not contain any Input values.
-        :rtype: Output[T_co]
+        :rtype: Output[U]
         """
 
         # Is it an output already? Recurse into the value contained within it.
@@ -325,7 +325,7 @@ class Output(Generic[T_co]):
                 # directly with no arguments.
                 lambda d: typ(**d) if d else typ()
             )
-            return cast(Output[T_co], o_typ)
+            return cast(Output[U], o_typ)
 
         # Is a (non-empty) dict, list, or tuple? Recurse into the values within them.
         if val and isinstance(val, dict):
@@ -340,17 +340,17 @@ class Output(Generic[T_co]):
                 return Output.all(**d)
 
             o_dict: Output[dict] = Output.all(*keys).apply(liftValues)
-            return cast(Output[T_co], o_dict)
+            return cast(Output[U], o_dict)
 
         if val and isinstance(val, list):
             o_list: Output[list] = Output.all(*val)
-            return cast(Output[T_co], o_list)
+            return cast(Output[U], o_list)
 
         if val and isinstance(val, tuple):
             # We can splat a tuple into all, but we'll always get back a list...
             o_list = Output.all(*val)
             # ...so we need to convert back to a tuple.
-            return cast(Output[T_co], o_list.apply(tuple))
+            return cast(Output[U], o_list.apply(tuple))
 
         # If it's not an output, tuple, list, or dict, it must be known and not secret
         is_known_fut: asyncio.Future[bool] = asyncio.Future()
@@ -373,7 +373,7 @@ class Output(Generic[T_co]):
         return Output(set(), value_fut, is_known_fut, is_secret_fut)
 
     @staticmethod
-    def _from_input_shallow(val: Input[T]) -> "Output[T]":
+    def _from_input_shallow(val: Input[U]) -> "Output[U]":
         """
         Like `from_input`, but does not recur deeply. Instead, checks if `val` is an `Output` value
         and returns it as is. Otherwise, promotes a known value or future to `Output`.
@@ -404,7 +404,7 @@ class Output(Generic[T_co]):
         return Output(set(), value_fut, is_known_fut, is_secret_fut)
 
     @staticmethod
-    def unsecret(val: "Output[T]") -> "Output[T]":
+    def unsecret(val: "Output[U]") -> "Output[U]":
         """
         Takes an existing Output, deeply unwraps the nested values and returns a new Output without any secrets included
 
@@ -417,7 +417,7 @@ class Output(Generic[T_co]):
         return Output(val._resources, val._future, val._is_known, is_secret)
 
     @staticmethod
-    def secret(val: Input[T]) -> "Output[T]":
+    def secret(val: Input[U]) -> "Output[U]":
         """
         Takes an Input value and produces an Output value from it, deeply unwrapping nested Input values as necessary
         given the type. It also marks the returned Output as a secret, so its contents will be persisted in an encrypted
@@ -437,22 +437,22 @@ class Output(Generic[T_co]):
     # https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants:~:text=considered%20unsafely%20overlapping
     @overload
     @staticmethod
-    def all(*args: "Output[T_co]") -> "Output[List[T_co]]": ...  # type: ignore
+    def all(*args: "Output[U]") -> "Output[List[U]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(**kwargs: "Output[T_co]") -> "Output[Dict[str, T_co]]": ...  # type: ignore
+    def all(**kwargs: "Output[U]") -> "Output[Dict[str, U]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(*args: Input[T_co]) -> "Output[List[T_co]]": ...  # type: ignore
+    def all(*args: Input[U]) -> "Output[List[U]]": ...  # type: ignore
 
     @overload
     @staticmethod
-    def all(**kwargs: Input[T_co]) -> "Output[Dict[str, T_co]]": ...  # type: ignore
+    def all(**kwargs: Input[U]) -> "Output[Dict[str, U]]": ...  # type: ignore
 
     @staticmethod
-    def all(*args: Input[T_co], **kwargs: Input[T_co]):
+    def all(*args: Input[U], **kwargs: Input[U]) -> "Output[list[U] | dict[str, U]]":
         """
         Produces an Output of a list (if args i.e a list of inputs are supplied)
         or dict (if kwargs i.e. keyworded arguments are supplied).


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Pyright >= 1.1.354 assumes the typevar is Unknown if the generic class
that holds the staticmethods has no default type parameter, however in
our case the staticmethods have no link to the class's typevar.

Fixes https://github.com/pulumi/pulumi/issues/15914
Fixes https://github.com/pulumi/pulumi/issues/16194

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
