### PR TITLE
Fix non-interactive flag for 'new' and 'config env' commands

### DIFF
--- a/changelog/pending/20240606--cli-config-new--fix-non-interactive-flag-for-new-and-config-env-commands.yaml
+++ b/changelog/pending/20240606--cli-config-new--fix-non-interactive-flag-for-new-and-config-env-commands.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/config,new
+  description: Fix non-interactive flag for 'new' and 'config env' commands"

--- a/pkg/cmd/pulumi/config_env.go
+++ b/pkg/cmd/pulumi/config_env.go
@@ -34,8 +34,6 @@ func newConfigEnvCmd(stackRef *string) *cobra.Command {
 	impl := configEnvCmd{
 		stdin:            os.Stdin,
 		stdout:           os.Stdout,
-		interactive:      cmdutil.Interactive(),
-		color:            cmdutil.GetGlobalColorization(),
 		readProject:      readProject,
 		requireStack:     requireStack,
 		loadProjectStack: loadProjectStack,
@@ -80,6 +78,11 @@ type configEnvCmd struct {
 	saveProjectStack func(stack backend.Stack, ps *workspace.ProjectStack) error
 
 	stackRef *string
+}
+
+func (cmd *configEnvCmd) initArgs() {
+	cmd.interactive = cmdutil.Interactive()
+	cmd.color = cmdutil.GetGlobalColorization()
 }
 
 func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,

--- a/pkg/cmd/pulumi/config_env_add.go
+++ b/pkg/cmd/pulumi/config_env_add.go
@@ -32,7 +32,10 @@ func newConfigEnvAddCmd(parent *configEnvCmd) *cobra.Command {
 			"per the ESC merge rules. The list of stacks behaves as if it were the import list in an anonymous\n" +
 			"environment.",
 		Args: cmdutil.MinimumNArgs(1),
-		Run:  cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context(), args)
+		}),
 	}
 
 	cmd.Flags().BoolVar(

--- a/pkg/cmd/pulumi/config_env_init.go
+++ b/pkg/cmd/pulumi/config_env_init.go
@@ -50,7 +50,10 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 			"then replaces the stack's configuration values with a reference to that environment.\n" +
 			"The environment will be created in the same organization as the stack.",
 		Args: cmdutil.NoArgs,
-		Run:  cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context(), args)
+		}),
 	}
 
 	cmd.Flags().StringVar(

--- a/pkg/cmd/pulumi/config_env_ls.go
+++ b/pkg/cmd/pulumi/config_env_ls.go
@@ -31,7 +31,10 @@ func newConfigEnvLsCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Lists imported environments.",
 		Long:  "Lists the environments imported into a stack's configuration.",
 		Args:  cmdutil.NoArgs,
-		Run:   cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context(), args)
+		}),
 	}
 
 	cmd.Flags().BoolVarP(

--- a/pkg/cmd/pulumi/config_env_rm.go
+++ b/pkg/cmd/pulumi/config_env_rm.go
@@ -30,7 +30,10 @@ func newConfigEnvRmCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Remove environments from a stack",
 		Long:  "Removes an environment from a stack's import list.",
 		Args:  cmdutil.ExactArgs(1),
-		Run:   cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error { return impl.run(cmd.Context(), args) }),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context(), args)
+		}),
 	}
 
 	cmd.Flags().BoolVar(

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -458,7 +458,6 @@ func useSpecifiedDir(dir string) (string, error) {
 //nolint:vetshadow
 func newNewCmd() *cobra.Command {
 	args := newArgs{
-		interactive:    cmdutil.Interactive(),
 		prompt:         promptForValue,
 		chooseTemplate: chooseTemplate,
 	}
@@ -544,6 +543,7 @@ func newNewCmd() *cobra.Command {
 				return nil
 			}
 
+			args.interactive = cmdutil.Interactive()
 			args.yes = args.yes || skipConfirmations()
 			return runNew(ctx, args)
 		}),


### PR DESCRIPTION
# Description

The command line flags are not parsed yet when the command definition is
created. We need to wait until we're in the command's `Run` method
before we can read the flags.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
