### PR TITLE
[display] Enable WASM compilation

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -131,6 +131,7 @@ jobs:
             | go run github.com/t0yv0/goreleaser-filter@v0.3.0 -goos ${{ inputs.os }} -goarch ${{ inputs.arch }} \
             | goreleaser release -f - -p 5 --skip-validate --clean --snapshot
       - uses: actions/upload-artifact@v2
+        if: ${{ inputs.os != 'js' }}
         with:
           name: artifacts-cli-${{ inputs.os }}-${{ inputs.arch }}
           retention-days: 1

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -32,7 +32,7 @@ on:
         description: "Version to produce"
         type: string
       version-set:
-        required: false
+        required: true
         description: "Set of language versions to use for builds, lints, releases, etc."
         type: string
       enable-coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
 
   build-display-wasm-module:
     name: build display WASM module
+    needs: [matrix]
     uses: ./.github/workflows/ci-build-binaries.yml
     with:
       ref: ${{ inputs.ref }}
@@ -300,6 +301,7 @@ jobs:
       os: js
       arch: wasm
       build-platform: "ubuntu-latest"
+      version-set: ${{ needs.matrix.outputs.version-set }}
     secrets: inherit
 
   build-sdks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,17 @@ jobs:
       enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
     secrets: inherit
 
+  build-display-wasm-module:
+    name: build display WASM module
+    uses: ./.github/workflows/ci-build-binaries.yml
+    with:
+      ref: ${{ inputs.ref }}
+      version: ${{ inputs.version }}
+      os: js
+      arch: wasm
+      build-platform: "ubuntu-latest"
+    secrets: inherit
+
   build-sdks:
     name: Build SDKs
     needs: [matrix]

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ __pycache__
 *.tmp
 test-results/
 yarn-error.log
+pkg/backend/display/wasm/mod.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,3 @@ __pycache__
 *.tmp
 test-results/
 yarn-error.log
-pkg/backend/display/wasm/mod.wasm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,18 @@ builds:
   dir: sdk/python/cmd/pulumi-language-python
   main: ./
   gobinary: ../../../../scripts/go-wrapper.sh
+- <<: *pulumibin
+  id: pulumi-display-wasm
+  binary: pulumi-display
+  dir: pkg
+  main: ./backend/display/wasm
+  goos: ['js']
+  goarch: ['wasm']
+  hooks:
+    post:
+      # Check the size of the WASM module.
+      - |
+        sh -c "[ `du -k {{ .Path }} | cut -f1` -le 79182 ] || (echo 'error: WASM module > 77M'; exit 1)"
 
 archives:
 - id: pulumi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,8 +45,7 @@ builds:
   hooks:
     post:
       # Check the size of the WASM module.
-      - |
-        sh -c "[ `du -k {{ .Path }} | cut -f1` -le 79182 ] || (echo 'error: WASM module > 77M'; exit 1)"
+      - sh -c "[ `du -k {{ .Path }} | cut -f1` -le 79182 ] || (echo 'error: WASM module > 77M'; exit 1)"
 
 archives:
 - id: pulumi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,8 @@ builds:
   hooks:
     post:
       # Check the size of the WASM module.
-      - sh -c "[ `du -k {{ .Path }} | cut -f1` -le 79182 ] || (echo 'error: WASM module > 77M'; exit 1)"
+      - |
+        sh -c "[ `du -k {{ .Path }} | cut -f1` -le 79182 ] || (echo 'error: WASM module > 77M'; exit 1)"
 
 archives:
 - id: pulumi

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,11 @@ generate::
 	$(call STEP_MESSAGE)
 	echo "This command does not do anything anymore. It will be removed in a future version."
 
-build:: build-proto go.ensure
+build:: build-proto build_wasm_display go.ensure
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
+
+build_display_wasm:: go.ensure
+	cd pkg && GOOS=js GOARCH=wasm go build -o ./backend/display/wasm/mod.wasm -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ./backend/display/wasm
 
 install:: .ensure.phony go.ensure
 	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build:: build-proto build_wasm_display go.ensure
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
 
 build_display_wasm:: go.ensure
