### PR TITLE
Normalize plugin.Provider methods to (Context, Request) -> (Response, error)

### DIFF
--- a/changelog/pending/20240606--pkg--refactor-plugin-provider.yaml
+++ b/changelog/pending/20240606--pkg--refactor-plugin-provider.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg
+  description: Refactor plugin.Provider to a `Method(context.Context, MethodRequest) (MethodResponse, error)` style interface.

--- a/cmd/pulumi-test-language/interface_test.go
+++ b/cmd/pulumi-test-language/interface_test.go
@@ -102,13 +102,13 @@ func TestProviderVersions(t *testing.T) {
 			version, err := getProviderVersion(provider)
 			require.NoError(t, err)
 
-			schema, err := provider.GetSchema(plugin.GetSchemaRequest{})
+			schema, err := provider.GetSchema(context.Background(), plugin.GetSchemaRequest{})
 			require.NoError(t, err)
 
 			var schemaJSON struct {
 				Version string `json:"version"`
 			}
-			err = json.Unmarshal(schema, &schemaJSON)
+			err = json.Unmarshal(schema.Schema, &schemaJSON)
 			require.NoError(t, err)
 
 			assert.Equal(t, version.String(), schemaJSON.Version,

--- a/cmd/pulumi-test-language/providers/fail_on_create_provider.go
+++ b/cmd/pulumi-test-language/providers/fail_on_create_provider.go
@@ -15,6 +15,7 @@
 package providers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,7 +23,6 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -38,15 +38,19 @@ func (p *FailOnCreateProvider) Close() error {
 	return nil
 }
 
-func (p *FailOnCreateProvider) Configure(inputs resource.PropertyMap) error {
-	return nil
+func (p *FailOnCreateProvider) Configure(
+	context.Context, plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
 }
 
 func (p *FailOnCreateProvider) Pkg() tokens.Package {
 	return "fail_on_create"
 }
 
-func (p *FailOnCreateProvider) GetSchema(request plugin.GetSchemaRequest) ([]byte, error) {
+func (p *FailOnCreateProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
 	resourceProperties := map[string]schema.PropertySpec{
 		"value": {
 			TypeSpec: schema.TypeSpec{
@@ -73,100 +77,107 @@ func (p *FailOnCreateProvider) GetSchema(request plugin.GetSchemaRequest) ([]byt
 	}
 
 	jsonBytes, err := json.Marshal(pkg)
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonBytes, nil
+	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
 }
 
-func (p *FailOnCreateProvider) CheckConfig(urn resource.URN, oldInputs, newInputs resource.PropertyMap,
-	allowUnknowns bool,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (p *FailOnCreateProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
 	// Expect just the version
-	version, ok := newInputs["version"]
+	version, ok := req.News["version"]
 	if !ok {
-		return nil, makeCheckFailure("version", "missing version"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "missing version")}, nil
 	}
 	if !version.IsString() {
-		return nil, makeCheckFailure("version", "version is not a string"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "version is not a string")}, nil
 	}
 	if version.StringValue() != "4.0.0" {
-		return nil, makeCheckFailure("version", "version is not 4.0.0"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "version is not 4.0.0")}, nil
 	}
 
-	if len(newInputs) != 1 {
-		return nil, makeCheckFailure("", fmt.Sprintf("too many properties: %v", newInputs)), nil
+	if len(req.News) != 1 {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+		}, nil
 	}
 
-	return newInputs, nil, nil
+	return plugin.CheckConfigResponse{Properties: req.News}, nil
 }
 
-func (p *FailOnCreateProvider) Check(urn resource.URN, oldInputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, randomSeed []byte,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (p *FailOnCreateProvider) Check(
+	_ context.Context, req plugin.CheckRequest,
+) (plugin.CheckResponse, error) {
 	// URN should be of the form "fail_on_create:index:Resource"
-	if urn.Type() != "fail_on_create:index:Resource" {
-		return nil, makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", urn.Type())), nil
+	if req.URN.Type() != "fail_on_create:index:Resource" {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
+		}, nil
 	}
 
 	// Expect just the boolean value
-	value, ok := newInputs["value"]
+	value, ok := req.News["value"]
 	if !ok {
-		return nil, makeCheckFailure("value", "missing value"), nil
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("value", "missing value"),
+		}, nil
 	}
 	if !value.IsBool() {
-		return nil, makeCheckFailure("value", "value is not a boolean"), nil
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("value", "value is not a boolean"),
+		}, nil
 	}
-	if len(newInputs) != 1 {
-		return nil, makeCheckFailure("", fmt.Sprintf("too many properties: %v", newInputs)), nil
+	if len(req.News) != 1 {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+		}, nil
 	}
 
-	return newInputs, nil, nil
+	return plugin.CheckResponse{Properties: req.News}, nil
 }
 
 func (p *FailOnCreateProvider) Create(
-	urn resource.URN, news resource.PropertyMap,
-	timeout float64, preview bool,
-) (resource.ID, resource.PropertyMap, resource.Status, error) {
-	return resource.ID(""), nil, resource.StatusOK, errors.New("failed create")
+	context.Context, plugin.CreateRequest,
+) (plugin.CreateResponse, error) {
+	return plugin.CreateResponse{}, errors.New("failed create")
 }
 
-func (p *FailOnCreateProvider) GetPluginInfo() (workspace.PluginInfo, error) {
+func (p *FailOnCreateProvider) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	ver := semver.MustParse("4.0.0")
 	return workspace.PluginInfo{
 		Version: &ver,
 	}, nil
 }
 
-func (p *FailOnCreateProvider) SignalCancellation() error {
+func (p *FailOnCreateProvider) SignalCancellation(context.Context) error {
 	return nil
 }
 
-func (p *FailOnCreateProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return nil, "", nil
+func (p *FailOnCreateProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
 }
 
-func (p *FailOnCreateProvider) GetMappings(key string) ([]string, error) {
-	return nil, nil
+func (p *FailOnCreateProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
 }
 
 func (p *FailOnCreateProvider) DiffConfig(
-	urn resource.URN, oldInputs, ouldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+	context.Context, plugin.DiffConfigRequest,
+) (plugin.DiffConfigResponse, error) {
 	return plugin.DiffResult{}, nil
 }
 
 func (p *FailOnCreateProvider) Diff(
-	urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+	context.Context, plugin.DiffRequest,
+) (plugin.DiffResponse, error) {
 	return plugin.DiffResult{}, nil
 }
 
 func (p *FailOnCreateProvider) Delete(
-	urn resource.URN, id resource.ID, oldInputs, oldOutputs resource.PropertyMap, timeout float64,
-) (resource.Status, error) {
-	return resource.StatusOK, nil
+	context.Context, plugin.DeleteRequest,
+) (plugin.DeleteResponse, error) {
+	return plugin.DeleteResponse{}, nil
 }

--- a/cmd/pulumi-test-language/providers/large_provider.go
+++ b/cmd/pulumi-test-language/providers/large_provider.go
@@ -15,6 +15,7 @@
 package providers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,15 +42,19 @@ func (p *LargeProvider) Close() error {
 	return nil
 }
 
-func (p *LargeProvider) Configure(inputs resource.PropertyMap) error {
-	return nil
+func (p *LargeProvider) Configure(
+	context.Context, plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
 }
 
 func (p *LargeProvider) Pkg() tokens.Package {
 	return "large"
 }
 
-func (p *LargeProvider) GetSchema(request plugin.GetSchemaRequest) ([]byte, error) {
+func (p *LargeProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
 	resourceProperties := map[string]schema.PropertySpec{
 		"value": {
 			TypeSpec: schema.TypeSpec{
@@ -76,77 +81,80 @@ func (p *LargeProvider) GetSchema(request plugin.GetSchemaRequest) ([]byte, erro
 	}
 
 	jsonBytes, err := json.Marshal(pkg)
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonBytes, nil
+	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
 }
 
-func (p *LargeProvider) CheckConfig(urn resource.URN, oldInputs, newInputs resource.PropertyMap,
-	allowUnknowns bool,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (p *LargeProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
 	// Expect just the version
-	version, ok := newInputs["version"]
+	version, ok := req.News["version"]
 	if !ok {
-		return nil, makeCheckFailure("version", "missing version"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "missing version")}, nil
 	}
 	if !version.IsString() {
-		return nil, makeCheckFailure("version", "version is not a string"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "version is not a string")}, nil
 	}
 	if version.StringValue() != "4.3.2" {
-		return nil, makeCheckFailure("version", "version is not 4.3.2"), nil
+		return plugin.CheckConfigResponse{Failures: makeCheckFailure("version", "version is not 4.3.2")}, nil
 	}
 
-	if len(newInputs) != 1 {
-		return nil, makeCheckFailure("", fmt.Sprintf("too many properties: %v", newInputs)), nil
+	if len(req.News) != 1 {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+		}, nil
 	}
 
-	return newInputs, nil, nil
+	return plugin.CheckConfigResponse{Properties: req.News}, nil
 }
 
-func (p *LargeProvider) Check(urn resource.URN, oldInputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, randomSeed []byte,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	if urn.Type() != "large:index:String" {
-		return nil, makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", urn.Type())), nil
+func (p *LargeProvider) Check(
+	_ context.Context, req plugin.CheckRequest,
+) (plugin.CheckResponse, error) {
+	if req.URN.Type() != "large:index:String" {
+		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type()))}, nil
 	}
 
 	// Expect just the boolean value
-	value, ok := newInputs["value"]
+	value, ok := req.News["value"]
 	if !ok {
-		return nil, makeCheckFailure("value", "missing value"), nil
+		return plugin.CheckResponse{Failures: makeCheckFailure("value", "missing value")}, nil
 	}
 	if !value.IsString() {
-		return nil, makeCheckFailure("value", "value is not a string"), nil
+		return plugin.CheckResponse{Failures: makeCheckFailure("value", "value is not a string")}, nil
 	}
-	if len(newInputs) != 1 {
-		return nil, makeCheckFailure("", fmt.Sprintf("too many properties: %v", newInputs)), nil
+	if len(req.News) != 1 {
+		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News))}, nil
 	}
 
-	return newInputs, nil, nil
+	return plugin.CheckResponse{Properties: req.News}, nil
 }
 
 func (p *LargeProvider) Create(
-	urn resource.URN, news resource.PropertyMap,
-	timeout float64, preview bool,
-) (resource.ID, resource.PropertyMap, resource.Status, error) {
-	if urn.Type() != "large:index:String" {
-		return "", nil, resource.StatusUnknown, fmt.Errorf("invalid URN type: %s", urn.Type())
+	_ context.Context, req plugin.CreateRequest,
+) (plugin.CreateResponse, error) {
+	if req.URN.Type() != "large:index:String" {
+		return plugin.CreateResponse{
+			Status: resource.StatusUnknown,
+		}, fmt.Errorf("invalid URN type: %s", req.URN.Type())
 	}
 
 	id := "id"
-	if preview {
+	if req.Preview {
 		id = ""
 	}
 
 	// Take the input value and _massively_ expand it.
-	value, ok := news["value"]
+	value, ok := req.Properties["value"]
 	if !ok {
-		return "", nil, resource.StatusUnknown, errors.New("missing value")
+		return plugin.CreateResponse{
+			Status: resource.StatusUnknown,
+		}, errors.New("missing value")
 	}
 	if !value.IsString() {
-		return "", nil, resource.StatusUnknown, errors.New("value is not a string")
+		return plugin.CreateResponse{
+			Status: resource.StatusUnknown,
+		}, errors.New("value is not a string")
 	}
 
 	// aim for 100mb of data (400mb is the size limit we normally set, but nodejs is far more limited)
@@ -155,44 +163,50 @@ func (p *LargeProvider) Create(
 		"value": resource.NewStringProperty(
 			strings.Repeat(value.StringValue(), repeat)),
 	}
-	return resource.ID(id), result, resource.StatusOK, nil
+	return plugin.CreateResponse{
+		ID:         resource.ID(id),
+		Properties: result,
+		Status:     resource.StatusOK,
+	}, nil
 }
 
-func (p *LargeProvider) GetPluginInfo() (workspace.PluginInfo, error) {
+func (p *LargeProvider) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	ver := semver.MustParse("4.3.2")
 	return workspace.PluginInfo{
 		Version: &ver,
 	}, nil
 }
 
-func (p *LargeProvider) SignalCancellation() error {
+func (p *LargeProvider) SignalCancellation(context.Context) error {
 	return nil
 }
 
-func (p *LargeProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return nil, "", nil
+func (p *LargeProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
 }
 
-func (p *LargeProvider) GetMappings(key string) ([]string, error) {
-	return nil, nil
+func (p *LargeProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
 }
 
 func (p *LargeProvider) DiffConfig(
-	urn resource.URN, oldInputs, ouldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+	context.Context, plugin.DiffConfigRequest,
+) (plugin.DiffConfigResponse, error) {
 	return plugin.DiffResult{}, nil
 }
 
 func (p *LargeProvider) Diff(
-	urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+	context.Context, plugin.DiffRequest,
+) (plugin.DiffResponse, error) {
 	return plugin.DiffResult{}, nil
 }
 
 func (p *LargeProvider) Delete(
-	urn resource.URN, id resource.ID, oldInputs, oldOutputs resource.PropertyMap, timeout float64,
-) (resource.Status, error) {
-	return resource.StatusOK, nil
+	context.Context, plugin.DeleteRequest,
+) (plugin.DeleteResponse, error) {
+	return plugin.DeleteResponse{}, nil
 }

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -124,11 +124,11 @@ func schemaFromSchemaSource(ctx context.Context, packageSource string, args []st
 		}
 	}
 
-	bytes, err := p.GetSchema(request)
+	schema, err := p.GetSchema(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(bytes, &spec)
+	err = json.Unmarshal(schema.Schema, &spec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/package_extract_mapping.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
@@ -47,18 +48,21 @@ func newExtractMappingCommand() *cobra.Command {
 			}
 			defer p.Close()
 
-			data, mapped, err := p.GetMapping(key, provider)
+			mapping, err := p.GetMapping(cmd.Context(), plugin.GetMappingRequest{
+				Key:      key,
+				Provider: provider,
+			})
 			if err != nil {
 				return fmt.Errorf("get mapping: %w", err)
 			}
 
-			if mapped == "" {
+			if mapping.Provider == "" {
 				return fmt.Errorf("no mapping found for key %q", key)
 			}
 
-			fmt.Printf("%s maps to provider %s\n", source, mapped)
+			fmt.Printf("%s maps to provider %s\n", source, mapping.Provider)
 
-			err = os.WriteFile(out, data, 0o600)
+			err = os.WriteFile(out, mapping.Data, 0o600)
 			if err != nil {
 				return fmt.Errorf("write mapping data file: %w", err)
 			}

--- a/pkg/codegen/convert/plugin_mapper_test.go
+++ b/pkg/codegen/convert/plugin_mapper_test.go
@@ -47,15 +47,24 @@ func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
 
-func (prov *testProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return prov.mapping(key, provider)
+func (prov *testProvider) GetMapping(
+	_ context.Context, req plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	data, provider, err := prov.mapping(req.Key, req.Provider)
+	return plugin.GetMappingResponse{
+		Data:     data,
+		Provider: provider,
+	}, err
 }
 
-func (prov *testProvider) GetMappings(key string) ([]string, error) {
+func (prov *testProvider) GetMappings(
+	_ context.Context, req plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
 	if prov.mappings == nil {
-		return nil, nil
+		return plugin.GetMappingsResponse{}, nil
 	}
-	return prov.mappings(key)
+	keys, err := prov.mappings(req.Key)
+	return plugin.GetMappingsResponse{Keys: keys}, err
 }
 
 func semverMustParse(s string) *semver.Version {

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -34,8 +34,8 @@ func TestImportOption(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffF: func(urn resource.URN, id resource.ID,
-					oldInputs, oldOutputs, newInputs resource.PropertyMap, ignoreChanges []string,
+				DiffF: func(_ resource.URN, _ resource.ID,
+					_, oldOutputs, newInputs resource.PropertyMap, _ []string,
 				) (plugin.DiffResult, error) {
 					if oldOutputs["foo"].DeepEquals(newInputs["foo"]) {
 						return plugin.DiffResult{Changes: plugin.DiffNone}, nil
@@ -53,12 +53,12 @@ func TestImportOption(t *testing.T) {
 						},
 					}, nil
 				},
-				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
-					preview bool,
+				CreateF: func(_ resource.URN, news resource.PropertyMap, _ float64,
+					_ bool,
 				) (resource.ID, resource.PropertyMap, resource.Status, error) {
 					return "created-id", news, resource.StatusOK, nil
 				},
-				ReadF: func(urn resource.URN, id resource.ID,
+				ReadF: func(_ resource.URN, _ resource.ID,
 					inputs, state resource.PropertyMap,
 				) (plugin.ReadResult, resource.Status, error) {
 					assert.Equal(t, expectedInputs, inputs)
@@ -99,7 +99,7 @@ func TestImportOption(t *testing.T) {
 	// actual resource state.
 	project := p.GetProject()
 	_, err := TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
-	assert.ErrorContains(t, err, "step application failed: inputs to import do not match the existing resource")
+	require.ErrorContains(t, err, "step application failed: inputs to import do not match the existing resource")
 
 	// Run a second update after fixing the inputs. The import should succeed.
 	inputs["foo"] = resource.NewStringProperty("bar")

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -56,74 +56,73 @@ func (p *builtinProvider) Parameterize(
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.
-func (p *builtinProvider) GetSchema(plugin.GetSchemaRequest) ([]byte, error) {
-	return []byte("{}"), nil
+func (p *builtinProvider) GetSchema(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+	return plugin.GetSchemaResponse{Schema: []byte("{}")}, nil
 }
 
-func (p *builtinProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return nil, "", nil
+func (p *builtinProvider) GetMapping(context.Context, plugin.GetMappingRequest) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
 }
 
-func (p *builtinProvider) GetMappings(key string) ([]string, error) {
-	return []string{}, nil
+func (p *builtinProvider) GetMappings(context.Context, plugin.GetMappingsRequest) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
 }
 
 // CheckConfig validates the configuration for this resource provider.
-func (p *builtinProvider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap, allowUnknowns bool,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	return nil, nil, nil
+func (p *builtinProvider) CheckConfig(context.Context, plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
+	return plugin.CheckConfigResponse{}, nil
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *builtinProvider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+func (p *builtinProvider) DiffConfig(context.Context, plugin.DiffConfigRequest) (plugin.DiffConfigResponse, error) {
 	return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 }
 
-func (p *builtinProvider) Configure(props resource.PropertyMap) error {
-	return nil
+func (p *builtinProvider) Configure(context.Context, plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
 }
 
 const stackReferenceType = "pulumi:pulumi:StackReference"
 
-func (p *builtinProvider) Check(urn resource.URN, state, inputs resource.PropertyMap,
-	allowUnknowns bool, randomSeed []byte,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	typ := urn.Type()
+func (p *builtinProvider) Check(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+	typ := req.URN.Type()
 	if typ != stackReferenceType {
-		return nil, nil, fmt.Errorf("unrecognized resource type '%v'", urn.Type())
+		return plugin.CheckResponse{}, fmt.Errorf("unrecognized resource type '%v'", typ)
 	}
 
 	// We only need to warn about this in Check. This won't be called for Reads but Creates or Updates will
 	// call Check first.
 	msg := "The \"pulumi:pulumi:StackReference\" resource type is deprecated. " +
 		"Update your SDK or if already up to date raise an issue at https://github.com/pulumi/pulumi/issues."
-	p.diag.Warningf(diag.Message(urn, msg))
+	p.diag.Warningf(diag.Message(req.URN, msg))
 
-	for k := range inputs {
+	for k := range req.News {
 		if k != "name" {
-			return nil, []plugin.CheckFailure{{Property: k, Reason: fmt.Sprintf("unknown property \"%v\"", k)}}, nil
+			return plugin.CheckResponse{
+				Failures: []plugin.CheckFailure{{Property: k, Reason: fmt.Sprintf("unknown property \"%v\"", k)}},
+			}, nil
 		}
 	}
 
-	name, ok := inputs["name"]
+	name, ok := req.News["name"]
 	if !ok {
-		return nil, []plugin.CheckFailure{{Property: "name", Reason: `missing required property "name"`}}, nil
+		return plugin.CheckResponse{
+			Failures: []plugin.CheckFailure{{Property: "name", Reason: `missing required property "name"`}},
+		}, nil
 	}
 	if !name.IsString() && !name.IsComputed() {
-		return nil, []plugin.CheckFailure{{Property: "name", Reason: `property "name" must be a string`}}, nil
+		return plugin.CheckResponse{
+			Failures: []plugin.CheckFailure{{Property: "name", Reason: `property "name" must be a string`}},
+		}, nil
 	}
-	return inputs, nil, nil
+	return plugin.CheckResponse{Properties: req.News}, nil
 }
 
-func (p *builtinProvider) Diff(urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
-	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
+func (p *builtinProvider) Diff(_ context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+	contract.Assertf(req.URN.Type() == stackReferenceType,
+		"expected resource type %v, got %v", stackReferenceType, req.URN.Type())
 
-	if !newInputs["name"].DeepEquals(oldOutputs["name"]) {
+	if !req.NewInputs["name"].DeepEquals(req.OldInputs["name"]) {
 		return plugin.DiffResult{
 			Changes:     plugin.DiffSome,
 			ReplaceKeys: []resource.PropertyKey{"name"},
@@ -133,75 +132,72 @@ func (p *builtinProvider) Diff(urn resource.URN, id resource.ID, oldInputs, oldO
 	return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 }
 
-func (p *builtinProvider) Create(urn resource.URN, inputs resource.PropertyMap, timeout float64,
-	preview bool,
-) (resource.ID, resource.PropertyMap, resource.Status, error) {
-	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
+func (p *builtinProvider) Create(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+	contract.Assertf(req.URN.Type() == stackReferenceType,
+		"expected resource type %v, got %v", stackReferenceType, req.URN.Type())
 
-	state, err := p.readStackReference(inputs)
+	state, err := p.readStackReference(req.Properties)
 	if err != nil {
-		return "", nil, resource.StatusUnknown, err
+		return plugin.CreateResponse{Status: resource.StatusUnknown}, err
 	}
 
 	var id resource.ID
-	if !preview {
+	if !req.Preview {
 		// generate a new uuid
 		uuid, err := uuid.NewV4()
 		if err != nil {
-			return "", nil, resource.StatusOK, err
+			return plugin.CreateResponse{Status: resource.StatusOK}, err
 		}
 		id = resource.ID(uuid.String())
 	}
 
-	return id, state, resource.StatusOK, nil
+	return plugin.CreateResponse{
+		ID:         id,
+		Properties: state,
+		Status:     resource.StatusOK,
+	}, nil
 }
 
-func (p *builtinProvider) Update(urn resource.URN, id resource.ID,
-	oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	timeout float64, ignoreChanges []string, preview bool,
-) (resource.PropertyMap, resource.Status, error) {
-	contract.Failf("unexpected update for builtin resource %v", urn)
-	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
-
-	return oldOutputs, resource.StatusOK, errors.New("unexpected update for builtin resource")
+func (p *builtinProvider) Update(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+	contract.Failf("unexpected update for builtin resource %v", req.URN)
+	return plugin.UpdateResponse{}, nil
 }
 
-func (p *builtinProvider) Delete(urn resource.URN, id resource.ID,
-	oldInputs, oldOutputs resource.PropertyMap, timeout float64,
-) (resource.Status, error) {
-	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
+func (p *builtinProvider) Delete(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+	contract.Assertf(req.URN.Type() == stackReferenceType,
+		"expected resource type %v, got %v", stackReferenceType, req.URN.Type())
 
-	return resource.StatusOK, nil
+	return plugin.DeleteResponse{Status: resource.StatusOK}, nil
 }
 
-func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
-	inputs, state resource.PropertyMap,
-) (plugin.ReadResult, resource.Status, error) {
-	contract.Requiref(urn != "", "urn", "must not be empty")
-	contract.Requiref(id != "", "id", "must not be empty")
-	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
+func (p *builtinProvider) Read(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+	contract.Requiref(req.URN != "", "urn", "must not be empty")
+	contract.Requiref(req.ID != "", "id", "must not be empty")
+	contract.Assertf(req.URN.Type() == stackReferenceType,
+		"expected resource type %v, got %v", stackReferenceType, req.URN.Type())
 
-	for k := range inputs {
+	for k := range req.Inputs {
 		if k != "name" {
-			return plugin.ReadResult{}, resource.StatusUnknown, fmt.Errorf("unknown property \"%v\"", k)
+			return plugin.ReadResponse{Status: resource.StatusUnknown}, fmt.Errorf("unknown property \"%v\"", k)
 		}
 	}
 
-	outputs, err := p.readStackReference(state)
+	outputs, err := p.readStackReference(req.State)
 	if err != nil {
-		return plugin.ReadResult{}, resource.StatusUnknown, err
+		return plugin.ReadResponse{Status: resource.StatusUnknown}, err
 	}
 
-	return plugin.ReadResult{
-		Inputs:  inputs,
-		Outputs: outputs,
-	}, resource.StatusOK, nil
+	return plugin.ReadResponse{
+		ReadResult: plugin.ReadResult{
+			Inputs:  req.Inputs,
+			Outputs: outputs,
+		},
+		Status: resource.StatusOK,
+	}, nil
 }
 
-func (p *builtinProvider) Construct(info plugin.ConstructInfo, typ tokens.Type, name string, parent resource.URN,
-	inputs resource.PropertyMap, options plugin.ConstructOptions,
-) (plugin.ConstructResult, error) {
-	return plugin.ConstructResult{}, errors.New("builtin resources may not be constructed")
+func (p *builtinProvider) Construct(context.Context, plugin.ConstructRequest) (plugin.ConstructResponse, error) {
+	return plugin.ConstructResponse{}, errors.New("builtin resources may not be constructed")
 }
 
 const (
@@ -210,52 +206,41 @@ const (
 	getResource              = "pulumi:pulumi:getResource"
 )
 
-func (p *builtinProvider) Invoke(tok tokens.ModuleMember,
-	args resource.PropertyMap,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	switch tok {
+func (p *builtinProvider) Invoke(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+	var outs resource.PropertyMap
+	var err error
+	switch req.Tok {
 	case readStackOutputs:
-		outs, err := p.readStackReference(args)
-		if err != nil {
-			return nil, nil, err
-		}
-		return outs, nil, nil
+		outs, err = p.readStackReference(req.Args)
 	case readStackResourceOutputs:
-		outs, err := p.readStackResourceOutputs(args)
-		if err != nil {
-			return nil, nil, err
-		}
-		return outs, nil, nil
+		outs, err = p.readStackResourceOutputs(req.Args)
 	case getResource:
-		outs, err := p.getResource(args)
-		if err != nil {
-			return nil, nil, err
-		}
-		return outs, nil, nil
+		outs, err = p.getResource(req.Args)
 	default:
-		return nil, nil, fmt.Errorf("unrecognized function name: '%v'", tok)
+		err = fmt.Errorf("unrecognized function name: '%v'", req.Tok)
 	}
+	if err != nil {
+		return plugin.InvokeResponse{}, err
+	}
+	return plugin.InvokeResponse{Properties: outs}, nil
 }
 
 func (p *builtinProvider) StreamInvoke(
-	tok tokens.ModuleMember, args resource.PropertyMap,
-	onNext func(resource.PropertyMap) error,
-) ([]plugin.CheckFailure, error) {
-	return nil, errors.New("the builtin provider does not implement streaming invokes")
+	context.Context, plugin.StreamInvokeRequest,
+) (plugin.StreamInvokeResponse, error) {
+	return plugin.StreamInvokeResponse{}, errors.New("the builtin provider does not implement streaming invokes")
 }
 
-func (p *builtinProvider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
-	options plugin.CallOptions,
-) (plugin.CallResult, error) {
+func (p *builtinProvider) Call(context.Context, plugin.CallRequest) (plugin.CallResponse, error) {
 	return plugin.CallResult{}, errors.New("the builtin provider does not implement call")
 }
 
-func (p *builtinProvider) GetPluginInfo() (workspace.PluginInfo, error) {
+func (p *builtinProvider) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	// return an error: this should not be called for the builtin provider
 	return workspace.PluginInfo{}, errors.New("the builtin provider does not report plugin info")
 }
 
-func (p *builtinProvider) SignalCancellation() error {
+func (p *builtinProvider) SignalCancellation(context.Context) error {
 	p.cancel()
 	return nil
 }

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -43,22 +43,22 @@ func TestBuiltinProvider(t *testing.T) {
 	t.Run("GetSchema", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		b, err := p.GetSchema(plugin.GetSchemaRequest{})
+		b, err := p.GetSchema(context.Background(), plugin.GetSchemaRequest{})
 		assert.NoError(t, err)
-		assert.Equal(t, []byte("{}"), b)
+		assert.Equal(t, []byte("{}"), b.Schema)
 	})
 	t.Run("GetMapping", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		b, s, err := p.GetMapping("key", "provider")
+		m, err := p.GetMapping(context.Background(), plugin.GetMappingRequest{Key: "key", Provider: "provider"})
 		assert.NoError(t, err)
-		assert.Nil(t, b)
-		assert.Equal(t, "", s)
+		assert.Nil(t, m.Data)
+		assert.Equal(t, "", m.Provider)
 	})
 	t.Run("GetMappings", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		strs, err := p.GetMappings("key")
+		strs, err := p.GetMappings(context.Background(), plugin.GetMappingsRequest{Key: "key"})
 		assert.NoError(t, err)
 		assert.Empty(t, strs)
 	})
@@ -67,9 +67,12 @@ func TestBuiltinProvider(t *testing.T) {
 		t.Run("builtin only supports stack reference type", func(t *testing.T) {
 			t.Parallel()
 			p := &builtinProvider{}
-			_, _, err := p.Check(
-				resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
-				resource.PropertyMap{}, resource.PropertyMap{}, true, nil)
+			_, err := p.Check(context.Background(), plugin.CheckRequest{
+				URN:           resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
+				Olds:          resource.PropertyMap{},
+				News:          resource.PropertyMap{},
+				AllowUnknowns: true,
+			})
 			assert.ErrorContains(t, err, "unrecognized resource type")
 		})
 		t.Run("missing `name` input property", func(t *testing.T) {
@@ -77,15 +80,18 @@ func TestBuiltinProvider(t *testing.T) {
 			p := &builtinProvider{
 				diag: &deploytest.NoopSink{},
 			}
-			_, failures, err := p.Check(
-				resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				resource.PropertyMap{}, resource.PropertyMap{}, true, nil)
+			resp, err := p.Check(context.Background(), plugin.CheckRequest{
+				URN:           resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
+				Olds:          resource.PropertyMap{},
+				News:          resource.PropertyMap{},
+				AllowUnknowns: true,
+			})
 			assert.Equal(t, []plugin.CheckFailure{
 				{
 					Property: "name",
 					Reason:   `missing required property "name"`,
 				},
-			}, failures)
+			}, resp.Failures)
 			assert.NoError(t, err)
 		})
 		t.Run(`property "name" must be a string`, func(t *testing.T) {
@@ -93,17 +99,20 @@ func TestBuiltinProvider(t *testing.T) {
 			p := &builtinProvider{
 				diag: &deploytest.NoopSink{},
 			}
-			_, failures, err := p.Check(
-				resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				resource.PropertyMap{}, resource.PropertyMap{
+			resp, err := p.Check(context.Background(), plugin.CheckRequest{
+				URN:  resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
+				Olds: resource.PropertyMap{},
+				News: resource.PropertyMap{
 					"name": resource.NewNumberProperty(10),
-				}, true, nil)
+				},
+				AllowUnknowns: true,
+			})
 			assert.Equal(t, []plugin.CheckFailure{
 				{
 					Property: "name",
 					Reason:   `property "name" must be a string`,
 				},
-			}, failures)
+			}, resp.Failures)
 			assert.NoError(t, err)
 		})
 		t.Run("ok", func(t *testing.T) {
@@ -111,16 +120,18 @@ func TestBuiltinProvider(t *testing.T) {
 			p := &builtinProvider{
 				diag: &deploytest.NoopSink{},
 			}
-			checked, failures, err := p.Check(
-				resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				resource.PropertyMap{}, resource.PropertyMap{
+			resp, err := p.Check(context.Background(), plugin.CheckRequest{
+				URN: resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
+				News: resource.PropertyMap{
 					"name": resource.NewStringProperty("res-name"),
-				}, true, nil)
-			assert.Nil(t, failures)
+				},
+				AllowUnknowns: true,
+			})
+			assert.Nil(t, resp.Failures)
 			assert.NoError(t, err)
 			assert.Equal(t, resource.PropertyMap{
 				"name": resource.NewStringProperty("res-name"),
-			}, checked)
+			}, resp.Properties)
 		})
 	})
 	t.Run("Update (always fails)", func(t *testing.T) {
@@ -129,19 +140,20 @@ func TestBuiltinProvider(t *testing.T) {
 			p := &builtinProvider{}
 
 			oldOutputs := resource.PropertyMap{"cookie": resource.NewStringProperty("yum")}
-			_, _, err := p.Update(
-				resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
-				"some-id",
-				nil, oldOutputs,
-				resource.PropertyMap{}, 0, nil, false,
-			)
+			_, err := p.Update(context.Background(), plugin.UpdateRequest{
+				URN:        resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
+				ID:         "some-id",
+				OldInputs:  nil,
+				OldOutputs: oldOutputs,
+				NewInputs:  resource.PropertyMap{},
+			})
 			contract.Ignore(err)
 		})
 	})
 	t.Run("Construct (always fails)", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		_, err := p.Construct(plugin.ConstructInfo{}, "", "", "", resource.PropertyMap{}, plugin.ConstructOptions{})
+		_, err := p.Construct(context.Background(), plugin.ConstructRequest{Inputs: resource.PropertyMap{}})
 		assert.ErrorContains(t, err, "builtin resources may not be constructed")
 	})
 	t.Run("Invoke", func(t *testing.T) {
@@ -151,8 +163,11 @@ func TestBuiltinProvider(t *testing.T) {
 			t.Run("err", func(t *testing.T) {
 				t.Parallel()
 				p := &builtinProvider{}
-				_, _, err := p.Invoke(readStackOutputs, resource.PropertyMap{
-					"name": resource.NewStringProperty("res-name"),
+				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
+					Tok: readStackOutputs,
+					Args: resource.PropertyMap{
+						"name": resource.NewStringProperty("res-name"),
+					},
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
 			})
@@ -170,17 +185,20 @@ func TestBuiltinProvider(t *testing.T) {
 						},
 					},
 				}
-				out, failures, err := p.Invoke(readStackOutputs, resource.PropertyMap{
-					"name": resource.NewStringProperty("res-name"),
+				resp, err := p.Invoke(context.Background(), plugin.InvokeRequest{
+					Tok: readStackOutputs,
+					Args: resource.PropertyMap{
+						"name": resource.NewStringProperty("res-name"),
+					},
 				})
 				assert.NoError(t, err)
 				assert.True(t, called)
-				assert.Nil(t, failures)
+				assert.Nil(t, resp.Failures)
 
-				assert.Equal(t, "res-name", out["name"].V)
+				assert.Equal(t, "res-name", resp.Properties["name"].V)
 
-				assert.Equal(t, "foo", out["outputs"].ObjectValue()["normal"].StringValue())
-				assert.Len(t, out["secretOutputNames"].V, 1)
+				assert.Equal(t, "foo", resp.Properties["outputs"].ObjectValue()["normal"].StringValue())
+				assert.Len(t, resp.Properties["secretOutputNames"].V, 1)
 			})
 		})
 		t.Run(readStackResourceOutputs, func(t *testing.T) {
@@ -188,8 +206,11 @@ func TestBuiltinProvider(t *testing.T) {
 			t.Run("err", func(t *testing.T) {
 				t.Parallel()
 				p := &builtinProvider{}
-				_, _, err := p.Invoke(readStackResourceOutputs, resource.PropertyMap{
-					"stackName": resource.NewStringProperty("res-name"),
+				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
+					Tok: readStackResourceOutputs,
+					Args: resource.PropertyMap{
+						"stackName": resource.NewStringProperty("res-name"),
+					},
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
 			})
@@ -204,8 +225,11 @@ func TestBuiltinProvider(t *testing.T) {
 						},
 					},
 				}
-				_, _, err := p.Invoke(readStackResourceOutputs, resource.PropertyMap{
-					"stackName": resource.NewStringProperty("res-name"),
+				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
+					Tok: readStackResourceOutputs,
+					Args: resource.PropertyMap{
+						"stackName": resource.NewStringProperty("res-name"),
+					},
 				})
 				assert.NoError(t, err)
 				assert.True(t, called)
@@ -218,8 +242,11 @@ func TestBuiltinProvider(t *testing.T) {
 				p := &builtinProvider{
 					resources: &gsync.Map[urn.URN, *resource.State]{},
 				}
-				_, _, err := p.Invoke(getResource, resource.PropertyMap{
-					"urn": resource.NewStringProperty("res-name"),
+				_, err := p.Invoke(context.Background(), plugin.InvokeRequest{
+					Tok: getResource,
+					Args: resource.PropertyMap{
+						"urn": resource.NewStringProperty("res-name"),
+					},
 				})
 				assert.ErrorContains(t, err, "unknown resource")
 			})
@@ -228,20 +255,19 @@ func TestBuiltinProvider(t *testing.T) {
 	t.Run("StreamInvoke (unimplemented)", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		_, err := p.StreamInvoke(tokens.ModuleMember(""), resource.PropertyMap{}, nil)
+		_, err := p.StreamInvoke(context.Background(), plugin.StreamInvokeRequest{})
 		assert.ErrorContains(t, err, "the builtin provider does not implement streaming invokes")
 	})
 	t.Run("Call (unimplemented)", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		_, err := p.Call(tokens.ModuleMember(""), resource.PropertyMap{},
-			plugin.CallInfo{}, plugin.CallOptions{})
+		_, err := p.Call(context.Background(), plugin.CallRequest{})
 		assert.ErrorContains(t, err, "the builtin provider does not implement call")
 	})
 	t.Run("GetPluginInfo (always fails)", func(t *testing.T) {
 		t.Parallel()
 		p := &builtinProvider{}
-		_, err := p.GetPluginInfo()
+		_, err := p.GetPluginInfo(context.Background())
 		assert.ErrorContains(t, err, "the builtin provider does not report plugin info")
 	})
 	t.Run("SignalCancellation", func(t *testing.T) {
@@ -252,9 +278,9 @@ func TestBuiltinProvider(t *testing.T) {
 				called = true
 			},
 		}
-		assert.NoError(t, p.SignalCancellation())
+		assert.NoError(t, p.SignalCancellation(context.Background()))
 		assert.True(t, called)
 		// Ensure idempotent.
-		assert.NoError(t, p.SignalCancellation())
+		assert.NoError(t, p.SignalCancellation(context.Background()))
 	})
 }

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -399,7 +399,7 @@ func (host *pluginHost) SignalCancellation() error {
 
 	var err error
 	for _, prov := range host.providers {
-		if pErr := prov.SignalCancellation(); pErr != nil {
+		if pErr := prov.SignalCancellation(context.TODO()); pErr != nil {
 			err = pErr
 		}
 	}

--- a/pkg/resource/deploy/deploytest/provider_test.go
+++ b/pkg/resource/deploy/deploytest/provider_test.go
@@ -39,13 +39,13 @@ func TestProvider(t *testing.T) {
 					return errors.New("expected error")
 				},
 			}
-			assert.Error(t, prov.SignalCancellation())
+			assert.Error(t, prov.SignalCancellation(context.Background()))
 			assert.True(t, called)
 		})
 		t.Run("no CancelF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			assert.NoError(t, prov.SignalCancellation())
+			assert.NoError(t, prov.SignalCancellation(context.Background()))
 		})
 	})
 	t.Run("Close", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestProvider(t *testing.T) {
 			Name:    "expected-name",
 			Version: semver.MustParse("1.0.0"),
 		}
-		info, err := prov.GetPluginInfo()
+		info, err := prov.GetPluginInfo(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, "expected-name", info.Name)
 		// Ensure reference is passed correctly.
@@ -83,7 +83,7 @@ func TestProvider(t *testing.T) {
 					return nil, expectedErr
 				},
 			}
-			_, err := prov.GetSchema(plugin.GetSchemaRequest{
+			_, err := prov.GetSchema(context.Background(), plugin.GetSchemaRequest{
 				Version:           1,
 				SubpackageName:    "expected-subpackage",
 				SubpackageVersion: &expectedVersion,
@@ -94,9 +94,9 @@ func TestProvider(t *testing.T) {
 		t.Run("no GetSchemaF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			b, err := prov.GetSchema(plugin.GetSchemaRequest{})
+			b, err := prov.GetSchema(context.Background(), plugin.GetSchemaRequest{})
 			assert.NoError(t, err)
-			assert.Equal(t, []byte("{}"), b)
+			assert.Equal(t, []byte("{}"), b.Schema)
 		})
 	})
 	t.Run("CheckConfig", func(t *testing.T) {
@@ -116,29 +116,32 @@ func TestProvider(t *testing.T) {
 					return nil, nil, expectedErr
 				},
 			}
-			_, _, err := prov.CheckConfig(
-				resource.URN("expected-urn"),
-				resource.PropertyMap{
+			_, err := prov.CheckConfig(context.Background(), plugin.CheckConfigRequest{
+				URN: resource.URN("expected-urn"),
+				Olds: resource.PropertyMap{
 					"old": resource.NewStringProperty("old-value"),
 				},
-				resource.PropertyMap{
+				News: resource.PropertyMap{
 					"new": resource.NewStringProperty("new-value"),
 				},
-				true,
-			)
+				AllowUnknowns: true,
+			})
 			assert.ErrorIs(t, err, expectedErr)
 			assert.True(t, called)
 		})
 		t.Run("no CheckConfigF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			news, failures, err := prov.CheckConfig(resource.URN(""), nil /* olds */, resource.PropertyMap{
-				"expected": resource.NewStringProperty("expected-value"),
-			}, true)
+			resp, err := prov.CheckConfig(context.Background(), plugin.CheckConfigRequest{
+				News: resource.PropertyMap{
+					"expected": resource.NewStringProperty("expected-value"),
+				},
+				AllowUnknowns: true,
+			})
 			assert.NoError(t, err)
-			assert.Empty(t, failures)
+			assert.Empty(t, resp.Failures)
 			// Should return the news.
-			assert.Equal(t, resource.NewStringProperty("expected-value"), news["expected"])
+			assert.Equal(t, resource.NewStringProperty("expected-value"), resp.Properties["expected"])
 		})
 	})
 	t.Run("Construct", func(t *testing.T) {
@@ -168,15 +171,14 @@ func TestProvider(t *testing.T) {
 						return plugin.ConstructResult{}, expectedErr
 					},
 				}
-				_, err := prov.Construct(
-					plugin.ConstructInfo{
+				_, err := prov.Construct(context.Background(), plugin.ConstructRequest{
+					Type: tokens.Type("some-type"),
+					Name: "name",
+					Info: plugin.ConstructInfo{
 						MonitorAddress: "expected-endpoint",
 					},
-					tokens.Type("some-type"),
-					"name",
-					resource.URN("<parent-urn>"),
-					nil, /* inputs */
-					plugin.ConstructOptions{})
+					Parent: resource.URN("<parent-urn>"),
+				})
 				assert.ErrorIs(t, err, expectedErr)
 				assert.True(t, dialCalled)
 				assert.True(t, constructCalled)
@@ -195,13 +197,11 @@ func TestProvider(t *testing.T) {
 							return plugin.ConstructResult{}, nil
 						},
 					}
-					_, err := prov.Construct(
-						plugin.ConstructInfo{},
-						tokens.Type("some-type"),
-						"name",
-						resource.URN("<parent-urn>"),
-						nil, /* inputs */
-						plugin.ConstructOptions{})
+					_, err := prov.Construct(context.Background(), plugin.ConstructRequest{
+						Type:   tokens.Type("some-type"),
+						Name:   "name",
+						Parent: resource.URN("<parent-urn>"),
+					})
 					assert.ErrorContains(t, err, "could not connect to resource monitor")
 				})
 				t.Run("injected error", func(t *testing.T) {
@@ -224,13 +224,11 @@ func TestProvider(t *testing.T) {
 							return plugin.ConstructResult{}, nil
 						},
 					}
-					_, err := prov.Construct(
-						plugin.ConstructInfo{},
-						tokens.Type("some-type"),
-						"name",
-						resource.URN("<parent-urn>"),
-						nil, /* inputs */
-						plugin.ConstructOptions{})
+					_, err := prov.Construct(context.Background(), plugin.ConstructRequest{
+						Type:   tokens.Type("some-type"),
+						Name:   "name",
+						Parent: resource.URN("<parent-urn>"),
+					})
 					assert.ErrorIs(t, err, expectedErr)
 					assert.True(t, dialCalled)
 				})
@@ -244,13 +242,11 @@ func TestProvider(t *testing.T) {
 					return nil, nil
 				},
 			}
-			_, err := prov.Construct(
-				plugin.ConstructInfo{},
-				tokens.Type("some-type"),
-				"name",
-				resource.URN("<parent-urn>"),
-				nil, /* inputs */
-				plugin.ConstructOptions{})
+			_, err := prov.Construct(context.Background(), plugin.ConstructRequest{
+				Type:   tokens.Type("some-type"),
+				Name:   "name",
+				Parent: resource.URN("<parent-urn>"),
+			})
 			assert.NoError(t, err)
 		})
 	})
@@ -270,18 +266,20 @@ func TestProvider(t *testing.T) {
 					return expectedPropertyMap, nil, nil
 				},
 			}
-			res, _, err := prov.Invoke("expected-tok", nil)
+			resp, err := prov.Invoke(context.Background(), plugin.InvokeRequest{
+				Tok: "expected-tok",
+			})
 			assert.NoError(t, err)
 			assert.True(t, called)
-			assert.Equal(t, expectedPropertyMap, res)
+			assert.Equal(t, expectedPropertyMap, resp.Properties)
 		})
 		t.Run("no InvokeF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			news, failures, err := prov.Invoke("", nil)
+			resp, err := prov.Invoke(context.Background(), plugin.InvokeRequest{})
 			assert.NoError(t, err)
-			assert.Empty(t, failures)
-			assert.Equal(t, resource.PropertyMap{}, news)
+			assert.Empty(t, resp.Failures)
+			assert.Equal(t, resource.PropertyMap{}, resp.Properties)
 		})
 	})
 	t.Run("StreamInvoke", func(t *testing.T) {
@@ -298,13 +296,13 @@ func TestProvider(t *testing.T) {
 					return nil, expectedErr
 				},
 			}
-			_, err := prov.StreamInvoke("expected-tok", nil, nil)
+			_, err := prov.StreamInvoke(context.Background(), plugin.StreamInvokeRequest{Tok: "expected-tok"})
 			assert.ErrorIs(t, err, expectedErr)
 		})
 		t.Run("no StreamInvokeF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			_, err := prov.StreamInvoke("", nil, nil)
+			_, err := prov.StreamInvoke(context.Background(), plugin.StreamInvokeRequest{})
 			assert.ErrorContains(t, err, "StreamInvoke unimplemented")
 		})
 	})
@@ -334,7 +332,7 @@ func TestProvider(t *testing.T) {
 						return plugin.CallResult{}, expectedErr
 					},
 				}
-				_, err := prov.Call("expected-tok", nil, plugin.CallInfo{}, plugin.CallOptions{})
+				_, err := prov.Call(context.Background(), plugin.CallRequest{Tok: "expected-tok"})
 				assert.ErrorIs(t, err, expectedErr)
 				assert.True(t, dialCalled)
 				assert.True(t, callCalled)
@@ -352,7 +350,7 @@ func TestProvider(t *testing.T) {
 							return plugin.CallResult{}, nil
 						},
 					}
-					_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+					_, err := prov.Call(context.Background(), plugin.CallRequest{})
 					assert.ErrorContains(t, err, "could not connect to resource monitor")
 				})
 				t.Run("injected error", func(t *testing.T) {
@@ -374,7 +372,7 @@ func TestProvider(t *testing.T) {
 							return plugin.CallResult{}, expectedErr
 						},
 					}
-					_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+					_, err := prov.Call(context.Background(), plugin.CallRequest{})
 					assert.ErrorIs(t, err, expectedErr)
 					assert.True(t, dialCalled)
 				})
@@ -388,7 +386,7 @@ func TestProvider(t *testing.T) {
 					return nil, nil
 				},
 			}
-			_, err := prov.Call("", nil, plugin.CallInfo{}, plugin.CallOptions{})
+			_, err := prov.Call(context.Background(), plugin.CallRequest{})
 			assert.NoError(t, err)
 		})
 	})
@@ -404,16 +402,19 @@ func TestProvider(t *testing.T) {
 					return nil, "", expectedErr
 				},
 			}
-			_, _, err := prov.GetMapping("expected-key", "expected-provider")
+			_, err := prov.GetMapping(context.Background(), plugin.GetMappingRequest{
+				Key:      "expected-key",
+				Provider: "expected-provider",
+			})
 			assert.ErrorIs(t, err, expectedErr)
 		})
 		t.Run("no GetMappingF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			mappingB, mappingStr, err := prov.GetMapping("", "")
+			resp, err := prov.GetMapping(context.Background(), plugin.GetMappingRequest{})
 			assert.NoError(t, err)
-			assert.Equal(t, "", mappingStr)
-			assert.Nil(t, mappingB)
+			assert.Equal(t, "", resp.Provider)
+			assert.Nil(t, resp.Data)
 		})
 	})
 	t.Run("GetMappings", func(t *testing.T) {
@@ -427,13 +428,13 @@ func TestProvider(t *testing.T) {
 					return nil, expectedErr
 				},
 			}
-			_, err := prov.GetMappings("expected-key")
+			_, err := prov.GetMappings(context.Background(), plugin.GetMappingsRequest{Key: "expected-key"})
 			assert.ErrorIs(t, err, expectedErr)
 		})
 		t.Run("no GetMappingsF", func(t *testing.T) {
 			t.Parallel()
 			prov := &Provider{}
-			mappingStrs, err := prov.GetMappings("")
+			mappingStrs, err := prov.GetMappings(context.Background(), plugin.GetMappingsRequest{})
 			assert.NoError(t, err)
 			assert.Empty(t, mappingStrs)
 		})

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -268,7 +268,10 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		if checksums := req.PluginChecksums(); checksums != nil {
 			providers.SetProviderChecksums(inputs, checksums)
 		}
