### PR TITLE
Add removeStack options to NodeJS Auto API SDK

### DIFF
--- a/changelog/pending/20240605--sdk-nodejs--add-options-to-workspace-removestack.yaml
+++ b/changelog/pending/20240605--sdk-nodejs--add-options-to-workspace-removestack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add options to Workspace::removeStack()

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -471,8 +471,20 @@ export class LocalWorkspace implements Workspace {
      *
      * @param stackName The stack to remove
      */
-    async removeStack(stackName: string): Promise<void> {
-        await this.runPulumiCmd(["stack", "rm", "--yes", stackName]);
+    async removeStack(stackName: string, opts?: RemoveOptions): Promise<void> {
+        const args = ["stack", "rm", "--yes"];
+
+        if (opts?.force) {
+            args.push("--force");
+        }
+
+        if (opts?.preserveConfig) {
+            args.push("--preserve-config");
+        }
+
+        args.push(stackName);
+
+        await this.runPulumiCmd(args);
     }
     /**
      * Adds environments to the end of a stack's import list. Imported environments are merged in order
@@ -1106,4 +1118,16 @@ export interface ListOptions {
      * List all stacks instead of just stacks for the current project
      */
     all?: boolean;
+}
+
+export interface RemoveOptions {
+    /**
+     * Forces deletion of the stack, leaving behind any resources managed by the stack
+     */
+    force?: boolean;
+
+    /**
+     * Do not delete the corresponding Pulumi.<stack-name>.yaml configuration file for the stack
+     */
+    preserveConfig?: boolean;
 }

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -14,7 +14,7 @@
 
 import { PulumiCommand } from "./cmd";
 import { ConfigMap, ConfigValue } from "./config";
-import { ListOptions } from "./localWorkspace";
+import { ListOptions, RemoveOptions } from "./localWorkspace";
 import { ProjectSettings } from "./projectSettings";
 import { OutputMap } from "./stack";
 import { StackSettings } from "./stackSettings";
@@ -228,7 +228,7 @@ export interface Workspace {
      *
      * @param stackName The stack to remove
      */
-    removeStack(stackName: string): Promise<void>;
+    removeStack(stackName: string, opts?: RemoveOptions): Promise<void>;
     /**
      * Returns all Stacks from the underlying backend based on the provided options.
      * This queries backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -681,22 +681,30 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(refRes.summary.kind, "refresh");
         assert.strictEqual(refRes.summary.result, "succeeded");
 
+        let removedStack: boolean;
         try {
             await stack.workspace.removeStack(stackName);
-            throw new Error("Stack was able to remove without the force flag and without destroying it first");
+            removedStack = true;
         } catch (e) {
             // we expect there to be an error because the force flag was not set
+            removedStack = false;
         }
+
+        assert.strictEqual(removedStack, false, "Stack was able to remove without the force flag and without destroying it first");
 
         await stack.workspace.removeStack(stackName, { force: true });
 
+        let stackExists: boolean;
         try {
             await stack.workspace.selectStack(stackName);
-            throw new Error("Stack should have been removed, but we could still select it");
+            stackExists = true;
         } catch (e) {
             // we shouldn't be able to select the stack after it's been removed
             // we expect this error
+            stackExists = false;
         }
+
+        assert.strictEqual(stackExists, false, "Stack should have been removed, but we could still select it");
     });
     it(`refreshes before preview`, async () => {
         // We create a simple program, and scan the output for an indication

--- a/sdk/python/lib/pulumi/automation/__init__.py
+++ b/sdk/python/lib/pulumi/automation/__init__.py
@@ -149,7 +149,6 @@ from ._workspace import (
     Workspace,
     WhoAmIResult,
     Deployment,
-    RemoveStackOptions
 )
 
 from ._output import OutputMap, OutputValue
@@ -221,7 +220,6 @@ __all__ = [
     "Workspace",
     "Deployment",
     "WhoAmIResult",
-    "RemoveStackOptions",
     # _output
     "OutputMap",
     "OutputValue",

--- a/sdk/python/lib/pulumi/automation/__init__.py
+++ b/sdk/python/lib/pulumi/automation/__init__.py
@@ -149,6 +149,7 @@ from ._workspace import (
     Workspace,
     WhoAmIResult,
     Deployment,
+    RemoveStackOptions
 )
 
 from ._output import OutputMap, OutputValue
@@ -220,6 +221,7 @@ __all__ = [
     "Workspace",
     "Deployment",
     "WhoAmIResult",
+    "RemoveStackOptions",
     # _output
     "OutputMap",
     "OutputValue",

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -38,7 +38,6 @@ from ._workspace import (
     StackSummary,
     WhoAmIResult,
     Workspace,
-    RemoveStackOptions,
 )
 from .errors import InvalidVersionError
 
@@ -412,13 +411,12 @@ class LocalWorkspace(Workspace):
         args.append(stack_name)
         self._run_pulumi_cmd_sync(args)
 
-    def remove_stack(self, stack_name: str, opts: Optional[RemoveStackOptions]) -> None:
+    def remove_stack(self, stack_name: str, force: Optional[bool] = None, preserve_config: Optional[bool] = None) -> None:
         args = ["stack", "rm", "--yes"]
-        if opts is not None:
-            if opts.force:
-                args.append("--force")
-            if opts.preserve_config:
-                args.append("--preserve-config")
+        if force:
+            args.append("--force")
+        if preserve_config:
+            args.append("--preserve-config")
         args.append(stack_name)
         self._run_pulumi_cmd_sync(args)
 

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -411,7 +411,12 @@ class LocalWorkspace(Workspace):
         args.append(stack_name)
         self._run_pulumi_cmd_sync(args)
 
-    def remove_stack(self, stack_name: str, force: Optional[bool] = None, preserve_config: Optional[bool] = None) -> None:
+    def remove_stack(
+        self,
+        stack_name: str,
+        force: Optional[bool] = None,
+        preserve_config: Optional[bool] = None,
+    ) -> None:
         args = ["stack", "rm", "--yes"]
         if force:
             args.append("--force")

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -38,6 +38,7 @@ from ._workspace import (
     StackSummary,
     WhoAmIResult,
     Workspace,
+    RemoveStackOptions,
 )
 from .errors import InvalidVersionError
 
@@ -411,8 +412,15 @@ class LocalWorkspace(Workspace):
         args.append(stack_name)
         self._run_pulumi_cmd_sync(args)
 
-    def remove_stack(self, stack_name: str) -> None:
-        self._run_pulumi_cmd_sync(["stack", "rm", "--yes", stack_name])
+    def remove_stack(self, stack_name: str, opts: Optional[RemoveStackOptions]) -> None:
+        args = ["stack", "rm", "--yes"]
+        if opts is not None:
+            if opts.force:
+                args.append("--force")
+            if opts.preserve_config:
+                args.append("--preserve-config")
+        args.append(stack_name)
+        self._run_pulumi_cmd_sync(args)
 
     def list_stacks(self, include_all: Optional[bool] = None) -> List[StackSummary]:
         args = ["stack", "ls", "--json"]

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -396,7 +396,12 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def remove_stack(self, stack_name: str, force: Optional[bool] = None, preserve_config: Optional[bool] = None) -> None:
+    def remove_stack(
+        self,
+        stack_name: str,
+        force: Optional[bool] = None,
+        preserve_config: Optional[bool] = None,
+    ) -> None:
         """
         Deletes the stack and all associated configuration and history.
 

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -112,6 +112,19 @@ class Deployment:
         return f"Deployment(version={self.version!r}, deployment={self.deployment!r})"
 
 
+class RemoveStackOptions:
+    force: Optional[bool] = None
+    preserve_config: Optional[bool] = None
+
+    def __init__(
+        self,
+        force: Optional[bool] = None,
+        preserve_config: Optional[bool] = None
+    ):
+        self.force = force
+        self.preserve_config = preserve_config
+
+
 class Workspace(ABC):
     """
     Workspace is the execution context containing a single Pulumi project, a program, and multiple stacks.
@@ -396,7 +409,7 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def remove_stack(self, stack_name: str) -> None:
+    def remove_stack(self, stack_name: str, opts: Optional[RemoveStackOptions]) -> None:
         """
         Deletes the stack and all associated configuration and history.
 

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -112,19 +112,6 @@ class Deployment:
         return f"Deployment(version={self.version!r}, deployment={self.deployment!r})"
 
 
-class RemoveStackOptions:
-    force: Optional[bool] = None
-    preserve_config: Optional[bool] = None
-
-    def __init__(
-        self,
-        force: Optional[bool] = None,
-        preserve_config: Optional[bool] = None
-    ):
-        self.force = force
-        self.preserve_config = preserve_config
-
-
 class Workspace(ABC):
     """
     Workspace is the execution context containing a single Pulumi project, a program, and multiple stacks.
@@ -409,7 +396,7 @@ class Workspace(ABC):
         """
 
     @abstractmethod
-    def remove_stack(self, stack_name: str, opts: Optional[RemoveStackOptions]) -> None:
+    def remove_stack(self, stack_name: str, force: Optional[bool] = None, preserve_config: Optional[bool] = None) -> None:
         """
         Deletes the stack and all associated configuration and history.
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -39,10 +39,11 @@ from pulumi.automation import (
     Stack,
     StackSettings,
     StackAlreadyExistsError,
+    StackNotFoundError,
     fully_qualified_stack_name,
 )
 from pulumi.resource import (
-    CustomResource,
+    ComponentResource,
     ResourceOptions,
 )
 
@@ -772,7 +773,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
         # we shouldn't be able to select the stack after it's been removed
         # we expect this error
-        with self.assertRaises(CommandError):
+        with self.assertRaises(StackNotFoundError):
             stack.workspace.select_stack(stack_name)
 
     def test_stack_lifecycle_async_inline_program(self):
@@ -1167,17 +1168,17 @@ def pulumi_program():
 
 
 def pulumi_program_with_resource():
-    class MyCustomResource(CustomResource):
+    class MyComponentResource(ComponentResource):
         def __init__(
             self,
             name: str,
             opts: Optional[ResourceOptions] = None,
         ):
-            super(MyCustomResource, self).__init__(
+            super(MyComponentResource, self).__init__(
                 "my:module:MyResource", name, None, opts
             )
 
-    MyCustomResource("res")
+    MyComponentResource("res")
 
 
 async def async_pulumi_program():

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -796,7 +796,7 @@ class TestLocalWorkspace(unittest.TestCase):
 
         self.assertFalse(removed_stack, "Stack was able to remove without the force flag and without destroying it first")
 
-        stack.workspace.remove_stack(stack_name, opts=RemoveStackOptions(force=True))
+        stack.workspace.remove_stack(stack_name, force=True)
 
         stack_exists: bool
         try:

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -763,52 +763,49 @@ class TestLocalWorkspace(unittest.TestCase):
             "buzz": ConfigValue(value="secret", secret=True),
         }
 
+        stack.set_all_config(stack_config)
+
+        # pulumi up
+        up_res = stack.up()
+        self.assertEqual(len(up_res.outputs), 3)
+        self.assertEqual(up_res.outputs["exp_static"].value, "foo")
+        self.assertFalse(up_res.outputs["exp_static"].secret)
+        self.assertEqual(up_res.outputs["exp_cfg"].value, "abc")
+        self.assertFalse(up_res.outputs["exp_cfg"].secret)
+        self.assertEqual(up_res.outputs["exp_secret"].value, "secret")
+        self.assertTrue(up_res.outputs["exp_secret"].secret)
+        self.assertEqual(up_res.summary.kind, "update")
+        self.assertEqual(up_res.summary.result, "succeeded")
+
+        # pulumi preview
+        preview_result = stack.preview()
+        self.assertEqual(preview_result.change_summary.get(OpType.SAME), 1)
+
+        # pulumi refresh
+        refresh_res = stack.refresh()
+        self.assertEqual(refresh_res.summary.kind, "refresh")
+        self.assertEqual(refresh_res.summary.result, "succeeded")
+
+        # pulumi stack rm
+        removed_stack: bool
         try:
-            stack.set_all_config(stack_config)
-
-            # pulumi up
-            up_res = stack.up()
-            self.assertEqual(len(up_res.outputs), 3)
-            self.assertEqual(up_res.outputs["exp_static"].value, "foo")
-            self.assertFalse(up_res.outputs["exp_static"].secret)
-            self.assertEqual(up_res.outputs["exp_cfg"].value, "abc")
-            self.assertFalse(up_res.outputs["exp_cfg"].secret)
-            self.assertEqual(up_res.outputs["exp_secret"].value, "secret")
-            self.assertTrue(up_res.outputs["exp_secret"].secret)
-            self.assertEqual(up_res.summary.kind, "update")
-            self.assertEqual(up_res.summary.result, "succeeded")
-
-            # pulumi preview
-            preview_result = stack.preview()
-            self.assertEqual(preview_result.change_summary.get(OpType.SAME), 1)
-
-            # pulumi refresh
-            refresh_res = stack.refresh()
-            self.assertEqual(refresh_res.summary.kind, "refresh")
-            self.assertEqual(refresh_res.summary.result, "succeeded")
-
-            # pulumi stack rm
-            removed_stack: bool
-            try:
-                stack.workspace.remove_stack(stack_name)
-                removed_stack = True
-            except:
-                removed_stack = False
-
-            self.assertFalse(removed_stack, "Stack was able to remove without the force flag and without destroying it first")
-
-            stack.workspace.remove_stack(stack_name, opts=RemoveStackOptions(force=True))
-
-            stack_exists: bool
-            try:
-                stack.workspace.select_stack(stack_name)
-                stack_exists = True
-            except:
-                stack_exists = False
-
-            self.assertFalse(stack_exists, "Stack should have been removed, but we could still select it")
-        finally:
             stack.workspace.remove_stack(stack_name)
+            removed_stack = True
+        except:
+            removed_stack = False
+
+        self.assertFalse(removed_stack, "Stack was able to remove without the force flag and without destroying it first")
+
+        stack.workspace.remove_stack(stack_name, opts=RemoveStackOptions(force=True))
+
+        stack_exists: bool
+        try:
+            stack.workspace.select_stack(stack_name)
+            stack_exists = True
+        except:
+            stack_exists = False
+
+        self.assertFalse(stack_exists, "Stack should have been removed, but we could still select it")
 
     def test_stack_lifecycle_async_inline_program(self):
         project_name = "async_inline_python"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR adds an optional `opts` argument to the NodeJS SDK `Workspace::removeStack` method, which has `force` and `preserveConfig` optional booleans. Setting these bools to true will add their corresponding CLI flag to the command.

Fixes #16332 

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