-	cd pkg && GOOS=js GOARCH=wasm go build -o ./backend/display/wasm/mod.wasm -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ./backend/display/wasm
+	cd pkg && GOOS=js GOARCH=wasm go build -o ../bin/pulumi-display.wasm -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ./backend/display/wasm
 
 install:: .ensure.phony go.ensure
 	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}

--- a/pkg/backend/display/wasm/main.go
+++ b/pkg/backend/display/wasm/main.go
@@ -1,31 +1,25 @@
-// Copyright 2016-2022, Pulumi Corporation.
+//go:build js && wasm
+
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build !windows && !js
-// +build !windows,!js
-
-package rpcutil
+package main
 
 import (
-	"errors"
-	"os"
-
-	"github.com/pkg/term/termios"
+	_ "github.com/pulumi/pulumi/pkg/v3/backend/display"
 )
 
-var errUnsupported = errors.New("unsupported")
-
-func openPty() (*os.File, *os.File, error) {
-	return termios.Pty()
+func main() {
+	done := make(chan struct{}, 0)
+	<-done
 }

--- a/pkg/backend/display/wasm/main.go
+++ b/pkg/backend/display/wasm/main.go
@@ -1,6 +1,4 @@
-//go:build js && wasm
-
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build js && wasm
+
 package main
 
 import (

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -18,12 +18,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"sync"
-	"time"
 
-	"github.com/edsrzf/mmap-go"
 	"github.com/natefinch/atomic"
 
 	"github.com/blang/semver"
@@ -316,54 +312,4 @@ func (l *pluginLoader) loadPluginSchemaBytes(pkg string, version *semver.Version
 	}
 
 	return schemaBytes, provider, nil
-}
-
-var mmapedFiles = make(map[string]mmap.MMap)
-
-func (l *pluginLoader) loadCachedSchemaBytes(pkg string, path string, schemaTime time.Time) ([]byte, bool) {
-	if l.cacheOptions.disableFileCache {
-		return nil, false
-	}
-
-	if schemaMmap, ok := mmapedFiles[path]; ok {
-		return schemaMmap, true
-	}
-
-	success := false
-	schemaFile, err := os.OpenFile(path, os.O_RDONLY, 0o644)
-	defer func() {
-		if !success {
-			schemaFile.Close()
-		}
-	}()
-	if err != nil {
-		return nil, success
-	}
-
-	stat, err := schemaFile.Stat()
-	if err != nil {
-		return nil, success
-	}
-	cachedAt := stat.ModTime()
-
-	if schemaTime.After(cachedAt) {
-		return nil, success
-	}
-
-	if l.cacheOptions.disableMmap {
-		data, err := io.ReadAll(schemaFile)
-		if err != nil {
-			return nil, success
-		}
-		success = true
-		return data, success
-	}
-
-	schemaMmap, err := mmap.Map(schemaFile, mmap.RDONLY, 0)
-	if err != nil {
-		return nil, success
-	}
-	success = true
-
-	return schemaMmap, success
 }

--- a/pkg/codegen/schema/loader_js.go
+++ b/pkg/codegen/schema/loader_js.go
@@ -1,0 +1,12 @@
+//go:build js
+// +build js
+
+package schema
+
+import (
+	"time"
+)
+
+func (l *pluginLoader) loadCachedSchemaBytes(pkg string, path string, schemaTime time.Time) ([]byte, bool) {
+	return nil, false
+}

--- a/pkg/codegen/schema/loader_js.go
+++ b/pkg/codegen/schema/loader_js.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build js
 // +build js
 

--- a/pkg/codegen/schema/loader_mmap.go
+++ b/pkg/codegen/schema/loader_mmap.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build !js
 // +build !js
 

--- a/pkg/codegen/schema/loader_mmap.go
+++ b/pkg/codegen/schema/loader_mmap.go
@@ -1,0 +1,62 @@
+//go:build !js
+// +build !js
+
+package schema
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/edsrzf/mmap-go"
+)
+
+var mmapedFiles = make(map[string]mmap.MMap)
+
+func (l *pluginLoader) loadCachedSchemaBytes(pkg string, path string, schemaTime time.Time) ([]byte, bool) {
+	if l.cacheOptions.disableFileCache {
+		return nil, false
+	}
+
+	if schemaMmap, ok := mmapedFiles[path]; ok {
+		return schemaMmap, true
+	}
+
+	success := false
+	schemaFile, err := os.OpenFile(path, os.O_RDONLY, 0o644)
+	defer func() {
+		if !success {
+			schemaFile.Close()
+		}
+	}()
+	if err != nil {
+		return nil, success
+	}
+
+	stat, err := schemaFile.Stat()
+	if err != nil {
+		return nil, success
+	}
+	cachedAt := stat.ModTime()
+
+	if schemaTime.After(cachedAt) {
+		return nil, success
+	}
+
+	if l.cacheOptions.disableMmap {
+		data, err := io.ReadAll(schemaFile)
+		if err != nil {
+			return nil, success
+		}
+		success = true
+		return data, success
+	}
+
+	schemaMmap, err := mmap.Map(schemaFile, mmap.RDONLY, 0)
+	if err != nil {
+		return nil, success
+	}
+	success = true
+
+	return schemaMmap, success
+}