-		inputs, failures, err := i.deployment.providers.Check(urn, nil, inputs, false, nil)
+		resp, err := i.deployment.providers.Check(ctx, plugin.CheckRequest{
+			URN:  urn,
+			News: inputs,
+		})
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to validate provider config: %w", err)
 		}
@@ -276,7 +279,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		state := resource.NewState(typ, urn, true, false, "", inputs, nil, "", false, false, nil, nil, "", nil, false,
 			nil, nil, nil, "", false, "", nil, nil, "")
 		// TODO(seqnum) should default providers be created with 1? When do they ever get recreated/replaced?
-		if issueCheckErrors(i.deployment, state, urn, failures) {
+		if issueCheckErrors(i.deployment, state, urn, resp.Failures) {
 			return nil, false, nil
 		}
 

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -263,43 +263,39 @@ func (r *Registry) Parameterize(context.Context, plugin.ParameterizeRequest) (pl
 }
 
 // GetSchema returns the JSON-serialized schema for the provider.
-func (r *Registry) GetSchema(plugin.GetSchemaRequest) ([]byte, error) {
+func (r *Registry) GetSchema(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
 	contract.Failf("GetSchema must not be called on the provider registry")
 
-	return nil, errors.New("the provider registry has no schema")
+	return plugin.GetSchemaResponse{}, errors.New("the provider registry has no schema")
 }
 
-func (r *Registry) GetMapping(key, provider string) ([]byte, string, error) {
+func (r *Registry) GetMapping(context.Context, plugin.GetMappingRequest) (plugin.GetMappingResponse, error) {
 	contract.Failf("GetMapping must not be called on the provider registry")
 
-	return nil, "", errors.New("the provider registry has no mappings")
+	return plugin.GetMappingResponse{}, errors.New("the provider registry has no mappings")
 }
 
-func (r *Registry) GetMappings(key string) ([]string, error) {
+func (r *Registry) GetMappings(context.Context, plugin.GetMappingsRequest) (plugin.GetMappingsResponse, error) {
 	contract.Failf("GetMappings must not be called on the provider registry")
 
-	return nil, errors.New("the provider registry has no mappings")
+	return plugin.GetMappingsResponse{}, errors.New("the provider registry has no mappings")
 }
 
 // CheckConfig validates the configuration for this resource provider.
-func (r *Registry) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap, allowUnknowns bool,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (r *Registry) CheckConfig(context.Context, plugin.CheckConfigRequest) (plugin.CheckConfigResponse, error) {
 	contract.Failf("CheckConfig must not be called on the provider registry")
-	return nil, nil, errors.New("the provider registry is not configurable")
+	return plugin.CheckConfigResponse{}, errors.New("the provider registry is not configurable")
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (r *Registry) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
+func (r *Registry) DiffConfig(context.Context, plugin.DiffConfigRequest) (plugin.DiffConfigResponse, error) {
 	contract.Failf("DiffConfig must not be called on the provider registry")
 	return plugin.DiffResult{}, errors.New("the provider registry is not configurable")
 }
 
-func (r *Registry) Configure(props resource.PropertyMap) error {
+func (r *Registry) Configure(context.Context, plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 	contract.Failf("Configure must not be called on the provider registry")
-	return errors.New("the provider registry is not configurable")
+	return plugin.ConfigureResponse{}, errors.New("the provider registry is not configurable")
 }
 
 // Check validates the configuration for a particular provider resource.
@@ -310,44 +306,51 @@ func (r *Registry) Configure(props resource.PropertyMap) error {
 //   - we need to keep the newly-loaded provider around in case we need to diff its config
 //   - if we are running a preview, we need to configure the provider, as its corresponding CRUD operations will not run
 //     (we would normally configure the provider in Create or Update).
-func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
-	allowUnknowns bool, randomSeed []byte,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	contract.Requiref(IsProviderType(urn.Type()), "urn", "must be a provider type, got %v", urn.Type())
+func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+	contract.Requiref(IsProviderType(req.URN.Type()), "urn", "must be a provider type, got %v", req.URN.Type())
 
-	label := fmt.Sprintf("%s.Check(%s)", r.label(), urn)
-	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(olds), len(news))
+	label := fmt.Sprintf("%s.Check(%s)", r.label(), req.URN)
+	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(req.Olds), len(req.News))
 
 	// Parse the version from the provider properties and load the provider.
-	version, err := GetProviderVersion(news)
+	version, err := GetProviderVersion(req.News)
 	if err != nil {
-		return nil, []plugin.CheckFailure{{Property: "version", Reason: err.Error()}}, nil
+		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
+			Property: "version", Reason: err.Error(),
+		}}}, nil
 	}
-	downloadURL, err := GetProviderDownloadURL(news)
+	downloadURL, err := GetProviderDownloadURL(req.News)
 	if err != nil {
-		return nil, []plugin.CheckFailure{{Property: "pluginDownloadURL", Reason: err.Error()}}, nil
+		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
+			Property: "pluginDownloadURL", Reason: err.Error(),
+		}}}, nil
 	}
 	// TODO: We should thread checksums through here.
