### PR TITLE
Add support for `--all` parameter of the `stack ls` command to the Automation API

### DIFF
--- a/changelog/pending/20240524--auto-go-nodejs-python--add-support-for-all-parameter-of-the-stack-ls-command-to-the-automation-api.yaml
+++ b/changelog/pending/20240524--auto-go-nodejs-python--add-support-for-all-parameter-of-the-stack-ls-command-to-the-automation-api.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: auto/go,nodejs,python
-  description: Add support for all parameter of the Stack ls command to the Automation API
+  description: Add support for `--all` parameter of the `stack ls` command to the Automation API

--- a/changelog/pending/20240524--auto-go-nodejs-python--add-support-for-all-parameter-of-the-stack-ls-command-to-the-automation-api.yaml
+++ b/changelog/pending/20240524--auto-go-nodejs-python--add-support-for-all-parameter-of-the-stack-ls-command-to-the-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add support for all parameter of the Stack ls command to the Automation API

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blang/semver"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optlist"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -595,22 +596,19 @@ func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string, opts
 
 // ListStacks returns all Stacks created under the current Project.
 // This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
-func (l *LocalWorkspace) ListStacks(ctx context.Context) ([]StackSummary, error) {
-	return l.listStacks(ctx, false)
-}
-
-// ListAllStacks returns all Stacks the current logged-in Pulumi identity has access to.
-// This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
-func (l *LocalWorkspace) ListAllStacks(ctx context.Context) ([]StackSummary, error) {
-	return l.listStacks(ctx, true)
-}
-
-func (l *LocalWorkspace) listStacks(ctx context.Context, all bool) ([]StackSummary, error) {
+func (l *LocalWorkspace) ListStacks(ctx context.Context, opts ...optlist.Option) ([]StackSummary, error) {
 	var stacks []StackSummary
 	args := []string{"stack", "ls", "--json"}
-	if all {
+
+	optListOpts := &optlist.Options{}
+	for _, o := range opts {
+		o.ApplyOption(optListOpts)
+	}
+
+	if optListOpts.All {
 		args = append(args, "--all")
 	}
+
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return stacks, newAutoError(fmt.Errorf("could not list stacks: %w", err), stdout, stderr, errCode)

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -596,29 +596,28 @@ func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string, opts
 // ListStacks returns all Stacks created under the current Project.
 // This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
 func (l *LocalWorkspace) ListStacks(ctx context.Context) ([]StackSummary, error) {
-	var stacks []StackSummary
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "ls", "--json")
-	if err != nil {
-		return stacks, newAutoError(fmt.Errorf("could not list stacks: %w", err), stdout, stderr, errCode)
-	}
-	err = json.Unmarshal([]byte(stdout), &stacks)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal config value: %w", err)
-	}
-	return stacks, nil
+	return l.listStacks(ctx, false)
 }
 
 // ListAllStacks returns all Stacks the current logged-in Pulumi identity has access to.
 // This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
 func (l *LocalWorkspace) ListAllStacks(ctx context.Context) ([]StackSummary, error) {
+	return l.listStacks(ctx, true)
+}
+
+func (l *LocalWorkspace) listStacks(ctx context.Context, all bool) ([]StackSummary, error) {
 	var stacks []StackSummary
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "ls", "--json", "--all")
+	args := []string{"stack", "ls", "--json"}
+	if all {
+		args = append(args, "--all")
+	}
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
-		return stacks, newAutoError(fmt.Errorf("could not list all stacks: %w", err), stdout, stderr, errCode)
+		return stacks, newAutoError(fmt.Errorf("could not list stacks: %w", err), stdout, stderr, errCode)
 	}
 	err = json.Unmarshal([]byte(stdout), &stacks)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal all stacks value: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal list stacks value: %w", err)
 	}
 	return stacks, nil
 }

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -608,6 +608,21 @@ func (l *LocalWorkspace) ListStacks(ctx context.Context) ([]StackSummary, error)
 	return stacks, nil
 }
 
