### PR TITLE
[cli/import] Add flag --json which would serialize the import diffs, operations, and overall output as JSON

### DIFF
--- a/changelog/pending/20240606--cli-import--add-flag-json-to-pulumi-import-which-would-serialize-the-import-diffs-operations-and-overall-output-as-json.yaml
+++ b/changelog/pending/20240606--cli-import--add-flag-json-to-pulumi-import-which-would-serialize-the-import-diffs-operations-and-overall-output-as-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/import
+  description: Add flag --json to pulumi import which would serialize the import diffs, operations, and overall output as JSON

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -544,6 +544,7 @@ func newImportCmd() *cobra.Command {
 	var execAgent string
 
 	// Flags for engine.UpdateOptions.
+	var jsonDisplay bool
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
@@ -815,6 +816,7 @@ func newImportCmd() *cobra.Command {
 				Type:             displayType,
 				EventLogPath:     eventLogPath,
 				Debug:            debug,
+				JSONDisplay:      jsonDisplay,
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -968,11 +970,11 @@ func newImportCmd() *cobra.Command {
 
 				if validImports {
 					// we only want to output the helper string if there is a set of valid imports to convert into code
-					// this protects against invalid package types or import errors that will not actually result in
+					// this protects against invalid package types or import errors that will not actually result
 					// in a codegen call
 					// It's a little bit more memory but is a better experience that writing to stdout and then an error
 					// occurring
-					if outputFilePath == "" {
+					if outputFilePath == "" && !jsonDisplay {
 						fmt.Print("Please copy the following code into your Pulumi application. Not doing so\n" +
 							"will cause Pulumi to report that an update will happen on the next update command.\n\n")
 						if protectResources {
@@ -1051,6 +1053,9 @@ func newImportCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&skipPreview, "skip-preview", false,
 		"Do not calculate a preview before performing the import")
+	cmd.Flags().BoolVarP(
+		&jsonDisplay, "json", "j", false,
+		"Serialize the import diffs, operations, and overall output as JSON")
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")


### PR DESCRIPTION
# Description

Small addition for `pulumi import` so that it prints out import diffs and operations as JSON, not just using the default display. 

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
