### PR TITLE
Autoinstall dependencies using Poetry in GetRequiredPlugins

### DIFF
--- a/changelog/pending/20240604--sdk-python--autoinstall-dependencies-using-poetry-in-getrequiredplugins.yaml
+++ b/changelog/pending/20240604--sdk-python--autoinstall-dependencies-using-poetry-in-getrequiredplugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Autoinstall dependencies using Poetry in GetRequiredPlugins

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -124,6 +124,15 @@ func (p *poetry) ValidateVenv(ctx context.Context) error {
 	return nil
 }
 
+func (p *poetry) EnsureVenv(ctx context.Context, cwd string, showOutput bool, infoWriter, errorWriter io.Writer) error {
+	_, err := p.virtualenvPath(ctx)
+	if err != nil {
+		// Couldn't get the virtualenv path, this means it does not exist. Let's create it.
+		return p.InstallDependencies(ctx, cwd, showOutput, infoWriter, errorWriter)
+	}
+	return nil
+}
+
 func (p *poetry) virtualenvPath(ctx context.Context) (string, error) {
 	pathCmd := exec.CommandContext(ctx, p.poetryExecutable, "env", "info", "--path") //nolint:gosec
 	pathCmd.Dir = p.directory

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -50,6 +50,8 @@ type Info struct {
 type Toolchain interface {
 	// InstallDependencies installs the dependencies of the project found in `cwd`.
 	InstallDependencies(ctx context.Context, cwd string, showOutput bool, infoWriter, errorWriter io.Writer) error
+	// EnsureVenv validates virtual environment of the toolchain and creates it if it doesn't exist.
+	EnsureVenv(ctx context.Context, cwd string, showOutput bool, infoWriter, errorWriter io.Writer) error
 	// ValidateVenv checks if the virtual environment of the toolchain is valid.
 	ValidateVenv(ctx context.Context) error
 	// ListPackages returns a list of Python packages installed in the toolchain.

--- a/tests/integration/python/poetry/.gitignore
+++ b/tests/integration/python/poetry/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/poetry/Pulumi.yaml
+++ b/tests/integration/python/poetry/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: pulumi-python-poetry
+description: A simple Python Pulumi program that uses Poetry.
+runtime:
+  name: python
+  options:
+    toolchain: poetry

--- a/tests/integration/python/poetry/__main__.py
+++ b/tests/integration/python/poetry/__main__.py
@@ -1,0 +1,7 @@
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+"""An example program that needs a poetry venv to run"""
+
+import pulumi
+
+pulumi.export("foo", "bar")

--- a/tests/integration/python/poetry/poetry.toml
+++ b/tests/integration/python/poetry/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+# Create the venv inside the project directory so it gets cleaned up when we remove the temp directory used for the tests.
+in-project = true

--- a/tests/integration/python/poetry/pyproject.toml
+++ b/tests/integration/python/poetry/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "pulumi-python-poetry"
+description = ""
+package-mode = false
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pulumi = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Description

Refactor pip specific `prepareVirtualEnvironment` and expose functionality via Toolchain.EnsureVenv.

This makes it so that calls to `pulumi up/refresh/etc` create the poetry managed virtual env if it does not exist yet.

Stacked on top of https://github.com/pulumi/pulumi/pull/16315

Ref https://github.com/pulumi/pulumi/issues/15937

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
