### PR TITLE
Prefer pluginDownloadURLOverrides over PluginDownloadURL specified in the package

### DIFF
--- a/changelog/pending/20240513--sdk-go--prefer-plugindownloadurloverrides-over-plugindownloadurl-specified-in-the-package.yaml
+++ b/changelog/pending/20240513--sdk-go--prefer-plugindownloadurloverrides-over-plugindownloadurl-specified-in-the-package.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Prefer pluginDownloadURLOverrides over PluginDownloadURL specified in the package

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -871,6 +871,11 @@ func (info *PluginInfo) SetFileMetadata(path string) error {
 
 func (spec PluginSpec) GetSource() (PluginSource, error) {
 	baseSource, err := func() (PluginSource, error) {
+		// If the plugin name matches an override, download the plugin from the override URL.
+		if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
+			return newHTTPSource(spec.Name, spec.Kind, urlMustParse(url)), nil
+		}
+
 		// The plugin has a set URL use that.
 		if spec.PluginDownloadURL != "" {
 			// Support schematised URLS if the URL has a "schema" part we recognize
@@ -889,11 +894,6 @@ func (spec PluginSpec) GetSource() (PluginSource, error) {
 			default:
 				return nil, fmt.Errorf("unknown plugin source scheme: %s", url.Scheme)
 			}
-		}
-
-		// If the plugin name matches an override, download the plugin from the override URL.
-		if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
-			return newHTTPSource(spec.Name, spec.Kind, urlMustParse(url)), nil
 		}
 
 		// Use our default fallback behaviour of github then get.pulumi.com


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Overriding plugin download URLs with compilation flags was originally added in #8798. Its intent was allowing our customers to override download locations for all plugins, so that only trusted pre-approved plugins could be downloaded.

Since then, we've added `PluginDownloadURL` for a package, which is the default URL for that package's binary if it's shipped outside our Pulumi org. Currently, `PluginDownloadURL` takes precedence over `pluginDownloadURLOverrides`, which means it's impossible to override third-party package binary locations.

This PR changes plugin source resolution to flip the priority of those two. If an override matches regex, its URL will take priority over the default `PluginDownloadURL` specified in the package.

I have added tests to verify `pluginDownloadURLOverrides` with and without `PluginDownloadURL`. The second one fails before my change.

Resolves #16058

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
