### PR TITLE
[engine/import] Guess ID references of dependant resources when generating code for import operations

### DIFF
--- a/changelog/pending/20240515--engine--guess-id-references-of-dependant-resources-when-generating-code-for-import-operations.yaml
+++ b/changelog/pending/20240515--engine--guess-id-references-of-dependant-resources-when-generating-code-for-import-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Guess ID references of dependant resources when generating code for import operations

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -38,8 +38,39 @@ var Null = &model.Variable{
 	VariableType: model.NoneType,
 }
 
+type PathedLiteralValue struct {
+	Root                string
+	Value               string
+	ExpressionReference *model.ScopeTraversalExpression
+}
+
+type ImportState struct {
+	Names               NameTable
+	PathedLiteralValues []PathedLiteralValue
+}
+
+// filterSelfReferences filters out self-references from the import state so that if a resource has a property
+// that happens to have the same value as the ID of that resource, it doesn't create a self-reference.
+func filterSelfReferences(resourceName string, importState ImportState) ImportState {
+	pathedLiteralValues := make([]PathedLiteralValue, 0)
+	for _, pathedLiteralValue := range importState.PathedLiteralValues {
+		if pathedLiteralValue.Root != resourceName {
+			pathedLiteralValues = append(pathedLiteralValues, pathedLiteralValue)
+		}
+	}
+
+	return ImportState{
+		Names:               importState.Names,
+		PathedLiteralValues: pathedLiteralValues,
+	}
+}
+
 // GenerateHCL2Definition generates a Pulumi HCL2 definition for a given resource.
