### PR TITLE
Rewrite `DeletedWith` properties when renaming stacks

### DIFF
--- a/changelog/pending/20240516--backend-diy--rewrite-deletedwith-references-when-renaming-stacks.yaml
+++ b/changelog/pending/20240516--backend-diy--rewrite-deletedwith-references-when-renaming-stacks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Rewrite DeletedWith references when renaming stacks

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -188,6 +188,10 @@ func RenameStack(deployment *apitype.DeploymentV3, newName tokens.StackName, new
 			}
 		}
 
+		if res.DeletedWith != "" {
+			res.DeletedWith = rewriteUrn(res.DeletedWith)
+		}
+
 		if res.Provider != "" {
 			providerRef, err := providers.ParseReference(res.Provider)
 			contract.AssertNoErrorf(err, "failed to parse provider reference from validated checkpoint")


### PR DESCRIPTION
When renaming a stack, we need to rewrite URN references to use the new stack name instead of the old one. Presently such references can occur as:

* `Parent` references
* `Provider` references
* `Dependencies`
* `PropertyDependencies`
* `DeletedWith` references

The current renaming implementation fails to rewrite `DeletedWith` references. Previously this went unnoticed since such references were also omitted when checking snapshot integrity. Now that integrity checks correctly inspect `DeletedWith` properties, the omission during rename has been surfaced. This commit fixes renaming to handle `DeletedWith` correctly. A follow-up should also ensure that renaming checks integrity itself prior to operation completion.

Fixes #16215 