### PR TITLE
avoid new issues being created when dispatched acceptance tests fail

### DIFF
--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -4,6 +4,8 @@
 #
 # Reusable workflows, "uses" jobs, *must* specify the main branch.
 
+name: dispatched-acceptance-test
+
 on:
   repository_dispatch:
     types: [run-acceptance-tests-command]


### PR DESCRIPTION
Name the CI test appropriately to make use of the skipping functionality introduced in https://github.com/pulumi/home/pull/3457.

Fixes: https://github.com/pulumi/pulumi/issues/14026