+// ListAllStacks returns all Stacks the current logged-in Pulumi identity has access to.
+// This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+func (l *LocalWorkspace) ListAllStacks(ctx context.Context) ([]StackSummary, error) {
+	var stacks []StackSummary
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "ls", "--json", "--all")
+	if err != nil {
+		return stacks, newAutoError(fmt.Errorf("could not list all stacks: %w", err), stdout, stderr, errCode)
+	}
+	err = json.Unmarshal([]byte(stdout), &stacks)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal all stacks value: %w", err)
+	}
+	return stacks, nil
+}
+
 // InstallPlugin acquires the plugin matching the specified name and version.
 func (l *LocalWorkspace) InstallPlugin(ctx context.Context, name string, version string) error {
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "plugin", "install", "resource", name, version)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2720,6 +2720,39 @@ func TestWhoAmIDetailed(t *testing.T) {
 	}
 }
 
+func TestListStacks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	pDir := filepath.Join(".", "test", "testproj")
+	m := mockPulumiCommand{
+		stdout: `[{"name": "testorg1/testproj1/teststack1", 
+				   "current": false, 
+				   "url": "https://app.pulumi.com/testorg1/testproj1/teststack1"}, 
+				  {"name": "testorg1/testproj1/teststack2", 
+				   "current": false, 
+				   "url": "https://app.pulumi.com/testorg1/testproj1/teststack2"}]`,
+		stderr:   "",
+		exitCode: 0,
+		err:      nil,
+	}
+
+	workspace, err := NewLocalWorkspace(ctx, WorkDir(pDir), Pulumi(&m))
+	require.NoError(t, err)
+
+	stacks, err := workspace.ListStacks(ctx)
+
+	assert.NoError(t, err)
+	assert.Len(t, stacks, 2)
+	assert.Equal(t, "testorg1/testproj1/teststack1", stacks[0].Name)
+	assert.Equal(t, false, stacks[0].Current)
+	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack1", stacks[0].URL)
+	assert.Equal(t, "testorg1/testproj1/teststack2", stacks[1].Name)
+	assert.Equal(t, false, stacks[1].Current)
+	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack2", stacks[1].URL)
+}
+
 func TestListAllStacks(t *testing.T) {
 	t.Parallel()
 
@@ -2732,7 +2765,7 @@ func TestListAllStacks(t *testing.T) {
 				   "url": "https://app.pulumi.com/testorg1/testproj1/teststack1"}, 
 				  {"name": "testorg1/testproj2/teststack2", 
 				   "current": false, 
-				   "url": "https://app.pulumi.com/testorg1/testproj2/teststack1"}]`,
+				   "url": "https://app.pulumi.com/testorg1/testproj2/teststack2"}]`,
 		stderr:   "",
 		exitCode: 0,
 		err:      nil,
