### PR TITLE
[go/program-gen] Fix union type type resolution in Go program generation

### DIFF
--- a/changelog/pending/20240530--programgen-go--fix-union-type-type-resolution-in-go-program-generation.yaml
+++ b/changelog/pending/20240530--programgen-go--fix-union-type-type-resolution-in-go-program-generation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Fix union type resolution in Go program generation

--- a/tests/testdata/codegen/azure-native-v2-eventgrid-pp/azure-native-v2-eventgrid.pp
+++ b/tests/testdata/codegen/azure-native-v2-eventgrid-pp/azure-native-v2-eventgrid.pp
@@ -1,4 +1,8 @@
 resource "example" "azure-native:eventgrid:EventSubscription" {
+    destination = {
+        endpointType = "EventHub"
+        resourceId = "example"
+    }
     expirationTimeUtc = "example"
     scope = "example"
 }

--- a/tests/testdata/codegen/azure-native-v2-eventgrid-pp/dotnet/azure-native-v2-eventgrid.cs
+++ b/tests/testdata/codegen/azure-native-v2-eventgrid-pp/dotnet/azure-native-v2-eventgrid.cs
@@ -7,6 +7,11 @@ return await Deployment.RunAsync(() =>
 {
     var example = new AzureNative.EventGrid.EventSubscription("example", new()
     {
+        Destination = new AzureNative.EventGrid.Inputs.EventHubEventSubscriptionDestinationArgs
+        {
+            EndpointType = "EventHub",
+            ResourceId = "example",
+        },
         ExpirationTimeUtc = "example",
         Scope = "example",
     });

--- a/tests/testdata/codegen/azure-native-v2-eventgrid-pp/go/azure-native-v2-eventgrid.go
+++ b/tests/testdata/codegen/azure-native-v2-eventgrid-pp/go/azure-native-v2-eventgrid.go
@@ -8,6 +8,10 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := eventgrid.NewEventSubscription(ctx, "example", &eventgrid.EventSubscriptionArgs{
+			Destination: &eventgrid.EventHubEventSubscriptionDestinationArgs{
+				EndpointType: pulumi.String("EventHub"),
+				ResourceId:   pulumi.String("example"),
+			},
 			ExpirationTimeUtc: pulumi.String("example"),
 			Scope:             pulumi.String("example"),
 		})

--- a/tests/testdata/codegen/azure-native-v2-eventgrid-pp/nodejs/azure-native-v2-eventgrid.ts
+++ b/tests/testdata/codegen/azure-native-v2-eventgrid-pp/nodejs/azure-native-v2-eventgrid.ts
@@ -2,6 +2,10 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azure_native from "@pulumi/azure-native";
 
 const example = new azure_native.eventgrid.EventSubscription("example", {
+    destination: {
+        endpointType: "EventHub",
+        resourceId: "example",
+    },
     expirationTimeUtc: "example",
     scope: "example",
 });

--- a/tests/testdata/codegen/azure-native-v2-eventgrid-pp/python/azure-native-v2-eventgrid.py
+++ b/tests/testdata/codegen/azure-native-v2-eventgrid-pp/python/azure-native-v2-eventgrid.py
@@ -2,5 +2,9 @@ import pulumi
 import pulumi_azure_native as azure_native
 
 example = azure_native.eventgrid.EventSubscription("example",
+    destination=azure_native.eventgrid.EventHubEventSubscriptionDestinationArgs(
+        endpoint_type="EventHub",
+        resource_id="example",
+    ),
     expiration_time_utc="example",
     scope="example")

--- a/tests/testdata/codegen/basic-unions-pp/go/basic-unions.go
+++ b/tests/testdata/codegen/basic-unions-pp/go/basic-unions.go
@@ -9,9 +9,9 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		// properties field is bound to union case ServerPropertiesForReplica
 		_, err := basicunions.NewExampleServer(ctx, "replica", &basicunions.ExampleServerArgs{
-			Properties: basicunions.ServerPropertiesForReplica{
-				CreateMode: "Replica",
-				Version:    "0.1.0-dev",
+			Properties: &basicunions.ServerPropertiesForReplicaArgs{
+				CreateMode: pulumi.String("Replica"),
+				Version:    pulumi.String("0.1.0-dev"),
 			},
 		})
 		if err != nil {
@@ -19,9 +19,9 @@ func main() {
 		}
 		// properties field is bound to union case ServerPropertiesForRestore
 		_, err = basicunions.NewExampleServer(ctx, "restore", &basicunions.ExampleServerArgs{
-			Properties: basicunions.ServerPropertiesForRestore{
-				CreateMode:         "PointInTimeRestore",
-				RestorePointInTime: "example",
+			Properties: &basicunions.ServerPropertiesForRestoreArgs{
+				CreateMode:         pulumi.String("PointInTimeRestore"),
+				RestorePointInTime: pulumi.String("example"),
 			},
 		})
 		if err != nil {

--- a/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
@@ -247,9 +247,9 @@ var exampleServerResource = new Example.ExampleServer("exampleServerResource", n
 
 ```go
 example, err := example.NewExampleServer(ctx, "exampleServerResource", &example.ExampleServerArgs{
-	Properties: example.ServerPropertiesForReplica{
-		CreateMode: "Replica",
-		Version:    "string",
+	Properties: &example.ServerPropertiesForReplicaArgs{
+		CreateMode: pulumi.String("Replica"),
+		Version:    pulumi.String("string"),
 	},
 })
 ```


### PR DESCRIPTION
# Description

Fixes https://github.com/pulumi/pulumi-azure-native/issues/1554 

### Context
The problem here is that when we compute `InputType: model.Type` in `pcl.Resource`, we map the types of input properties of resources from `schema.Type` into `model.Type`. When one of these properties is a `schema.UnionType` (union of objects to be exact), we map that _as is_ to `model.UnionType` which trips up Go program-gen as it doesn't know how to reduce the type to the actual _selected_ object type based on the resource inputs. 

### Resolution
The way to fix this is not in Go program-gen, instead we _reduce_ the computed union types during the binding phase into the actual object types based on the resource inputs so that all program generators only work against explicit objects rather than having to deal with unions of objects

### Example:

```pcl
resource "example" "azure-native:eventgrid:EventSubscription" {
    destination = {
        endpointType = "EventHub"
        resourceId = "example"
    }
    expirationTimeUtc = "example"
    scope = "example"
}
```

Before:
```go
pulumi.Run(func(ctx *pulumi.Context) error {
	_, err := eventgrid.NewEventSubscription(ctx, "example", &eventgrid.EventSubscriptionArgs{
		Destination: eventgrid.EventHubEventSubscriptionDestination{
			EndpointType: "EventHub",
			ResourceId:   "example",
		},
		ExpirationTimeUtc: pulumi.String("example"),
		Scope:             pulumi.String("example"),
	})
	if err != nil {
		return err
	}
	return nil
})
```

After:
```go
pulumi.Run(func(ctx *pulumi.Context) error {
	_, err := eventgrid.NewEventSubscription(ctx, "example", &eventgrid.EventSubscriptionArgs{
		Destination: &eventgrid.EventHubEventSubscriptionDestinationArgs{
			EndpointType: pulumi.String("EventHub"),
			ResourceId:   pulumi.String("example"),
		},
		ExpirationTimeUtc: pulumi.String("example"),
		Scope:             pulumi.String("example"),
	})
	if err != nil {
		return err
	}
	return nil
})
```

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
