### PR TITLE
update homebrew tap push to use `main`

### DIFF
--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -83,4 +83,4 @@ jobs:
         run: |
           set -euo pipefail
 
-          git push origin HEAD:master
+          git push origin HEAD:main


### PR DESCRIPTION
We're in the process of renaming the main branch in our repos to `main` from `master`.  I'm planning to do homebrew-tap next, and this `git push` will need to be updated to keep that working.

This is meant to be merged right after the branch is renamed in that repo.