### PR TITLE
Lock state access in `builtinProvider.getResource`

### DIFF
--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -321,6 +321,10 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 		return nil, fmt.Errorf("unknown resource %v", urn.StringValue())
 	}
 
+	// Take the state lock so we can safely read the Outputs.
+	state.Lock.Lock()
+	defer state.Lock.Unlock()
+
 	return resource.PropertyMap{
 		"urn":   urn,
 		"id":    resource.NewStringProperty(string(state.ID)),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Found by data race checker.