### PR TITLE
Fix documentation comments in the NodeJS SDK

### DIFF
--- a/sdk/nodejs/automation/events.ts
+++ b/sdk/nodejs/automation/events.ts
@@ -15,21 +15,27 @@
 // NOTE: The interfaces in this file are intended to align with the serialized
 // JSON types defined and versioned in sdk/go/common/apitype/events.go
 
-// CancelEvent is emitted when the user initiates a cancellation of the update in progress, or
-// the update successfully completes.
 import { OpMap, OpType } from "./stack";
 
+/**
+ * CancelEvent is emitted when the user initiates a cancellation of the update in progress, or
+ * the update successfully completes.
+ */
 export type CancelEvent = {};
 
-// StdoutEngineEvent is emitted whenever a generic message is written, for example warnings
-// from the pulumi CLI itself. Less common than DiagnosticEvent
+/**
+ * StdoutEngineEvent is emitted whenever a generic message is written, for example warnings
+ * from the pulumi CLI itself. Less common than DiagnosticEvent
+ */
 export interface StdoutEngineEvent {
     message: string;
     color: string;
 }
 
-// DiagnosticEvent is emitted whenever a diagnostic message is provided, for example errors from
-// a cloud resource provider while trying to create or update a resource.
+/**
+ * DiagnosticEvent is emitted whenever a diagnostic message is provided, for example errors from
+ * a cloud resource provider while trying to create or update a resource.
+ */
 export interface DiagnosticEvent {
     urn?: string;
     prefix?: string;
@@ -40,7 +46,9 @@ export interface DiagnosticEvent {
     ephemeral?: boolean;
 }
 
-// PolicyEvent is emitted whenever there is a Policy violation.
+/**
+ * PolicyEvent is emitted whenever there is a Policy violation.
+ */
 export interface PolicyEvent {
     resourceUrn?: string;
     message: string;
@@ -52,141 +60,225 @@ export interface PolicyEvent {
     enforcementLevel: "warning" | "mandatory";
 }
 
-// PreludeEvent is emitted at the start of an update.
+/**
+ * PreludeEvent is emitted at the start of an update.
+ */
 export interface PreludeEvent {
-    // config contains the keys and values for the update.
-    // Encrypted configuration values may be blinded.
+    /**
+     * config contains the keys and values for the update.
+     * Encrypted configuration values may be blinded.
+     */
     config: Record<string, string>;
 }
 
-// SummaryEvent is emitted at the end of an update, with a summary of the changes made.
+/**
+ * SummaryEvent is emitted at the end of an update, with a summary of the changes made.
+ */
 export interface SummaryEvent {
-    // maybeCorrupt is set if one or more of the resources is in an invalid state.
+    /**
+     * maybeCorrupt is set if one or more of the resources is in an invalid state.
+     */
     maybeCorrupt: boolean;
-    // duration is the number of seconds the update was executing.
+    /**
+     * duration is the number of seconds the update was executing.
+     */
     durationSeconds: number;
-    // resourceChanges contains the count for resource change by type. The keys are deploy.StepOp,
-    // which is not exported in this package.
+    /**
+     * resourceChanges contains the count for resource change by type. The keys are deploy.StepOp,
+     * which is not exported in this package.
+     */
     resourceChanges: OpMap;
-    // policyPacks run during update. Maps PolicyPackName -> version.
-    // Note: When this field was initially added, we forgot to add the JSON tag
-    // and are now locked into using PascalCase for this field to maintain backwards
-    // compatibility. For older clients this will map to the version, while for newer ones
-    // it will be the version tag prepended with "v".
+    /**
+     * policyPacks run during update. Maps PolicyPackName -> version.
+     * Note: When this field was initially added, we forgot to add the JSON tag
+     * and are now locked into using PascalCase for this field to maintain backwards
+     * compatibility. For older clients this will map to the version, while for newer ones
+     * it will be the version tag prepended with "v".
+     */
     policyPacks: Record<string, string>;
 }
 
 export enum DiffKind {
-    // add indicates that the property was added.
+    /**
+     * add indicates that the property was added.
+     */
     add = "add",
-    // addReplace indicates that the property was added and requires that the resource be replaced.
+    /**
+     * addReplace indicates that the property was added and requires that the resource be replaced.
+     */
     addReplace = "add-replace",
-    // delete indicates that the property was deleted.
+    /**
+     * delete indicates that the property was deleted.
+     */
     delete = "delete",
-    // deleteReplace indicates that the property was deleted and requires that the resource be replaced.
+    /**
+     * deleteReplace indicates that the property was deleted and requires that the resource be replaced.
+     */
     deleteReplace = "delete-replace",
-    // update indicates that the property was updated.
+    /**
+     * update indicates that the property was updated.
+     */
     update = "update",
-    // updateReplace indicates that the property was updated and requires that the resource be replaced.
+    /**
+     * updateReplace indicates that the property was updated and requires that the resource be replaced.
+     */
     updateReplace = "update-replace",
 }
 
-// PropertyDiff describes the difference between a single property's old and new values.
+/**
+ * PropertyDiff describes the difference between a single property's old and new values.
+ */
 export interface PropertyDiff {
-    // diffKind is the kind of difference.
+    /**
+     * diffKind is the kind of difference.
+     */
     diffKind: DiffKind;
-    // inputDiff is true if this is a difference between old and new inputs rather than old state and new inputs.
+    /**
+     * inputDiff is true if this is a difference between old and new inputs rather than old state and new inputs.
+     */
     inputDiff: boolean;
 }
 
-// StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
-// to migrate a set of cloud resources from one state to another.
+/**
+ * StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
+ * to migrate a set of cloud resources from one state to another.
+ */
 export interface StepEventMetadata {
-    // Op is the operation being performed.
+    /**
+     * Op is the operation being performed.
+     */
     op: OpType;
     urn: string;
     type: string;
 
-    // Old is the state of the resource before performing the step.
+    /**
+     * Old is the state of the resource before performing the step.
+     */
     old?: StepEventStateMetadata;
-    // New is the state of the resource after performing the step.
+    /**
+     * New is the state of the resource after performing the step.
+     */
     new?: StepEventStateMetadata;
 
-    // Keys causing a replacement (only applicable for "create" and "replace" Ops).
+    /**
+     * Keys causing a replacement (only applicable for "create" and "replace" Ops).
+     */
     keys?: string[];
-    // Keys that changed with this step.
+    /**
+     * Keys that changed with this step.
+     */
     diffs?: string[];
-    // The diff for this step as a list of property paths and difference types.
+    /**
+     * The diff for this step as a list of property paths and difference types.
+     */
     detailedDiff?: Record<string, PropertyDiff>;
-    // Logical is set if the step is a logical operation in the program.
+    /**
+     * Logical is set if the step is a logical operation in the program.
+     */
     logical?: boolean;
-    // Provider actually performing the step.
+    /**
+     * Provider actually performing the step.
+     */
     provider: string;
 }
 
-// StepEventStateMetadata is the more detailed state information for a resource as it relates to
-// a step(s) being performed.
+/**
+ * StepEventStateMetadata is the more detailed state information for a resource as it relates to
+ * a step(s) being performed.
+ */
 export interface StepEventStateMetadata {
     type: string;
     urn: string;
 
-    // Custom indicates if the resource is managed by a plugin.
+    /**
+     * Custom indicates if the resource is managed by a plugin.
+     */
     custom?: boolean;
-    // Delete is true when the resource is pending deletion due to a replacement.
+    /**
+     * Delete is true when the resource is pending deletion due to a replacement.
+     */
     delete?: boolean;
-    // ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
+    /**
+     * ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
+     */
     id: string;
-    // Parent is an optional parent URN that this resource belongs to.
+    /**
+     * Parent is an optional parent URN that this resource belongs to.
+     */
     parent: string;
-    // Protect is true to "protect" this resource (protected resources cannot be deleted).
+    /**
+     * Protect is true to "protect" this resource (protected resources cannot be deleted).
+     */
     protect?: boolean;
-    // RetainOnDelete is true if the resource is not physically deleted when it is logically deleted.
+    /**
+     * RetainOnDelete is true if the resource is not physically deleted when it is logically deleted.
+     */
     retainOnDelete?: boolean;
-    // Inputs contains the resource's input properties (as specified by the program). Secrets have
-    // filtered out, and large assets have been replaced by hashes as applicable.
+    /**
+     * Inputs contains the resource's input properties (as specified by the program). Secrets have
+     * filtered out, and large assets have been replaced by hashes as applicable.
+     */
     inputs: Record<string, any>;
-    // Outputs contains the resource's complete output state (as returned by the resource provider).
+    /**
+     * Outputs contains the resource's complete output state (as returned by the resource provider).
+     */
     outputs: Record<string, any>;
-    // Provider is the resource's provider reference
+    /**
+     * Provider is the resource's provider reference
+     */
     provider: string;
-    // InitErrors is the set of errors encountered in the process of initializing resource.
+    /**
+     * InitErrors is the set of errors encountered in the process of initializing resource.
+     */
     initErrors?: string[];
 }
 
-// ResourcePreEvent is emitted before a resource is modified.
+/**
+ * ResourcePreEvent is emitted before a resource is modified.
+ */
 export interface ResourcePreEvent {
     metadata: StepEventMetadata;
     planning?: boolean;
 }
 
-// ResOutputsEvent is emitted when a resource is finished being provisioned.
+/**
+ * ResOutputsEvent is emitted when a resource is finished being provisioned.
+ */
 export interface ResOutputsEvent {
     metadata: StepEventMetadata;
     planning?: boolean;
 }
 
-// ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is
-// emitted before this event, indicating the root cause of the error.
+/**
+ * ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is
+ * emitted before this event, indicating the root cause of the error.
+ */
 export interface ResOpFailedEvent {
     metadata: StepEventMetadata;
     status: number;
     steps: number;
 }
 
-// EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
-// message. EngineEvent is a discriminated union of all possible event types, and exactly one
-// field will be non-nil.
+/**
+ * EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
+ * message. EngineEvent is a discriminated union of all possible event types, and exactly one
+ * field will be non-nil.
+ */
 export interface EngineEvent {
-    // Sequence is a unique, and monotonically increasing number for each engine event sent to the
-    // Pulumi Service. Since events may be sent concurrently, and/or delayed via network routing,
-    // the sequence number is to ensure events can be placed into a total ordering.
-    //
-    // - No two events can have the same sequence number.
-    // - Events with a lower sequence number must have been emitted before those with a higher
-    //   sequence number.
+    /**
+     * Sequence is a unique, and monotonically increasing number for each engine event sent to the
+     * Pulumi Service. Since events may be sent concurrently, and/or delayed via network routing,
+     * the sequence number is to ensure events can be placed into a total ordering.
+     *
+     * - No two events can have the same sequence number.
+     * - Events with a lower sequence number must have been emitted before those with a higher
+     *   sequence number.
+     */
     sequence: number;
 
-    // Timestamp is a Unix timestamp (seconds) of when the event was emitted.
+    /**
+     * Timestamp is a Unix timestamp (seconds) of when the event was emitted.
+     */
     timestamp: number;
 
     cancelEvent?: CancelEvent;

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -406,29 +406,35 @@ async function applyHelperAsync<T, U>(
     return liftInnerOutput(allResources, transformed, /*isKnown*/ true, isSecret);
 }
 
-// Returns an promise denoting if the output is a secret or not. This is not the same as just calling `.isSecret`
-// because in cases where the output does not have a `isSecret` property and it is a Proxy, we need to ignore
-// the isSecret member that the proxy reports back.
-// This calls the public implementation so that we only make any calculations in a single place.
-/** @internal */
+/**
+ * Returns a promise denoting if the output is a secret or not. This is not the same as just calling `.isSecret`
+ * because in cases where the output does not have a `isSecret` property and it is a Proxy, we need to ignore
+ * the isSecret member that the proxy reports back.
+ *
+ * This calls the public implementation so that we only make any calculations in a single place.
+ *
+ * @internal
+ */
 export function isSecretOutput<T>(o: Output<T>): Promise<boolean> {
     return isSecret(o);
 }
 
-// Helper function for `output`.  This function trivially recurses through an object, copying it,
-// while also lifting any inner Outputs (with all their respective state) to a top-level Output at
-// the end.  If there are no inner outputs, this will not affect the data (except by producing a new
-// copy of it).
-//
-// Importantly:
-//
-//  1. Resources encountered while recursing are not touched.  This helps ensure they stay Resources
-//     (with an appropriate prototype chain).
-//  2. Primitive values (string, number, etc.) are returned as is.
-//  3. Arrays and Record are recursed into.  An Array<...> that contains any Outputs wil become an
-//     Output<Array<Unwrapped>>.  A Record<string, ...> that contains any Output values will be an
-//     Output<Record<string, Unwrap<...>>.  In both cases of recursion, the outer Output's
-//     known/secret/resources will be computed from the nested Outputs.
+/**
+ * Helper function for `output`.  This function trivially recurses through an object, copying it,
+ * while also lifting any inner Outputs (with all their respective state) to a top-level Output at
+ * the end.  If there are no inner outputs, this will not affect the data (except by producing a new
+ * copy of it).
+ *
+ * Importantly:
+ *
+ *  1. Resources encountered while recursing are not touched.  This helps ensure they stay Resources
+ *     (with an appropriate prototype chain).
+ *  2. Primitive values (string, number, etc.) are returned as is.
+ *  3. Arrays and Record are recursed into.  An Array<...> that contains any Outputs wil become an
+ *     Output<Array<Unwrapped>>.  A Record<string, ...> that contains any Output values will be an
+ *     Output<Record<string, Unwrap<...>>.  In both cases of recursion, the outer Output's
+ *     known/secret/resources will be computed from the nested Outputs.
+ */
 function outputRec(val: any): any {
     if (val === null || typeof val !== "object") {
         // strings, numbers, booleans, functions, symbols, undefineds, nulls are all returned as
@@ -577,6 +583,9 @@ export function unsecret<T>(val: Output<T>): Output<T> {
     );
 }
 
+/**
+ * [isSecret] returns `true` if and only if the provided [Output] is a secret.
+ */
 export function isSecret<T>(val: Output<T>): Promise<boolean> {
     return Output.isInstance(val.isSecret) ? Promise.resolve(false) : val.isSecret;
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -65,9 +65,11 @@ export function createUrn(
     return interpolate`${parentPrefix}${type}::${name}`;
 }
 
-// inheritedChildAlias computes the alias that should be applied to a child based on an alias applied to it's parent.
-// This may involve changing the name of the resource in cases where the resource has a named derived from the name of
-// the parent, and the parent name changed.
+/**
+ * inheritedChildAlias computes the alias that should be applied to a child based on an alias applied to it's parent.
+ * This may involve changing the name of the resource in cases where the resource has a named derived from the name of
+ * the parent, and the parent name changed.
+ */
 function inheritedChildAlias(
     childName: string,
     parentName: string,
@@ -96,7 +98,9 @@ function inheritedChildAlias(
     return createUrn(aliasName, childType, parentAlias);
 }
 
-// Extract the type and name parts of a URN
+/**
+ * Extracts the type and name from a URN.
+ */
 function urnTypeAndName(urn: URN) {
     const parts = urn.split("::");
     const typeParts = parts[2].split("$");
@@ -106,9 +110,12 @@ function urnTypeAndName(urn: URN) {
     };
 }
 
-// Make a copy of the aliases array, and add to it any implicit aliases inherited from its parent.
-// If there are N child aliases, and M parent aliases, there will be (M+1)*(N+1)-1 total aliases,
-// or, as calculated in the logic below, N+(M*(1+N)).
+/**
+ * allAliases computes the full set of aliases for a child resource given a set of aliases applied to the child and
+ * parent resources. This includes the child resource's own aliases, as well as aliases inherited from the parent.
+ * If there are N child aliases, and M parent aliases, there will be (M+1)*(N+1)-1 total aliases,
+ * or, as calculated in the logic below, N+(M*(1+N)).
+ */
 export function allAliases(
     childAliases: Input<URN | Alias>[],
     childName: string,
@@ -293,26 +300,28 @@ export abstract class Resource {
         return utils.isInstance<Resource>(obj, "__pulumiResource");
     }
 
-    // sourcePosition returns the source position of the user code that instantiated this resource.
-    //
-    // This is somewhat brittle in that it expects a call stack of the form:
-    // - Resource class constructor
-    // - abstract Resource subclass constructor
-    // - concrete Resource subclass constructor
-    // - user code
-    //
-    // This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
-    //
-    // For example, consider the AWS S3 Bucket resource. When user code instantiates a Bucket, the stack will look like
-    // this:
-    //
-    //     new Resource (/path/to/resource.ts:123:45)
-    //     new CustomResource (/path/to/resource.ts:678:90)
-    //     new Bucket (/path/to/bucket.ts:987:65)
-    //     <user code> (/path/to/index.ts:4:3)
-    //
-    // Because Node can only give us the stack trace as text, we parse out the source position using a regex that
-    // matches traces of this form (see stackTraceRegExp above).
+    /**
+     * sourcePosition returns the source position of the user code that instantiated this resource.
+     *
+     * This is somewhat brittle in that it expects a call stack of the form:
+     * - Resource class constructor
+     * - abstract Resource subclass constructor
+     * - concrete Resource subclass constructor
+     * - user code
+     *
+     * This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
+     *
+     * For example, consider the AWS S3 Bucket resource. When user code instantiates a Bucket, the stack will look like
+     * this:
+     *
+     *     new Resource (/path/to/resource.ts:123:45)
+     *     new CustomResource (/path/to/resource.ts:678:90)
+     *     new Bucket (/path/to/bucket.ts:987:65)
+     *     <user code> (/path/to/index.ts:4:3)
+     *
+     * Because Node can only give us the stack trace as text, we parse out the source position using a regex that
+     * matches traces of this form (see stackTraceRegExp above).
+     */
     private static sourcePosition(): SourcePosition | undefined {
         const stackObj: any = {};
         Error.captureStackTrace(stackObj, Resource.sourcePosition);
@@ -339,7 +348,9 @@ export abstract class Resource {
         };
     }
 
-    // getProvider fetches the provider for the given module member, if any.
+    /**
+     * Returns the provider for the given module member, if one exists.
+     */
     public getProvider(moduleMember: string): ProviderResource | undefined {
         const pkg = pkgFromType(moduleMember);
         if (pkg === undefined) {
@@ -610,7 +621,10 @@ export interface Alias {
     project?: Input<string>;
 }
 
-// collapseAliasToUrn turns an Alias into a URN given a set of default data
+/**
+ * Converts an alias into a URN given a set of default data for the missing
+ * values.
+ */
 function collapseAliasToUrn(
     alias: Input<Alias | string>,
     defaultName: string,

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -56,7 +56,11 @@ export function hasFunctionMember(obj: any, memberName: string | number | symbol
 }
 
 // Workaround errors we sometimes get on some machines saying that Object.values is not available.
-/** @internal */
+/**
+ * A polyfill for Object.values
+ *
+ * @internal
+ */
 export function values(obj: object): any[] {
     const result: any[] = [];
     for (const key of Object.keys(obj)) {


### PR DESCRIPTION
This commit fixes a few errant documentation comments that use `//` instead of the recognised `/**`. This should hopefully improve documentation generation as well as hover-over documentation provided by e.g. TSServer.