### PR TITLE
[engine/import] Guess references to properties between dependant resources during import

### DIFF
--- a/changelog/pending/20240520--engine--guess-references-to-deeply-nested-properties-between-dependant-resources-during-import.yaml
+++ b/changelog/pending/20240520--engine--guess-references-to-deeply-nested-properties-between-dependant-resources-during-import.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Guess references to (deeply nested) properties between dependant resources during import

--- a/changelog/pending/20240520--engine--guess-references-to-deeply-nested-properties-between-dependant-resources-during-import.yaml
+++ b/changelog/pending/20240520--engine--guess-references-to-deeply-nested-properties-between-dependant-resources-during-import.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: engine
-  description: Guess references to (deeply nested) properties between dependant resources during import
+  description: Guess references to properties 'name' and 'arn' between dependant resources during import

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -619,7 +619,10 @@ func newImportCmd() *cobra.Command {
 			"            {\n" +
 			"                ...\n" +
 			"            }\n" +
-			"        ]\n" +
+			"        ],\n" +
+			"        \"ancestorTypes\": {\n" +
+			"            \"child-type-token\": [\"ancestor-type-token1\", \"ancestor-type-token2\"]\n" +
+			"         },\n" +
 			"    }\n" +
 			"\n" +
 			"The name table maps language names to parent and provider URNs. These names are\n" +
@@ -645,6 +648,11 @@ func newImportCmd() *cobra.Command {
 			"\n" +
 			"If a resource does not specify any properties the default behaviour is to\n" +
 			"import using all required properties.\n" +
+			"\n" +
+			"The ancestorTypes map is an optional field that maps child types to their ancestor types.\n" +
+			"When generating code from the import, the generator will use this map to guess input values of \n" +
+			"the child resource that correspond with outputs of the specified ancestor resources.\n" +
+			"The code generator will then replace the inputs to symbolic references of outputs of the ancestor types.\n" +
 			"\n" +
 			"You can use `pulumi preview` with the `--import-file` option to emit an import file\n" +
 			"for all resources that need creating from the preview. This will fill in all the name,\n" +

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -163,9 +163,8 @@ type importSpec struct {
 }
 
 type importFile struct {
-	NameTable     map[string]resource.URN `json:"nameTable,omitempty"`
-	Resources     []importSpec            `json:"resources,omitempty"`
-	AncestorTypes map[string][]string     `json:"ancestorTypes,omitempty"`
+	NameTable map[string]resource.URN `json:"nameTable,omitempty"`
+	Resources []importSpec            `json:"resources,omitempty"`
 }
 
 func readImportFile(p string) (importFile, error) {
@@ -470,7 +469,7 @@ type programGeneratorFunc func(
 func generateImportedDefinitions(ctx *plugin.Context,
 	out io.Writer, stackName tokens.StackName, projectName tokens.PackageName,
 	snap *deploy.Snapshot, programGenerator programGeneratorFunc, names importer.NameTable,
-	imports []deploy.Import, protectResources bool, ancestorTypes map[string][]string,
+	imports []deploy.Import, protectResources bool,
 ) (bool, error) {
 	defer func() {
 		v := recover()
@@ -528,7 +527,7 @@ func generateImportedDefinitions(ctx *plugin.Context,
 			return err
 		}
 		return nil
-	}, resources, names, ancestorTypes)
+	}, resources, names)
 }
 
 func newImportCmd() *cobra.Command {
@@ -620,9 +619,6 @@ func newImportCmd() *cobra.Command {
 			"                ...\n" +
 			"            }\n" +
 			"        ],\n" +
-			"        \"ancestorTypes\": {\n" +
-			"            \"child-type-token\": [\"ancestor-type-token1\", \"ancestor-type-token2\"]\n" +
-			"         },\n" +
 			"    }\n" +
 			"\n" +
 			"The name table maps language names to parent and provider URNs. These names are\n" +
@@ -648,11 +644,6 @@ func newImportCmd() *cobra.Command {
 			"\n" +
 			"If a resource does not specify any properties the default behaviour is to\n" +
 			"import using all required properties.\n" +
-			"\n" +
-			"The ancestorTypes map is an optional field that maps child types to their ancestor types.\n" +
-			"When generating code from the import, the generator will use this map to guess input values of \n" +
-			"the child resource that correspond with outputs of the specified ancestor resources.\n" +
-			"The code generator will then replace the inputs to symbolic references of outputs of the ancestor types.\n" +
 			"\n" +
 			"You can use `pulumi preview` with the `--import-file` option to emit an import file\n" +
 			"for all resources that need creating from the preview. This will fill in all the name,\n" +
@@ -967,7 +958,7 @@ func newImportCmd() *cobra.Command {
 
 				validImports, err := generateImportedDefinitions(
 					pCtx, output, s.Ref().Name(), proj.Name, deployment, programGenerator, nameTable, imports,
-					protectResources, importFile.AncestorTypes)
+					protectResources)
 				if err != nil {
 					if _, ok := err.(*importer.DiagnosticsError); ok {
 						err = fmt.Errorf("internal error: %w", err)

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -41,7 +41,6 @@ var Null = &model.Variable{
 type PathedLiteralValue struct {
 	Root                string
 	Value               string
-	Identity            bool
 	ExpressionReference *model.ScopeTraversalExpression
 }
 

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -41,6 +41,7 @@ var Null = &model.Variable{
 type PathedLiteralValue struct {
 	Root                string
 	Value               string
+	Identity            bool
 	ExpressionReference *model.ScopeTraversalExpression
 }
 
@@ -86,7 +87,7 @@ func GenerateHCL2Definition(
 	}
 
 	var items []model.BodyItem
-	name := state.URN.Name()
+	name := sanitizeName(state.URN.Name())
 	// Check if _this_ urn is in the name table, if so we need to set logicalName and use the mapped name for
 	// the resource block.
 	if mappedName, ok := importState.Names[state.URN]; ok {
@@ -95,12 +96,12 @@ func GenerateHCL2Definition(
 			Value: &model.TemplateExpression{
 				Parts: []model.Expression{
 					&model.LiteralValueExpression{
-						Value: cty.StringVal(name),
+						Value: cty.StringVal(state.URN.Name()),
 					},
 				},
 			},
 		})
-		name = mappedName
+		name = sanitizeName(mappedName)
 	}
 
 	// keep track of a set of added references to avoid adding the same reference to the dependsOn list

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -718,10 +718,6 @@ func generateValue(
 		switch arg := typ.(type) {
 		case *schema.ObjectType:
 			for _, p := range arg.Properties {
-				// Ignore internal properties.
-				if strings.HasPrefix(string(p.Name), "__") {
-					continue
-				}
 				x, err := generatePropertyValue(p, obj[resource.PropertyKey(p.Name)], importState, onReferenceFound)
 				if err != nil {
 					return nil, err

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -262,7 +262,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 				Names: names,
 			}
 
-			block, err := GenerateHCL2Definition(loader, state, importState, nil)
+			block, err := GenerateHCL2Definition(loader, state, importState)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -346,17 +346,11 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 		states = append(states, state)
 	}
 
-	ancestorTypes := map[string][]string{
-		"aws:s3/bucketObject:BucketObject": {
-			"aws:s3/bucket:Bucket",
-		},
-	}
-
 	importState := createImportState(states, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -375,6 +369,91 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 
 resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
     bucket = exampleBucket.id
+    storageClass = "STANDARD"
+
+}
+`
+
+	assert.Equal(t, expectedCode, hcl2Text.String(), "Generated HCL2 code does not match expected code")
+}
+
+func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *testing.T) {
+	t.Parallel()
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+
+	resources := []apitype.ResourceV3{
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
+			ID:     "provider-generated-bucket-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucket:Bucket",
+			Outputs: map[string]interface{}{
+				"name": "bucketName-12345",
+				"arn":  "arn:aws:s3:bucket-12345",
+			},
+		},
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject",
+			ID:     "provider-generated-bucket-object-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucketObject:BucketObject",
+			Inputs: map[string]interface{}{
+				// this will be replaced with a reference to exampleBucket.name in the generated code
+				"bucket":       "bucketName-12345",
+				"storageClass": "STANDARD",
+			},
+		},
+		{
+			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObjectUsingArn",
+			ID:     "provider-generated-bucket-object-id-abc123",
+			Custom: true,
+			Type:   "aws:s3/bucketObject:BucketObject",
+			Inputs: map[string]interface{}{
+				// this will be replaced with a reference to exampleBucket.arn in the generated code
+				"bucket":       "arn:aws:s3:bucket-12345",
+				"storageClass": "STANDARD",
+			},
+		},
+	}
+
+	states := make([]*resource.State, 0)
+	for _, r := range resources {
+		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		states = append(states, state)
+	}
+
+	importState := createImportState(states, names)
+
+	var hcl2Text strings.Builder
+	for i, state := range states {
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pre := ""
+		if i > 0 {
+			pre = "\n"
+		}
+		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
+		contract.IgnoreError(err)
+	}
+
+	expectedCode := `resource exampleBucket "aws:s3/bucket:Bucket" {
+
+}
+
+resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
+    bucket = exampleBucket.name
+    storageClass = "STANDARD"
+
+}
+
+resource exampleBucketObjectUsingArn "aws:s3/bucketObject:BucketObject" {
+    bucket = exampleBucket.arn
     storageClass = "STANDARD"
 
 }
@@ -423,17 +502,11 @@ func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *
 		states = append(states, state)
 	}
 
-	ancestorTypes := map[string][]string{
-		"aws:s3/bucketObject:BucketObject": {
-			"aws:s3/bucket:Bucket",
-		},
-	}
-
 	importState := createImportState(states, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -495,7 +568,7 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, nil)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -511,139 +584,6 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 	expectedCode := `resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
     bucket = "provider-generated-bucket-object-id-abc123"
     storageClass = "STANDARD"
-
-}
-`
-
-	assert.Equal(t, expectedCode, hcl2Text.String(), "Generated HCL2 code does not match expected code")
-}
-
-func TestGenerateHCL2DefinitionsReplacesDeeplyNestedReferencesToLiterals(t *testing.T) {
-	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
-
-	resources := []apitype.ResourceV3{
-		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::exampleBucket",
-			ID:     "provider-generated-bucket-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucket:Bucket",
-			Outputs: map[string]interface{}{
-				"someValue": "STANDARD",
-				"fromObject": map[string]interface{}{
-					"deeply": map[string]interface{}{
-						"nested": "nested value 123",
-					},
-				},
-				"fromArray": []interface{}{
-					map[string]interface{}{
-						"element": "array value 123",
-					},
-				},
-				"fromPlainArray": []interface{}{
-					"plain array value 123",
-				},
-			},
-		},
-		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject1",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
-			Inputs: map[string]interface{}{
-				"bucket":       "provider-generated-bucket-id-abc123",
-				"storageClass": "STANDARD",
-			},
-		},
-		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject2",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
-			Inputs: map[string]interface{}{
-				"bucket":       "provider-generated-bucket-id-abc123",
-				"storageClass": "nested value 123",
-			},
-		},
-		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject3",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
-			Inputs: map[string]interface{}{
-				"bucket":       "provider-generated-bucket-id-abc123",
-				"storageClass": "array value 123",
-			},
-		},
-		{
-			URN:    "urn:pulumi:stack::project::aws:s3/bucketObject:BucketObject::exampleBucketObject4",
-			ID:     "provider-generated-bucket-object-id-abc123",
-			Custom: true,
-			Type:   "aws:s3/bucketObject:BucketObject",
-			Inputs: map[string]interface{}{
-				"bucket":       "provider-generated-bucket-id-abc123",
-				"storageClass": "plain array value 123",
-			},
-		},
-	}
-
-	states := make([]*resource.State, 0)
-	for _, r := range resources {
-		state, err := stack.DeserializeResource(r, config.NopDecrypter, config.NopEncrypter)
-		if !assert.NoError(t, err) {
-			t.Fatal()
-		}
-		states = append(states, state)
-	}
-
-	ancestorTypes := map[string][]string{
-		"aws:s3/bucketObject:BucketObject": {
-			"aws:s3/bucket:Bucket",
-		},
-	}
-
-	importState := createImportState(states, names)
-
-	var hcl2Text strings.Builder
-	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		pre := ""
-		if i > 0 {
-			pre = "\n"
-		}
-		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
-		contract.IgnoreError(err)
-	}
-
-	expectedCode := `resource exampleBucket "aws:s3/bucket:Bucket" {
-
-}
-
-resource exampleBucketObject1 "aws:s3/bucketObject:BucketObject" {
-    bucket = exampleBucket.id
-    storageClass = exampleBucket.someValue
-
-}
-
-resource exampleBucketObject2 "aws:s3/bucketObject:BucketObject" {
-    bucket = exampleBucket.id
-    storageClass = exampleBucket.fromObject.deeply.nested
-
-}
-
-resource exampleBucketObject3 "aws:s3/bucketObject:BucketObject" {
-    bucket = exampleBucket.id
-    storageClass = exampleBucket.fromArray[0].element
-
-}
-
-resource exampleBucketObject4 "aws:s3/bucketObject:BucketObject" {
-    bucket = exampleBucket.id
-    storageClass = exampleBucket.fromPlainArray[0]
 
 }
 `

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -262,7 +262,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 				Names: names,
 			}
 
-			block, err := GenerateHCL2Definition(loader, state, importState)
+			block, err := GenerateHCL2Definition(loader, state, importState, nil)
 			if !assert.NoError(t, err) {
 				t.Fatal()
 			}
@@ -346,11 +346,17 @@ func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 		states = append(states, state)
 	}
 
