### PR TITLE
Sort depdencies in GenerateProject

### DIFF
--- a/changelog/pending/20240606--programgen-nodejs--sort-depdencies-in-generateproject.yaml
+++ b/changelog/pending/20240606--programgen-nodejs--sort-depdencies-in-generateproject.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: programgen/nodejs
+  description: Sort depdencies in GenerateProject

--- a/changelog/pending/20240606--programgen-nodejs--sort-depdencies-in-generateproject.yaml
+++ b/changelog/pending/20240606--programgen-nodejs--sort-depdencies-in-generateproject.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: programgen/nodejs
-  description: Sort depdencies in GenerateProject
+  description: Sort dependencies in GenerateProject

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -229,7 +229,15 @@ func GenerateProject(
 	if err != nil {
 		return err
 	}
-	for _, p := range packages {
+	// Sort the dependencies to ensure a deterministic package.json. Note that the typescript and
+	// @pulumi/pulumi dependencies are already added above and not sorted.
+	sortedPackageNames := make([]string, 0, len(packages))
+	for k := range packages {
+		sortedPackageNames = append(sortedPackageNames, k)
+	}
+	sort.Strings(sortedPackageNames)
+	for _, k := range sortedPackageNames {
+		p := packages[k]
 		if p.Name == PulumiToken {
 			continue
 		}


### PR DESCRIPTION
# Description

This helps avoiding flakiness in tests using snapshots.

```
=== FAIL: . TestLanguage/forceTsc=true-/l2-failed-create-continue-on-error (54.39s)
    language_test.go:242: program snapshot validation failed:
        expected file package.json does not match actual file:
        
        --- expected
        +++ actual
        @@ -6,7 +6,7 @@
         	"dependencies": ***
         		"typescript": "^4.0.0",
         		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
        -		"@pulumi/fail_on_create": "ROOT/artifacts/pulumi-fail_on_create-4.0.0.tgz",
        -		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
        +		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz",
        +		"@pulumi/fail_on_create": "ROOT/artifacts/pulumi-fail_on_create-4.0.0.tgz"
```

Fixes https://github.com/pulumi/pulumi/issues/16340

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