-	provider, err := loadProvider(GetProviderPackage(urn.Type()), version, downloadURL, nil, r.host, r.builtins)
+	provider, err := loadProvider(GetProviderPackage(req.URN.Type()), version, downloadURL, nil, r.host, r.builtins)
 	if err != nil {
-		return nil, nil, err
+		return plugin.CheckResponse{}, err
 	}
 	if provider == nil {
-		return nil, nil, errors.New("could not find plugin")
+		return plugin.CheckResponse{}, errors.New("could not find plugin")
 	}
 
 	// Check the provider's config. If the check fails, unload the provider.
-	inputs, failures, err := provider.CheckConfig(urn, olds, news, allowUnknowns)
-	if len(failures) != 0 || err != nil {
+	resp, err := provider.CheckConfig(ctx, plugin.CheckConfigRequest{
+		URN:           req.URN,
+		Olds:          req.Olds,
+		News:          req.News,
+		AllowUnknowns: true,
+	})
+	if len(resp.Failures) != 0 || err != nil {
 		closeErr := r.host.CloseProvider(provider)
 		contract.IgnoreError(closeErr)
-		return nil, failures, err
+		return plugin.CheckResponse{Failures: resp.Failures}, err
 	}
 
 	// Create a provider reference using the URN and the unconfigured ID and register the provider.
-	r.setProvider(mustNewReference(urn, UnconfiguredID), provider)
+	r.setProvider(mustNewReference(req.URN, UnconfiguredID), provider)
 
-	return inputs, nil, nil
+	return plugin.CheckResponse{Properties: resp.Properties}, nil
 }
 
 // RegisterAliases informs the registry that the new provider object with the given URN is aliased to the given list
