### PR TITLE
remove extraneous `ContinueOnError` field

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -299,8 +299,6 @@ type UpdateOptions struct {
 	SkipPreview bool
 	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
 	PreviewOnly bool
-	// ContinueOnError, when true, causes the update to continue even if there are errors.
-	ContinueOnError bool
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.


### PR DESCRIPTION
This field was something I tried to use during development, but then decided to only use it in the engine options.  Remove it to avoid further confusion.