--- a/sdk/go/common/util/cmdutil/child_js.go
+++ b/sdk/go/common/util/cmdutil/child_js.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2018, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !js
-// +build !windows,!js
+//go:build js
+// +build js
 
-package rpcutil
+package cmdutil
 
 import (
 	"errors"
 	"os"
-
-	"github.com/pkg/term/termios"
+	"os/exec"
 )
 
-var errUnsupported = errors.New("unsupported")
+func killProcessGroup(proc *os.Process) error {
+	panic(errors.New("unsupported"))
+}
 
-func openPty() (*os.File, *os.File, error) {
-	return termios.Pty()
+func KillChildren(pid int) error {
+	panic(errors.New("unsupported"))
+}
+
+func processExistsWithParent(pid int, ppid int) (bool, error) {
+	panic(errors.New("unsupported"))
+}
+
+func RegisterProcessGroup(cmd *exec.Cmd) {
+	panic(errors.New("unsupported"))
 }

--- a/sdk/go/common/util/cmdutil/child_unix.go
+++ b/sdk/go/common/util/cmdutil/child_unix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package cmdutil
 

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -22,16 +22,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/rivo/uniseg"
 	"golang.org/x/term"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // Emoji controls whether emojis will by default be printed in the output.
@@ -101,25 +97,6 @@ func readConsolePlain(stdout io.Writer, stdin io.Reader, prompt string) (string,
 		raw.WriteByte(b[0])
 	}
 	return RemoveTrailingNewline(raw.String()), nil
-}
-
-func readConsoleFancy(stdout io.Writer, stdin io.Reader, prompt string, secret bool) (string, error) {
-	final, err := tea.NewProgram(
-		newReadConsoleModel(prompt, secret),
-		tea.WithInput(stdin),
-		tea.WithOutput(stdout),
-	).Run()
-	if err != nil {
-		return "", err
-	}
-
-	model, ok := final.(readConsoleModel)
-	contract.Assertf(ok, "expected readConsoleModel, got %T", final)
-	if model.Canceled {
-		return "", io.EOF
-	}
-
-	return model.Value, nil
 }
 
 // IsTruthy returns true if the given string represents a CLI input interpreted as "true".
@@ -326,86 +303,4 @@ func max(a, b int) int {
 		return a
 	}
 	return b
