### PR TITLE
Infer additional secret properties in engine, from schemata

### DIFF
--- a/changelog/pending/20240513--engine--extend-additionalsecretoutputs-in-engine-based-on-resource-schemata.yaml
+++ b/changelog/pending/20240513--engine--extend-additionalsecretoutputs-in-engine-based-on-resource-schemata.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Extend additionalSecretOutputs in engine based on resource schemata

--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -300,11 +300,11 @@ func (h *testHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Fl
 func (h *testHost) ResolvePlugin(
 	kind apitype.PluginKind, name string, version *semver.Version,
 ) (*workspace.PluginInfo, error) {
-	panic("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (h *testHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	// We're not using project plugins, in fact this method shouldn't even really exists on Host given it's
+	// We're not using project plugins, in fact this method shouldn't even really exist on Host given it's
 	// just reading off Pulumi.yaml.
 	return nil
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -474,14 +475,22 @@ func newUpdateSource(ctx context.Context,
 	}
 
 	// If that succeeded, create a new source that will perform interpretation of the compiled program.
-	return deploy.NewEvalSource(plugctx, &deploy.EvalRunInfo{
-		Proj:        proj,
-		Pwd:         pwd,
-		Program:     main,
-		ProjectRoot: projectRoot,
-		Args:        args,
-		Target:      target,
-	}, defaultProviderVersions, dryRun), nil
+	schemaLoader := schema.NewPluginLoader(plugctx.Host)
+
+	return deploy.NewEvalSource(
+		plugctx,
+		&deploy.EvalRunInfo{
+			Proj:        proj,
+			Pwd:         pwd,
+			Program:     main,
+			ProjectRoot: projectRoot,
+			Args:        args,
+			Target:      target,
+		},
+		defaultProviderVersions,
+		dryRun,
+		schemaLoader,
+	), nil
 }
 
 func update(ctx *Context, info *deploymentContext, opts *deploymentOptions,


### PR DESCRIPTION
This commit modifies calls to `RegisterResource` so that they load resource schemata, enabling the engine to modify resource properties according to the schema instead of the caller (e.g. the SDK). As part of this commit, the engine will now extend `additionalSecretOutputs` options with `Secret` properties it finds in the schema. In a later commit, this will allow us to stop generating SDK code to set these properties correctly client-side. The schema may be used in subsequent pieces of work to handle other concerns, such as defaults, though this is not tackled in this commit.

Note that for this to even work at all, we need to cache provider loads when providers are loaded for the purpose of schema lookup. Ordinarily, provider loads are not cached -- if a program instantiates the same name/version of a provider twice with different parameters, for instance, we want those instantiations to yield two separate, independent instances. However, when loading schema, not only does this not matter (two providers will have the same schema if and only if they share the same name/version), it's of critical importance that we cache provider loads by name/version, lest we instantiate a provider for _every resource_ in the program that depends on it. This commit thus introduces such a cache to the `pluginLoader` backing schema loads (which thankfully is separate from the means we use to load providers during program execution).

Note that in a program context, this may mean we have a number of potentially avoidable provider loads: if there are `P` distinct providers in a program, we will perform `2P` loads where we previously performed `P`. We are betting that this will not have a severe impact on performance, but could be wrong. Ideally we could avoid the double loading by sharing a "schema load" (`GetSchema` being akin to a "static" method call) with an "instantiation load" (`Check`, `Diff` etc. being akin to "instance" methods). Unfortunately, as it stands today, provider loads are coupled/the same as provider instances, so this would likely require a substantial rethink/rework to make it possible (there is no way to load the "class definition" without instantiating it, to continue the static/instance analogy).

*Note: This work is almost entirely aped from https://github.com/pulumi/pulumi/compare/master...zaid/additional-secret-properties-from-schema as preparation for looking at how we handle other things (names, defaulting, etc.) in engine.*