@@ -2747,8 +2780,10 @@ func TestListAllStacks(t *testing.T) {
 	assert.Len(t, stacks, 2)
 	assert.Equal(t, "testorg1/testproj1/teststack1", stacks[0].Name)
 	assert.Equal(t, false, stacks[0].Current)
+	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack1", stacks[0].URL)
 	assert.Equal(t, "testorg1/testproj2/teststack2", stacks[1].Name)
 	assert.Equal(t, false, stacks[1].Current)
+	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj2/teststack2", stacks[1].URL)
 }
 
 func BenchmarkBulkSetConfigMixed(b *testing.B) {

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/debug"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optlist"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
@@ -58,11 +59,12 @@ const (
 )
 
 type mockPulumiCommand struct {
-	version  semver.Version
-	stdout   string
-	stderr   string
-	exitCode int
-	err      error
+	version      semver.Version
+	stdout       string
+	stderr       string
+	exitCode     int
+	err          error
+	capturedArgs []string
 }
 
 func (m *mockPulumiCommand) Version() semver.Version {
@@ -77,6 +79,7 @@ func (m *mockPulumiCommand) Run(ctx context.Context,
 	additionalEnv []string,
 	args ...string,
 ) (string, string, int, error) {
+	m.capturedArgs = args
 	return m.stdout, m.stderr, m.exitCode, m.err
 }
 
@@ -2753,6 +2756,33 @@ func TestListStacks(t *testing.T) {
 	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj1/teststack2", stacks[1].URL)
 }
 
+func TestListStacksCorrectArgs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	pDir := filepath.Join(".", "test", "testproj")
+	m := mockPulumiCommand{
+		stdout: `[{"name": "testorg1/testproj1/teststack1", 
+				"current": false, 
+				"url": "https://app.pulumi.com/testorg1/testproj1/teststack1"}, 
+				{"name": "testorg1/testproj1/teststack2", 
+				"current": false, 
+				"url": "https://app.pulumi.com/testorg1/testproj1/teststack2"}]`,
+		stderr:   "",
+		exitCode: 0,
+		err:      nil,
+	}
+
+	workspace, err := NewLocalWorkspace(ctx, WorkDir(pDir), Pulumi(&m))
+	require.NoError(t, err)
+
+	_, err = workspace.ListStacks(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"stack", "ls", "--json"}, m.capturedArgs)
+}
+
 func TestListAllStacks(t *testing.T) {
 	t.Parallel()
 
@@ -2774,7 +2804,7 @@ func TestListAllStacks(t *testing.T) {
 	workspace, err := NewLocalWorkspace(ctx, WorkDir(pDir), Pulumi(&m))
 	require.NoError(t, err)
 
-	stacks, err := workspace.ListAllStacks(ctx)
+	stacks, err := workspace.ListStacks(ctx, optlist.All())
 
 	assert.NoError(t, err)
 	assert.Len(t, stacks, 2)
@@ -2784,6 +2814,33 @@ func TestListAllStacks(t *testing.T) {
 	assert.Equal(t, "testorg1/testproj2/teststack2", stacks[1].Name)
 	assert.Equal(t, false, stacks[1].Current)
 	assert.Equal(t, "https://app.pulumi.com/testorg1/testproj2/teststack2", stacks[1].URL)
+}
+
+func TestListStacksAllCorrectArgs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	pDir := filepath.Join(".", "test", "testproj")
+	m := mockPulumiCommand{
+		stdout: `[{"name": "testorg1/testproj1/teststack1", 
+				"current": false, 
+				"url": "https://app.pulumi.com/testorg1/testproj1/teststack1"}, 
+				{"name": "testorg1/testproj1/teststack2", 
+				"current": false, 
+				"url": "https://app.pulumi.com/testorg1/testproj1/teststack2"}]`,
+		stderr:   "",
+		exitCode: 0,
+		err:      nil,
+	}
+
+	workspace, err := NewLocalWorkspace(ctx, WorkDir(pDir), Pulumi(&m))
+	require.NoError(t, err)
+
+	_, err = workspace.ListStacks(ctx, optlist.All())
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"stack", "ls", "--json", "--all"}, m.capturedArgs)
 }
 
 func BenchmarkBulkSetConfigMixed(b *testing.B) {

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2720,6 +2720,37 @@ func TestWhoAmIDetailed(t *testing.T) {
 	}
 }
 
