### PR TITLE
Plugin interface cleanup

### DIFF
--- a/changelog/pending/20240530--sdk--exchange-parsetolerant-for-parse-in-plugin-provider-parameterize.yaml
+++ b/changelog/pending/20240530--sdk--exchange-parsetolerant-for-parse-in-plugin-provider-parameterize.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk
+  description: Exchange ParseTolerant for Parse in plugin.Provider.Parameterize

--- a/changelog/pending/20240530--sdk--exchange-parsetolerant-for-parse-in-plugin-provider-parameterize.yaml
+++ b/changelog/pending/20240530--sdk--exchange-parsetolerant-for-parse-in-plugin-provider-parameterize.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: sdk
-  description: Exchange ParseTolerant for Parse in plugin.Provider.Parameterize

--- a/changelog/pending/20240530--sdk--require-consumers-to-set-an-explicit-forward-compatibility-policy-for-forward-compatibility-in-plugin-provider.yaml
+++ b/changelog/pending/20240530--sdk--require-consumers-to-set-an-explicit-forward-compatibility-policy-for-forward-compatibility-in-plugin-provider.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Require consumers to set an explicit forward compatibility policy for forward compatibility in plugin.Provider

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -113,14 +113,14 @@ func schemaFromSchemaSource(ctx context.Context, packageSource string, args []st
 
 	var request plugin.GetSchemaRequest
 	if len(args) > 0 {
-		name, version, err := p.Parameterize(plugin.ParameterizeArgs{Args: args})
+		resp, err := p.Parameterize(ctx, plugin.ParameterizeRequest{Parameters: plugin.ParameterizeArgs{Args: args}})
 		if err != nil {
 			return nil, fmt.Errorf("parameterize: %w", err)
 		}
 
 		request = plugin.GetSchemaRequest{
-			SubpackageName:    name,
-			SubpackageVersion: version,
+			SubpackageName:    resp.Name,
+			SubpackageVersion: resp.Version,
 		}
 	}
 

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -18,7 +18,7 @@ import (
 )
 
 type builtinProvider struct {
-	plugin.NotForwardCompatableProvider
+	plugin.NotForwardCompatibleProvider
 
 	context context.Context
 	cancel  context.CancelFunc

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
 
 	"github.com/pulumi/pulumi/pkg/v3/util/gsync"
@@ -48,8 +47,10 @@ func (p *builtinProvider) Pkg() tokens.Package {
 	return "pulumi"
 }
 
-func (p *builtinProvider) Parameterize(plugin.ParameterizeParameters) (string, *semver.Version, error) {
-	return "", nil, errors.New("the builtin provider has no parameters")
+func (p *builtinProvider) Parameterize(
+	context.Context, plugin.ParameterizeRequest,
+) (plugin.ParameterizeResponse, error) {
+	return plugin.ParameterizeResponse{}, errors.New("the builtin provider has no parameters")
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -18,6 +18,8 @@ import (
 )
 
 type builtinProvider struct {
+	plugin.NotForwardCompatableProvider
+
 	context context.Context
 	cancel  context.CancelFunc
 	diag    diag.Sink

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -29,6 +29,8 @@ import (
 )
 
 type Provider struct {
+	plugin.NotForwardCompatableProvider
+
 	Name    string
 	Package tokens.Package
 	Version semver.Version

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Provider struct {
-	plugin.NotForwardCompatableProvider
+	plugin.NotForwardCompatibleProvider
 
 	Name    string
 	Package tokens.Package

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -38,7 +38,7 @@ type Provider struct {
 
 	DialMonitorF func(ctx context.Context, endpoint string) (*ResourceMonitor, error)
 
-	ParameterizeF func(plugin.ParameterizeParameters) (string, *semver.Version, error)
+	ParameterizeF func(ctx context.Context, request plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error)
 
 	GetSchemaF func(request plugin.GetSchemaRequest) ([]byte, error)
 
@@ -100,11 +100,13 @@ func (prov *Provider) GetPluginInfo() (workspace.PluginInfo, error) {
 	}, nil
 }
 
-func (prov *Provider) Parameterize(params plugin.ParameterizeParameters) (string, *semver.Version, error) {
+func (prov *Provider) Parameterize(
+	ctx context.Context, params plugin.ParameterizeRequest,
+) (plugin.ParameterizeResponse, error) {
 	if prov.ParameterizeF == nil {
-		return "", nil, errors.New("no parameters")
+		return plugin.ParameterizeResponse{}, errors.New("no parameters")
 	}
-	return prov.ParameterizeF(params)
+	return prov.ParameterizeF(ctx, params)
 }
 
 func (prov *Provider) GetSchema(request plugin.GetSchemaRequest) ([]byte, error) {

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -134,6 +134,8 @@ func GetProviderVersion(inputs resource.PropertyMap) (*semver.Version, error) {
 // In order to fit neatly in to the existing infrastructure for managing resources using Pulumi, a provider regidstry
 // itself implements the plugin.Provider interface.
 type Registry struct {
+	plugin.NotForwardCompatableProvider
+
 	host      plugin.Host
 	isPreview bool
 	providers map[Reference]plugin.Provider

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -15,6 +15,7 @@
 package providers
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -253,10 +254,10 @@ func (r *Registry) label() string {
 	return "ProviderRegistry"
 }
 
-func (r *Registry) Parameterize(plugin.ParameterizeParameters) (string, *semver.Version, error) {
+func (r *Registry) Parameterize(context.Context, plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
 	contract.Failf("Parameterize must not be called on the provider registry")
 
-	return "", nil, errors.New("the provider registry has no parameters")
+	return plugin.ParameterizeResponse{}, errors.New("the provider registry has no parameters")
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -134,7 +134,7 @@ func GetProviderVersion(inputs resource.PropertyMap) (*semver.Version, error) {
 // In order to fit neatly in to the existing infrastructure for managing resources using Pulumi, a provider regidstry
 // itself implements the plugin.Provider interface.
 type Registry struct {
-	plugin.NotForwardCompatableProvider
+	plugin.NotForwardCompatibleProvider
 
 	host      plugin.Host
 	isPreview bool

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -172,6 +172,13 @@ type Provider interface {
 	// error) if it doesn't have any mappings for the given key.
 	// If a provider implements this method GetMapping will be called using the results from this method.
 	GetMappings(key string) ([]string, error)
+
+	// mustEmbed *requires* that implementers make an explicit choice about forward compatibility.
+	//
+	// If [UnimplementedProvider] is embedded, then the struct will be forward compatible.
+	//
+	// If [NotForwardCompatableProvider] is embedded, then the struct *will not* be forward compatible.
+	mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatableProvider)
 }
 
 type GrpcProvider interface {

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -177,8 +177,8 @@ type Provider interface {
 	//
 	// If [UnimplementedProvider] is embedded, then the struct will be forward compatible.
 	//
-	// If [NotForwardCompatableProvider] is embedded, then the struct *will not* be forward compatible.
-	mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatableProvider)
+	// If [NotForwardCompatibleProvider] is embedded, then the struct *will not* be forward compatible.
+	mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatibleProvider)
 }
 
 type GrpcProvider interface {

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -66,6 +66,8 @@ const kubernetesProviderType = "pulumi:providers:kubernetes"
 
 // provider reflects a resource plugin, loaded dynamically for a single package.
 type provider struct {
+	NotForwardCompatableProvider
+
 	ctx                    *Context                         // a plugin context for caching, etc.
 	pkg                    tokens.Package                   // the Pulumi package containing this provider's resources.
 	plug                   *plugin                          // the actual plugin process wrapper.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -339,7 +339,7 @@ func (p *provider) Parameterize(parameters ParameterizeParameters) (string, *sem
 	}
 	var version *semver.Version
 	if resp.Version != "" {
-		v, err := semver.ParseTolerant(resp.Version)
+		v, err := semver.Parse(resp.Version)
 		if err != nil {
 			return "", nil, err
 		}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -66,7 +66,7 @@ const kubernetesProviderType = "pulumi:providers:kubernetes"
 
 // provider reflects a resource plugin, loaded dynamically for a single package.
 type provider struct {
-	NotForwardCompatableProvider
+	NotForwardCompatibleProvider
 
 	ctx                    *Context                         // a plugin context for caching, etc.
 	pkg                    tokens.Package                   // the Pulumi package containing this provider's resources.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -303,9 +303,9 @@ func isDiffCheckConfigLogicallyUnimplemented(err *rpcerror.Error, providerType t
 	return false
 }
 
-func (p *provider) Parameterize(parameters ParameterizeParameters) (string, *semver.Version, error) {
+func (p *provider) Parameterize(ctx context.Context, request ParameterizeRequest) (ParameterizeResponse, error) {
 	var params pulumirpc.ParameterizeRequest
-	switch p := parameters.(type) {
+	switch p := request.Parameters.(type) {
 	case ParameterizeArgs:
 		params.Parameters = &pulumirpc.ParameterizeRequest_Args{
 			Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
@@ -319,7 +319,7 @@ func (p *provider) Parameterize(parameters ParameterizeParameters) (string, *sem
 		}
 		value, err := structpb.NewValue(p.Value)
 		if err != nil {
-			return "", nil, err
+			return ParameterizeResponse{}, err
 		}
 		params.Parameters = &pulumirpc.ParameterizeRequest_Value{
 			Value: &pulumirpc.ParameterizeRequest_ParametersValue{
@@ -335,17 +335,17 @@ func (p *provider) Parameterize(parameters ParameterizeParameters) (string, *sem
 	}
 	resp, err := p.clientRaw.Parameterize(p.requestContext(), &params)
 	if err != nil {
-		return "", nil, err
+		return ParameterizeResponse{}, err
 	}
 	var version *semver.Version
 	if resp.Version != "" {
 		v, err := semver.Parse(resp.Version)
 		if err != nil {
-			return "", nil, err
+			return ParameterizeResponse{}, err
 		}
 		version = &v
 	}
-	return resp.Name, version, err
+	return ParameterizeResponse{Name: resp.Name, Version: version}, err
 }
 
 // GetSchema fetches the schema for this resource provider, if any.

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -152,16 +152,16 @@ func (p *providerServer) Parameterize(
 			Value:   nil,
 		}
 	}
-	name, version, err := p.provider.Parameterize(params)
+	resp, err := p.provider.Parameterize(ctx, ParameterizeRequest{Parameters: params})
 	if err != nil {
 		return nil, err
 	}
 	var v string
-	if version != nil {
-		v = version.String()
+	if resp.Version != nil {
+		v = resp.Version.String()
 	}
 	return &pulumirpc.ParameterizeResponse{
-		Name:    name,
+		Name:    resp.Name,
 		Version: v,
 	}, nil
 }

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -140,7 +140,7 @@ func (p *providerServer) Parameterize(
 	case *pulumirpc.ParameterizeRequest_Value:
 		var version *semver.Version
 		if v := p.Value.GetVersion(); v != "" {
-			pV, err := semver.ParseTolerant(v)
+			pV, err := semver.Parse(v)
 			if err != nil {
 				return nil, err
 			}

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -16,7 +16,8 @@
 package plugin
 
 import (
-	"github.com/blang/semver"
+	"context"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -39,8 +40,8 @@ func (p *UnimplementedProvider) Pkg() tokens.Package {
 	return tokens.Package("")
 }
 
-func (p *UnimplementedProvider) Parameterize(ParameterizeParameters) (string, *semver.Version, error) {
-	return "", nil, status.Error(codes.Unimplemented, "Parameterize is not yet implemented")
+func (p *UnimplementedProvider) Parameterize(context.Context, ParameterizeRequest) (ParameterizeResponse, error) {
+	return ParameterizeResponse{}, status.Error(codes.Unimplemented, "Parameterize is not yet implemented")
 }
 
 func (p *UnimplementedProvider) GetSchema(GetSchemaRequest) ([]byte, error) {

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -25,8 +25,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// UnimplementedProvider can be embedded to have forward compatible implementations.
-type UnimplementedProvider struct{}
+// NotForwardCompatable can be embedded to explicitly opt out of forward compatibility.
+//
+// Either NotForwardCompatableProvider or [UnimplementedProvider] must be embedded to
+// implement [Provider].
+type NotForwardCompatableProvider struct{}
+
+// UnimplementedProvider can be embedded to have a forward compatible implementation of
+// [Provider].
+//
+// Either NotForwardCompatableProvider or [UnimplementedProvider] must be embedded to
+// implement [Provider].
+type UnimplementedProvider struct{ NotForwardCompatableProvider }
 
 func (p *UnimplementedProvider) Close() error {
 	return status.Error(codes.Unimplemented, "Close is not yet implemented")
@@ -110,4 +120,7 @@ func (p *UnimplementedProvider) GetMapping(key, provider string) ([]byte, string
 
 func (p *UnimplementedProvider) GetMappings(key string) ([]string, error) {
 	return nil, status.Error(codes.Unimplemented, "GetMappings is not yet implemented")
+}
+
+func (p NotForwardCompatableProvider) mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatableProvider) {
 }

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -25,18 +25,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// NotForwardCompatable can be embedded to explicitly opt out of forward compatibility.
+// NotForwardCompatible can be embedded to explicitly opt out of forward compatibility.
 //
-// Either NotForwardCompatableProvider or [UnimplementedProvider] must be embedded to
+// Either NotForwardCompatibleProvider or [UnimplementedProvider] must be embedded to
 // implement [Provider].
-type NotForwardCompatableProvider struct{}
+type NotForwardCompatibleProvider struct{}
 
 // UnimplementedProvider can be embedded to have a forward compatible implementation of
 // [Provider].
 //
-// Either NotForwardCompatableProvider or [UnimplementedProvider] must be embedded to
+// Either NotForwardCompatibleProvider or [UnimplementedProvider] must be embedded to
 // implement [Provider].
-type UnimplementedProvider struct{ NotForwardCompatableProvider }
+type UnimplementedProvider struct{ NotForwardCompatibleProvider }
 
 func (p *UnimplementedProvider) Close() error {
 	return status.Error(codes.Unimplemented, "Close is not yet implemented")
@@ -122,5 +122,5 @@ func (p *UnimplementedProvider) GetMappings(key string) ([]string, error) {
 	return nil, status.Error(codes.Unimplemented, "GetMappings is not yet implemented")
 }
 
-func (p NotForwardCompatableProvider) mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatableProvider) {
+func (p NotForwardCompatibleProvider) mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatibleProvider) {
 }


### PR DESCRIPTION
This PR is best reviewed commit by commit:
- bbe1fc6b2f906f3f7a291cd13247b3d40cf33ab8 exchanges `ParseTolerant` for `Parse` in `Parameterize`.
- 76df18be56c1b01573f80f876f3b2a878fb1f9e7 updates the `Parameterize` interface for forward compatibility.
- 746c057668a2db8889ce6bd04eaf7392dd3d92c3 requires implementors of `plugin.Provider` to make a forward compatibility choice explicitly. This is similar to what we require for gRPC already. Since this will release with bbe1fc6b2f906f3f7a291cd13247b3d40cf33ab8, consumers will already need to update their `plugin.Provider` implementor, minimizing the disturbance.