### PR TITLE
Fix plugin run to pickup binary path correctly

### DIFF
--- a/pkg/cmd/pulumi/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin_run.go
@@ -68,12 +68,13 @@ func (cmd *pluginRunCmd) run(args []string) error {
 	d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
 
 	path, err := workspace.GetPluginPath(d, kind, name, version, nil)
-	var me *workspace.MissingError
-	if !errors.As(err, &me) {
-		// Not a MissingError, return the original error.
-		return fmt.Errorf("could not get plugin path: %w", err)
-	}
 	if err != nil {
+		var me *workspace.MissingError
+		if !errors.As(err, &me) {
+			// Not a MissingError, return the original error.
+			return fmt.Errorf("could not get plugin path: %w", err)
+		}
+
 		// Try to install the plugin, unless auto plugin installs are turned off.
 		if env.DisableAutomaticPluginAcquisition.Value() {
 			return err
@@ -93,6 +94,11 @@ func (cmd *pluginRunCmd) run(args []string) error {
 		_, err = pkgWorkspace.InstallPlugin(pluginSpec, log)
 		if err != nil {
 			return err
+		}
+
+		path, err = workspace.GetPluginPath(d, kind, name, version, nil)
+		if err != nil {
+			return fmt.Errorf("could not get plugin path: %w", err)
 		}
 	}
 

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -432,3 +432,23 @@ func TestRelativePluginPath(t *testing.T) {
 	e.RunCommand("pulumi", "install")
 	e.RunCommand("pulumi", "preview")
 }
+
+// Quick sanity tests for https://github.com/pulumi/pulumi/issues/16248. Ensure we can run plugins and auto-fetch them.
+//
+//nolint:paralleltest // changes env vars
+func TestPluginRun(t *testing.T) {
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
+
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+
+	removeRandomFromLocalPlugins := func() {
+		e.RunCommand("pulumi", "plugin", "rm", "resource", "random", "--all", "--yes")
+	}
+	removeRandomFromLocalPlugins()
+
+	_, stderr := e.RunCommandExpectError("pulumi", "plugin", "run", "--kind=resource", "random", "--", "--help")
+	assert.Contains(t, stderr, "flag: help requested")
+	_, stderr = e.RunCommandExpectError("pulumi", "plugin", "run", "--kind=resource", "random", "--", "--help")
+	assert.Contains(t, stderr, "flag: help requested")
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes two bugs with plugin run:
1. That it err'd even if it found the path
2. That it didn't correctly find the path if it auto-installed

Fixes https://github.com/pulumi/pulumi/issues/16248

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
