### PR TITLE
fix panic with --continue-on-error on delete after failed create

### DIFF
--- a/changelog/pending/20240524--engine--fix-panic-with-continue-on-error-on-delete-after-failed-create.yaml
+++ b/changelog/pending/20240524--engine--fix-panic-with-continue-on-error-on-delete-after-failed-create.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix panic with --continue-on-error on delete after failed create

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -399,6 +399,7 @@ func (ex *deploymentExecutor) performDeletes(
 	// is conservative, but correct.
 	erroredDeps := mapset.NewSet[*resource.State]()
 	seenErrors := mapset.NewSet[Step]()
+	ex.stepExec.ClearErroredSteps()
 	for _, antichain := range deleteChains {
 		if ex.stepExec.opts.ContinueOnError {
 			erroredSteps := ex.stepExec.GetErroredSteps()

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -160,12 +160,6 @@ func (se *stepExecutor) Unlock() {
 	se.workerLock.Unlock()
 }
 
-func (se *stepExecutor) ClearErroredSteps() {
-	se.erroredStepLock.Lock()
-	defer se.erroredStepLock.Unlock()
-	se.erroredSteps = make([]Step, 0)
-}
-
 func (se *stepExecutor) GetErroredSteps() []Step {
 	se.erroredStepLock.RLock()
 	defer se.erroredStepLock.RUnlock()

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -160,6 +160,12 @@ func (se *stepExecutor) Unlock() {
 	se.workerLock.Unlock()
 }
 
+func (se *stepExecutor) ClearErroredSteps() {
+	se.erroredStepLock.Lock()
+	defer se.erroredStepLock.Unlock()
+	se.erroredSteps = make([]Step, 0)
+}
+
 func (se *stepExecutor) GetErroredSteps() []Step {
 	se.erroredStepLock.RLock()
 	defer se.erroredStepLock.RUnlock()

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -236,6 +236,12 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) mapset.Set[*resou
 	return set
 }
 
+// Contains returns whether the given resource is in the dependency graph.
+func (dg *DependencyGraph) Contains(res *resource.State) bool {
+	_, ok := dg.index[res]
+	return ok
+}
+
 // `TransitiveDependenciesOf` calculates the set of resources upon which the
 // given resource depends, directly or indirectly. This includes the resource's
 // provider, parent, any resources in the `Dependencies` list, any resources in


### PR DESCRIPTION
For deleting resources when `--continue-on-error` is given, we look up a failed resources transitive dependencies in the dependency graph. This is used to skip those resources from being destroyed to keep the dependency chains correctly intact.

The errors for looking these dependencies up are recorded in the step executor, whenever a resource execution fails.  This includes errors from resources that are supposed to be created.

However when a resource fails to create that resource does not exist in the dependency graph at all, so we cannot look it up, and we get a panic because we try to access a nil pointer.

When deleting resources we do not need to care about resources that failed earlier, so we can just clear the errored steps before going ahead with the deletes.

Fixes https://github.com/pulumi/pulumi/issues/16258

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
