### PR TITLE
Improve error handling when downloading policy packs

### DIFF
--- a/changelog/pending/20240603--backend-service--improve-error-reporting-when-policy-pack-download-fails.yaml
+++ b/changelog/pending/20240603--backend-service--improve-error-reporting-when-policy-pack-download-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: Improve error reporting when policy pack download fails

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -952,6 +952,10 @@ func (pc *Client) DownloadPolicyPack(ctx context.Context, url string) (io.ReadCl
 		return nil, fmt.Errorf("Failed to download compressed PolicyPack: %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Failed to download compressed PolicyPack: %s", resp.Status)
+	}
+
 	return resp.Body, nil
 }
 


### PR DESCRIPTION
The HTTP client in Go only returns an error if there is a protocol level failure, or an error caused by client policy (which we don't use).  However the policy pack can fail to be downloaded, and return a non 200 HTTP status.  This should still be considered an error.

Currently we would only detect this when trying to unpack the policy pack.  Catching and returning this error earlier allows us to give better information about the failure to the user.

I got curious about https://github.com/pulumi/pulumi/issues/16275, and did a short dive into the code.  It looks like this should give us a better error message there.