### PR TITLE
Flip stack transforms to non-experimental

### DIFF
--- a/changelog/pending/20240529--sdk-go-nodejs-python--make-stack-transforms-a-stable-non-experimental-feature.yaml
+++ b/changelog/pending/20240529--sdk-go-nodejs-python--make-stack-transforms-a-stable-non-experimental-feature.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go,nodejs,python
+  description: Make stack transforms a stable, non-experimental feature

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -294,7 +294,7 @@ func (ctx *Context) IsConfigSecret(key string) bool {
 }
 
 // registerTransform starts up a callback server if not already running and registers the given transform.
-func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback, error) {
+func (ctx *Context) registerTransform(t ResourceTransform) (*pulumirpc.Callback, error) {
 	if !ctx.state.supportsTransforms {
 		return nil, errors.New("the Pulumi CLI does not support transforms. Please update the Pulumi CLI")
 	}
@@ -384,7 +384,7 @@ func (ctx *Context) registerTransform(t XResourceTransform) (*pulumirpc.Callback
 			opts.Version = rpcReq.Options.Version
 		}
 
-		args := &XResourceTransformArgs{
+		args := &ResourceTransformArgs{
 			Custom: rpcReq.Custom,
 			Type:   rpcReq.Type,
 			Name:   rpcReq.Name,
@@ -2118,10 +2118,8 @@ func (ctx *Context) RegisterStackTransformation(t ResourceTransformation) error 
 	return nil
 }
 
-// XRegisterStackTransform adds a transform to all future resources constructed in this Pulumi stack.
-//
-// Experimental.
-func (ctx *Context) XRegisterStackTransform(t XResourceTransform) error {
+// RegisterStackTransform adds a transform to all future resources constructed in this Pulumi stack.
+func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
 	cb, err := ctx.registerTransform(t)
 	if err != nil {
 		return err

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -381,9 +381,7 @@ type ResourceOptions struct {
 
 	// Transforms is a list of functions that transform
 	// the resource's properties during construction.
-	//
-	// Experimental.
-	Transforms []XResourceTransform
+	Transforms []ResourceTransform
 
 	// URN is the URN of a previously-registered resource of this type.
 	URN string
@@ -434,7 +432,7 @@ type resourceOptions struct {
 	Providers               map[string]ProviderResource
 	ReplaceOnChanges        []string
 	Transformations         []ResourceTransformation
-	Transforms              []XResourceTransform
+	Transforms              []ResourceTransform
 	URN                     string
 	Version                 string
 	PluginDownloadURL       string
@@ -856,9 +854,7 @@ func Transformations(o []ResourceTransformation) ResourceOption {
 }
 
 // Transforms is an optional list of transforms to be applied to the resource.
-//
-// Experimental.
-func Transforms(o []XResourceTransform) ResourceOption {
+func Transforms(o []ResourceTransform) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
 		ro.Transforms = append(ro.Transforms, o...)
 	})

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -16,10 +16,8 @@ package pulumi
 
 import "golang.org/x/net/context"
 
-// XResourceTransformArgs is the argument bag passed to a resource transform.
-//
-// Experimental.
-type XResourceTransformArgs struct {
+// ResourceTransformArgs is the argument bag passed to a resource transform.
+type ResourceTransformArgs struct {
 	// If the resource is a custom or component resource
 	Custom bool
 	// The type of the resource.
@@ -32,24 +30,20 @@ type XResourceTransformArgs struct {
 	Opts ResourceOptions
 }
 
-// XResourceTransformResult is the result that must be returned by a resource transform
+// ResourceTransformResult is the result that must be returned by a resource transform
 // callback. It includes new values to use for the `props` and `opts` of the `Resource` in place of
 // the originally provided values.
-//
-// Experimental.
-type XResourceTransformResult struct {
+type ResourceTransformResult struct {
 	// The new properties to use in place of the original `props`.
 	Props Map
 	// The new resource options to use in place of the original `opts`.
 	Opts ResourceOptions
 }
 
-// XResourceTransform is the callback signature for the `transforms` resource option.  A
+// ResourceTransform is the callback signature for the `transforms` resource option.  A
 // transform is passed the same set of inputs provided to the `Resource` constructor, and can
 // optionally return back alternate values for the `props` and/or `opts` prior to the resource
 // actually being created.  The effect will be as though those props and opts were passed in place
 // of the original call to the `Resource` constructor.  If the transform returns nil,
 // this indicates that the resource will not be transformed.
-//
-// Experimental.
-type XResourceTransform func(context.Context, *XResourceTransformArgs) *XResourceTransformResult
+type ResourceTransform func(context.Context, *ResourceTransformArgs) *ResourceTransformResult

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -221,10 +221,8 @@ export function registerStackTransformation(t: ResourceTransformation) {
 
 /**
  * Add a transformation to all future resources constructed in this Pulumi stack.
- *
- * This method is experimental.
  */
-export function xRegisterStackTransform(t: ResourceTransform) {
+export function registerStackTransform(t: ResourceTransform) {
     if (!getStore().supportsTransforms) {
         throw new Error("The Pulumi CLI does not support transforms. Please update the Pulumi CLI");
     }

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -45,7 +45,7 @@ from .settings import (
 from .stack import (
     run_in_stack,
     register_stack_transformation,
-    x_register_stack_transform,
+    register_stack_transform,
 )
 
 from .invoke import (
@@ -87,7 +87,7 @@ __all__ = [
     # stack
     "run_in_stack",
     "register_stack_transformation",
-    "x_register_stack_transform",
+    "register_stack_transform",
     # invoke
     "invoke",
     "invoke_async",

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -302,11 +302,9 @@ def register_stack_transformation(t: ResourceTransformation):
         root_resource._transformations = root_resource._transformations + [t]
 
 
-def x_register_stack_transform(t: ResourceTransform):
+def register_stack_transform(t: ResourceTransform):
     """
     Add a transform to all future resources constructed in this Pulumi stack.
-
-    This function is experimental.
     """
     if not _sync_monitor_supports_transforms():
         raise Exception(

--- a/tests/integration/transforms/go/simple/main.go
+++ b/tests/integration/transforms/go/simple/main.go
@@ -69,11 +69,11 @@ func NewMyOtherComponent(ctx *pulumi.Context, name string, opts ...pulumi.Resour
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		// Scenario #1 - apply a transform to a CustomResource
-		_, err := NewRandom(ctx, "res1", &RandomArgs{Length: pulumi.Int(5)}, pulumi.Transforms([]pulumi.XResourceTransform{
-			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		_, err := NewRandom(ctx, "res1", &RandomArgs{Length: pulumi.Int(5)}, pulumi.Transforms([]pulumi.ResourceTransform{
+			func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 				fmt.Printf("res1 transform\n")
 				rta.Opts.AdditionalSecretOutputs = append(rta.Opts.AdditionalSecretOutputs, "result")
-				return &pulumi.XResourceTransformResult{
+				return &pulumi.ResourceTransformResult{
 					Props: rta.Props,
 					Opts:  rta.Opts,
 				}
@@ -84,12 +84,12 @@ func main() {
 		}
 
 		// Scenario #2 - apply a transform to a Component to transform it's children
-		_, err = NewMyComponent(ctx, "res2", pulumi.Transforms([]pulumi.XResourceTransform{
-			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		_, err = NewMyComponent(ctx, "res2", pulumi.Transforms([]pulumi.ResourceTransform{
+			func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 				fmt.Printf("res2 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Opts.AdditionalSecretOutputs = append(rta.Opts.AdditionalSecretOutputs, "result")
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}
@@ -102,14 +102,14 @@ func main() {
 		}
 
 		// Scenario #3 - apply a transform to the Stack to transform all (future) resources in the stack
-		err = ctx.XRegisterStackTransform(func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		err = ctx.RegisterStackTransform(func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 			fmt.Printf("stack transform\n")
 			fmt.Printf("%v %v\n", rta.Type, rta.Props)
 			if rta.Type == "testprovider:index:Random" {
 				rta.Props["prefix"] = pulumi.String("stackDefault")
 				rta.Opts.AdditionalSecretOutputs = append(rta.Opts.AdditionalSecretOutputs, "result")
 
-				return &pulumi.XResourceTransformResult{
+				return &pulumi.ResourceTransformResult{
 					Props: rta.Props,
 					Opts:  rta.Opts,
 				}
@@ -132,25 +132,25 @@ func main() {
 		// 2. First parent transform
 		// 3. Second parent transform
 		// 4. Stack transform
-		_, err = NewMyComponent(ctx, "res4", pulumi.Transforms([]pulumi.XResourceTransform{
-			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		_, err = NewMyComponent(ctx, "res4", pulumi.Transforms([]pulumi.ResourceTransform{
+			func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 				fmt.Printf("res4 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Props["prefix"] = pulumi.String("default1")
 
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}
 				}
 				return nil
 			},
-			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 				fmt.Printf("res4 transform 2\n")
 				if rta.Type == "testprovider:index:Random" {
 					rta.Props["prefix"] = pulumi.String("default2")
 
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}
@@ -163,14 +163,14 @@ func main() {
 		}
 
 		// Scenario #5 - mutate the properties of a resource
-		_, err = NewRandom(ctx, "res5", &RandomArgs{Length: pulumi.Int(10)}, pulumi.Transforms([]pulumi.XResourceTransform{
-			func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+		_, err = NewRandom(ctx, "res5", &RandomArgs{Length: pulumi.Int(10)}, pulumi.Transforms([]pulumi.ResourceTransform{
+			func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 				fmt.Printf("res5 transform\n")
 				if rta.Type == "testprovider:index:Random" {
 					length := rta.Props["length"].(pulumi.Float64)
 					rta.Props["length"] = length * 2
 
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}
@@ -194,11 +194,11 @@ func main() {
 
 		_, err = NewRandom(ctx, "res6", &RandomArgs{Length: pulumi.Int(10)},
 			pulumi.Provider(provider1),
-			pulumi.Transforms([]pulumi.XResourceTransform{
-				func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			pulumi.Transforms([]pulumi.ResourceTransform{
+				func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 					fmt.Printf("res6 transform\n")
 					rta.Opts.Provider = provider2
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}
@@ -212,11 +212,11 @@ func main() {
 		// Scenario #7 - mutate the provider on a component resource
 		_, err = NewComponent(ctx, "res7", &ComponentArgs{Length: pulumi.Int(10)},
 			pulumi.Provider(provider1),
-			pulumi.Transforms([]pulumi.XResourceTransform{
-				func(_ context.Context, rta *pulumi.XResourceTransformArgs) *pulumi.XResourceTransformResult {
+			pulumi.Transforms([]pulumi.ResourceTransform{
+				func(_ context.Context, rta *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
 					fmt.Printf("res7 transform\n")
 					rta.Opts.Provider = provider2
-					return &pulumi.XResourceTransformResult{
+					return &pulumi.ResourceTransformResult{
 						Props: rta.Props,
 						Opts:  rta.Opts,
 					}

--- a/tests/integration/transforms/nodejs/simple/index.ts
+++ b/tests/integration/transforms/nodejs/simple/index.ts
@@ -44,7 +44,7 @@ const res2 = new MyComponent("res2", {
 });
 
 // Scenario #3 - apply a transform to the Stack to transform all (future) resources in the stack
-pulumi.runtime.xRegisterStackTransform(async ({ type, props, opts }) => {
+pulumi.runtime.registerStackTransform(async ({ type, props, opts }) => {
     console.log("stack transform");
     if (type === "testprovider:index:Random") {
         return {

--- a/tests/integration/transforms/nodejs/single/index.ts
+++ b/tests/integration/transforms/nodejs/single/index.ts
@@ -3,7 +3,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { Random } from "./random";
 
-pulumi.runtime.xRegisterStackTransform(async ({ type, props, opts }) => {
+pulumi.runtime.registerStackTransform(async ({ type, props, opts }) => {
     console.log("stack transform");
     return undefined;
 });

--- a/tests/integration/transforms/python/simple/__main__.py
+++ b/tests/integration/transforms/python/simple/__main__.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pulumi import Output, ComponentResource, ResourceOptions, ResourceTransformArgs, ResourceTransformResult
-from pulumi.runtime import x_register_stack_transform
+from pulumi.runtime import register_stack_transform
 from random_ import Component, Random, Provider
 
 class MyComponent(ComponentResource):
@@ -55,7 +55,7 @@ def res3_transform(args: ResourceTransformArgs):
                 additional_secret_outputs=["result"],
             )))
 
-x_register_stack_transform(res3_transform)
+register_stack_transform(res3_transform)
 
 res3 = Random("res3", Output.secret(5))
 


### PR DESCRIPTION
Registering stack transforms is now non-experimental. This change updates the function signatures in the Go, Node.js, and Python SDKs along with associated types and comments.

Follow-up to #16080