-func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names NameTable) (*model.Block, error) {
+func GenerateHCL2Definition(
+	loader schema.Loader,
+	state *resource.State,
+	importState ImportState,
+) (*model.Block, error) {
 	// TODO: pull the package version from the resource's provider
 	pkg, err := schema.LoadPackageReference(loader, string(state.Type.Package()), nil)
 	if err != nil {
@@ -58,7 +89,7 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 	name := state.URN.Name()
 	// Check if _this_ urn is in the name table, if so we need to set logicalName and use the mapped name for
 	// the resource block.
-	if mappedName, ok := names[state.URN]; ok {
+	if mappedName, ok := importState.Names[state.URN]; ok {
 		items = append(items, &model.Attribute{
 			Name: "__logicalName",
 			Value: &model.TemplateExpression{
@@ -72,8 +103,17 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 		name = mappedName
 	}
 
+	// keep track of a set of added references to avoid adding the same reference to the dependsOn list
+	// when the resource is already implicitly referenced via its properties
+	addedReferences := make(map[string]bool)
+	onReferenceFound := func(rootName string) {
+		addedReferences[rootName] = true
+	}
+
+	importStateWithoutSelfRefs := filterSelfReferences(name, importState)
 	for _, p := range r.InputProperties {
-		x, err := generatePropertyValue(p, state.Inputs[resource.PropertyKey(p.Name)])
+		input := state.Inputs[resource.PropertyKey(p.Name)]
+		x, err := generatePropertyValue(p, input, importStateWithoutSelfRefs, onReferenceFound)
 		if err != nil {
 			return nil, err
 		}
@@ -85,7 +125,7 @@ func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names N
 		}
 	}
 
-	resourceOptions, err := makeResourceOptions(state, names)
+	resourceOptions, err := makeResourceOptions(state, importState.Names, addedReferences)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +167,7 @@ func appendResourceOption(block *model.Block, name string, value model.Expressio
 	return block
 }
 
-func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, error) {
+func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[string]bool) (*model.Block, error) {
 	var resourceOptions *model.Block
 	if state.Parent != "" && state.Parent.QualifiedType() != resource.RootStackType {
 		name, ok := names[state.Parent]
@@ -150,14 +190,20 @@ func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, 
 		}
 	}
 	if len(state.Dependencies) != 0 {
-		deps := make([]model.Expression, len(state.Dependencies))
-		for i, d := range state.Dependencies {
+		deps := make([]model.Expression, 0)
+		for _, d := range state.Dependencies {
 			name, ok := names[d]
 			if !ok {
 				return nil, fmt.Errorf("no name for resource %v", d)
 			}
-			deps[i] = newVariableReference(name)
+			// implicitly referenced resource via their properties do not need to be added to the dependsOn list
+			// for example if you have a property bucket: exampleBucket.id then exampleBucket doesn't need to
+			// be explicitly added to the dependsOn list
+			if _, alreadyImplicitlyReferenced := addedRefs[name]; !alreadyImplicitlyReferenced {
+				deps = append(deps, newVariableReference(name))
+			}
 		}
+
 		resourceOptions = appendResourceOption(resourceOptions, "dependsOn", &model.TupleConsExpression{
 			Tokens:      syntax.NewTupleConsTokens(len(deps)),
 			Expressions: deps,
@@ -307,6 +353,8 @@ func simplerType(t, u schema.Type) bool {
 
 // zeroValue constructs a zero value of the given type.
 func zeroValue(t schema.Type) model.Expression {
+	emptyImportState := ImportState{}
+	onReferenceAdded := func(string) {}
 	switch t := t.(type) {
 	case *schema.OptionalType:
 		return model.VariableReference(Null)
@@ -350,15 +398,15 @@ func zeroValue(t schema.Type) model.Expression {
 	}
 	switch t {
 	case schema.BoolType:
-		x, err := generateValue(t, resource.NewBoolProperty(false))
+		x, err := generateValue(t, resource.NewBoolProperty(false), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.IntType, schema.NumberType:
-		x, err := generateValue(t, resource.NewNumberProperty(0))
+		x, err := generateValue(t, resource.NewNumberProperty(0), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.StringType:
-		x, err := generateValue(t, resource.NewStringProperty(""))
+		x, err := generateValue(t, resource.NewStringProperty(""), emptyImportState, onReferenceAdded)
 		contract.IgnoreError(err)
 		return x
 	case schema.ArchiveType, schema.AssetType:
@@ -374,7 +422,12 @@ func zeroValue(t schema.Type) model.Expression {
 // generatePropertyValue generates the value for the given property. If the value is absent and the property is
 // required, a zero value for the property's type is generated. If the value is absent and the property is not
 // required, no value is generated (i.e. this function returns nil).
-func generatePropertyValue(property *schema.Property, value resource.PropertyValue) (model.Expression, error) {
+func generatePropertyValue(
+	property *schema.Property,
+	value resource.PropertyValue,
+	importState ImportState,
+	onReferenceFound func(string),
+) (model.Expression, error) {
 	if !value.HasValue() {
 		if !property.IsRequired() {
 			return nil, nil
@@ -382,7 +435,7 @@ func generatePropertyValue(property *schema.Property, value resource.PropertyVal
 		return zeroValue(property.Type), nil
 	}
 
-	return generateValue(property.Type, value)
+	return generateValue(property.Type, value, importState, onReferenceFound)
 }
 
 // valueStructurallyTypedAs returns true if the given value is structurally typed as the given schema type.
@@ -594,7 +647,12 @@ func reduceUnionType(schemaUnion *schema.UnionType, value resource.PropertyValue
 
 // generateValue generates a value from the given property value. The given type may or may not match the shape of the
 // given value.
-func generateValue(typ schema.Type, value resource.PropertyValue) (model.Expression, error) {
+func generateValue(
+	typ schema.Type,
+	value resource.PropertyValue,
+	importState ImportState,
+	onReferenceFound func(string),
+) (model.Expression, error) {
 	typ = codegen.UnwrapType(typ)
 
 	if unionType, ok := typ.(*schema.UnionType); ok {
@@ -613,7 +671,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 		arr := value.ArrayValue()
 		exprs := make([]model.Expression, len(arr))
 		for i, v := range arr {
-			x, err := generateValue(elementType, v)
+			x, err := generateValue(elementType, v, importState, onReferenceFound)
 			if err != nil {
 				return nil, err
 			}
@@ -644,7 +702,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 		switch arg := typ.(type) {
 		case *schema.ObjectType:
 			for _, p := range arg.Properties {
-				x, err := generatePropertyValue(p, obj[resource.PropertyKey(p.Name)])
+				x, err := generatePropertyValue(p, obj[resource.PropertyKey(p.Name)], importState, onReferenceFound)
 				if err != nil {
 					return nil, err
 				}
@@ -670,7 +728,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 					continue
 				}
 
-				x, err := generateValue(elementType, obj[k])
+				x, err := generateValue(elementType, obj[k], importState, onReferenceFound)
 				if err != nil {
 					return nil, err
 				}
@@ -691,7 +749,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 			Items:  items,
 		}, nil
 	case value.IsSecret():
-		arg, err := generateValue(typ, value.SecretValue().Element)
+		arg, err := generateValue(typ, value.SecretValue().Element, importState, onReferenceFound)
 		if err != nil {
 			return nil, err
 		}
@@ -726,6 +784,13 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 				Args: []model.Expression{x},
 			}, nil
 		default:
+			for _, pathedValue := range importState.PathedLiteralValues {
+				if pathedValue.Value == value.StringValue() {
+					onReferenceFound(pathedValue.Root)
+					return pathedValue.ExpressionReference, nil
+				}
+			}
+
 			return x, nil
 		}
 	default:

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -258,7 +258,11 @@ func TestGenerateHCL2Definition(t *testing.T) {
 				t.Fatal()
 			}
 
-			block, err := GenerateHCL2Definition(loader, state, names)
+			importState := ImportState{
+				Names: names,
+			}
+
+			block, err := GenerateHCL2Definition(loader, state, importState)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -307,6 +311,199 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
+	t.Parallel()
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+
+	resources := []apitype.ResourceV3{
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
+			ID:     "provider-generated-bucket-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucket:Bucket",
+		},
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:     "provider-generated-bucket-object-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucketObject:BucketObject",
+			Inputs: map[string]interface{}{
+				// this will be replaced with a reference to exampleBucket.id in the generated code
+				"bucket":       "provider-generated-bucket-id-abc123",
+				"storageClass": "STANDARD",
+			},
+		},
+	}
+
+	states := make([]*resource.State, 0)
+	for _, r := range resources {
+		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		states = append(states, state)
+	}
+
+	importState := createImportState(states, names)
+
+	var hcl2Text strings.Builder
+	for i, state := range states {
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pre := ""
+		if i > 0 {
+			pre = "\n"
+		}
+		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
+		contract.IgnoreError(err)
+	}
+
+	expectedCode := `resource exampleBucket "aws:s3/bucket:Bucket" {
+
+}
+
+resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
+    bucket = exampleBucket.id
+    storageClass = "STANDARD"
+
+}
+`
+
+	assert.Equal(t, expectedCode, hcl2Text.String(), "Generated HCL2 code does not match expected code")
+}
+
+func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *testing.T) {
+	t.Parallel()
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+
+	resources := []apitype.ResourceV3{
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::firstBucket",
+			ID:     "provider-generated-bucket-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucket:Bucket",
+		},
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::secondBucket",
+			ID:     "provider-generated-bucket-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucket:Bucket",
+		},
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:     "provider-generated-bucket-object-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucketObject:BucketObject",
+			Inputs: map[string]interface{}{
+				// this will *NOT* be replaced with a reference to either firstBucket.id or secondBucket.id
+				// because both have the same ID and it would be ambiguous
+				"bucket":       "provider-generated-bucket-id-abc123",
+				"storageClass": "STANDARD",
+			},
+		},
+	}
+
+	states := make([]*resource.State, 0)
+	for _, r := range resources {
+		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		states = append(states, state)
+	}
+
+	importState := createImportState(states, names)
+
+	var hcl2Text strings.Builder
+	for i, state := range states {
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pre := ""
+		if i > 0 {
+			pre = "\n"
+		}
+		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
+		contract.IgnoreError(err)
+	}
+
+	expectedCode := `resource firstBucket "aws:s3/bucket:Bucket" {
+
+}
+
+resource secondBucket "aws:s3/bucket:Bucket" {
+
+}
+
+resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
+    bucket = "provider-generated-bucket-id-abc123"
+    storageClass = "STANDARD"
+
+}
+`
+
+	assert.Equal(t, expectedCode, hcl2Text.String(), "Generated HCL2 code does not match expected code")
+}
+
+func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
+	t.Parallel()
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+
+	resources := []apitype.ResourceV3{
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:     "provider-generated-bucket-object-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucketObject:BucketObject",
+			Inputs: map[string]interface{}{
+				// this literal value will stay as is since it shouldn't self-reference the bucket object itself
+				"bucket":       "provider-generated-bucket-object-id-abc123",
+				"storageClass": "STANDARD",
+			},
+		},
+	}
+
+	states := make([]*resource.State, 0)
+	for _, r := range resources {
+		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		states = append(states, state)
+	}
+
+	importState := createImportState(states, names)
+
+	var hcl2Text strings.Builder
+	for i, state := range states {
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pre := ""
+		if i > 0 {
+			pre = "\n"
+		}
+		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
+		contract.IgnoreError(err)
+	}
+
+	expectedCode := `resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
+    bucket = "provider-generated-bucket-object-id-abc123"
+    storageClass = "STANDARD"
+
+}
+`
+
+	assert.Equal(t, expectedCode, hcl2Text.String(), "Generated HCL2 code does not match expected code")
 }
 
 func TestSimplerType(t *testing.T) {


### PR DESCRIPTION
### Description

Taking an initial attempt at #10025 where we now try to guess ID references of dependant resources instead of writing out the IDs as literal values. 
Instead of:
```hcl
// has ID=provider-generated-bucket-id-abc123
resource exampleBucket "aws:s3/bucket:Bucket" {}

resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
    bucket = "provider-generated-bucket-id-abc123"
    storageClass = "STANDARD"
}
```
We generate:
```hcl
resource exampleBucket "aws:s3/bucket:Bucket" {}

resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
    bucket = exampleBucket.id
    storageClass = "STANDARD"
}
```
This implies a dependency between `exampleBucketObject` and `exampleBucket` without explicitly being added into the `dependsOn` array (it would be redundant) 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
