### PR TITLE
Allow passing runtime options as args in pulumi new

### DIFF
--- a/changelog/pending/20240607--cli-new--allow-passing-runtime-options-as-args-in-pulumi-new.yaml
+++ b/changelog/pending/20240607--cli-new--allow-passing-runtime-options-as-args-in-pulumi-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Allow passing runtime options as args in pulumi new

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -84,6 +84,7 @@ type newArgs struct {
 	aiPrompt             string
 	aiLanguage           httpstate.PulumiAILanguage
 	templateMode         bool
+	runtimeOptions       []string
 }
 
 func runNew(ctx context.Context, args newArgs) error {
@@ -335,6 +336,14 @@ func runNew(ctx context.Context, args newArgs) error {
 	proj.AddConfigStackTags(map[string]string{
 		apitype.ProjectTemplateTag: templateTag,
 	})
+
+	for _, opt := range args.runtimeOptions {
+		parts := strings.Split(strings.TrimSpace(opt), "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid runtime option: %s", opt)
+		}
+		proj.Runtime.SetOption(parts[0], parts[1])
+	}
 
 	if err = workspace.SaveProject(proj); err != nil {
 		return fmt.Errorf("saving project: %w", err)
@@ -653,6 +662,10 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&args.templateMode, "template-mode", "t", false,
 		"Run in template mode, which will skip prompting for AI or Template functionality",
+	)
+	cmd.PersistentFlags().StringSliceVar(
+		&args.runtimeOptions, "runtime-options", []string{},
+		"Additional options for the language runtime (format: key1=value1,key2=value2)",
 	)
 
 	return cmd

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -442,7 +442,7 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 
 	e.Stdin = strings.NewReader("poetry\n")
-	e.RunCommand("pulumi", "new", "python", "--force", "--non-interactive", "--yes", "--generate-only",
+	e.RunCommand("pulumi", "new", "python", "--force", "--generate-only",
 		"--name", "test_project",
 		"--description", "A python test using poetry as toolchain",
 		"--stack", "test",
@@ -450,6 +450,31 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 
 	expected := map[string]interface{}{
 		"toolchain": "poetry",
+	}
+	checkRuntimeOptions(t, e.RootPath, expected)
+}
+
+func TestNewPythonRuntimeOptions(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "new", "python", "--force", "--non-interactive", "--yes", "--generate-only",
+		"--name", "test_project",
+		"--description", "A python test using poetry as toolchain",
+		"--stack", "test",
+		"--runtime-options", "toolchain=pip,virtualenv=mytestenv",
+	)
+
+	expected := map[string]interface{}{
+		"toolchain":  "pip",
+		"virtualenv": "mytestenv",
 	}
 	checkRuntimeOptions(t, e.RootPath, expected)
 }


### PR DESCRIPTION
# Description

Stacked on top of https://github.com/pulumi/pulumi/pull/16346

Fixes https://github.com/pulumi/pulumi/issues/16348

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"julienp/pulumi-new-options","parentHead":"48099cffa524f79209acda006001d9c2904b5b18","parentPull":16346,"trunk":"master"}
```
-->
