### PR TITLE
Populate pulumi:template tag also for interactively selected templates

### DIFF
--- a/changelog/pending/20240603--cli-new--populate-pulumi-template-tag-also-for-interactively-selected-templates.yaml
+++ b/changelog/pending/20240603--cli-new--populate-pulumi-template-tag-also-for-interactively-selected-templates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Populate pulumi:template tag also for interactively selected templates

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -431,6 +431,7 @@ func TestInvalidTemplateName(t *testing.T) {
 		chdir(t, tempdir)
 
 		args := newArgs{
+			chooseTemplate:    chooseTemplate,
 			interactive:       false,
 			yes:               true,
 			secretsProvider:   "default",

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -1055,32 +1055,57 @@ func TestPulumiNewConflictingProject(t *testing.T) {
 //nolint:paralleltest // changes directory for process
 func TestPulumiNewSetsTemplateTag(t *testing.T) {
 	tests := []struct {
-		input    string
+		argument string
+		prompted string
 		expected string
 	}{
 		{
 			"typescript",
+			"",
 			"typescript",
 		},
 		{
 			"https://github.com/pulumi/templates/tree/master/yaml?foo=bar",
+			"",
 			"https://github.com/pulumi/templates/tree/master/yaml",
+		},
+		{
+			"",
+			"python",
+			"python",
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.input, func(t *testing.T) {
+		name := tt.argument
+		if name == "" {
+			name = tt.prompted
+		}
+		t.Run(name, func(t *testing.T) {
 			tempdir := tempProjectDir(t)
 			chdir(t, tempdir)
+			uniqueProjectName := filepath.Base(tempdir) + "test"
+
+			chooseTemplateMock := func(templates []workspace.Template, opts display.Options,
+			) (workspace.Template, error) {
+				for _, template := range templates {
+					if template.Name == tt.prompted {
+						return template, nil
+					}
+				}
+				return workspace.Template{}, errors.New("template not found")
+			}
 
 			args := newArgs{
-				interactive:       false,
+				interactive:       tt.prompted != "",
 				generateOnly:      true,
 				yes:               true,
+				templateMode:      true,
 				name:              projectName,
-				prompt:            promptForValue,
+				prompt:            promptMock(uniqueProjectName, stackName),
+				chooseTemplate:    chooseTemplateMock,
 				secretsProvider:   "default",
-				templateNameOrURL: tt.input,
+				templateNameOrURL: tt.argument,
 			}
 
 			err := runNew(context.Background(), args)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The following lines are added to `Pulumi.yaml` after a `pulumi new` command:

```yaml
config:
  pulumi:tags:
    value:
      pulumi:template: alicloud-fsharp
```

where `pulumi:template` points to a name or a URL of the template that was used for project instantiation.

The problem is that this currently works only if the template name is specified as a CLI argument, not selected interactively. This PR fixes the field population for the interactive case by using `template.Name` for the tag value, not just the input argument.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16037

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
