### PR TITLE
Fix race in language conformance tests Log method

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -42,11 +42,15 @@ type hostEngine struct {
 	pulumirpc.UnimplementedEngineServer
 	t *testing.T
 
+	logLock         sync.Mutex
 	logRepeat       int
 	previousMessage string
 }
 
 func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty.Empty, error) {
+	e.logLock.Lock()
+	defer e.logLock.Unlock()
+
 	var sev diag.Severity
 	switch req.Severity {
 	case pulumirpc.LogSeverity_DEBUG:

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -44,11 +44,15 @@ type hostEngine struct {
 	pulumirpc.UnimplementedEngineServer
 	t *testing.T
 
+	logLock         sync.Mutex
 	logRepeat       int
 	previousMessage string
 }
 
 func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty.Empty, error) {
+	e.logLock.Lock()
+	defer e.logLock.Unlock()
+
 	var sev diag.Severity
 	switch req.Severity {
 	case pulumirpc.LogSeverity_DEBUG:


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The engine can call Log in parallel, so we need to lock to maintain our `previousMessage` correctness.