@@ -363,33 +366,38 @@ func (r *Registry) RegisterAlias(providerURN, alias resource.URN) {
 
 // Diff diffs the configuration of the indicated provider. The provider corresponding to the given URN must have
 // previously been loaded by a call to Check.
-func (r *Registry) Diff(urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
-	contract.Requiref(id != "", "id", "must not be empty")
+func (r *Registry) Diff(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+	contract.Requiref(req.ID != "", "id", "must not be empty")
 
-	label := fmt.Sprintf("%s.Diff(%s,%s)", r.label(), urn, id)
+	label := fmt.Sprintf("%s.Diff(%s,%s)", r.label(), req.URN, req.ID)
 	logging.V(7).Infof("%s: executing (#oldInputs=%d#oldOutputs=%d,#newInputs=%d)",
-		label, len(oldInputs), len(oldOutputs), len(newInputs))
+		label, len(req.OldInputs), len(req.OldOutputs), len(req.NewInputs))
 
 	// Create a reference using the URN and the unconfigured ID and fetch the provider.
-	provider, ok := r.GetProvider(mustNewReference(urn, UnconfiguredID))
+	provider, ok := r.GetProvider(mustNewReference(req.URN, UnconfiguredID))
 	if !ok {
 		// If the provider was not found in the registry under its URN and the unconfigured ID, then it must have not have
 		// been subject to a call to `Check`. This can happen when we are diffing a provider's inputs as part of
 		// evaluating the fanout of a delete-before-replace operation. In this case, we can just use the old provider
 		// (which we should have loaded during diff search), and we will not unload it.
-		provider, ok = r.GetProvider(mustNewReference(urn, id))
-		contract.Assertf(ok, "Provider must have been registered at some point for DBR Diff (%v::%v)", urn, id)
+		provider, ok = r.GetProvider(mustNewReference(req.URN, req.ID))
+		contract.Assertf(ok, "Provider must have been registered at some point for DBR Diff (%v::%v)", req.URN, req.ID)
 	}
 
 	// Diff the properties.
-	diff, err := provider.DiffConfig(urn, oldInputs, oldOutputs, newInputs, allowUnknowns, ignoreChanges)
+	diff, err := provider.DiffConfig(context.Background(), plugin.DiffConfigRequest{
+		URN:           req.URN,
+		OldInputs:     req.OldInputs,
+		OldOutputs:    req.OldOutputs,
+		NewInputs:     req.NewInputs,
+		AllowUnknowns: req.AllowUnknowns,
+		IgnoreChanges: req.IgnoreChanges,
+	})
 	if err != nil {
 		return plugin.DiffResult{Changes: plugin.DiffUnknown}, err
 	}
 	if diff.Changes == plugin.DiffUnknown {
-		if oldOutputs.DeepEquals(newInputs) {
+		if req.OldOutputs.DeepEquals(req.NewInputs) {
 			diff.Changes = plugin.DiffNone
 		} else {
 			diff.Changes = plugin.DiffSome
@@ -457,7 +465,9 @@ func (r *Registry) Same(res *resource.State) error {
 	}
 	contract.Assertf(provider != nil, "provider must not be nil")
 
-	if err := provider.Configure(res.Inputs); err != nil {
+	if _, err := provider.Configure(context.Background(), plugin.ConfigureRequest{
+		Inputs: res.Inputs,
+	}); err != nil {
 		closeErr := r.host.CloseProvider(provider)
 		contract.IgnoreError(closeErr)
 		return fmt.Errorf("configure provider '%v': %w", urn, err)
@@ -474,150 +484,138 @@ func (r *Registry) Same(res *resource.State) error {
 // registers it under the assigned (URN, ID).
 //
 // The provider must have been loaded by a prior call to Check.
-func (r *Registry) Create(urn resource.URN, news resource.PropertyMap, timeout float64,
-	preview bool,
-) (resource.ID, resource.PropertyMap, resource.Status, error) {
-	label := fmt.Sprintf("%s.Create(%s)", r.label(), urn)
-	logging.V(7).Infof("%s executing (#news=%v)", label, len(news))
+func (r *Registry) Create(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+	label := fmt.Sprintf("%s.Create(%s)", r.label(), req.URN)
+	logging.V(7).Infof("%s executing (#news=%v)", label, len(req.Properties))
 
 	// Fetch the unconfigured provider, configure it, and register it under a new ID. We remove the
 	// unconfigured ID from the provider map so nothing else tries to use and re-configure this instance.
-	provider, ok := r.deleteProvider(mustNewReference(urn, UnconfiguredID))
+	provider, ok := r.deleteProvider(mustNewReference(req.URN, UnconfiguredID))
 	if !ok {
 		// The unconfigured provider may have been Same'd after Check and this provider could be a replacement create.
 		// In which case we need to start up a fresh copy.
 
-		providerPkg := GetProviderPackage(urn.Type())
+		providerPkg := GetProviderPackage(req.URN.Type())
 
 		// Parse the provider version, then load, configure, and register the provider.
-		version, err := GetProviderVersion(news)
+		version, err := GetProviderVersion(req.Properties)
 		if err != nil {
-			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("parse version for %v provider '%v': %w", providerPkg, urn, err)
+			return plugin.CreateResponse{Status: resource.StatusUnknown},
+				fmt.Errorf("parse version for %v provider '%v': %w", providerPkg, req.URN, err)
 		}
-		downloadURL, err := GetProviderDownloadURL(news)
+		downloadURL, err := GetProviderDownloadURL(req.Properties)
 		if err != nil {
-			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("parse download URL for %v provider '%v': %w", providerPkg, urn, err)
+			return plugin.CreateResponse{Status: resource.StatusUnknown},
+				fmt.Errorf("parse download URL for %v provider '%v': %w", providerPkg, req.URN, err)
 		}
 		// TODO: We should thread checksums through here.
 		provider, err = loadProvider(providerPkg, version, downloadURL, nil, r.host, r.builtins)
 		if err != nil {
-			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, urn, err)
+			return plugin.CreateResponse{Status: resource.StatusUnknown},
+				fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, req.URN, err)
 		}
 		if provider == nil {
-			return "", nil, resource.StatusUnknown,
-				fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, urn, version)
+			return plugin.CreateResponse{Status: resource.StatusUnknown},
+				fmt.Errorf("find plugin for %v provider '%v' at version %v", providerPkg, req.URN, version)
 		}
 	}
 
-	if err := provider.Configure(news); err != nil {
-		return "", nil, resource.StatusOK, err
+	if _, err := provider.Configure(context.Background(), plugin.ConfigureRequest{
+		Inputs: req.Properties,
+	}); err != nil {
+		return plugin.CreateResponse{Status: resource.StatusOK}, err
 	}
 
 	id := resource.ID(UnknownID)
-	if !preview {
+	if !req.Preview {
 		// generate a new uuid
 		uuid, err := uuid.NewV4()
 		if err != nil {
-			return "", nil, resource.StatusOK, err
+			return plugin.CreateResponse{Status: resource.StatusOK}, err
 		}
 		id = resource.ID(uuid.String())
 		contract.Assertf(id != UnknownID, "resource ID must not be unknown")
 	}
 
-	r.setProvider(mustNewReference(urn, id), provider)
-	return id, news, resource.StatusOK, nil
+	r.setProvider(mustNewReference(req.URN, id), provider)
+	return plugin.CreateResponse{
+		ID:         id,
+		Properties: req.Properties,
+		Status:     resource.StatusOK,
+	}, nil
 }
 
 // Update configures the provider with the given URN and ID using the indicated configuration and registers it at the
 // reference indicated by the (URN, ID) pair.
 //
-// THe provider must have been loaded by a prior call to Check.
-func (r *Registry) Update(urn resource.URN, id resource.ID,
-	oldInputs, oldOutputs, newInputs resource.PropertyMap, timeout float64,
-	ignoreChanges []string, preview bool,
-) (resource.PropertyMap, resource.Status, error) {
-	label := fmt.Sprintf("%s.Update(%s,%s)", r.label(), id, urn)
+// The provider must have been loaded by a prior call to Check.
+func (r *Registry) Update(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+	label := fmt.Sprintf("%s.Update(%s,%s)", r.label(), req.ID, req.URN)
 	logging.V(7).Infof("%s: executing (#oldInputs=%d#oldOutputs=%d,#newInputs=%d)",
-		label, len(oldInputs), len(oldOutputs), len(newInputs))
+		label, len(req.OldInputs), len(req.OldOutputs), len(req.NewInputs))
 
 	// Fetch the unconfigured provider, configure it, and register it under a new ID. We remove the
 	// unconfigured ID from the provider map so nothing else tries to use and re-configure this instance.
-	provider, ok := r.deleteProvider(mustNewReference(urn, UnconfiguredID))
-	contract.Assertf(ok, "'Check' and 'Diff' must be called before 'Update' (%v)", urn)
+	provider, ok := r.deleteProvider(mustNewReference(req.URN, UnconfiguredID))
+	contract.Assertf(ok, "'Check' and 'Diff' must be called before 'Update' (%v)", req.URN)
 
-	if err := provider.Configure(newInputs); err != nil {
-		return nil, resource.StatusUnknown, err
+	if _, err := provider.Configure(ctx, plugin.ConfigureRequest{Inputs: req.NewInputs}); err != nil {
+		return plugin.UpdateResponse{Status: resource.StatusUnknown}, err
 	}
 
 	// Publish the configured provider.
-	r.setProvider(mustNewReference(urn, id), provider)
-	return newInputs, resource.StatusOK, nil
+	r.setProvider(mustNewReference(req.URN, req.ID), provider)
+	return plugin.UpdateResponse{Properties: req.NewInputs, Status: resource.StatusOK}, nil
 }
 
 // Delete unregisters and unloads the provider with the given URN and ID. If the provider was never loaded
 // this is a no-op.
-func (r *Registry) Delete(urn resource.URN, id resource.ID, oldInputs, oldOutputs resource.PropertyMap,
-	timeout float64,
-) (resource.Status, error) {
+func (r *Registry) Delete(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
 	contract.Assertf(!r.isPreview, "Delete must not be called during preview")
 
-	ref := mustNewReference(urn, id)
+	ref := mustNewReference(req.URN, req.ID)
 	provider, has := r.deleteProvider(ref)
 	if !has {
-		return resource.StatusOK, nil
+		return plugin.DeleteResponse{}, nil
 	}
 
 	closeErr := r.host.CloseProvider(provider)
 	contract.IgnoreError(closeErr)
-	return resource.StatusOK, nil
+	return plugin.DeleteResponse{}, nil
 }
 
-func (r *Registry) Read(urn resource.URN, id resource.ID,
-	inputs, state resource.PropertyMap,
-) (plugin.ReadResult, resource.Status, error) {
-	return plugin.ReadResult{}, resource.StatusUnknown, errors.New("provider resources may not be read")
+func (r *Registry) Read(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
+	return plugin.ReadResponse{}, errors.New("provider resources may not be read")
 }
 
-func (r *Registry) Construct(info plugin.ConstructInfo, typ tokens.Type, name string, parent resource.URN,
-	inputs resource.PropertyMap, options plugin.ConstructOptions,
-) (plugin.ConstructResult, error) {
+func (r *Registry) Construct(context.Context, plugin.ConstructRequest) (plugin.ConstructResponse, error) {
 	return plugin.ConstructResult{}, errors.New("provider resources may not be constructed")
 }
 
-func (r *Registry) Invoke(tok tokens.ModuleMember,
-	args resource.PropertyMap,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (r *Registry) Invoke(context.Context, plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 	// It is the responsibility of the eval source to ensure that we never attempt an invoke using the provider
 	// registry.
 	contract.Failf("Invoke must not be called on the provider registry")
-	return nil, nil, errors.New("the provider registry is not invokable")
+	return plugin.InvokeResponse{}, errors.New("the provider registry is not invokable")
 }
 
-func (r *Registry) StreamInvoke(
-	tok tokens.ModuleMember, args resource.PropertyMap,
-	onNext func(resource.PropertyMap) error,
-) ([]plugin.CheckFailure, error) {
-	return nil, errors.New("the provider registry does not implement streaming invokes")
+func (r *Registry) StreamInvoke(context.Context, plugin.StreamInvokeRequest) (plugin.StreamInvokeResponse, error) {
+	return plugin.StreamInvokeResponse{}, errors.New("the provider registry does not implement streaming invokes")
 }
 
-func (r *Registry) Call(tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
-	options plugin.CallOptions,
-) (plugin.CallResult, error) {
+func (r *Registry) Call(context.Context, plugin.CallRequest) (plugin.CallResponse, error) {
 	// It is the responsibility of the eval source to ensure that we never attempt an call using the provider
 	// registry.
 	contract.Failf("Call must not be called on the provider registry")
 	return plugin.CallResult{}, errors.New("the provider registry is not callable")
 }
 
-func (r *Registry) GetPluginInfo() (workspace.PluginInfo, error) {
+func (r *Registry) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	// return an error: this should not be called for the provider registry
 	return workspace.PluginInfo{}, errors.New("the provider registry does not report plugin info")
 }
 
-func (r *Registry) SignalCancellation() error {
+func (r *Registry) SignalCancellation(context.Context) error {
 	// At the moment there isn't anything reasonable we can do here. In the future, it might be nice to plumb
 	// cancellation through the plugin loader and cancel any outstanding load requests here.
 	return nil

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -15,6 +15,7 @@
 package providers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -123,43 +124,52 @@ func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
 
-func (prov *testProvider) GetSchema(plugin.GetSchemaRequest) ([]byte, error) {
-	return []byte("{}"), nil
+func (prov *testProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
+	return plugin.GetSchemaResponse{Schema: []byte("{}")}, nil
 }
 
-func (prov *testProvider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap, allowUnknowns bool,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	return prov.checkConfig(urn, olds, news, allowUnknowns)
+func (prov *testProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
+	props, failures, err := prov.checkConfig(req.URN, req.Olds, req.News, req.AllowUnknowns)
+	return plugin.CheckConfigResponse{Properties: props, Failures: failures}, err
 }
 
-func (prov *testProvider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string,
-) (plugin.DiffResult, error) {
-	return prov.diffConfig(urn, oldOutputs, newInputs, allowUnknowns, ignoreChanges)
+func (prov *testProvider) DiffConfig(
+	_ context.Context, req plugin.DiffConfigRequest,
+) (plugin.DiffConfigResponse, error) {
+	return prov.diffConfig(req.URN, req.OldOutputs, req.NewInputs, req.AllowUnknowns, req.IgnoreChanges)
 }
 
-func (prov *testProvider) Configure(inputs resource.PropertyMap) error {
-	if err := prov.config(inputs); err != nil {
-		return err
+func (prov *testProvider) Configure(
+	_ context.Context, req plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	if err := prov.config(req.Inputs); err != nil {
+		return plugin.ConfigureResponse{}, err
 	}
 	prov.configured = true
-	return nil
+	return plugin.ConfigureResponse{}, nil
 }
 
-func (prov *testProvider) GetPluginInfo() (workspace.PluginInfo, error) {
+func (prov *testProvider) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{
 		Name:    "testProvider",
 		Version: &prov.version,
 	}, nil
 }
 
-func (prov *testProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return nil, "", nil
+func (prov *testProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
 }
 
-func (prov *testProvider) GetMappings(key string) ([]string, error) {
-	return []string{}, nil
+func (prov *testProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
 }
 
 type providerLoader struct {
@@ -318,7 +328,7 @@ func TestNewRegistryOldState(t *testing.T) {
 		ver, err := GetProviderVersion(old.Inputs)
 		assert.NoError(t, err)
 		if ver != nil {
-			info, err := p.GetPluginInfo()
+			info, err := p.GetPluginInfo(context.Background())
 			assert.NoError(t, err)
 			assert.True(t, info.Version.GTE(*ver))
 		}
@@ -371,10 +381,14 @@ func TestCRUD(t *testing.T) {
 		timeout := float64(120)
 
 		// Check
-		inputs, failures, err := r.Check(urn, olds, news, false, nil)
+		check, err := r.Check(context.Background(), plugin.CheckRequest{
+			URN:  urn,
+			Olds: olds,
+			News: news,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, news, inputs)
-		assert.Empty(t, failures)
+		assert.Equal(t, news, check.Properties)
+		assert.Empty(t, check.Failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
 		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
@@ -382,15 +396,19 @@ func TestCRUD(t *testing.T) {
 		assert.False(t, p.(*testProvider).configured)
 
 		// Create
-		id, outs, status, err := r.Create(urn, inputs, timeout, false)
+		create, err := r.Create(context.Background(), plugin.CreateRequest{
+			URN:        urn,
+			Properties: check.Properties,
+			Timeout:    timeout,
+		})
 		assert.NoError(t, err)
-		assert.NotEqual(t, "", id)
-		assert.NotEqual(t, UnconfiguredID, id)
-		assert.NotEqual(t, UnknownID, id)
-		assert.Equal(t, resource.PropertyMap{}, outs)
-		assert.Equal(t, resource.StatusOK, status)
+		assert.NotEqual(t, "", create.ID)
+		assert.NotEqual(t, UnconfiguredID, create.ID)
+		assert.NotEqual(t, UnknownID, create.ID)
+		assert.Equal(t, resource.PropertyMap{}, create.Properties)
+		assert.Equal(t, resource.StatusOK, create.Status)
 
-		p2, ok := r.GetProvider(Reference{urn: urn, id: id})
+		p2, ok := r.GetProvider(Reference{urn: urn, id: create.ID})
 		assert.True(t, ok)
 		assert.Equal(t, p, p2)
 		assert.True(t, p2.(*testProvider).configured)
@@ -407,10 +425,14 @@ func TestCRUD(t *testing.T) {
 		assert.True(t, ok)
 
 		// Check
-		inputs, failures, err := r.Check(urn, olds, news, false, nil)
+		check, err := r.Check(context.Background(), plugin.CheckRequest{
+			URN:  urn,
+			Olds: olds,
+			News: news,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, news, inputs)
-		assert.Empty(t, failures)
+		assert.Equal(t, news, check.Properties)
+		assert.Empty(t, check.Failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
 		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
@@ -419,7 +441,12 @@ func TestCRUD(t *testing.T) {
 		assert.False(t, p.(*testProvider).configured)
 
 		// Diff
-		diff, err := r.Diff(urn, id, nil, olds, news, false, nil)
+		diff, err := r.Diff(context.Background(), plugin.DiffRequest{
+			URN:        urn,
+			ID:         id,
+			OldOutputs: olds,
+			NewInputs:  news,
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, plugin.DiffResult{Changes: plugin.DiffNone}, diff)
 
@@ -429,10 +456,16 @@ func TestCRUD(t *testing.T) {
 		assert.Equal(t, old, p2)
 
 		// Update
-		outs, status, err := r.Update(urn, id, nil, olds, inputs, timeout, nil, false)
+		update, err := r.Update(context.Background(), plugin.UpdateRequest{
+			URN:        urn,
+			ID:         id,
+			OldOutputs: olds,
+			NewInputs:  check.Properties,
+			Timeout:    timeout,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, resource.PropertyMap{}, outs)
-		assert.Equal(t, resource.StatusOK, status)
+		assert.Equal(t, resource.PropertyMap{}, update.Properties)
+		assert.Equal(t, resource.StatusOK, update.Status)
 
 		p3, ok := r.GetProvider(Reference{urn: urn, id: id})
 		assert.True(t, ok)
@@ -450,9 +483,15 @@ func TestCRUD(t *testing.T) {
 		assert.True(t, ok)
 
 		// Delete
-		status, err := r.Delete(urn, id, resource.PropertyMap{}, resource.PropertyMap{}, timeout)
+		resp, err := r.Delete(context.Background(), plugin.DeleteRequest{
+			URN:     urn,
+			ID:      id,
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+			Timeout: timeout,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, resource.StatusOK, status)
+		assert.Equal(t, resource.StatusOK, resp.Status)
 
 		_, ok = r.GetProvider(Reference{urn: urn, id: id})
 		assert.False(t, ok)
@@ -525,10 +564,14 @@ func TestCRUDPreview(t *testing.T) {
 		olds, news := resource.PropertyMap{}, resource.PropertyMap{}
 
 		// Check
-		inputs, failures, err := r.Check(urn, olds, news, false, nil)
+		check, err := r.Check(context.Background(), plugin.CheckRequest{
+			URN:  urn,
+			Olds: olds,
+			News: news,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, news, inputs)
-		assert.Empty(t, failures)
+		assert.Equal(t, news, check.Properties)
+		assert.Empty(t, check.Failures)
 
 		// The provider should not be configured: configuration will occur during the previewed Create.
 		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
@@ -546,10 +589,14 @@ func TestCRUDPreview(t *testing.T) {
 		assert.True(t, ok)
 
 		// Check
-		inputs, failures, err := r.Check(urn, olds, news, false, nil)
+		check, err := r.Check(context.Background(), plugin.CheckRequest{
+			URN:  urn,
+			Olds: olds,
+			News: news,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, news, inputs)
-		assert.Empty(t, failures)
+		assert.Equal(t, news, check.Properties)
+		assert.Empty(t, check.Failures)
 
 		// The provider should remain unconfigured.
 		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
@@ -558,7 +605,12 @@ func TestCRUDPreview(t *testing.T) {
 		assert.False(t, p.(*testProvider).configured)
 
 		// Diff
-		diff, err := r.Diff(urn, id, nil, olds, news, false, nil)
+		diff, err := r.Diff(context.Background(), plugin.DiffRequest{
+			URN:        urn,
+			ID:         id,
+			OldOutputs: olds,
+			NewInputs:  news,
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, plugin.DiffResult{Changes: plugin.DiffNone}, diff)
 
@@ -579,10 +631,14 @@ func TestCRUDPreview(t *testing.T) {
 		assert.True(t, ok)
 
 		// Check
-		inputs, failures, err := r.Check(urn, olds, news, false, nil)
+		check, err := r.Check(context.Background(), plugin.CheckRequest{
+			URN:  urn,
+			Olds: olds,
+			News: news,
+		})
 		assert.NoError(t, err)
-		assert.Equal(t, news, inputs)
-		assert.Empty(t, failures)
+		assert.Equal(t, news, check.Properties)
+		assert.Empty(t, check.Failures)
 
 		// The provider should remain unconfigured.
 		p, ok := r.GetProvider(Reference{urn: urn, id: UnconfiguredID})
@@ -591,7 +647,12 @@ func TestCRUDPreview(t *testing.T) {
 		assert.False(t, p.(*testProvider).configured)
 
 		// Diff
-		diff, err := r.Diff(urn, id, nil, olds, news, false, nil)
+		diff, err := r.Diff(context.Background(), plugin.DiffRequest{
+			URN:        urn,
+			ID:         id,
+			OldOutputs: olds,
+			NewInputs:  news,
+		})
 		assert.NoError(t, err)
 		assert.True(t, diff.Replace())
 
@@ -616,10 +677,14 @@ func TestCRUDNoProviders(t *testing.T) {
 	olds, news := resource.PropertyMap{}, resource.PropertyMap{}
 
 	// Check
-	inputs, failures, err := r.Check(urn, olds, news, false, nil)
+	check, err := r.Check(context.Background(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: olds,
+		News: news,
+	})
 	assert.Error(t, err)
-	assert.Empty(t, failures)
-	assert.Nil(t, inputs)
+	assert.Empty(t, check.Failures)
+	assert.Nil(t, check.Properties)
 }
 
 func TestCRUDWrongPackage(t *testing.T) {
@@ -638,10 +703,14 @@ func TestCRUDWrongPackage(t *testing.T) {
 	olds, news := resource.PropertyMap{}, resource.PropertyMap{}
 
 	// Check
-	inputs, failures, err := r.Check(urn, olds, news, false, nil)
+	check, err := r.Check(context.Background(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: olds,
+		News: news,
+	})
 	assert.Error(t, err)
-	assert.Empty(t, failures)
-	assert.Nil(t, inputs)
+	assert.Empty(t, check.Failures)
+	assert.Nil(t, check.Properties)
 }
 
 func TestCRUDWrongVersion(t *testing.T) {
@@ -660,10 +729,14 @@ func TestCRUDWrongVersion(t *testing.T) {
 	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewStringProperty("1.0.0")}
 
 	// Check
-	inputs, failures, err := r.Check(urn, olds, news, false, nil)
+	check, err := r.Check(context.Background(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: olds,
+		News: news,
+	})
 	assert.Error(t, err)
-	assert.Empty(t, failures)
-	assert.Nil(t, inputs)
+	assert.Empty(t, check.Failures)
+	assert.Nil(t, check.Properties)
 }
 
 func TestCRUDBadVersionNotString(t *testing.T) {
@@ -682,11 +755,15 @@ func TestCRUDBadVersionNotString(t *testing.T) {
 	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewBoolProperty(true)}
 
 	// Check
-	inputs, failures, err := r.Check(urn, olds, news, false, nil)
+	check, err := r.Check(context.Background(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: olds,
+		News: news,
+	})
 	assert.NoError(t, err)
-	assert.Len(t, failures, 1)
-	assert.Equal(t, "version", string(failures[0].Property))
-	assert.Nil(t, inputs)
+	assert.Len(t, check.Failures, 1)
+	assert.Equal(t, "version", string(check.Failures[0].Property))
+	assert.Nil(t, check.Properties)
 }
 
 func TestCRUDBadVersion(t *testing.T) {
@@ -705,11 +782,15 @@ func TestCRUDBadVersion(t *testing.T) {
 	olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewStringProperty("foo")}
 
 	// Check
-	inputs, failures, err := r.Check(urn, olds, news, false, nil)
+	check, err := r.Check(context.Background(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: olds,
+		News: news,
+	})
 	assert.NoError(t, err)
-	assert.Len(t, failures, 1)
-	assert.Equal(t, "version", string(failures[0].Property))
-	assert.Nil(t, inputs)
+	assert.Len(t, check.Failures, 1)
+	assert.Equal(t, "version", string(check.Failures[0].Property))
+	assert.Nil(t, check.Properties)
 }
 
 //nolint:paralleltest
@@ -788,11 +869,15 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 			olds, news := resource.PropertyMap{}, resource.PropertyMap{"version": resource.NewBoolProperty(true)}
 
 			// Check
-			inputs, failures, err := r.Check(providerURN, olds, news, false, nil)
+			check, err := r.Check(context.Background(), plugin.CheckRequest{
+				URN:  providerURN,
+				Olds: olds,
+				News: news,
+			})
 			assert.NoError(t, err)
-			assert.Len(t, failures, 1)
-			assert.Equal(t, "version", string(failures[0].Property))
-			assert.Nil(t, inputs)
+			assert.Len(t, check.Failures, 1)
+			assert.Equal(t, "version", string(check.Failures[0].Property))
+			assert.Nil(t, check.Properties)
 		}(i)
 	}
 }
@@ -815,85 +900,85 @@ func TestRegistry(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _ = r.GetSchema(plugin.GetSchemaRequest{})
+			_, _ = r.GetSchema(context.Background(), plugin.GetSchemaRequest{})
 		})
 	})
 	t.Run("GetMapping", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _, _ = r.GetMapping("", "")
+			_, _ = r.GetMapping(context.Background(), plugin.GetMappingRequest{})
 		})
 	})
 	t.Run("GetMappings", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _ = r.GetMappings("")
+			_, _ = r.GetMappings(context.Background(), plugin.GetMappingsRequest{})
 		})
 	})
 	t.Run("CheckConfig", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _, _ = r.CheckConfig("", resource.PropertyMap{}, resource.PropertyMap{}, true)
+			_, _ = r.CheckConfig(context.Background(), plugin.CheckConfigRequest{AllowUnknowns: true})
 		})
 	})
 	t.Run("DiffConfig", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _ = r.DiffConfig("", resource.PropertyMap{}, resource.PropertyMap{}, resource.PropertyMap{}, true, nil)
+			_, _ = r.DiffConfig(context.Background(), plugin.DiffConfigRequest{AllowUnknowns: true})
 		})
 	})
 	t.Run("Configure", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_ = r.Configure(resource.PropertyMap{})
+			_, _ = r.Configure(context.Background(), plugin.ConfigureRequest{})
 		})
 	})
 	t.Run("Read", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
-		_, _, err := r.Read("", "", resource.PropertyMap{}, resource.PropertyMap{})
+		_, err := r.Read(context.Background(), plugin.ReadRequest{})
 		assert.ErrorContains(t, err, "provider resources may not be read")
 	})
 	t.Run("Construct", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
-		_, err := r.Construct(plugin.ConstructInfo{}, "", "", "", resource.PropertyMap{}, plugin.ConstructOptions{})
+		_, err := r.Construct(context.Background(), plugin.ConstructRequest{})
 		assert.ErrorContains(t, err, "provider resources may not be constructed")
 	})
 	t.Run("Invoke", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _, _ = r.Invoke("", resource.PropertyMap{})
+			_, _ = r.Invoke(context.Background(), plugin.InvokeRequest{})
 		})
 	})
 	t.Run("StreamInvoke", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
-		_, err := r.StreamInvoke("", resource.PropertyMap{}, nil)
+		_, err := r.StreamInvoke(context.Background(), plugin.StreamInvokeRequest{})
 		assert.ErrorContains(t, err, "the provider registry does not implement streaming invokes")
 	})
 	t.Run("Call", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
 		assert.Panics(t, func() {
-			_, _ = r.Call("", resource.PropertyMap{}, plugin.CallInfo{}, plugin.CallOptions{})
+			_, _ = r.Call(context.Background(), plugin.CallRequest{})
 		})
 	})
 	t.Run("GetPluginInfo", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
-		_, err := r.GetPluginInfo()
+		_, err := r.GetPluginInfo(context.Background())
 		assert.ErrorContains(t, err, "the provider registry does not report plugin info")
 	})
 	t.Run("SignalCancellation", func(t *testing.T) {
 		t.Parallel()
 		r := &Registry{}
-		assert.Nil(t, r.SignalCancellation())
+		assert.Nil(t, r.SignalCancellation(context.Background()))
 	})
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -384,7 +384,7 @@ func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (
 			host, host.ctx, pkg, version,
 			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig))
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo()
+			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
@@ -520,7 +520,7 @@ func (host *defaultHost) SignalCancellation() error {
 	_, err := host.loadPlugin(host.loadRequests, func() (interface{}, error) {
 		var result error
 		for _, plug := range host.resourcePlugins {
-			if err := plug.Plugin.SignalCancellation(); err != nil {
+			if err := plug.Plugin.SignalCancellation(host.ctx.Request()); err != nil {
 				result = multierror.Append(result, errors.Wrapf(err,
 					"Error signaling cancellation to resource provider '%s'", plug.Info.Name))
 			}

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -74,6 +74,166 @@ type ParameterizeResponse struct {
 	Version *semver.Version
 }
 
+type GetSchemaResponse struct {
+	Schema []byte
+}
+
+type CheckConfigRequest struct {
+	URN           resource.URN
+	Olds, News    resource.PropertyMap
+	AllowUnknowns bool
+}
+
+type CheckConfigResponse struct {
+	Properties resource.PropertyMap
+	Failures   []CheckFailure
+}
+
+type DiffConfigRequest struct {
+	URN                              resource.URN
+	OldInputs, OldOutputs, NewInputs resource.PropertyMap
+	AllowUnknowns                    bool
+	IgnoreChanges                    []string
+}
+
+type DiffConfigResponse = DiffResult
+
+type ConfigureRequest struct {
+	Inputs resource.PropertyMap
+}
+
+type ConfigureResponse struct{}
+
+type CheckRequest struct {
+	URN resource.URN
+	// TODO Change to (State, Input)
+	Olds, News    resource.PropertyMap
+	AllowUnknowns bool
+	RandomSeed    []byte
+}
+
+type CheckResponse struct {
+	Properties resource.PropertyMap
+	Failures   []CheckFailure
+}
+
+type DiffRequest struct {
+	URN resource.URN
+	ID  resource.ID
+	// TODO Change to (OldInputs, OldState, NewInputs)
+	OldInputs, OldOutputs, NewInputs resource.PropertyMap
+	AllowUnknowns                    bool
+	IgnoreChanges                    []string
+}
+
+type DiffResponse = DiffResult
+
+type CreateRequest struct {
+	URN        resource.URN
+	Properties resource.PropertyMap
+	Timeout    float64
+	Preview    bool
+}
+
+type CreateResponse struct {
+	ID         resource.ID
+	Properties resource.PropertyMap
+	Status     resource.Status
+}
+
+type ReadRequest struct {
+	URN           resource.URN
+	ID            resource.ID
+	Inputs, State resource.PropertyMap
+}
+
+type ReadResponse struct {
+	ReadResult
+	Status resource.Status
+}
+
+type UpdateRequest struct {
+	URN                              resource.URN
+	ID                               resource.ID
+	OldInputs, OldOutputs, NewInputs resource.PropertyMap
+	Timeout                          float64
+	IgnoreChanges                    []string
+	Preview                          bool
+}
+
+type UpdateResponse struct {
+	Properties resource.PropertyMap
+	Status     resource.Status
+}
+
+type DeleteRequest struct {
+	URN             resource.URN
+	ID              resource.ID
+	Inputs, Outputs resource.PropertyMap
+	Timeout         float64
+}
+
+type DeleteResponse struct {
+	Status resource.Status
+}
+
+type ConstructRequest struct {
+	Info    ConstructInfo
+	Type    tokens.Type
+	Name    string
+	Parent  resource.URN
+	Inputs  resource.PropertyMap
+	Options ConstructOptions
+}
+
+type ConstructResponse = ConstructResult
+
+type InvokeRequest struct {
+	Tok  tokens.ModuleMember
+	Args resource.PropertyMap
+}
+
+type InvokeResponse struct {
+	Properties resource.PropertyMap
+	Failures   []CheckFailure
+}
+
+type StreamInvokeRequest struct {
+	Tok    tokens.ModuleMember
+	Args   resource.PropertyMap
+	OnNext func(resource.PropertyMap) error
+}
+
+type StreamInvokeResponse struct {
+	Failures []CheckFailure
+}
+
+type CallRequest struct {
+	Tok     tokens.ModuleMember
+	Args    resource.PropertyMap
+	Info    CallInfo
+	Options CallOptions
+}
+
+type CallResponse = CallResult
+
+type GetMappingRequest struct {
+	Key, Provider string
+}
+
+type GetMappingResponse struct {
+	Data     []byte
+	Provider string
+}
+
+type GetMappingsRequest struct {
+	Key string
+}
+
+type GetMappingsResponse struct {
+	Keys []string
+}
+
 // Provider presents a simple interface for orchestrating resource create, read, update, and delete operations.  Each
 // provider understands how to handle all of the resource types within a single package.
 //
@@ -101,77 +261,63 @@ type Provider interface {
 	Pkg() tokens.Package
 
 	// Parameterize adds a sub-package to this provider instance.
-	Parameterize(ctx context.Context, request ParameterizeRequest) (ParameterizeResponse, error)
+	Parameterize(context.Context, ParameterizeRequest) (ParameterizeResponse, error)
 
 	// GetSchema returns the schema for the provider.
-	GetSchema(request GetSchemaRequest) ([]byte, error)
+	GetSchema(context.Context, GetSchemaRequest) (GetSchemaResponse, error)
 
 	// CheckConfig validates the configuration for this resource provider.
-	CheckConfig(urn resource.URN, olds, news resource.PropertyMap,
-		allowUnknowns bool) (resource.PropertyMap, []CheckFailure, error)
+	CheckConfig(context.Context, CheckConfigRequest) (CheckConfigResponse, error)
 	// DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-	DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap, allowUnknowns bool,
-		ignoreChanges []string) (DiffResult, error)
+	DiffConfig(context.Context, DiffConfigRequest) (DiffConfigResponse, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
-	Configure(inputs resource.PropertyMap) error
+	Configure(context.Context, ConfigureRequest) (ConfigureResponse, error)
 
 	// Check validates that the given property bag is valid for a resource of the given type and returns the inputs
 	// that should be passed to successive calls to Diff, Create, or Update for this resource.
-	Check(urn resource.URN, olds, news resource.PropertyMap,
-		allowUnknowns bool, randomSeed []byte) (resource.PropertyMap, []CheckFailure, error)
+	Check(context.Context, CheckRequest) (CheckResponse, error)
 	// Diff checks what impacts a hypothetical update will have on the resource's properties.
-	Diff(urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap,
-		allowUnknowns bool, ignoreChanges []string) (DiffResult, error)
+	Diff(context.Context, DiffRequest) (DiffResponse, error)
 	// Create allocates a new instance of the provided resource and returns its unique resource.ID.
-	Create(urn resource.URN, news resource.PropertyMap, timeout float64, preview bool) (resource.ID,
-		resource.PropertyMap, resource.Status, error)
+	Create(context.Context, CreateRequest) (CreateResponse, error)
 	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
 	// identify the resource; this is typically just the resource ID, but may also include some properties.  If the
 	// resource is missing (for instance, because it has been deleted), the resulting property map will be nil.
-	Read(urn resource.URN, id resource.ID,
-		inputs, state resource.PropertyMap) (ReadResult, resource.Status, error)
+	Read(context.Context, ReadRequest) (ReadResponse, error)
 	// Update updates an existing resource with new values.
-	Update(urn resource.URN, id resource.ID,
-		oldInputs, oldOutputs, newInputs resource.PropertyMap, timeout float64,
-		ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, error)
+	Update(context.Context, UpdateRequest) (UpdateResponse, error)
 	// Delete tears down an existing resource. The inputs and outputs are the last recorded ones from state.
-	Delete(urn resource.URN, id resource.ID,
-		inputs, outputs resource.PropertyMap, timeout float64) (resource.Status, error)
+	Delete(context.Context, DeleteRequest) (DeleteResponse, error)
 
 	// Construct creates a new component resource.
-	Construct(info ConstructInfo, typ tokens.Type, name string, parent resource.URN, inputs resource.PropertyMap,
-		options ConstructOptions) (ConstructResult, error)
+	Construct(context.Context, ConstructRequest) (ConstructResponse, error)
 
 	// Invoke dynamically executes a built-in function in the provider.
-	Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
+	Invoke(context.Context, InvokeRequest) (InvokeResponse, error)
 	// StreamInvoke dynamically executes a built-in function in the provider, which returns a stream
 	// of responses.
-	StreamInvoke(
-		tok tokens.ModuleMember,
-		args resource.PropertyMap,
-		onNext func(resource.PropertyMap) error) ([]CheckFailure, error)
+	StreamInvoke(context.Context, StreamInvokeRequest) (StreamInvokeResponse, error)
 	// Call dynamically executes a method in the provider associated with a component resource.
-	Call(tok tokens.ModuleMember, args resource.PropertyMap, info CallInfo,
-		options CallOptions) (CallResult, error)
+	Call(context.Context, CallRequest) (CallResponse, error)
 
 	// GetPluginInfo returns this plugin's information.
-	GetPluginInfo() (workspace.PluginInfo, error)
+	GetPluginInfo(context.Context) (workspace.PluginInfo, error)
 
 	// SignalCancellation asks all resource providers to gracefully shut down and abort any ongoing
 	// operations. Operation aborted in this way will return an error (e.g., `Update` and `Create`
 	// will either a creation error or an initialization error. SignalCancellation is advisory and
 	// non-blocking; it is up to the host to decide how long to wait after SignalCancellation is
 	// called before (e.g.) hard-closing any gRPC connection.
-	SignalCancellation() error
+	SignalCancellation(context.Context) error
 
 	// GetMapping returns the mapping (if any) for the provider. A provider should return an empty response
 	// (not an error) if it doesn't have a mapping for the given key.
-	GetMapping(key string, provider string) ([]byte, string, error)
+	GetMapping(context.Context, GetMappingRequest) (GetMappingResponse, error)
 
 	// GetMappings returns the mappings (if any) for the providers. A provider should return an empty list (not an
 	// error) if it doesn't have any mappings for the given key.
 	// If a provider implements this method GetMapping will be called using the results from this method.
-	GetMappings(key string) ([]string, error)
+	GetMappings(context.Context, GetMappingsRequest) (GetMappingsResponse, error)
 
 	// mustEmbed *requires* that implementers make an explicit choice about forward compatibility.
 	//

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -53,23 +53,23 @@ type stubProvider struct {
 	ConfigureFunc func(resource.PropertyMap) error
 }
 
-func (p *stubProvider) Configure(inputs resource.PropertyMap) error {
+func (p *stubProvider) Configure(ctx context.Context, req ConfigureRequest) (ConfigureResponse, error) {
 	if p.ConfigureFunc != nil {
-		return p.ConfigureFunc(inputs)
+		err := p.ConfigureFunc(req.Inputs)
+		return ConfigureResponse{}, err
 	}
-	return p.Provider.Configure(inputs)
+	return p.Provider.Configure(ctx, req)
 }
 
-func (p *stubProvider) Read(
-	urn resource.URN,
-	id resource.ID,
-	inputs,
-	state resource.PropertyMap,
-) (ReadResult, resource.Status, error) {
+func (p *stubProvider) Read(ctx context.Context, req ReadRequest) (ReadResponse, error) {
 	if p.ReadFunc != nil {
-		return p.ReadFunc(urn, id, inputs, state)
+		props, status, err := p.ReadFunc(req.URN, req.ID, req.Inputs, req.State)
+		return ReadResponse{
+			ReadResult: props,
+			Status:     status,
+		}, err
 	}
-	return p.Provider.Read(urn, id, inputs, state)
+	return p.Provider.Read(ctx, req)
 }
 
 // When importing random passwords, the secret passed as "ID" should not leak in plain text into the final ID.

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:lll
 package plugin
 
 import (
 	"context"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"google.golang.org/grpc/codes"
@@ -42,7 +40,7 @@ func (p *UnimplementedProvider) Close() error {
 	return status.Error(codes.Unimplemented, "Close is not yet implemented")
 }
 
-func (p *UnimplementedProvider) SignalCancellation() error {
+func (p *UnimplementedProvider) SignalCancellation(context.Context) error {
 	return status.Error(codes.Unimplemented, "SignalCancellation is not yet implemented")
 }
 
@@ -54,73 +52,74 @@ func (p *UnimplementedProvider) Parameterize(context.Context, ParameterizeReques
 	return ParameterizeResponse{}, status.Error(codes.Unimplemented, "Parameterize is not yet implemented")
 }
 
-func (p *UnimplementedProvider) GetSchema(GetSchemaRequest) ([]byte, error) {
-	return nil, status.Error(codes.Unimplemented, "GetSchema is not yet implemented")
+func (p *UnimplementedProvider) GetSchema(context.Context, GetSchemaRequest) (GetSchemaResponse, error) {
+	return GetSchemaResponse{}, status.Error(codes.Unimplemented, "GetSchema is not yet implemented")
 }
 
-func (p *UnimplementedProvider) CheckConfig(urn resource.URN, olds resource.PropertyMap, news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []CheckFailure, error) {
-	return resource.PropertyMap{}, nil, status.Error(codes.Unimplemented, "CheckConfig is not yet implemented")
+func (p *UnimplementedProvider) CheckConfig(context.Context, CheckConfigRequest) (CheckConfigResponse, error) {
+	return CheckConfigResponse{}, status.Error(codes.Unimplemented, "CheckConfig is not yet implemented")
 }
 
-func (p *UnimplementedProvider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (DiffResult, error) {
+func (p *UnimplementedProvider) DiffConfig(context.Context, DiffConfigRequest) (DiffConfigResponse, error) {
 	return DiffResult{}, status.Error(codes.Unimplemented, "DiffConfig is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Configure(inputs resource.PropertyMap) error {
-	return status.Error(codes.Unimplemented, "Configure is not yet implemented")
+func (p *UnimplementedProvider) Configure(context.Context, ConfigureRequest) (ConfigureResponse, error) {
+	return ConfigureResponse{}, status.Error(codes.Unimplemented, "Configure is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Check(urn resource.URN, olds resource.PropertyMap, news resource.PropertyMap, allowUnknowns bool, randomSeed []byte) (resource.PropertyMap, []CheckFailure, error) {
-	return resource.PropertyMap{}, nil, status.Error(codes.Unimplemented, "Check is not yet implemented")
+func (p *UnimplementedProvider) Check(context.Context, CheckRequest) (CheckResponse, error) {
+	return CheckResponse{}, status.Error(codes.Unimplemented, "Check is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Diff(urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (DiffResult, error) {
-	return DiffResult{}, status.Error(codes.Unimplemented, "Diff is not yet implemented")
+func (p *UnimplementedProvider) Diff(context.Context, DiffRequest) (DiffResponse, error) {
+	return DiffResponse{}, status.Error(codes.Unimplemented, "Diff is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Create(urn resource.URN, news resource.PropertyMap, timeout float64, preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
-	return resource.ID(""), resource.PropertyMap{}, resource.StatusUnknown, status.Error(codes.Unimplemented, "Create is not yet implemented")
+func (p *UnimplementedProvider) Create(context.Context, CreateRequest) (CreateResponse, error) {
+	return CreateResponse{}, status.Error(codes.Unimplemented, "Create is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Read(urn resource.URN, id resource.ID, inputs resource.PropertyMap, state resource.PropertyMap) (ReadResult, resource.Status, error) {
-	return ReadResult{}, resource.StatusUnknown, status.Error(codes.Unimplemented, "Read is not yet implemented")
+func (p *UnimplementedProvider) Read(context.Context, ReadRequest) (ReadResponse, error) {
+	return ReadResponse{}, status.Error(codes.Unimplemented, "Read is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Update(urn resource.URN, id resource.ID, oldInputs, oldOutputs, newInputs resource.PropertyMap, timeout float64, ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, error) {
-	return resource.PropertyMap{}, resource.StatusUnknown, status.Error(codes.Unimplemented, "Update is not yet implemented")
+func (p *UnimplementedProvider) Update(context.Context, UpdateRequest) (UpdateResponse, error) {
+	return UpdateResponse{}, status.Error(codes.Unimplemented, "Update is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Delete(urn resource.URN, id resource.ID, oldInputs, oldOutputs resource.PropertyMap, timeout float64) (resource.Status, error) {
-	return resource.StatusUnknown, status.Error(codes.Unimplemented, "Delete is not yet implemented")
+func (p *UnimplementedProvider) Delete(context.Context, DeleteRequest) (DeleteResponse, error) {
+	return DeleteResponse{}, status.Error(codes.Unimplemented, "Delete is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Construct(info ConstructInfo, typ tokens.Type, name string, parent resource.URN, inputs resource.PropertyMap, options ConstructOptions) (ConstructResult, error) {
-	return ConstructResult{}, status.Error(codes.Unimplemented, "Construct is not yet implemented")
+func (p *UnimplementedProvider) Construct(context.Context, ConstructRequest) (ConstructResponse, error) {
+	return ConstructResponse{}, status.Error(codes.Unimplemented, "Construct is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error) {
-	return resource.PropertyMap{}, nil, status.Error(codes.Unimplemented, "Invoke is not yet implemented")
+func (p *UnimplementedProvider) Invoke(context.Context, InvokeRequest) (InvokeResponse, error) {
+	return InvokeResponse{}, status.Error(codes.Unimplemented, "Invoke is not yet implemented")
 }
 
-func (p *UnimplementedProvider) StreamInvoke(tok tokens.ModuleMember, args resource.PropertyMap, onNext func(resource.PropertyMap) error) ([]CheckFailure, error) {
-	return nil, status.Error(codes.Unimplemented, "StreamInvoke is not yet implemented")
+func (p *UnimplementedProvider) StreamInvoke(context.Context, StreamInvokeRequest) (StreamInvokeResponse, error) {
+	return StreamInvokeResponse{}, status.Error(codes.Unimplemented, "StreamInvoke is not yet implemented")
 }
 
-func (p *UnimplementedProvider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info CallInfo, options CallOptions) (CallResult, error) {
-	return CallResult{}, status.Error(codes.Unimplemented, "Call is not yet implemented")
+func (p *UnimplementedProvider) Call(context.Context, CallRequest) (CallResponse, error) {
+	return CallResponse{}, status.Error(codes.Unimplemented, "Call is not yet implemented")
 }
 
-func (p *UnimplementedProvider) GetPluginInfo() (workspace.PluginInfo, error) {
+func (p *UnimplementedProvider) GetPluginInfo(context.Context) (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{}, status.Error(codes.Unimplemented, "GetPluginInfo is not yet implemented")
 }
 
-func (p *UnimplementedProvider) GetMapping(key, provider string) ([]byte, string, error) {
-	return nil, "", status.Error(codes.Unimplemented, "GetMapping is not yet implemented")
+func (p *UnimplementedProvider) GetMapping(context.Context, GetMappingRequest) (GetMappingResponse, error) {
+	return GetMappingResponse{}, status.Error(codes.Unimplemented, "GetMapping is not yet implemented")
 }
 
-func (p *UnimplementedProvider) GetMappings(key string) ([]string, error) {
-	return nil, status.Error(codes.Unimplemented, "GetMappings is not yet implemented")
+func (p *UnimplementedProvider) GetMappings(context.Context, GetMappingsRequest) (GetMappingsResponse, error) {
+	return GetMappingsResponse{}, status.Error(codes.Unimplemented, "GetMappings is not yet implemented")
 }
 
-func (p NotForwardCompatibleProvider) mustEmbedAForwardCompatibilityOption(UnimplementedProvider, NotForwardCompatibleProvider) {
+func (p NotForwardCompatibleProvider) mustEmbedAForwardCompatibilityOption(
+	UnimplementedProvider, NotForwardCompatibleProvider) {
 }


### PR DESCRIPTION
Normalize methods on plugin.Provider to the form:

```go
Method(context.Context, MethodRequest) (MethodResponse, error)
```

This provides a more consistent and forwards compatible interface for each of our methods.

---

I'm motivated to work on this because the bridge maintains a copy of this interface: `ProviderWithContext`. This doubles the pain of dealing with any breaking change and this PR would allow me to remove the extra interface. I'm willing to fix consumers of `plugin.Provider` in `pulumi/pulumi`, but I wanted to make sure that we would be willing to merge this PR if I get it green.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
