### PR TITLE
update dotnet version in tests to latest

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -378,4 +378,4 @@ const (
 )
 
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
-const PulumiDotnetSDKVersion = "3.62.0"
+const PulumiDotnetSDKVersion = "3.63.1"


### PR DESCRIPTION
Update to the latest dotnet version.  Pulumi.Awsx started depending on that, so using an earlier version makes the tests fail.

This happened a few times now, so we should really fix this in a way that doesn't require us to hardcode this version.  But I want to get the merge queue unblocked, and this is probably the quickest way to do that.