### PR TITLE
Revert "Prefer pluginDownloadURLOverrides over PluginDownloadURL specified in the package"

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -871,11 +871,6 @@ func (info *PluginInfo) SetFileMetadata(path string) error {
 
 func (spec PluginSpec) GetSource() (PluginSource, error) {
 	baseSource, err := func() (PluginSource, error) {
-		// If the plugin name matches an override, download the plugin from the override URL.
-		if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
-			return newHTTPSource(spec.Name, spec.Kind, urlMustParse(url)), nil
-		}
-
 		// The plugin has a set URL use that.
 		if spec.PluginDownloadURL != "" {
 			// Support schematised URLS if the URL has a "schema" part we recognize
@@ -894,6 +889,11 @@ func (spec PluginSpec) GetSource() (PluginSource, error) {
 			default:
 				return nil, fmt.Errorf("unknown plugin source scheme: %s", url.Scheme)
 			}
+		}
+
+		// If the plugin name matches an override, download the plugin from the override URL.
+		if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
+			return newHTTPSource(spec.Name, spec.Kind, urlMustParse(url)), nil
 		}
 
 		// Use our default fallback behaviour of github then get.pulumi.com

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -688,66 +688,6 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
 	})
-
-	t.Run("Source Override", func(t *testing.T) {
-		version := semver.MustParse("1.23.4")
-		spec := PluginSpec{
-			PluginDownloadURL: "",
-			Name:              "mock-override",
-			Version:           &version,
-			Kind:              apitype.PluginKind("resource"),
-		}
-		pluginDownloadURLOverridesParsed = []pluginDownloadURLOverride{
-			{
-				reg: regexp.MustCompile("mock-override"),
-				url: "http://mock-override.com",
-			},
-		}
-		source, err := spec.GetSource()
-		require.NoError(t, err)
-		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			assert.Equal(t,
-				"http://mock-override.com/pulumi-resource-mock-override-v1.23.4-windows-arm64.tar.gz",
-				req.URL.String())
-			return newMockReadCloser(expectedBytes)
-		}
-		r, l, err := source.Download(*spec.Version, "windows", "arm64", getHTTPResponse)
-		require.NoError(t, err)
-		readBytes, err := io.ReadAll(r)
-		require.NoError(t, err)
-		assert.Equal(t, int(l), len(readBytes))
-		assert.Equal(t, expectedBytes, readBytes)
-	})
-
-	t.Run("Source Override with Plugin Download Url", func(t *testing.T) {
-		version := semver.MustParse("1.23.4")
-		spec := PluginSpec{
-			PluginDownloadURL: "http://should-not-use-me.com",
-			Name:              "mock-override",
-			Version:           &version,
-			Kind:              apitype.PluginKind("resource"),
-		}
-		pluginDownloadURLOverridesParsed = []pluginDownloadURLOverride{
-			{
-				reg: regexp.MustCompile("mock-override"),
-				url: "http://mock-override.com",
-			},
-		}
-		source, err := spec.GetSource()
-		require.NoError(t, err)
-		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			assert.Equal(t,
-				"http://mock-override.com/pulumi-resource-mock-override-v1.23.4-windows-arm64.tar.gz",
-				req.URL.String())
-			return newMockReadCloser(expectedBytes)
-		}
-		r, l, err := source.Download(*spec.Version, "windows", "arm64", getHTTPResponse)
-		require.NoError(t, err)
-		readBytes, err := io.ReadAll(r)
-		require.NoError(t, err)
-		assert.Equal(t, int(l), len(readBytes))
-		assert.Equal(t, expectedBytes, readBytes)
-	})
 }
 
 //nolint:paralleltest // mutates environment variables


### PR DESCRIPTION
Reverts pulumi/pulumi#16186
Resolves https://github.com/pulumi/pulumi/issues/16316