### PR TITLE
Pending replace fix

### DIFF
--- a/changelog/pending/20240602--engine--fix-creation-of-resource-when-set-to-pendingreplacement-true.yaml
+++ b/changelog/pending/20240602--engine--fix-creation-of-resource-when-set-to-pendingreplacement-true.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix creation of resource when set to pendingReplacement=true

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1157,8 +1157,8 @@ func (sg *stepGenerator) generateStepsFromDiff(
 	}
 
 	// If there were changes check for a replacement vs. an in-place update.
-	if diff.Changes == plugin.DiffSome {
-		if diff.Replace() {
+	if diff.Changes == plugin.DiffSome || old.PendingReplacement {
+		if diff.Replace() || old.PendingReplacement {
 			// If this resource is protected we can't replace it because that entails a delete
 			// Note that we do allow unprotecting and replacing to happen in a single update
 			// cycle, we don't look at old.Protect here.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1305,8 +1305,14 @@ func (sg *stepGenerator) generateStepsFromDiff(
 					return nil, fmt.Errorf("could not load provider for resource %v: %w", old.URN, err)
 				}
 
+				var deleteStep Step
+				if old.PendingReplacement {
+					deleteStep = NewRemovePendingReplaceStep(sg.deployment, old)
+				} else {
+					deleteStep = NewDeleteReplacementStep(sg.deployment, sg.deletes, old, true)
+				}
 				return append(steps,
-					NewDeleteReplacementStep(sg.deployment, sg.deletes, old, true),
+					deleteStep,
 					NewReplaceStep(sg.deployment, old, new, diff.ReplaceKeys, diff.ChangedKeys, diff.DetailedDiff, false),
 					NewCreateReplacementStep(
 						sg.deployment, event, old, new, diff.ReplaceKeys, diff.ChangedKeys, diff.DetailedDiff, false),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

Before this fix, when a resource has `pendingReplacement: true`, pulumi attempts a delete-then-create. This fails because the resource does not exist in the provider. From the [docs](https://pulumi-developer-docs.readthedocs.io/en/latest/architecture/deployment-schema.html#pendingreplacement): "Tracks delete-before-replace resources that have been deleted but not yet recreated."

There are 2 fixes in this PR:
1. Updates the plan so that when `pendingReplacement` is set, the resource will not first be deleted.
2. When `pendingReplacement`, we need to create the resource even if there is no "diff" from the state, and it is always a replace rather than an update

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16288

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
