### PR TITLE
Resource docs: emit supporting types beyond the 200 limit

### DIFF
--- a/changelog/pending/20240513--docs--resource-docs-emit-supporting-types-beyond-the-200-limit.yaml
+++ b/changelog/pending/20240513--docs--resource-docs-emit-supporting-types-beyond-the-200-limit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: docs
+  description: "Resource docs: emit supporting types beyond the 200 limit"

--- a/changelog/pending/20240513--docs--resource-docs-emit-supporting-types-beyond-the-200-limit.yaml
+++ b/changelog/pending/20240513--docs--resource-docs-emit-supporting-types-beyond-the-200-limit.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: docs
-  description: "Resource docs: emit supporting types beyond the 200 limit"
+  description: "Resource docs: bump the number of displayed supporting types from 200 to 1000 by default"

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -334,13 +334,13 @@ The following state arguments are supported:
 
 ## Supporting Types
 
-{{- if ge (len .NestedTypes) 200 }}
-> **Note:** There are over 200 nested types for this resource.
-Only the first 200 types are included in this documentation.
+{{- if ge (len .NestedTypes) .MaxNestedTypes }}
+> **Note:** There are over {{ .MaxNestedTypes }} nested types for this resource.
+Only the first {{ .MaxNestedTypes }} types are included in this documentation.
 {{ end }}
 
 {{ range $index, $elem := .NestedTypes }}
-{{ if lt $index 200 }}
+{{ if lt $index $.MaxNestedTypes }}
 <h4 id="{{ $elem.AnchorID }}">
 {{ htmlSafe $elem.Name }}<pulumi-choosable type="language" values="python,go" class="inline">, {{ htmlSafe $elem.Name }}<wbr>Args</pulumi-choosable>
 </h4>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Originally motivated by uncontrolled pseudo-recurcive type expansion in AWS WafV2, we've limited the number of types that we should in the docs to 200: https://github.com/pulumi/pulumi/pull/12070

Our large customer that publishes their own packages and docs came back to us and said they have legitimate use cases with more than 200 types: #15507

I've grabbed stats about our current packages and still found a few offenders:

```
"aws:lex/v2modelsIntent:V2modelsIntent" 920
"aws:wafv2/ruleGroup:RuleGroup" 310
"aws:wafv2/webAcl:WebAcl" 523
"azure-native:datafactory:Dataset" 256
"azure-native:datafactory:LinkedService" 299
"azure-native:datafactory:Pipeline" 618
"azure-native:datamigration:ServiceTask" 291
"azure-native:datamigration:Task" 291
"aws-native:quicksight:Analysis" 589
"aws-native:quicksight:Dashboard" 606
"aws-native:quicksight:Template" 590
```

Therefore, I'm not entirely removing the limit in this PR, but 
a) bumping the default to 1000
b) applying 200 to the known offenders only

I don't love it's hard coded, but I haven't found a place to add simple configuration nob. Anyway, it's slightly less hard-coded than it used to be.

Fixes #15507

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
   - Existing docs gen tests cover that I haven't broken anything
   - I re-generated the AWS docs and they had no changes
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
