### PR TITLE
Run an empty `pulumi up` in DIY backend tests

### DIFF
--- a/tests/integration/backend/diy/helpers.go
+++ b/tests/integration/backend/diy/helpers.go
@@ -30,4 +30,10 @@ func loginAndCreateStack(t *testing.T, cloudURL string) {
 	out, err = exec.Command("pulumi", "stack", "ls").CombinedOutput()
 	assert.NoError(t, err, string(out))
 	assert.Contains(t, string(out), stackName+"*")
+
+	out, err = exec.Command("pulumi", "up", "--skip-preview").CombinedOutput()
+	assert.NoError(t, err, string(out))
+
+	out, err = exec.Command("pulumi", "destroy", "--skip-preview").CombinedOutput()
+	assert.NoError(t, err, string(out))
 }


### PR DESCRIPTION
Confirm that we can write all the necessary files in the backend after an update without failing. Part of investigating https://github.com/pulumi/pulumi/issues/15748