+	ancestorTypes := map[string][]string{
+		"aws:s3/bucketObject:BucketObject": {
+			"aws:s3/bucket:Bucket",
+		},
+	}
+
 	importState := createImportState(states, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -417,11 +423,17 @@ func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *
 		states = append(states, state)
 	}
 
+	ancestorTypes := map[string][]string{
+		"aws:s3/bucketObject:BucketObject": {
+			"aws:s3/bucket:Bucket",
+		},
+	}
+
 	importState := createImportState(states, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -483,7 +495,7 @@ func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -584,11 +596,17 @@ func TestGenerateHCL2DefinitionsReplacesDeeplyNestedReferencesToLiterals(t *test
 		states = append(states, state)
 	}
 
+	ancestorTypes := map[string][]string{
+		"aws:s3/bucketObject:BucketObject": {
+			"aws:s3/bucket:Bucket",
+		},
+	}
+
 	importState := createImportState(states, names)
 
 	var hcl2Text strings.Builder
 	for i, state := range states {
-		hcl2Def, err := GenerateHCL2Definition(loader, state, importState)
+		hcl2Def, err := GenerateHCL2Definition(loader, state, importState, ancestorTypes)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/importer/language.go
+++ b/pkg/importer/language.go
@@ -65,24 +65,14 @@ func (e *DiagnosticsError) String() string {
 
 func removeDuplicatePathedValues(pathedValues []PathedLiteralValue) []PathedLiteralValue {
 	uniqueValues := make([]PathedLiteralValue, 0)
-	identityOccurrences := make(map[string]int)
-	outputOccurrences := make(map[string]int)
+	occurrences := make(map[string]int)
 	for _, pathedValue := range pathedValues {
-		if pathedValue.Identity {
-			identityOccurrences[pathedValue.Value]++
-		} else {
-			outputOccurrences[pathedValue.Value]++
-		}
+		occurrences[pathedValue.Value]++
 	}
 
 	for _, pathedValue := range pathedValues {
-		if pathedValue.Identity && identityOccurrences[pathedValue.Value] > 1 {
-			// an identity value that has occurred multiple times is not unique
-			continue
-		}
-
-		if !pathedValue.Identity && outputOccurrences[pathedValue.Value] > 1 {
-			// an output value that has occurred multiple times is not unique
+		if occurrences[pathedValue.Value] > 1 {
+			// a value that has occurred multiple times is not unique
 			continue
 		}
 
@@ -138,9 +128,8 @@ func createImportState(states []*resource.State, names NameTable) ImportState {
 
 		name := sanitizeName(state.URN.Name())
 		pathedLiteralValues = append(pathedLiteralValues, PathedLiteralValue{
-			Root:     name,
-			Value:    resourceID,
-			Identity: true,
+			Root:  name,
+			Value: resourceID,
 			ExpressionReference: &model.ScopeTraversalExpression{
 				RootName: name,
 				Traversal: hcl.Traversal{


### PR DESCRIPTION
# Description

Following up and extending #16208 such that now we guess references to _properties_ `name` and `arn` between dependant resources when running an import based on their literal data retrieved from providers. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
