### PR TITLE
Update set-default command description

### DIFF
--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -75,10 +75,10 @@ func newOrgSetDefaultCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-default [NAME]",
 		Args:  cmdutil.ExactArgs(1),
-		Short: "Set the default organization for the current backend",
-		Long: "Set the default organization for the current backend.\n" +
+		Short: "Set the local default organization for the current backend",
+		Long: "Set the local default organization for the current backend.\n" +
 			"\n" +
-			"This command is used to set the default organization in which to create \n" +
+			"This command is used to set your local default organization in which to create \n" +
 			"projects and stacks for the current backend.\n" +
 			"\n" +
 			"Currently, only the managed and self-hosted backends support organizations. " +


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/11869

Updates the command description to be more explicit that this only alters default org configuration locally.