-}
-
-// readConsoleModel drives a bubbletea widget that reads from the console.
-type readConsoleModel struct {
-	input  textinput.Model
-	secret bool
-
-	// Canceled is set to true when the model finishes
-	// if the user canceled the operation by pressing Ctrl-C or Esc.
-	Canceled bool
-
-	// Value is the user's response to the prompt.
-	Value string
-}
-
-var _ tea.Model = readConsoleModel{}
-
-func newReadConsoleModel(prompt string, secret bool) readConsoleModel {
-	input := textinput.New()
-	input.Cursor.Style = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("205")) // 205 = hot pink cursor
-	if secret {
-		input.EchoMode = textinput.EchoPassword
-	}
-	if prompt != "" {
-		input.Prompt = prompt + ": "
-	}
-	input.Focus() // required to receive input
-
-	return readConsoleModel{
-		input:  input,
-		secret: secret,
-	}
-}
-
-// Init initializes the model.
-// We don't have any initialization to do, so we just return nil.
-func (readConsoleModel) Init() tea.Cmd { return nil }
-
-// Update handles a single tick of the bubbletea loop.
-func (m readConsoleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		// If the user pressed enter, Ctrl-C, or Esc,
-		// it's time to stop the bubbletea loop.
-		//
-		// Only Enter is considered a success.
-		//nolint:exhaustive // We only want special handling for these keys.
-		switch msg.Type {
-		case tea.KeyEnter, tea.KeyCtrlC, tea.KeyEsc:
-			m.Value = m.input.Value()
-			m.Canceled = msg.Type != tea.KeyEnter
-
-			m.input.Blur() // hide the cursor
-			if m.secret {
-				// If we're in secret mode, don't include
-				// the '*' characters in the final output
-				// so as not to leak the length of the input.
-				m.input.EchoMode = textinput.EchoNone
-			}
-
-			var cmds []tea.Cmd
-			if !m.Canceled {
-				// If the user accepts the input,
-				// we'll primnt the prompt to the terminal
-				// before exiting this loop.
-				cmds = append(cmds, tea.Println(m.input.View()))
-			}
-			cmds = append(cmds, tea.Quit)
-
-			return m, tea.Sequence(cmds...)
-		}
-	}
-
-	var cmd tea.Cmd
-	m.input, cmd = m.input.Update(msg)
-	return m, cmd
-}
-
-// View renders the prompt.
-func (m readConsoleModel) View() string {
-	return m.input.View()
 }

