### PR TITLE
[codegen] Fix camel casing of hyphenated properties

### DIFF
--- a/changelog/pending/20240514--sdkgen-dotnet--fix-camel-casing-of-hyphenated-properties.yaml
+++ b/changelog/pending/20240514--sdkgen-dotnet--fix-camel-casing-of-hyphenated-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: fix
+    scope: sdkgen/{dotnet,nodejs}
+    description: Fix camel casing of hyphenated properties

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -33,6 +33,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -1441,7 +1442,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 		// first generate the function definition
 		fmt.Fprintf(w, "        public static async Task%s InvokeAsync(", typeParamOrEmpty(typeParameter))
 		for _, prop := range fun.Inputs.Properties {
-			argumentName := LowerCamelCase(prop.Name)
+			argumentName := cgstrings.Camel(prop.Name)
 			argumentType := mod.typeString(prop.Type, "", false, false, true)
 			paramDeclaration := fmt.Sprintf("%s %s", argumentType, argumentName)
 			if !prop.IsRequired() {
@@ -1464,7 +1465,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 		funcBodyIndent()
 		fmt.Fprint(w, "var builder = ImmutableDictionary.CreateBuilder<string, object?>();\n")
 		for _, prop := range fun.Inputs.Properties {
-			argumentName := LowerCamelCase(prop.Name)
+			argumentName := cgstrings.Camel(prop.Name)
 			funcBodyIndent()
 			fmt.Fprintf(w, "builder[\"%s\"] = %s;\n", prop.Name, argumentName)
 		}
@@ -1572,7 +1573,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 		fmt.Fprintf(w, "        public static Output%s Invoke(", typeParamOrEmpty(typeParameter))
 		for _, prop := range fun.Inputs.Properties {
 			var paramDeclaration string
-			argumentName := LowerCamelCase(prop.Name)
+			argumentName := cgstrings.Camel(prop.Name)
 			propertyType := &schema.InputType{ElementType: prop.Type}
 			argumentType := mod.typeString(propertyType, "", true /* input */, false, true)
 			if prop.IsRequired() {
@@ -1592,7 +1593,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 		fmt.Fprint(w, "            var builder = ImmutableDictionary.CreateBuilder<string, object?>();\n")
 		if fun.Inputs != nil {
 			for _, prop := range fun.Inputs.Properties {
-				argumentName := LowerCamelCase(prop.Name)
+				argumentName := cgstrings.Camel(prop.Name)
 				fmt.Fprintf(w, "            builder[\"%s\"] = %s;\n", prop.Name, argumentName)
 			}
 		}

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -1027,7 +1028,7 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 		lambdaArg := "invoke"
 		if invokedFunctionSchema.ReturnType != nil {
 			if objectType, ok := invokedFunctionSchema.ReturnType.(*schema.ObjectType); ok && objectType != nil {
-				lambdaArg = LowerCamelCase(g.schemaTypeName(objectType))
+				lambdaArg = cgstrings.Camel(g.schemaTypeName(objectType))
 			}
 		}
 

--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -126,13 +126,13 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 	switch functionName {
 	case "filebase64":
 		return fmt.Sprintf(`
-%sstring ReadFileBase64(string path) 
+%sstring ReadFileBase64(string path)
 %s{
 %s    return Convert.ToBase64String(Encoding.UTF8.GetBytes(File.ReadAllText(path)));
 %s}`, indent, indent, indent, indent), true
 	case "filebase64sha256":
 		return fmt.Sprintf(`
-%sstring ComputeFileBase64Sha256(string path) 
+%sstring ComputeFileBase64Sha256(string path)
 %s{
 %s    var fileData = Encoding.UTF8.GetBytes(File.ReadAllText(path));
 %s    var hashData = SHA256.Create().ComputeHash(fileData);
@@ -140,28 +140,18 @@ func getHelperMethodIfNeeded(functionName string, indent string) (string, bool) 
 %s}`, indent, indent, indent, indent, indent, indent), true
 	case "sha1":
 		return fmt.Sprintf(`
-%sstring ComputeSHA1(string input) 
+%sstring ComputeSHA1(string input)
 %s{
 %s    var hash = SHA1.Create().ComputeHash(Encoding.UTF8.GetBytes(input));
 %s    return BitConverter.ToString(hash).Replace("-","").ToLowerInvariant();
 %s}`, indent, indent, indent, indent, indent), true
 	case "notImplemented":
 		return fmt.Sprintf(`
-%sobject NotImplemented(string errorMessage) 
+%sobject NotImplemented(string errorMessage)
 %s{
 %s    throw new System.NotImplementedException(errorMessage);
 %s}`, indent, indent, indent, indent), true
 	default:
 		return "", false
 	}
-}
-
-// LowerCamelCase sets the first character to lowercase
-// LowerCamelCase("LowerCamelCase") -> "lowerCamelCase"
-func LowerCamelCase(s string) string {
-	if s == "" {
-		return ""
-	}
-	runes := []rune(s)
-	return string(append([]rune{unicode.ToLower(runes[0])}, runes[1:]...))
 }

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -105,7 +106,7 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 }
 
 func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
-	return camel(m.Name)
+	return cgstrings.Camel(m.Name)
 }
 
 func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName string, r *schema.Resource,

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -34,6 +34,7 @@ import (
 	"unicode"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs/tstypes"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
@@ -74,14 +75,15 @@ func title(s string) string {
 	return string(append([]rune{unicode.ToUpper(runes[0])}, runes[1:]...))
 }
 
-// camel converts s to camel case.
+// dashedCamel converts s to camelCase while preserving punctuation. Not
+// appropriate for property names -- use cgstrings.Camel instead.
 //
 // Examples:
 // "helloWorld"    => "helloWorld"
 // "HelloWorld"    => "helloWorld"
 // "JSONObject"    => "jsonobject"
 // "My-FRIEND.Bob" => "my-FRIEND.Bob"
-func camel(s string) string {
+func dashedCamel(s string) string {
 	if s == "" {
 		return ""
 	}
@@ -281,15 +283,15 @@ func resourceName(r *schema.Resource) string {
 }
 
 func (mod *modContext) resourceFileName(r *schema.Resource) string {
-	fileName := camel(resourceName(r)) + ".ts"
+	fileName := dashedCamel(resourceName(r)) + ".ts"
 	if mod.isReservedSourceFileName(fileName) {
-		fileName = camel(resourceName(r)) + "_.ts"
+		fileName = dashedCamel(resourceName(r)) + "_.ts"
 	}
 	return fileName
 }
 
 func tokenToFunctionName(tok string) string {
-	return camel(tokenToName(tok))
+	return cgstrings.Camel(tokenToName(tok))
 }
 
 func (mod *modContext) typeAst(t schema.Type, input bool, constValue interface{}) tstypes.TypeAst {
@@ -510,7 +512,7 @@ func provideDefaultsFuncNameFromName(typeName string) string {
 		i = in
 	}
 	// path + camel(name) + ProvideDefaults suffix
-	return typeName[:i] + camel(typeName[i:]) + "ProvideDefaults"
+	return typeName[:i] + cgstrings.Camel(typeName[i:]) + "ProvideDefaults"
 }
 
 // The name of the function used to set defaults on the plain type.
@@ -919,7 +921,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 
 	// Generate methods.
 	genMethod := func(method *schema.Method) {
-		methodName := camel(method.Name)
+		methodName := cgstrings.Camel(method.Name)
 		fun := method.Function
 
 		var objectReturnType *schema.ObjectType
@@ -1032,7 +1034,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		}
 
 		if liftReturn {
-			fmt.Fprintf(w, "        return result.%s;\n", camel(objectReturnType.Properties[0].Name))
+			fmt.Fprintf(w, "        return result.%s;\n", cgstrings.Camel(objectReturnType.Properties[0].Name))
 		}
 		fmt.Fprintf(w, "    }\n")
 	}
@@ -2060,9 +2062,9 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 			return err
 		}
 
-		fileName := camel(tokenToName(f.Token)) + ".ts"
+		fileName := dashedCamel(tokenToName(f.Token)) + ".ts"
 		if mod.isReservedSourceFileName(fileName) {
-			fileName = camel(tokenToName(f.Token)) + "_.ts"
+			fileName = dashedCamel(tokenToName(f.Token)) + "_.ts"
 		}
 		addFunctionFile(funInfo, fileName, buffer.String())
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Updates node and dotnet to use `cgstrings.Camel` in order to correctly remove punctuation.

Fixes #15874

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
