### PR TITLE
language_test: allow more characters in the log before truncating

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -64,8 +64,8 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 	message := req.Message
 	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
 		// Cut down logs so they don't overwhelm the test output
-		if len(message) > 100 {
-			message = message[:100] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
+		if len(message) > 1024 {
+			message = message[:1024] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
 		}
 	}
 

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -66,8 +66,8 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 	message := req.Message
 	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
 		// Cut down logs so they don't overwhelm the test output
-		if len(message) > 100 {
-			message = message[:100] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
+		if len(message) > 1024 {
+			message = message[:1024] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
 		}
 	}
 


### PR DESCRIPTION
We initially introduced this limit for log messages in https://github.com/pulumi/pulumi/pull/16117.  However I've since realized that these log messages also include useful stacktraces (when the program being tested throws an exception), which are a bit longer.

The intention here is really to avoid *really* long messages, so increase the maximum message size a little to still avoid those, but allow us to see more of the stacktrace that should hopefully be useful for debugging.

The number is mostly still based on a guesstimate of what's useful, but it's easy to tweak if we need to tweak it further.