--- a/sdk/go/common/util/cmdutil/console_input.go
+++ b/sdk/go/common/util/cmdutil/console_input.go
@@ -1,0 +1,129 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !js
+// +build !js
+
+package cmdutil
+
+import (
+	"io"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func readConsoleFancy(stdout io.Writer, stdin io.Reader, prompt string, secret bool) (string, error) {
+	final, err := tea.NewProgram(
+		newReadConsoleModel(prompt, secret),
+		tea.WithInput(stdin),
+		tea.WithOutput(stdout),
+	).Run()
+	if err != nil {
+		return "", err
+	}
+
+	model, ok := final.(readConsoleModel)
+	contract.Assertf(ok, "expected readConsoleModel, got %T", final)
+	if model.Canceled {
+		return "", io.EOF
+	}
+
+	return model.Value, nil
+}
+
+// readConsoleModel drives a bubbletea widget that reads from the console.
+type readConsoleModel struct {
+	input  textinput.Model
+	secret bool
+
+	// Canceled is set to true when the model finishes
+	// if the user canceled the operation by pressing Ctrl-C or Esc.
+	Canceled bool
+
+	// Value is the user's response to the prompt.
+	Value string
+}
+
+var _ tea.Model = readConsoleModel{}
+
+func newReadConsoleModel(prompt string, secret bool) readConsoleModel {
+	input := textinput.New()
+	input.Cursor.Style = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("205")) // 205 = hot pink cursor
+	if secret {
+		input.EchoMode = textinput.EchoPassword
+	}
+	if prompt != "" {
+		input.Prompt = prompt + ": "
+	}
+	input.Focus() // required to receive input
+
+	return readConsoleModel{
+		input:  input,
+		secret: secret,
+	}
+}
+
+// Init initializes the model.
+// We don't have any initialization to do, so we just return nil.
+func (readConsoleModel) Init() tea.Cmd { return nil }
+
+// Update handles a single tick of the bubbletea loop.
+func (m readConsoleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// If the user pressed enter, Ctrl-C, or Esc,
+		// it's time to stop the bubbletea loop.
+		//
+		// Only Enter is considered a success.
+		//nolint:exhaustive // We only want special handling for these keys.
+		switch msg.Type {
+		case tea.KeyEnter, tea.KeyCtrlC, tea.KeyEsc:
+			m.Value = m.input.Value()
+			m.Canceled = msg.Type != tea.KeyEnter
+
+			m.input.Blur() // hide the cursor
+			if m.secret {
+				// If we're in secret mode, don't include
+				// the '*' characters in the final output
+				// so as not to leak the length of the input.
+				m.input.EchoMode = textinput.EchoNone
+			}
+
+			var cmds []tea.Cmd
+			if !m.Canceled {
+				// If the user accepts the input,
+				// we'll primnt the prompt to the terminal
+				// before exiting this loop.
+				cmds = append(cmds, tea.Println(m.input.View()))
+			}
+			cmds = append(cmds, tea.Quit)
+
+			return m, tea.Sequence(cmds...)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+// View renders the prompt.
+func (m readConsoleModel) View() string {
+	return m.input.View()
+}

--- a/sdk/go/common/util/cmdutil/console_input_js.go
+++ b/sdk/go/common/util/cmdutil/console_input_js.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2018, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !js
-// +build !windows,!js
+//go:build js
+// +build js
 
-package rpcutil
+package cmdutil
 
 import (
-	"errors"
-	"os"
-
-	"github.com/pkg/term/termios"
+	"io"
 )
 
-var errUnsupported = errors.New("unsupported")
-
-func openPty() (*os.File, *os.File, error) {
-	return termios.Pty()
+func readConsoleFancy(stdout io.Writer, stdin io.Reader, prompt string, secret bool) (string, error) {
+	return readConsolePlain(stdout, stdin, prompt)
 }

--- a/sdk/go/common/util/cmdutil/term_js.go
+++ b/sdk/go/common/util/cmdutil/term_js.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !js
-// +build !windows,!js
+//go:build js
+// +build js
 
-package rpcutil
+package cmdutil
 
-import (
-	"errors"
-	"os"
+import "errors"
 
-	"github.com/pkg/term/termios"
-)
+func shutdownProcessGroup(pid int) error {
+	panic(errors.New("unimplemented"))
+}
 
-var errUnsupported = errors.New("unsupported")
-
-func openPty() (*os.File, *os.File, error) {
-	return termios.Pty()
+func isWaitAlreadyExited(err error) bool {
+	panic(errors.New("unimplemented"))
 }

--- a/sdk/go/common/util/cmdutil/term_unix.go
+++ b/sdk/go/common/util/cmdutil/term_unix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package cmdutil
 

--- a/sdk/go/common/util/rpcutil/pty_js.go
+++ b/sdk/go/common/util/rpcutil/pty_js.go
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !js
-// +build !windows,!js
+//go:build js
+// +build js
 
 package rpcutil
 
 import (
 	"errors"
 	"os"
-
-	"github.com/pkg/term/termios"
 )
 
 var errUnsupported = errors.New("unsupported")
 
 func openPty() (*os.File, *os.File, error) {
-	return termios.Pty()
+	// termios.Pty() is not supported on WASM
+	return nil, nil, errUnsupported
 }


### PR DESCRIPTION
These changes contain some minor refactorings to conditionally disable the use of packages that are cannot be built for `GOOS=js GOARCH=wasm`. With these edits, `pkg/display` can be built targeting WASM.

These changes act as a safeguard to ensure that we are not adding additional code that will _prevent_ building `pkg/display` for WASM targets. They are not sufficient to produce a version of the display renderer that is appropriate for actual use in a WASM environment:

- The current renderer API is not well-suited for use outside the context of the CLI
- The current event stream format has no versioning data
- Actually building this code into a WASM module results in an unpleasantly large file (70M uncompressed, 13M gzipped)

These changes also add a size gate for the built WASM module. The gate is set to the 110% of the size of the WASM module as of this commit. Our goal is to lower the size of the WASM module over time; as we do so we will tighten this gate.

Part of #13258.