+func TestListAllStacks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	pDir := filepath.Join(".", "test", "testproj")
+	m := mockPulumiCommand{
+		stdout: `[{"name": "testorg1/testproj1/teststack1", 
+				   "current": false, 
+				   "url": "https://app.pulumi.com/testorg1/testproj1/teststack1"}, 
+				  {"name": "testorg1/testproj2/teststack2", 
+				   "current": false, 
+				   "url": "https://app.pulumi.com/testorg1/testproj2/teststack1"}]`,
+		stderr:   "",
+		exitCode: 0,
+		err:      nil,
+	}
+
+	workspace, err := NewLocalWorkspace(ctx, WorkDir(pDir), Pulumi(&m))
+	require.NoError(t, err)
+
+	stacks, err := workspace.ListAllStacks(ctx)
+
+	assert.NoError(t, err)
+	assert.Len(t, stacks, 2)
+	assert.Equal(t, "testorg1/testproj1/teststack1", stacks[0].Name)
+	assert.Equal(t, false, stacks[0].Current)
+	assert.Equal(t, "testorg1/testproj2/teststack2", stacks[1].Name)
+	assert.Equal(t, false, stacks[1].Current)
+}
+
 func BenchmarkBulkSetConfigMixed(b *testing.B) {
 	ctx := context.Background()
 	stackName := FullyQualifiedStackName(pulumiOrg, "set_config_mixed", "dev")

--- a/sdk/go/auto/optlist/optlist.go
+++ b/sdk/go/auto/optlist/optlist.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package optlist contains functional options to be used with workspace stack list operations
+// github.com/sdk/v3/go/auto workspace.ListStacks(context.Context, ...optlist.Option)
+package optlist
+
+func All() Option {
+	return optionFunc(func(opts *Options) {
+		opts.All = true
+	})
+}
+
+// Option is a parameter to be applied to a LocalWorkspace.ListStacks() operation
+type Option interface {
+	ApplyOption(*Options)
+}
+
+// ---------------------------------- implementation details ----------------------------------
+// Options is an implementation detail
+type Options struct {
+	// lists all stacks
+	All bool
+}
+
+type optionFunc func(*Options)
+
+// ApplyOption is an implementation detail
+func (o optionFunc) ApplyOption(opts *Options) {
+	o(opts)
+}

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -17,6 +17,7 @@ package auto
 import (
 	"context"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optlist"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -126,12 +127,9 @@ type Workspace interface {
 	SelectStack(context.Context, string) error
 	// RemoveStack deletes the stack and all associated configuration and history.
 	RemoveStack(context.Context, string, ...optremove.Option) error
-	// ListStacks returns all Stacks created under the current Project.
-	// This queries underlying backend and may return stacks not present in the Workspace.
-	ListStacks(context.Context) ([]StackSummary, error)
-	// ListAllStacks returns all Stacks the current logged-in Pulumi identity has access to.
-	// This queries underlying backend and may return stacks not present in the Workspace.
-	ListAllStacks(context.Context) ([]StackSummary, error)
+	// ListStacks returns all Stacks from the underlying backend based on the provided options.
+	// This queries the backend service and may return stacks not present in the Workspace.
+	ListStacks(context.Context, ...optlist.Option) ([]StackSummary, error)
 	// InstallPlugin acquires the plugin matching the specified name and version.
 	InstallPlugin(context.Context, string, string) error
 	// InstallPluginFromServer acquires the plugin matching the specified name and version.

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -129,6 +129,9 @@ type Workspace interface {
 	// ListStacks returns all Stacks created under the current Project.
 	// This queries underlying backend and may return stacks not present in the Workspace.
 	ListStacks(context.Context) ([]StackSummary, error)
+	// ListAllStacks returns all Stacks the current logged-in Pulumi identity has access to.
+	// This queries underlying backend and may return stacks not present in the Workspace.
+	ListAllStacks(context.Context) ([]StackSummary, error)
 	// InstallPlugin acquires the plugin matching the specified name and version.
 	InstallPlugin(context.Context, string, string) error
 	// InstallPluginFromServer acquires the plugin matching the specified name and version.

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -722,6 +722,14 @@ export class LocalWorkspace implements Workspace {
         return JSON.parse(result.stdout);
     }
     /**
+     * Returns all Stacks the current logged-in Pulumi identity has access to.
+     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     */
+    async listAllStacks(): Promise<StackSummary[]> {
+        const result = await this.runPulumiCmd(["stack", "ls", "--json", "--all"]);
+        return JSON.parse(result.stdout);
+    }
+    /**
      * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
      *
      * @param name the name of the plugin.

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -714,19 +714,19 @@ export class LocalWorkspace implements Workspace {
         return undefined;
     }
     /**
-     * Returns all Stacks created under the current Project.
+     * Returns all Stacks from the underlying backend based on the provided options.
      * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     *
+     * @param opts Options to customize the behavior of the list.
      */
-    async listStacks(): Promise<StackSummary[]> {
-        const result = await this.runPulumiCmd(["stack", "ls", "--json"]);
-        return JSON.parse(result.stdout);
-    }
-    /**
-     * Returns all Stacks the current logged-in Pulumi identity has access to.
-     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
-     */
-    async listAllStacks(): Promise<StackSummary[]> {
-        const result = await this.runPulumiCmd(["stack", "ls", "--json", "--all"]);
+    async listStacks(opts?: ListOptions): Promise<StackSummary[]> {
+        const args = ["stack", "ls", "--json"];
+        if (opts) {
+            if (opts.all) {
+                args.push("--all");
+            }
+        }
+        const result = await this.runPulumiCmd(args);
         return JSON.parse(result.stdout);
     }
     /**
@@ -1099,4 +1099,11 @@ function loadProjectSettings(workDir: string) {
         return yaml.safeLoad(contents) as ProjectSettings;
     }
     throw new Error(`failed to find project settings file in workdir: ${workDir}`);
+}
+
+export interface ListOptions {
+    /**
+     * List all stacks instead of just stacks for the current project
+     */
+    all?: boolean;
 }

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -235,7 +235,7 @@ export interface Workspace {
      *
      * @param opts Options to customize the behavior of the list.
      */
-    listStacks(opts: ListOptions): Promise<StackSummary[]>;
+    listStacks(opts?: ListOptions): Promise<StackSummary[]>;
     /**
      * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
      *

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -14,6 +14,7 @@
 
 import { PulumiCommand } from "./cmd";
 import { ConfigMap, ConfigValue } from "./config";
+import { ListOptions } from "./localWorkspace";
 import { ProjectSettings } from "./projectSettings";
 import { OutputMap } from "./stack";
 import { StackSettings } from "./stackSettings";
@@ -229,15 +230,12 @@ export interface Workspace {
      */
     removeStack(stackName: string): Promise<void>;
     /**
-     * Returns all Stacks created under the current Project.
-     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     * Returns all Stacks from the underlying backend based on the provided options.
+     * This queries backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     *
+     * @param opts Options to customize the behavior of the list.
      */
-    listStacks(): Promise<StackSummary[]>;
-    /**
-     * Returns all Stacks the current logged-in Pulumi identity has access to.
-     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
-     */
-    listAllStacks(): Promise<StackSummary[]>;
+    listStacks(opts: ListOptions): Promise<StackSummary[]>;
     /**
      * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
      *

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -234,6 +234,11 @@ export interface Workspace {
      */
     listStacks(): Promise<StackSummary[]>;
     /**
+     * Returns all Stacks the current logged-in Pulumi identity has access to.
+     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     */
+    listAllStacks(): Promise<StackSummary[]>;
+    /**
      * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
      *
      * @param name the name of the plugin.

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -143,6 +143,72 @@ describe("LocalWorkspace", () => {
             await workspace.removeStack(stackName);
         });
     });
+    describe("ListStack Methods", async () => {
+        it(`listStacks`, async () => {
+            const mockWithReturnedStacks = {
+                command: "pulumi",
+                version: null,
+                run: async () =>
+                    new CommandResult(
+                        `[{
+                              "name": "testorg1/testproj1/teststack1",
+                              "current": false,
+                              "url": "https://app.pulumi.com/testorg1/testproj1/teststack1"
+                          },
+                          {
+                              "name": "testorg1/testproj1/teststack2",
+                              "current": false,
+                              "url": "https://app.pulumi.com/testorg1/testproj1/teststack2"
+                          }]`,
+                        "",
+                        0,
+                    ),
+            };
+            const workspace = await LocalWorkspace.create({
+                pulumiCommand: mockWithReturnedStacks,
+            });
+            const stacks = await workspace.listStacks();
+            assert.strictEqual(stacks.length, 2);
+            assert.strictEqual(stacks[0].name, "testorg1/testproj1/teststack1");
+            assert.strictEqual(stacks[0].current, false);
+            assert.strictEqual(stacks[0].url, "https://app.pulumi.com/testorg1/testproj1/teststack1");
+            assert.strictEqual(stacks[1].name, "testorg1/testproj1/teststack2");
+            assert.strictEqual(stacks[1].current, false);
+            assert.strictEqual(stacks[1].url, "https://app.pulumi.com/testorg1/testproj1/teststack2");
+        });
+        it(`listAllStacks`, async () => {
+            const mockWithReturnedStacks = {
+                command: "pulumi",
+                version: null,
+                run: async () =>
+                    new CommandResult(
+                        `[{
+                              "name": "testorg1/testproj1/teststack1",
+                              "current": false,
+                              "url": "https://app.pulumi.com/testorg1/testproj1/teststack1"
+                          },
+                          {
+                              "name": "testorg1/testproj2/teststack2",
+                              "current": false,
+                              "url": "https://app.pulumi.com/testorg1/testproj2/teststack2"
+                          }]`,
+                        "",
+                        0,
+                    ),
+            };
+            const workspace = await LocalWorkspace.create({
+                pulumiCommand: mockWithReturnedStacks,
+            });
+            const stacks = await workspace.listAllStacks();
+            assert.strictEqual(stacks.length, 2);
+            assert.strictEqual(stacks[0].name, "testorg1/testproj1/teststack1");
+            assert.strictEqual(stacks[0].current, false);
+            assert.strictEqual(stacks[0].url, "https://app.pulumi.com/testorg1/testproj1/teststack1");
+            assert.strictEqual(stacks[1].name, "testorg1/testproj2/teststack2");
+            assert.strictEqual(stacks[1].current, false);
+            assert.strictEqual(stacks[1].url, "https://app.pulumi.com/testorg1/testproj2/teststack2");
+        });
+    });
     it(`Environment functions`, async function () {
         // Skipping test because the required environments are in the moolumi org.
         if (getTestOrg() !== "moolumi") {

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -415,35 +415,16 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(["stack", "rm", "--yes", stack_name])
 
     def list_stacks(self) -> List[StackSummary]:
-        result = self._run_pulumi_cmd_sync(["stack", "ls", "--json"])
-        json_list = json.loads(result.stdout)
-        stack_list: List[StackSummary] = []
-        for stack_json in json_list:
-            stack = StackSummary(
-                name=stack_json["name"],
-                current=stack_json["current"],
-                update_in_progress=(
-                    stack_json["updateInProgress"]
-                    if "updateInProgress" in stack_json
-                    else None
-                ),
-                last_update=(
-                    datetime.strptime(stack_json["lastUpdate"], _DATETIME_FORMAT)
-                    if "lastUpdate" in stack_json
-                    else None
-                ),
-                resource_count=(
-                    stack_json["resourceCount"]
-                    if "resourceCount" in stack_json
-                    else None
-                ),
-                url=stack_json["url"] if "url" in stack_json else None,
-            )
-            stack_list.append(stack)
-        return stack_list
+        return self._list_stacks(all=False)
 
     def list_all_stacks(self) -> List[StackSummary]:
-        result = self._run_pulumi_cmd_sync(["stack", "ls", "--json", "--all"])
+        return self._list_stacks(all=True)
+
+    def _list_stacks(self, all: bool) -> List[StackSummary]:
+        args = ["stack", "ls", "--json"]
+        if all:
+            args.append("--all")
+        result = self._run_pulumi_cmd_sync(args)
         json_list = json.loads(result.stdout)
         stack_list: List[StackSummary] = []
         for stack_json in json_list:

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -441,7 +441,7 @@ class LocalWorkspace(Workspace):
             )
             stack_list.append(stack)
         return stack_list
-    
+
     def list_all_stacks(self) -> List[StackSummary]:
         result = self._run_pulumi_cmd_sync(["stack", "ls", "--json", "--all"])
         json_list = json.loads(result.stdout)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -414,13 +414,7 @@ class LocalWorkspace(Workspace):
     def remove_stack(self, stack_name: str) -> None:
         self._run_pulumi_cmd_sync(["stack", "rm", "--yes", stack_name])
 
-    def list_stacks(self) -> List[StackSummary]:
-        return self._list_stacks(include_all=False)
-
-    def list_all_stacks(self) -> List[StackSummary]:
-        return self._list_stacks(include_all=True)
-
-    def _list_stacks(self, include_all: bool) -> List[StackSummary]:
+    def list_stacks(self, include_all: Optional[bool] = None) -> List[StackSummary]:
         args = ["stack", "ls", "--json"]
         if include_all:
             args.append("--all")

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -441,6 +441,34 @@ class LocalWorkspace(Workspace):
             )
             stack_list.append(stack)
         return stack_list
+    
+    def list_all_stacks(self) -> List[StackSummary]:
+        result = self._run_pulumi_cmd_sync(["stack", "ls", "--json", "--all"])
+        json_list = json.loads(result.stdout)
+        stack_list: List[StackSummary] = []
+        for stack_json in json_list:
+            stack = StackSummary(
+                name=stack_json["name"],
+                current=stack_json["current"],
+                update_in_progress=(
+                    stack_json["updateInProgress"]
+                    if "updateInProgress" in stack_json
+                    else None
+                ),
+                last_update=(
+                    datetime.strptime(stack_json["lastUpdate"], _DATETIME_FORMAT)
+                    if "lastUpdate" in stack_json
+                    else None
+                ),
+                resource_count=(
+                    stack_json["resourceCount"]
+                    if "resourceCount" in stack_json
+                    else None
+                ),
+                url=stack_json["url"] if "url" in stack_json else None,
+            )
+            stack_list.append(stack)
+        return stack_list
 
     def install_plugin(self, name: str, version: str, kind: str = "resource") -> None:
         self._run_pulumi_cmd_sync(["plugin", "install", kind, name, version])

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -415,14 +415,14 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(["stack", "rm", "--yes", stack_name])
 
     def list_stacks(self) -> List[StackSummary]:
-        return self._list_stacks(all=False)
+        return self._list_stacks(include_all=False)
 
     def list_all_stacks(self) -> List[StackSummary]:
-        return self._list_stacks(all=True)
+        return self._list_stacks(include_all=True)
 
-    def _list_stacks(self, all: bool) -> List[StackSummary]:
+    def _list_stacks(self, include_all: bool) -> List[StackSummary]:
         args = ["stack", "ls", "--json"]
-        if all:
+        if include_all:
             args.append("--all")
         result = self._run_pulumi_cmd_sync(args)
         json_list = json.loads(result.stdout)

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -414,6 +414,16 @@ class Workspace(ABC):
         """
 
     @abstractmethod
+    def list_all_stacks(self) -> List[StackSummary]:
+        """
+        Returns all Stacks the current logged-in Pulumi identity has access to.
+        This queries underlying backend and may return stacks not present in the Workspace
+        (as Pulumi.<stack>.yaml files).
+
+        :returns: List[StackSummary]
+        """
+
+    @abstractmethod
     def install_plugin(self, name: str, version: str, kind: str = "resource") -> None:
         """
         Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -404,22 +404,13 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def list_stacks(self) -> List[StackSummary]:
+    def list_stacks(self, include_all: Optional[bool] = None) -> List[StackSummary]:
         """
         Returns all Stacks created under the current Project.
         This queries underlying backend and may return stacks not present in the Workspace
         (as Pulumi.<stack>.yaml files).
 
-        :returns: List[StackSummary]
-        """
-
-    @abstractmethod
-    def list_all_stacks(self) -> List[StackSummary]:
-        """
-        Returns all Stacks the current logged-in Pulumi identity has access to.
-        This queries underlying backend and may return stacks not present in the Workspace
-        (as Pulumi.<stack>.yaml files).
-
+        :param include_all: List all stacks instead of just stacks for the current project
         :returns: List[StackSummary]
         """
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -34,6 +34,7 @@ from pulumi.automation import (
     PluginInfo,
     ProjectSettings,
     PulumiCommand,
+    CommandResult,
     StackSummary,
     Stack,
     StackSettings,
@@ -526,6 +527,74 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertEqual(result, project_name)
 
         ws.remove_stack(stack_name)
+
+    def test_list_stacks(self):
+        mock_with_returned_stacks = PulumiCommand()
+        mock_with_returned_stacks.run = lambda *args, **kwargs: CommandResult(
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "testorg1/testproj1/teststack1",
+                        "current": False,
+                        "url": "https://app.pulumi.com/testorg1/testproj1/teststack1",
+                    },
+                    {
+                        "name": "testorg1/testproj1/teststack2",
+                        "current": False,
+                        "url": "https://app.pulumi.com/testorg1/testproj1/teststack2",
+                    },
+                ]
+            ),
+            stderr="",
+            code=0,
+        )
+        ws = LocalWorkspace(pulumi_command=mock_with_returned_stacks)
+        stacks = ws.list_stacks()
+        self.assertEqual(len(stacks), 2)
+        self.assertEqual(stacks[0].name, "testorg1/testproj1/teststack1")
+        self.assertEqual(stacks[0].current, False)
+        self.assertEqual(
+            stacks[0].url, "https://app.pulumi.com/testorg1/testproj1/teststack1"
+        )
+        self.assertEqual(stacks[1].name, "testorg1/testproj1/teststack2")
+        self.assertEqual(stacks[1].current, False)
+        self.assertEqual(
+            stacks[1].url, "https://app.pulumi.com/testorg1/testproj1/teststack2"
+        )
+
+    def test_list_all_stacks(self):
+        mock_with_returned_stacks = PulumiCommand()
+        mock_with_returned_stacks.run = lambda *args, **kwargs: CommandResult(
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "testorg1/testproj1/teststack1",
+                        "current": False,
+                        "url": "https://app.pulumi.com/testorg1/testproj1/teststack1",
+                    },
+                    {
+                        "name": "testorg1/testproj2/teststack2",
+                        "current": False,
+                        "url": "https://app.pulumi.com/testorg1/testproj2/teststack2",
+                    },
+                ]
+            ),
+            stderr="",
+            code=0,
+        )
+        ws = LocalWorkspace(pulumi_command=mock_with_returned_stacks)
+        stacks = ws.list_all_stacks()
+        self.assertEqual(len(stacks), 2)
+        self.assertEqual(stacks[0].name, "testorg1/testproj1/teststack1")
+        self.assertEqual(stacks[0].current, False)
+        self.assertEqual(
+            stacks[0].url, "https://app.pulumi.com/testorg1/testproj1/teststack1"
+        )
+        self.assertEqual(stacks[1].name, "testorg1/testproj2/teststack2")
+        self.assertEqual(stacks[1].current, False)
+        self.assertEqual(
+            stacks[1].url, "https://app.pulumi.com/testorg1/testproj2/teststack2"
+        )
 
     def test_stack_status_methods(self):
         project_name = "python_test"

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -562,6 +562,34 @@ class TestLocalWorkspace(unittest.TestCase):
             stacks[1].url, "https://app.pulumi.com/testorg1/testproj1/teststack2"
         )
 
+    def test_list_stacks_with_correct_params(self):
+        captured_args = []
+        mock_with_returned_stacks = PulumiCommand()
+        mock_with_returned_stacks.run = lambda *args, **kwargs: (
+            captured_args.append(args[0]),
+            CommandResult(
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "testorg1/testproj1/teststack1",
+                            "current": False,
+                            "url": "https://app.pulumi.com/testorg1/testproj1/teststack1",
+                        },
+                        {
+                            "name": "testorg1/testproj2/teststack2",
+                            "current": False,
+                            "url": "https://app.pulumi.com/testorg1/testproj2/teststack2",
+                        },
+                    ]
+                ),
+                stderr="",
+                code=0,
+            ),
+        )[1]
+        ws = LocalWorkspace(pulumi_command=mock_with_returned_stacks)
+        ws.list_stacks()
+        self.assertEqual(captured_args[0], ["stack", "ls", "--json"])
+
     def test_list_all_stacks(self):
         mock_with_returned_stacks = PulumiCommand()
         mock_with_returned_stacks.run = lambda *args, **kwargs: CommandResult(
@@ -583,7 +611,7 @@ class TestLocalWorkspace(unittest.TestCase):
             code=0,
         )
         ws = LocalWorkspace(pulumi_command=mock_with_returned_stacks)
-        stacks = ws.list_all_stacks()
+        stacks = ws.list_stacks(include_all=True)
         self.assertEqual(len(stacks), 2)
         self.assertEqual(stacks[0].name, "testorg1/testproj1/teststack1")
         self.assertEqual(stacks[0].current, False)
@@ -595,6 +623,34 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertEqual(
             stacks[1].url, "https://app.pulumi.com/testorg1/testproj2/teststack2"
         )
+
+    def test_list_all_stacks_with_correct_params(self):
+        captured_args = []
+        mock_with_returned_stacks = PulumiCommand()
+        mock_with_returned_stacks.run = lambda *args, **kwargs: (
+            captured_args.append(args[0]),
+            CommandResult(
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "testorg1/testproj1/teststack1",
+                            "current": False,
+                            "url": "https://app.pulumi.com/testorg1/testproj1/teststack1",
+                        },
+                        {
+                            "name": "testorg1/testproj2/teststack2",
+                            "current": False,
+                            "url": "https://app.pulumi.com/testorg1/testproj2/teststack2",
+                        },
+                    ]
+                ),
+                stderr="",
+                code=0,
+            ),
+        )[1]
+        ws = LocalWorkspace(pulumi_command=mock_with_returned_stacks)
+        ws.list_stacks(include_all=True)
+        self.assertEqual(captured_args[0], ["stack", "ls", "--json", "--all"])
 
     def test_stack_status_methods(self):
         project_name = "python_test"


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds Go/Nodejs/Python automation API support for pulumi stack ls --all.

Fixes: [#14226](https://github.com/pulumi/pulumi/issues/14226)

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->