### PR TITLE
Abstract plugin.Parameterize away from the gRPC interface

### DIFF
--- a/changelog/pending/20240529--sdk--improve-plugin-parameterize-interface.yaml
+++ b/changelog/pending/20240529--sdk--improve-plugin-parameterize-interface.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Improve plugin parameterize interface

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -114,25 +113,14 @@ func schemaFromSchemaSource(ctx context.Context, packageSource string, args []st
 
 	var request plugin.GetSchemaRequest
 	if len(args) > 0 {
-		response, err := p.Parameterize(ctx, &pulumirpc.ParameterizeRequest{
-			Parameters: &pulumirpc.ParameterizeRequest_Args{
-				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
-					Args: args,
-				},
-			},
-		})
+		name, version, err := p.Parameterize(plugin.ParameterizeArgs{Args: args})
 		if err != nil {
 			return nil, fmt.Errorf("parameterize: %w", err)
 		}
 
-		ver, err := semver.Parse(response.Version)
-		if err != nil {
-			return nil, fmt.Errorf("parameterize returned invalid version: %w", err)
-		}
-
 		request = plugin.GetSchemaRequest{
-			SubpackageName:    response.Name,
-			SubpackageVersion: &ver,
+			SubpackageName:    name,
+			SubpackageVersion: version,
 		}
 	}
 

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
 
 	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
@@ -15,7 +16,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type builtinProvider struct {
@@ -48,9 +48,8 @@ func (p *builtinProvider) Pkg() tokens.Package {
 	return "pulumi"
 }
 
-func (p *builtinProvider) Parameterize(context.Context, *pulumirpc.ParameterizeRequest,
-) (*pulumirpc.ParameterizeResponse, error) {
-	return nil, errors.New("the builtin provider has no parameters")
+func (p *builtinProvider) Parameterize(plugin.ParameterizeParameters) (string, *semver.Version, error) {
+	return "", nil, errors.New("the builtin provider has no parameters")
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type Provider struct {
@@ -39,7 +38,7 @@ type Provider struct {
 
 	DialMonitorF func(ctx context.Context, endpoint string) (*ResourceMonitor, error)
 
-	ParameterizeF func(context.Context, *pulumirpc.ParameterizeRequest) (*pulumirpc.ParameterizeResponse, error)
+	ParameterizeF func(plugin.ParameterizeParameters) (string, *semver.Version, error)
 
 	GetSchemaF func(request plugin.GetSchemaRequest) ([]byte, error)
 
@@ -101,13 +100,11 @@ func (prov *Provider) GetPluginInfo() (workspace.PluginInfo, error) {
 	}, nil
 }
 
-func (prov *Provider) Parameterize(
-	ctx context.Context, req *pulumirpc.ParameterizeRequest,
-) (*pulumirpc.ParameterizeResponse, error) {
+func (prov *Provider) Parameterize(params plugin.ParameterizeParameters) (string, *semver.Version, error) {
 	if prov.ParameterizeF == nil {
-		return nil, errors.New("no parameters")
+		return "", nil, errors.New("no parameters")
 	}
-	return prov.ParameterizeF(ctx, req)
+	return prov.ParameterizeF(params)
 }
 
 func (prov *Provider) GetSchema(request plugin.GetSchemaRequest) ([]byte, error) {

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -15,7 +15,6 @@
 package providers
 
 import (
-	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -34,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 const (
@@ -255,11 +253,10 @@ func (r *Registry) label() string {
 	return "ProviderRegistry"
 }
 
-func (r *Registry) Parameterize(context.Context, *pulumirpc.ParameterizeRequest,
-) (*pulumirpc.ParameterizeResponse, error) {
+func (r *Registry) Parameterize(plugin.ParameterizeParameters) (string, *semver.Version, error) {
 	contract.Failf("Parameterize must not be called on the provider registry")
 
-	return nil, errors.New("the provider registry has no parameters")
+	return "", nil, errors.New("the provider registry has no parameters")
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -16,12 +16,10 @@
 package plugin
 
 import (
-	"context"
-
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -41,10 +39,8 @@ func (p *UnimplementedProvider) Pkg() tokens.Package {
 	return tokens.Package("")
 }
 
-func (p *UnimplementedProvider) Parameterize(
-	context.Context, *pulumirpc.ParameterizeRequest,
-) (*pulumirpc.ParameterizeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Parameterize is not yet implemented")
+func (p *UnimplementedProvider) Parameterize(ParameterizeParameters) (string, *semver.Version, error) {
+	return "", nil, status.Error(codes.Unimplemented, "Parameterize is not yet implemented")
 }
 
 func (p *UnimplementedProvider) GetSchema(GetSchemaRequest) ([]byte, error) {


### PR DESCRIPTION
`plugin.Provider` exists to provide a low-level abstraction *on top of* the gRPC interface. It should not expose the gRPC types directly. The key diff in this commit is:

```patch
-	Parameterize(
-		ctx context.Context, req *pulumirpc.ParameterizeRequest,
-	) (*pulumirpc.ParameterizeResponse, error)
+	Parameterize(parameters ParameterizeParameters) (string, *semver.Version, error)
```

```patch
+type ParameterizeParameters interface {
+	isParameterizeParameters()
+}
+
+type (
+	ParameterizeArgs struct {
+		Args []string
+	}
+
+	ParameterizeValue struct {
+		Name    string
+		Version *semver.Version
+		// Value must be one of:
+		// - nil
+		// - bool
+		// - int, int32, int64
+		// - uint, uint32, uint64
+		// - float32, float64
+		// - string
+		// - []byte
+		// - map[string]interface{}
+		// - []interface{}
+		Value any
+	}
+)
+
+func (ParameterizeArgs) isParameterizeParameters()  {}
+func (ParameterizeValue) isParameterizeParameters() {}
```

This is the new interface exposed in `plugin`. The rest of the PR is simply complying with the new interface.

While this change is technically breaking (since it was released in v3.116.0), its a heavily experimental feature and the providers team (my team) is the biggest consumer of `plugin`. Before this PR, `Parameterize` was the *only* method that dirrectly exposed the gRPC interface it was "abstracting".

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

## Checklist

- [X] I have run `make tidy` to update any new dependencies
- [X] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
