### PR TITLE
[docs] Fix generating constructor examples for resources that have numeric enums as input

### DIFF
--- a/changelog/pending/20240517--docs--fix-generating-constructor-examples-for-resources-that-have-enumeric-enums-as-input.yaml
+++ b/changelog/pending/20240517--docs--fix-generating-constructor-examples-for-resources-that-have-enumeric-enums-as-input.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Fix generating constructor examples for resources that have numeric enums as input

--- a/pkg/codegen/docs/constructor_syntax_generator.go
+++ b/pkg/codegen/docs/constructor_syntax_generator.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -149,28 +148,47 @@ func (g *constructorSyntaxGenerator) writeValue(
 		_, _, resourceNameFromToken, _ := pcl.DecomposeToken(valueType.Token, hcl.Range{})
 		write("%s", camelCase(resourceNameFromToken))
 	case *schema.EnumType:
-		cases := make([]string, len(valueType.Elements))
-		for index, c := range valueType.Elements {
-			if c.DeprecationMessage != "" {
-				continue
+		if valueType.ElementType == schema.NumberType || valueType.ElementType == schema.IntType {
+			var value interface{}
+			for _, elem := range valueType.Elements {
+				if elem.DeprecationMessage != "" {
+					continue
+				}
+
+				value = elem.Value
+				break
 			}
 
-			if stringCase, ok := c.Value.(string); ok && stringCase != "" {
-				cases[index] = stringCase
-			} else if intCase, ok := c.Value.(int); ok {
-				cases[index] = strconv.Itoa(intCase)
+			if value != nil {
+				write(fmt.Sprintf("%v", value))
 			} else {
-				if c.Name != "" {
-					cases[index] = c.Name
+				// all of them enum cases deprecated
+				// choose the first one
+				write(fmt.Sprintf("%v", valueType.Elements[0].Value))
+			}
+		} else {
+			cases := make([]string, len(valueType.Elements))
+			for index, c := range valueType.Elements {
+				if c.DeprecationMessage != "" {
+					continue
+				}
+
+				if stringCase, ok := c.Value.(string); ok && stringCase != "" {
+					cases[index] = stringCase
+				} else {
+					if c.Name != "" {
+						cases[index] = c.Name
+					}
 				}
 			}
+
+			if len(cases) > 0 {
+				write(fmt.Sprintf("%q", cases[0]))
+			} else {
+				write("null")
+			}
 		}
 
-		if len(cases) > 0 {
-			write(fmt.Sprintf("%q", cases[0]))
-		} else {
-			write("null")
-		}
 	case *schema.UnionType:
 		if isUnionOfObjects(valueType) && len(valueType.ElementTypes) >= 1 {
 			writeValue(valueType.ElementTypes[0])

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -200,10 +200,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			switch {
 			case to.Type.Equals(model.StringType):
 				underlyingType = "string"
+			case to.Type.Equals(model.IntType):
+				underlyingType = "int"
 			default:
-				panic(fmt.Sprintf(
-					"Unsafe enum conversions from type %s not implemented yet: %s => %s",
-					from.Type(), from, to))
+				underlyingType = "float64"
 			}
 			pkg, mod, typ, _ := pcl.DecomposeToken(to.Token, to.SyntaxNode().Range())
 			mod = g.getModOrAlias(pkg, mod, mod)

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -568,7 +568,13 @@ func EnumMember(t *model.EnumType, value cty.Value) (*schema.Enum, bool) {
 	case t.Type.Equals(model.IntType):
 		f, _ := value.AsBigFloat().Int64()
 		for _, el := range src.Elements {
-			if el.Value.(int64) == f {
+			valueInt64, ok := el.Value.(int64)
+			if ok && valueInt64 == f {
+				return el, true
+			}
+
+			valueInt32, ok := el.Value.(int32)
+			if ok && int64(valueInt32) == f {
 				return el, true
 			}
 		}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -241,7 +241,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			}
 			var moduleNameOverrides map[string]string
 			if pkg, err := enum.(*schema.EnumType).PackageReference.Definition(); err == nil {
-				moduleNameOverrides = pkg.Language["python"].(PackageInfo).ModuleNameOverrides
+				if pkgInfo, ok := pkg.Language["python"].(PackageInfo); ok {
+					moduleNameOverrides = pkgInfo.ModuleNameOverrides
+				}
 			}
 			pkg := strings.ReplaceAll(components[0], "-", "_")
 			enumName := tokenToName(to.Token)

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -251,12 +251,12 @@ var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
 
 ```go
 example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
-Varieties: treev1.RubberTreeVarietyArray{
-tree.RubberTreeVarietyBurgundy,
-},
-Sizes: treev1.TreeSizeMap{
-"string": tree.TreeSizeSmall,
-},
+	Varieties: treev1.RubberTreeVarietyArray{
+		tree.RubberTreeVarietyBurgundy,
+	},
+	Sizes: treev1.TreeSizeMap{
+		"string": tree.TreeSizeSmall,
+	},
 })
 ```
 

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -232,7 +232,20 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var rubberTreeResource = new Plant.Tree.V1.RubberTree("rubberTreeResource", new()
+{
+    Diameter = Plant.Tree.V1.Diameter.Sixinch,
+    Type = Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    Container = new Plant.Inputs.ContainerArgs
+    {
+        Size = Plant.ContainerSize.FourInch,
+        Brightness = Plant.ContainerBrightness.ZeroPointOne,
+        Color = Plant.ContainerColor.Red,
+        Material = "string",
+    },
+    Farm = Plant.Tree.V1.Farm.Pulumi_Planters_Inc_,
+    Size = Plant.Tree.V1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -243,7 +256,18 @@ Coming soon!
 <pulumi-choosable type="language" values="go">
 
 ```go
-Coming soon!
+example, err := tree.NewRubberTree(ctx, "rubberTreeResource", &tree.RubberTreeArgs{
+	Diameter: tree.DiameterSixinch,
+	Type:     tree.RubberTreeVarietyBurgundy,
+	Container: &plantprovider.ContainerArgs{
+		Size:       plant.ContainerSizeFourInch,
+		Brightness: plant.ContainerBrightnessZeroPointOne,
+		Color:      pulumi.String(plant.ContainerColorRed),
+		Material:   pulumi.String("string"),
+	},
+	Farm: pulumi.String(tree.Farm_Pulumi_Planters_Inc_),
+	Size: tree.TreeSizeSmall,
+})
 ```
 
 </pulumi-choosable>
@@ -255,11 +279,11 @@ Coming soon!
 
 ```java
 var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.builder()
-    .diameter("sixinch")
+    .diameter(6)
     .type("Burgundy")
     .container(ContainerArgs.builder()
-        .size("FourInch")
-        .brightness("ZeroPointOne")
+        .size(4)
+        .brightness(0.1)
         .color("red")
         .material("string")
         .build())
@@ -276,7 +300,17 @@ var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.bui
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+rubber_tree_resource = plant.tree.v1.RubberTree("rubberTreeResource",
+    diameter=plant.tree.v1.Diameter.SIXINCH,
+    type=plant.tree.v1.RubberTreeVariety.BURGUNDY,
+    container=plant.ContainerArgs(
+        size=plant.ContainerSize.FOUR_INCH,
+        brightness=plant.ContainerBrightness.ZERO_POINT_ONE,
+        color=plant.ContainerColor.RED,
+        material="string",
+    ),
+    farm=plant.tree.v1.Farm.PULUMI_PLANTERS_INC_,
+    size=plant.tree.v1.TreeSize.SMALL)
 ```
 
 </pulumi-choosable>
@@ -287,7 +321,18 @@ Coming soon!
 <pulumi-choosable type="language" values="typescript">
 
 ```typescript
-Coming soon!
+const rubberTreeResource = new plant.tree.v1.RubberTree("rubberTreeResource", {
+    diameter: plant.tree.v1.Diameter.Sixinch,
+    type: plant.tree.v1.RubberTreeVariety.Burgundy,
+    container: {
+        size: plant.ContainerSize.FourInch,
+        brightness: plant.ContainerBrightness.ZeroPointOne,
+        color: plant.ContainerColor.Red,
+        material: "string",
+    },
+    farm: plant.tree.v1.Farm.Pulumi_Planters_Inc_,
+    size: plant.tree.v1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -301,11 +346,11 @@ Coming soon!
 type: plant:tree/v1:RubberTree
 properties:
     container:
-        brightness: ZeroPointOne
+        brightness: 0.1
         color: red
         material: string
-        size: FourInch
-    diameter: sixinch
+        size: 4
+    diameter: 6
     farm: Pulumi Planters Inc.
     size: small
     type: Burgundy

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
@@ -251,12 +251,12 @@ var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
 
 ```go
 example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
-Varieties: treev1.RubberTreeVarietyArray{
-tree.RubberTreeVarietyBurgundy,
-},
-Sizes: treev1.TreeSizeMap{
-"string": tree.TreeSizeSmall,
-},
+	Varieties: treev1.RubberTreeVarietyArray{
+		tree.RubberTreeVarietyBurgundy,
+	},
+	Sizes: treev1.TreeSizeMap{
+		"string": tree.TreeSizeSmall,
+	},
 })
 ```
 

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -232,7 +232,20 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var rubberTreeResource = new Plant.Tree.V1.RubberTree("rubberTreeResource", new()
+{
+    Diameter = Other.Tree.V1.Diameter.Sixinch,
+    Type = Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    Container = new Plant.Inputs.ContainerArgs
+    {
+        Size = Plant.ContainerSize.FourInch,
+        Brightness = Plant.ContainerBrightness.ZeroPointOne,
+        Color = Plant.ContainerColor.Red,
+        Material = "string",
+    },
+    Farm = Plant.Tree.V1.Farm.Pulumi_Planters_Inc_,
+    Size = Plant.Tree.V1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -243,7 +256,18 @@ Coming soon!
 <pulumi-choosable type="language" values="go">
 
 ```go
-Coming soon!
+example, err := tree.NewRubberTree(ctx, "rubberTreeResource", &tree.RubberTreeArgs{
+	Diameter: tree / v1.DiameterSixinch,
+	Type:     tree.RubberTreeVarietyBurgundy,
+	Container: &plant.ContainerArgs{
+		Size:       plant.ContainerSizeFourInch,
+		Brightness: plant.ContainerBrightnessZeroPointOne,
+		Color:      pulumi.String(plant.ContainerColorRed),
+		Material:   pulumi.String("string"),
+	},
+	Farm: pulumi.String(tree.Farm_Pulumi_Planters_Inc_),
+	Size: tree.TreeSizeSmall,
+})
 ```
 
 </pulumi-choosable>
@@ -255,11 +279,11 @@ Coming soon!
 
 ```java
 var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.builder()
-    .diameter("sixinch")
+    .diameter(6)
     .type("Burgundy")
     .container(ContainerArgs.builder()
-        .size("FourInch")
-        .brightness("ZeroPointOne")
+        .size(4)
+        .brightness(0.1)
         .color("red")
         .material("string")
         .build())
@@ -276,7 +300,17 @@ var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.bui
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+rubber_tree_resource = plant.tree.v1.RubberTree("rubberTreeResource",
+    diameter=other.tree.v1.Diameter.SIXINCH,
+    type=plant.tree.v1.RubberTreeVariety.BURGUNDY,
+    container=plant.ContainerArgs(
+        size=plant.ContainerSize.FOUR_INCH,
+        brightness=plant.ContainerBrightness.ZERO_POINT_ONE,
+        color=plant.ContainerColor.RED,
+        material="string",
+    ),
+    farm=plant.tree.v1.Farm.PULUMI_PLANTERS_INC_,
+    size=plant.tree.v1.TreeSize.SMALL)
 ```
 
 </pulumi-choosable>
@@ -287,7 +321,18 @@ Coming soon!
 <pulumi-choosable type="language" values="typescript">
 
 ```typescript
-Coming soon!
+const rubberTreeResource = new plant.tree.v1.RubberTree("rubberTreeResource", {
+    diameter: other.tree.v1.Diameter.Sixinch,
+    type: plant.tree.v1.RubberTreeVariety.Burgundy,
+    container: {
+        size: plant.ContainerSize.FourInch,
+        brightness: plant.ContainerBrightness.ZeroPointOne,
+        color: plant.ContainerColor.Red,
+        material: "string",
+    },
+    farm: plant.tree.v1.Farm.Pulumi_Planters_Inc_,
+    size: plant.tree.v1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -301,11 +346,11 @@ Coming soon!
 type: plant:tree/v1:RubberTree
 properties:
     container:
-        brightness: ZeroPointOne
+        brightness: 0.1
         color: red
         material: string
-        size: FourInch
-    diameter: sixinch
+        size: 4
+    diameter: 6
     farm: Pulumi Planters Inc.
     size: small
     type: Burgundy

--- a/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
@@ -228,7 +228,24 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var iamResourceResource = new Example.MyModule.IamResource("iamResourceResource", new()
+{
+    Config = new GoogleNative.Iam.Inputs.AuditConfigArgs
+    {
+        AuditLogConfigs = new[]
+        {
+            new GoogleNative.Iam.Inputs.AuditLogConfigArgs
+            {
+                ExemptedMembers = new[]
+                {
+                    "string",
+                },
+                LogType = GoogleNative.Iam.V1.AuditLogConfigLogType.LogTypeUnspecified,
+            },
+        },
+        Service = "string",
+    },
+});
 ```
 
 </pulumi-choosable>
@@ -281,7 +298,13 @@ var iamResourceResource = new IamResource("iamResourceResource", IamResourceArgs
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+iam_resource_resource = example.my_module.IamResource("iamResourceResource", config=google_native.iam.v1.AuditConfigArgs(
+    audit_log_configs=[google_native.iam.v1.AuditLogConfigArgs(
+        exempted_members=["string"],
+        log_type=google_native.iam.v1.AuditLogConfigLogType.LOG_TYPE_UNSPECIFIED,
+    )],
+    service="string",
+))
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/external-enum/docs/component/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/component/_index.md
@@ -229,7 +229,11 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var componentResource = new Example.Component("componentResource", new()
+{
+    LocalEnum = Example.Local.MyEnum.Pi,
+    RemoteEnum = GoogleNative.Accesscontextmanager.V1.DevicePolicyAllowedDeviceManagementLevelsItem.ManagementUnspecified,
+});
 ```
 
 </pulumi-choosable>
@@ -240,7 +244,10 @@ Coming soon!
 <pulumi-choosable type="language" values="go">
 
 ```go
-Coming soon!
+example, err := example.NewComponent(ctx, "componentResource", &example.ComponentArgs{
+	LocalEnum:  local.MyEnumPi,
+	RemoteEnum: accesscontextmanager / v1.DevicePolicyAllowedDeviceManagementLevelsItemManagementUnspecified,
+})
 ```
 
 </pulumi-choosable>
@@ -252,7 +259,7 @@ Coming soon!
 
 ```java
 var componentResource = new Component("componentResource", ComponentArgs.builder()
-    .localEnum("pi")
+    .localEnum(3.1415)
     .remoteEnum("MANAGEMENT_UNSPECIFIED")
     .build());
 ```
@@ -265,7 +272,9 @@ var componentResource = new Component("componentResource", ComponentArgs.builder
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+component_resource = example.Component("componentResource",
+    local_enum=example.local.MyEnum.PI,
+    remote_enum=google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem.MANAGEMENT_UNSPECIFIED)
 ```
 
 </pulumi-choosable>
@@ -276,7 +285,10 @@ Coming soon!
 <pulumi-choosable type="language" values="typescript">
 
 ```typescript
-Coming soon!
+const componentResource = new example.Component("componentResource", {
+    localEnum: example.local.MyEnum.Pi,
+    remoteEnum: google_native.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem.ManagementUnspecified,
+});
 ```
 
 </pulumi-choosable>
@@ -289,7 +301,7 @@ Coming soon!
 ```yaml
 type: example:Component
 properties:
-    localEnum: pi
+    localEnum: 3.1415
     remoteEnum: MANAGEMENT_UNSPECIFIED
 ```
 

--- a/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
@@ -229,7 +229,21 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var example_resourceResource = new Legacy_names.Example_resource("example_resourceResource", new()
+{
+    Map_enum = new[]
+    {
+        
+        {
+            { "string", Legacy_names.Enum_XYZ.Plain },
+        },
+    },
+    Request_HTTP = new Legacy_names.HTTP_module.Inputs.RequestArgs
+    {
+        URL = "string",
+        Content_body = "string",
+    },
+});
 ```
 
 </pulumi-choosable>
@@ -278,7 +292,14 @@ var example_resourceResource = new Example_resource("example_resourceResource", 
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+example_resource_resource = legacy_names.Example_resource("example_resourceResource",
+    map_enum=[{
+        "string": legacy_names.Enum_XYZ.PLAIN,
+    }],
+    request__http=legacy_names.htt_p_module.RequestArgs(
+        url="string",
+        content_body="string",
+    ))
 ```
 
 </pulumi-choosable>

--- a/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
@@ -241,7 +241,26 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var moduleResourceResource = new FooBar.ModuleResource("moduleResourceResource", new()
+{
+    PlainRequiredBool = false,
+    RequiredString = "string",
+    RequiredNumber = 0,
+    RequiredEnum = FooBar.EnumThing.Four,
+    RequiredBool = false,
+    PlainRequiredString = "string",
+    PlainRequiredNumber = 0,
+    PlainRequiredConst = "string",
+    OptionalString = "string",
+    PlainOptionalString = "string",
+    PlainOptionalNumber = 0,
+    PlainOptionalConst = "string",
+    PlainOptionalBool = false,
+    OptionalBool = false,
+    OptionalNumber = 0,
+    OptionalEnum = FooBar.EnumThing.Four,
+    OptionalConst = "string",
+});
 ```
 
 </pulumi-choosable>
@@ -252,7 +271,25 @@ Coming soon!
 <pulumi-choosable type="language" values="go">
 
 ```go
-Coming soon!
+example, err := foobar.NewModuleResource(ctx, "moduleResourceResource", &foobar.ModuleResourceArgs{
+	PlainRequiredBool:   false,
+	RequiredString:      pulumi.String("string"),
+	RequiredNumber:      pulumi.Float64(0),
+	RequiredEnum:        foobar.EnumThingFour,
+	RequiredBool:        pulumi.Bool(false),
+	PlainRequiredString: "string",
+	PlainRequiredNumber: 0,
+	PlainRequiredConst:  "string",
+	OptionalString:      pulumi.String("string"),
+	PlainOptionalString: "string",
+	PlainOptionalNumber: 0,
+	PlainOptionalConst:  "string",
+	PlainOptionalBool:   false,
+	OptionalBool:        pulumi.Bool(false),
+	OptionalNumber:      pulumi.Float64(0),
+	OptionalEnum:        foobar.EnumThingFour,
+	OptionalConst:       pulumi.String("string"),
+})
 ```
 
 </pulumi-choosable>
@@ -267,7 +304,7 @@ var moduleResourceResource = new ModuleResource("moduleResourceResource", Module
     .plainRequiredBool(false)
     .requiredString("string")
     .requiredNumber(0)
-    .requiredEnum("Four")
+    .requiredEnum(4)
     .requiredBool(false)
     .plainRequiredString("string")
     .plainRequiredNumber(0)
@@ -279,7 +316,7 @@ var moduleResourceResource = new ModuleResource("moduleResourceResource", Module
     .plainOptionalBool(false)
     .optionalBool(false)
     .optionalNumber(0)
-    .optionalEnum("Four")
+    .optionalEnum(4)
     .optionalConst("string")
     .build());
 ```
@@ -292,7 +329,24 @@ var moduleResourceResource = new ModuleResource("moduleResourceResource", Module
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+module_resource_resource = foobar.ModuleResource("moduleResourceResource",
+    plain_required_bool=False,
+    required_string="string",
+    required_number=0,
+    required_enum=foobar.EnumThing.FOUR,
+    required_bool=False,
+    plain_required_string="string",
+    plain_required_number=0,
+    plain_required_const="string",
+    optional_string="string",
+    plain_optional_string="string",
+    plain_optional_number=0,
+    plain_optional_const="string",
+    plain_optional_bool=False,
+    optional_bool=False,
+    optional_number=0,
+    optional_enum=foobar.EnumThing.FOUR,
+    optional_const="string")
 ```
 
 </pulumi-choosable>
@@ -303,7 +357,25 @@ Coming soon!
 <pulumi-choosable type="language" values="typescript">
 
 ```typescript
-Coming soon!
+const moduleResourceResource = new foobar.ModuleResource("moduleResourceResource", {
+    plainRequiredBool: false,
+    requiredString: "string",
+    requiredNumber: 0,
+    requiredEnum: foobar.EnumThing.Four,
+    requiredBool: false,
+    plainRequiredString: "string",
+    plainRequiredNumber: 0,
+    plainRequiredConst: "string",
+    optionalString: "string",
+    plainOptionalString: "string",
+    plainOptionalNumber: 0,
+    plainOptionalConst: "string",
+    plainOptionalBool: false,
+    optionalBool: false,
+    optionalNumber: 0,
+    optionalEnum: foobar.EnumThing.Four,
+    optionalConst: "string",
+});
 ```
 
 </pulumi-choosable>
@@ -318,7 +390,7 @@ type: foobar:ModuleResource
 properties:
     optionalBool: false
     optionalConst: string
-    optionalEnum: Four
+    optionalEnum: 4
     optionalNumber: 0
     optionalString: string
     plainOptionalBool: false
@@ -330,7 +402,7 @@ properties:
     plainRequiredNumber: 0
     plainRequiredString: string
     requiredBool: false
-    requiredEnum: Four
+    requiredEnum: 4
     requiredNumber: 0
     requiredString: string
 ```

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -251,12 +251,12 @@ var nurseryResource = new Plant.Tree.V1.Nursery("nurseryResource", new()
 
 ```go
 example, err := tree.NewNursery(ctx, "nurseryResource", &tree.NurseryArgs{
-Varieties: treev1.RubberTreeVarietyArray{
-tree.RubberTreeVarietyBurgundy,
-},
-Sizes: treev1.TreeSizeMap{
-"string": tree.TreeSizeSmall,
-},
+	Varieties: treev1.RubberTreeVarietyArray{
+		tree.RubberTreeVarietyBurgundy,
+	},
+	Sizes: treev1.TreeSizeMap{
+		"string": tree.TreeSizeSmall,
+	},
 })
 ```
 

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -232,7 +232,20 @@ The following reference example uses placeholder values for all [input propertie
 <pulumi-choosable type="language" values="csharp">
 
 ```csharp
-Coming soon!
+var rubberTreeResource = new Plant.Tree.V1.RubberTree("rubberTreeResource", new()
+{
+    Diameter = Plant.Tree.V1.Diameter.Sixinch,
+    Type = Plant.Tree.V1.RubberTreeVariety.Burgundy,
+    Container = new Plant.Inputs.ContainerArgs
+    {
+        Size = Plant.ContainerSize.FourInch,
+        Brightness = Plant.ContainerBrightness.ZeroPointOne,
+        Color = Plant.ContainerColor.Red,
+        Material = "string",
+    },
+    Farm = Plant.Tree.V1.Farm.Pulumi_Planters_Inc_,
+    Size = Plant.Tree.V1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -243,7 +256,18 @@ Coming soon!
 <pulumi-choosable type="language" values="go">
 
 ```go
-Coming soon!
+example, err := tree.NewRubberTree(ctx, "rubberTreeResource", &tree.RubberTreeArgs{
+	Diameter: tree.DiameterSixinch,
+	Type:     tree.RubberTreeVarietyBurgundy,
+	Container: &plant.ContainerArgs{
+		Size:       plant.ContainerSizeFourInch,
+		Brightness: plant.ContainerBrightnessZeroPointOne,
+		Color:      pulumi.String(plant.ContainerColorRed),
+		Material:   pulumi.String("string"),
+	},
+	Farm: pulumi.String(tree.Farm_Pulumi_Planters_Inc_),
+	Size: tree.TreeSizeSmall,
+})
 ```
 
 </pulumi-choosable>
@@ -255,11 +279,11 @@ Coming soon!
 
 ```java
 var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.builder()
-    .diameter("sixinch")
+    .diameter(6)
     .type("Burgundy")
     .container(ContainerArgs.builder()
-        .size("FourInch")
-        .brightness("ZeroPointOne")
+        .size(4)
+        .brightness(0.1)
         .color("red")
         .material("string")
         .build())
@@ -276,7 +300,17 @@ var rubberTreeResource = new RubberTree("rubberTreeResource", RubberTreeArgs.bui
 <pulumi-choosable type="language" values="python">
 
 ```python
-Coming soon!
+rubber_tree_resource = plant.tree.v1.RubberTree("rubberTreeResource",
+    diameter=plant.tree.v1.Diameter.SIXINCH,
+    type=plant.tree.v1.RubberTreeVariety.BURGUNDY,
+    container=plant.ContainerArgs(
+        size=plant.ContainerSize.FOUR_INCH,
+        brightness=plant.ContainerBrightness.ZERO_POINT_ONE,
+        color=plant.ContainerColor.RED,
+        material="string",
+    ),
+    farm=plant.tree.v1.Farm.PULUMI_PLANTERS_INC_,
+    size=plant.tree.v1.TreeSize.SMALL)
 ```
 
 </pulumi-choosable>
@@ -287,7 +321,18 @@ Coming soon!
 <pulumi-choosable type="language" values="typescript">
 
 ```typescript
-Coming soon!
+const rubberTreeResource = new plant.tree.v1.RubberTree("rubberTreeResource", {
+    diameter: plant.tree.v1.Diameter.Sixinch,
+    type: plant.tree.v1.RubberTreeVariety.Burgundy,
+    container: {
+        size: plant.ContainerSize.FourInch,
+        brightness: plant.ContainerBrightness.ZeroPointOne,
+        color: plant.ContainerColor.Red,
+        material: "string",
+    },
+    farm: plant.tree.v1.Farm.Pulumi_Planters_Inc_,
+    size: plant.tree.v1.TreeSize.Small,
+});
 ```
 
 </pulumi-choosable>
@@ -301,11 +346,11 @@ Coming soon!
 type: plant:tree/v1:RubberTree
 properties:
     container:
-        brightness: ZeroPointOne
+        brightness: 0.1
         color: red
         material: string
-        size: FourInch
-    diameter: sixinch
+        size: 4
+    diameter: 6
     farm: Pulumi Planters Inc.
     size: small
     type: Burgundy


### PR DESCRIPTION
# Description

Fixes #16191 

The original issue is that the intermediate PCL we generate used enum names instead of enum values for numeric enum inputs. This PR changes it so that the PCL program now uses the first numeric value for the first enum case then subsequently fixing downstream program-gen bugs that didn't know how to handle numeric values as inputs for enums. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
