### PR TITLE
Clean up deployment options

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -133,27 +133,42 @@ type deploymentOptions struct {
 	// creates resources to compare against the current checkpoint state (e.g., by evaluating a program, etc).
 	SourceFunc deploymentSourceFunc
 
-	DOT        bool         // true if we should print the DOT file for this deployment.
-	Events     eventEmitter // the channel to write events from the engine to.
-	Diag       diag.Sink    // the sink to use for diag'ing.
-	StatusDiag diag.Sink    // the sink to use for diag'ing status messages.
+	// true if we should print the DOT file for this deployment.
+	DOT bool
+	// the channel to write events from the engine to.
+	Events eventEmitter
+	// the sink to use for diag'ing.
+	Diag diag.Sink
+	// the sink to use for diag'ing status messages.
+	StatusDiag diag.Sink
 
-	isImport bool            // True if this is an import.
-	imports  []deploy.Import // Resources to import, if this is an import.
+	// True if this is an import operation.
+	isImport bool
+	// Resources to import, if this is an import.
+	imports []deploy.Import
 
-	// true if we're executing a refresh.
+	// true if this deployment is (only) a refresh operation. This should not be
+	// confused with UpdateOptions.Refresh, which will be true whenever a refresh
+	// is happening as part of an operation (e.g. `up --refresh`).
 	isRefresh bool
+
+	// true if this deployment is a dry run, such as a preview action or a preview
+	// operation preceding e.g. a refresh or destroy.
+	DryRun bool
 }
 
 // deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
 type deploymentSourceFunc func(
 	ctx context.Context,
 	client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
-	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error)
+	target *deploy.Target, plugctx *plugin.Context) (deploy.Source, error)
 
 // newDeployment creates a new deployment with the given context and options.
-func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOptions,
-	dryRun bool,
+func newDeployment(
+	ctx *Context,
+	info *deploymentContext,
+	actions runActions,
+	opts *deploymentOptions,
 ) (*deployment, error) {
 	contract.Assertf(info != nil, "a deployment context must be provided")
 	contract.Assertf(info.Update != nil, "update info cannot be nil")
@@ -193,7 +208,7 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,
 	// for example, loading any plugins which will be required to execute a program, among other things.
 	source, err := opts.SourceFunc(
-		cancelCtx, ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx, dryRun)
+		cancelCtx, ctx.BackendClient, opts, proj, pwd, main, projinfo.Root, target, plugctx)
 	if err != nil {
 		contract.IgnoreClose(plugctx)
 		return nil, err
@@ -201,11 +216,26 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 
 	localPolicyPackPaths := ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks)
 
+	deplOpts := &deploy.Options{
+		DryRun:                    opts.DryRun,
+		Parallel:                  opts.Parallel,
+		Refresh:                   opts.Refresh,
+		RefreshOnly:               opts.isRefresh,
+		ReplaceTargets:            opts.ReplaceTargets,
+		Targets:                   opts.Targets,
+		TargetDependents:          opts.TargetDependents,
+		UseLegacyDiff:             opts.UseLegacyDiff,
+		DisableResourceReferences: opts.DisableResourceReferences,
+		DisableOutputValues:       opts.DisableOutputValues,
+		GeneratePlan:              opts.UpdateOptions.GeneratePlan,
+		ContinueOnError:           opts.ContinueOnError,
+	}
+
 	var depl *deploy.Deployment
 	if !opts.isImport {
 		depl, err = deploy.NewDeployment(
-			plugctx, target, target.Snapshot, opts.Plan, source,
-			localPolicyPackPaths, dryRun, ctx.BackendClient)
+			plugctx, deplOpts, actions, target, target.Snapshot, opts.Plan, source,
+			localPolicyPackPaths, ctx.BackendClient)
 	} else {
 		_, defaultProviderInfo, pluginErr := installPlugins(cancelCtx, proj, pwd, main, target, plugctx,
 			false /*returnInstallErrors*/)
@@ -242,7 +272,8 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 			}
 		}
 
-		depl, err = deploy.NewImportDeployment(plugctx, target, proj.Name, opts.imports, dryRun)
+		depl, err = deploy.NewImportDeployment(
+			plugctx, deplOpts, actions, target, proj.Name, opts.imports)
 	}
 
 	if err != nil {
@@ -253,17 +284,27 @@ func newDeployment(ctx *Context, info *deploymentContext, opts *deploymentOption
 		Ctx:        info,
 		Plugctx:    plugctx,
 		Deployment: depl,
+		Actions:    actions,
 		Options:    opts,
 	}, nil
 }
 
 type deployment struct {
-	Ctx        *deploymentContext // deployment context information.
-	Plugctx    *plugin.Context    // the context containing plugins and their state.
-	Deployment *deploy.Deployment // the deployment created by this command.
-	Options    *deploymentOptions // the options used while deploying.
+	// deployment context information.
+	Ctx *deploymentContext
+	// the context containing plugins and their state.
+	Plugctx *plugin.Context
+	// the deployment created by this command.
+	Deployment *deploy.Deployment
+	// the actions to run during the deployment.
+	Actions runActions
+	// the options used while deploying.
+	Options *deploymentOptions
 }
 
+// runActions represents a set of actions to run as part of a deployment,
+// including callbacks that will be used to emit events at various points in the
+// deployment process.
 type runActions interface {
 	deploy.Events
 
@@ -272,9 +313,7 @@ type runActions interface {
 }
 
 // run executes the deployment. It is primarily responsible for handling cancellation.
-func (deployment *deployment) run(cancelCtx *Context, actions runActions,
-	preview bool,
-) (*deploy.Plan, display.ResourceChanges, error) {
+func (deployment *deployment) run(cancelCtx *Context) (*deploy.Plan, display.ResourceChanges, error) {
 	// Create a new context for cancellation and tracing.
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
@@ -284,7 +323,8 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 	}
 
 	// Emit an appropriate prelude event.
-	deployment.Options.Events.preludeEvent(preview, deployment.Ctx.Update.GetTarget().Config)
+	deployment.Options.Events.preludeEvent(
+		deployment.Options.DryRun, deployment.Ctx.Update.GetTarget().Config)
 
 	// Execute the deployment.
 	start := time.Now()
@@ -293,21 +333,7 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 	var newPlan *deploy.Plan
 	var walkError error
 	go func() {
-		opts := deploy.Options{
-			Events:                    actions,
-			Parallel:                  deployment.Options.Parallel,
-			Refresh:                   deployment.Options.Refresh,
-			RefreshOnly:               deployment.Options.isRefresh,
-			ReplaceTargets:            deployment.Options.ReplaceTargets,
-			Targets:                   deployment.Options.Targets,
-			TargetDependents:          deployment.Options.TargetDependents,
-			UseLegacyDiff:             deployment.Options.UseLegacyDiff,
-			DisableResourceReferences: deployment.Options.DisableResourceReferences,
-			DisableOutputValues:       deployment.Options.DisableOutputValues,
-			GeneratePlan:              deployment.Options.UpdateOptions.GeneratePlan,
-			ContinueOnError:           deployment.Options.ContinueOnError,
-		}
-		newPlan, walkError = deployment.Deployment.Execute(ctx, opts, preview)
+		newPlan, walkError = deployment.Deployment.Execute(ctx)
 		close(done)
 	}()
 
@@ -333,7 +359,7 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 	}
 
 	duration := time.Since(start)
-	changes := actions.Changes()
+	changes := deployment.Actions.Changes()
 
 	// Refresh and Import do not execute Policy Packs.
 	policies := map[string]string{}
@@ -348,7 +374,8 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions,
 	}
 
 	// Emit a summary event.
-	deployment.Options.Events.summaryEvent(preview, actions.MaybeCorrupt(), duration, changes, policies)
+	deployment.Options.Events.summaryEvent(
+		deployment.Options.DryRun, deployment.Actions.MaybeCorrupt(), duration, changes, policies)
 
 	return newPlan, changes, err
 }

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -130,7 +130,7 @@ func TestSourceFuncCancellation(t *testing.T) {
 	// Create a source func that waits for cancellation.
 	sourceF := func(ctx context.Context,
 		client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
-		target *deploy.Target, plugctx *plugin.Context, dryRun bool,
+		target *deploy.Target, plugctx *plugin.Context,
 	) (deploy.Source, error) {
 		// Send ops completion then wait for the cancellation signal.
 		close(ops)
@@ -159,9 +159,10 @@ func TestSourceFuncCancellation(t *testing.T) {
 		Events:     ctx.makeEventEmitter(t),
 		Diag:       diagtest.LogSink(t),
 		StatusDiag: diagtest.LogSink(t),
+		DryRun:     false,
 	}
 
-	_, err = newDeployment(&ctx.Context, info, opts, false)
+	_, err = newDeployment(&ctx.Context, info, nil, opts)
 	if !assert.ErrorIs(t, err, context.Canceled) {
 		t.FailNow()
 	}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -61,13 +61,14 @@ func Destroy(
 		Events:        emitter,
 		Diag:          newEventSink(emitter, false),
 		StatusDiag:    newEventSink(emitter, true),
-	}, dryRun)
+		DryRun:        dryRun,
+	})
 }
 
 func newDestroySource(
 	ctx context.Context,
 	client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
-	target *deploy.Target, plugctx *plugin.Context, dryRun bool,
+	target *deploy.Target, plugctx *plugin.Context,
 ) (deploy.Source, error) {
 	// Like Update, we need to gather the set of plugins necessary to delete everything in the snapshot.
 	// Unlike Update, we don't actually run the user's program so we only need the set of plugins described

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -48,5 +48,6 @@ func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Imp
 		StatusDiag:    newEventSink(emitter, true),
 		isImport:      true,
 		imports:       imports,
-	}, dryRun)
+		DryRun:        dryRun,
+	})
 }

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -65,12 +65,13 @@ func Refresh(
 		Diag:          newEventSink(emitter, false),
 		StatusDiag:    newEventSink(emitter, true),
 		isRefresh:     true,
-	}, dryRun)
+		DryRun:        dryRun,
+	})
 }
 
 func newRefreshSource(
 	ctx context.Context, client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main,
-	projectRoot string, target *deploy.Target, plugctx *plugin.Context, dryRun bool,
+	projectRoot string, target *deploy.Target, plugctx *plugin.Context,
 ) (deploy.Source, error) {
 	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.
 	// Unlike Update, we don't actually run the user's program so we only need the set of plugins described

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -52,17 +52,31 @@ type BackendClient interface {
 
 // Options controls the deployment process.
 type Options struct {
-	Events                    Events     // an optional events callback interface.
-	Parallel                  int        // the degree of parallelism for resource operations (<=1 for serial).
-	Refresh                   bool       // whether or not to refresh before executing the deployment.
-	RefreshOnly               bool       // whether or not to exit after refreshing.
-	Targets                   UrnTargets // If specified, only operate on specified resources.
-	ReplaceTargets            UrnTargets // If specified, mark the specified resources for replacement.
-	TargetDependents          bool       // true if we're allowing things to proceed, even with unspecified targets
-	UseLegacyDiff             bool       // whether or not to use legacy diffing behavior.
-	DisableResourceReferences bool       // true to disable resource reference support.
-	DisableOutputValues       bool       // true to disable output value support.
-	GeneratePlan              bool       // true to enable plan generation.
+	// true if the process is a dry run (that is, won't make any changes), such as
+	// during a preview action or when previewing another action like refresh or
+	// destroy.
+	DryRun bool
+	// the degree of parallelism for resource operations (<=1 for serial).
+	Parallel int
+	// whether or not to refresh before executing the deployment.
+	Refresh bool
+	// whether or not to exit after refreshing (i.e. this is specifically a
+	// refresh operation).
+	RefreshOnly bool
+	// if specified, only operate on the specified resources.
+	Targets UrnTargets
+	// if specified, mark the specified resources for replacement.
+	ReplaceTargets UrnTargets
+	// true if target dependents should be computed automatically.
+	TargetDependents bool
+	// whether or not to use legacy diffing behavior.
+	UseLegacyDiff bool
+	// true to disable resource reference support.
+	DisableResourceReferences bool
+	// true to disable output value support.
+	DisableOutputValues bool
+	// true to enable plan generation.
+	GeneratePlan bool
 	// true if we should continue with the deployment even if a resource operation fails.
 	ContinueOnError bool
 }
@@ -249,6 +263,10 @@ func (m *resourcePlans) plan() *Plan {
 type Deployment struct {
 	// the plugin context (for provider operations).
 	ctx *plugin.Context
+	// options for this deployment.
+	opts *Options
+	// event handlers for this deployment.
+	events Events
 	// the deployment target.
 	target *Target
 	// the old resource snapshot for comparison.
@@ -267,8 +285,6 @@ type Deployment struct {
 	source Source
 	// the policy packs to run during this deployment's generation.
 	localPolicyPackPaths []string
-	// true if this deployment is to be previewed.
-	preview bool
 	// the dependency graph of the old snapshot.
 	depGraph *graph.DependencyGraph
 	// the provider registry for this deployment.
@@ -414,8 +430,16 @@ func buildResourceMap(prev *Snapshot, preview bool) ([]*resource.State, map[reso
 //
 // Note that a deployment uses internal concurrency and parallelism in various ways, so it must be closed if for some
 // reason it isn't carried out to its final conclusion. This will result in cancellation and reclamation of resources.
-func NewDeployment(ctx *plugin.Context, target *Target, prev *Snapshot, plan *Plan, source Source,
-	localPolicyPackPaths []string, preview bool, backendClient BackendClient,
+func NewDeployment(
+	ctx *plugin.Context,
+	opts *Options,
+	events Events,
+	target *Target,
+	prev *Snapshot,
+	plan *Plan,
+	source Source,
+	localPolicyPackPaths []string,
+	backendClient BackendClient,
 ) (*Deployment, error) {
 	contract.Requiref(ctx != nil, "ctx", "must not be nil")
 	contract.Requiref(target != nil, "target", "must not be nil")
@@ -429,7 +453,7 @@ func NewDeployment(ctx *plugin.Context, target *Target, prev *Snapshot, plan *Pl
 	//
 	// NOTE: we can and do mutate prev.Resources, olds, and depGraph during execution after performing a refresh. See
 	// deploymentExecutor.refresh for details.
-	oldResources, olds, err := buildResourceMap(prev, preview)
+	oldResources, olds, err := buildResourceMap(prev, opts.DryRun)
 	if err != nil {
 		return nil, err
 	}
@@ -449,17 +473,18 @@ func NewDeployment(ctx *plugin.Context, target *Target, prev *Snapshot, plan *Pl
 	// Create a new provider registry. Although we really only need to pass in any providers that were present in the
 	// old resource list, the registry itself will filter out other sorts of resources when processing the prior state,
 	// so we just pass all of the old resources.
-	reg := providers.NewRegistry(ctx.Host, preview, builtins)
+	reg := providers.NewRegistry(ctx.Host, opts.DryRun, builtins)
 
 	return &Deployment{
 		ctx:                  ctx,
+		opts:                 opts,
+		events:               events,
 		target:               target,
 		prev:                 prev,
 		plan:                 plan,
 		olds:                 olds,
 		source:               source,
 		localPolicyPackPaths: localPolicyPackPaths,
-		preview:              preview,
 		depGraph:             depGraph,
 		providers:            reg,
 		goals:                newGoals,
@@ -553,7 +578,7 @@ func (d *Deployment) generateEventURN(event SourceEvent) resource.URN {
 }
 
 // Execute executes a deployment to completion, using the given cancellation context and running a preview or update.
-func (d *Deployment) Execute(ctx context.Context, opts Options, preview bool) (*Plan, error) {
+func (d *Deployment) Execute(ctx context.Context) (*Plan, error) {
 	deploymentExec := &deploymentExecutor{deployment: d}
-	return deploymentExec.Execute(ctx, opts, preview)
+	return deploymentExec.Execute(ctx)
 }

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -44,7 +44,7 @@ func TestPendingOperationsDeployment(t *testing.T) {
 		},
 	})
 
-	_, err := NewDeployment(&plugin.Context{}, &Target{}, snap, nil, NewNullSource("test"), nil, false, nil)
+	_, err := NewDeployment(&plugin.Context{}, &Options{}, nil, &Target{}, snap, nil, NewNullSource("test"), nil, nil)
 	assert.NoError(t, err)
 }
 

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -38,7 +38,7 @@ func TestImportDeployment(t *testing.T) {
 		t.Run("error in migrate providers", func(t *testing.T) {
 			t.Parallel()
 			var decrypterCalled bool
-			_, err := NewImportDeployment(&plugin.Context{}, &Target{
+			_, err := NewImportDeployment(&plugin.Context{}, &Options{}, nil, &Target{
 				Snapshot: &Snapshot{
 					Resources: []*resource.State{
 						{
@@ -57,7 +57,7 @@ func TestImportDeployment(t *testing.T) {
 						return "", errors.New("expected fail")
 					},
 				},
-			}, "projectName", nil, true)
+			}, "projectName", nil)
 			assert.ErrorContains(t, err, "could not fetch configuration for default provider")
 			assert.True(t, decrypterCalled)
 		})

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -50,7 +50,7 @@ type Source interface {
 	Info() interface{}
 
 	// Iterate begins iterating the source. Error is non-nil upon failure; otherwise, a valid iterator is returned.
-	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error)
+	Iterate(ctx context.Context, providers ProviderSource) (SourceIterator, error)
 }
 
 // A SourceIterator enumerates the list of resources that a source has to offer and tracks associated state.

--- a/pkg/resource/deploy/source_error.go
+++ b/pkg/resource/deploy/source_error.go
@@ -36,8 +36,6 @@ func (src *errorSource) Close() error                { return nil }
 func (src *errorSource) Project() tokens.PackageName { return src.project }
 func (src *errorSource) Info() interface{}           { return nil }
 
-func (src *errorSource) Iterate(
-	ctx context.Context, opts Options, providers ProviderSource,
-) (SourceIterator, error) {
+func (src *errorSource) Iterate(ctx context.Context, providers ProviderSource) (SourceIterator, error) {
 	panic("internal error: unexpected call to errorSource.Iterate")
 }

--- a/pkg/resource/deploy/source_error_test.go
+++ b/pkg/resource/deploy/source_error_test.go
@@ -40,7 +40,7 @@ func TestErrorSource(t *testing.T) {
 		t.Parallel()
 		s := &errorSource{}
 		assert.Panics(t, func() {
-			_, err := s.Iterate(context.Background(), Options{}, nil)
+			_, err := s.Iterate(context.Background(), nil)
 			contract.Ignore(err)
 		})
 	})

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -221,7 +221,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(t, fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
+	iter, err := NewEvalSource(ctx, runInfo, nil, EvalSourceOptions{}).Iterate(context.Background(), &testProviderSource{})
 	assert.NoError(t, err)
 
 	processed := 0
@@ -307,7 +307,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(t, fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
+	iter, err := NewEvalSource(ctx, runInfo, nil, EvalSourceOptions{}).Iterate(context.Background(), &testProviderSource{})
 	assert.NoError(t, err)
 
 	processed, defaults := 0, make(map[string]struct{})
@@ -423,7 +423,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(t, program)
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	iter, err := NewEvalSource(ctx, runInfo, nil, EvalSourceOptions{}).Iterate(context.Background(), providerSource)
 	assert.NoError(t, err)
 
 	reads := 0
@@ -501,7 +501,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 
 	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	iter, err := NewEvalSource(ctx, runInfo, nil, EvalSourceOptions{}).Iterate(context.Background(), providerSource)
 	assert.NoError(t, err)
 
 	reads, registers := 0, 0
@@ -681,7 +681,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 			ctx, err := newTestPluginContext(t, program)
 			assert.NoError(t, err)
 
-			iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+			iter, err := NewEvalSource(ctx, runInfo, nil, EvalSourceOptions{}).Iterate(context.Background(), providerSource)
 			assert.NoError(t, err)
 
 			for {
@@ -881,7 +881,7 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 			pluginCtx, err := newTestPluginContext(t, program)
 			require.NoError(t, err, "build plugin context")
 
-			evalSource := NewEvalSource(pluginCtx, runInfo, nil, false)
+			evalSource := NewEvalSource(pluginCtx, runInfo, nil, EvalSourceOptions{})
 			defer func() {
 				assert.NoError(t, evalSource.Close(), "close eval source")
 			}()
@@ -911,7 +911,7 @@ func TestResouceMonitor_remoteComponentResourceOptions(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			iter, res := evalSource.Iterate(ctx, Options{}, &testProviderSource{defaultProvider: provider})
+			iter, res := evalSource.Iterate(ctx, &testProviderSource{defaultProvider: provider})
 			require.Nil(t, res, "iterate eval source")
 
 			for ev, res := iter.Next(); ev != nil; ev, res = iter.Next() {
@@ -1421,7 +1421,7 @@ func TestStreamInvoke(t *testing.T) {
 					return nil, nil
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -1483,7 +1483,7 @@ func TestStreamInvoke(t *testing.T) {
 					return nil, expectedErr
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -1549,7 +1549,7 @@ func TestStreamInvoke(t *testing.T) {
 					}, nil
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -1611,7 +1611,7 @@ func TestStreamInvoke(t *testing.T) {
 				},
 			},
 			plugctx: plugctx,
-		}, reg, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, reg, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -1842,7 +1842,7 @@ func TestEvalSource(t *testing.T) {
 					},
 				},
 			}
-			_, err := src.Iterate(context.Background(), Options{}, &providerSourceMock{})
+			_, err := src.Iterate(context.Background(), &providerSourceMock{})
 			assert.ErrorContains(t, err, "failed to decrypt config")
 			assert.True(t, decrypterCalled)
 		})
@@ -1877,7 +1877,7 @@ func TestEvalSource(t *testing.T) {
 					},
 				},
 			}
-			_, err := src.Iterate(context.Background(), Options{}, &providerSourceMock{})
+			_, err := src.Iterate(context.Background(), &providerSourceMock{})
 			assert.ErrorContains(t, err, "failed to convert config to map")
 			assert.True(t, decrypterCalled)
 		})
@@ -2341,7 +2341,7 @@ func TestInvoke(t *testing.T) {
 					return nil, nil, expectedErr
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -2404,7 +2404,7 @@ func TestInvoke(t *testing.T) {
 					}, nil
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -2480,7 +2480,7 @@ func TestCall(t *testing.T) {
 					return plugin.CallResult{}, expectedErr
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		wg := &sync.WaitGroup{}
@@ -2568,7 +2568,7 @@ func TestCall(t *testing.T) {
 					return plugin.CallResult{}, expectedErr
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{
@@ -2641,7 +2641,7 @@ func TestCall(t *testing.T) {
 					return plugin.CallResult{}, nil
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{
@@ -2726,7 +2726,7 @@ func TestCall(t *testing.T) {
 					}, nil
 				},
 			},
-		}, providerRegChan, nil, nil, Options{}, nil, nil, opentracing.SpanFromContext(context.Background()))
+		}, providerRegChan, nil, nil, nil, nil, opentracing.SpanFromContext(context.Background()))
 		require.NoError(t, err)
 
 		args, err := plugin.MarshalProperties(resource.PropertyMap{

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -39,9 +39,7 @@ func (src *nullSource) Close() error                { return nil }
 func (src *nullSource) Project() tokens.PackageName { return src.project }
 func (src *nullSource) Info() interface{}           { return nil }
 
-func (src *nullSource) Iterate(
-	ctx context.Context, opts Options, providers ProviderSource,
-) (SourceIterator, error) {
+func (src *nullSource) Iterate(ctx context.Context, providers ProviderSource) (SourceIterator, error) {
 	contract.Ignore(ctx)
 	return &nullSourceIterator{}, nil
 }

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -280,7 +280,7 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			URN:        s.URN(),
 			Properties: s.new.Inputs,
 			Timeout:    s.new.CustomTimeouts.Create,
-			Preview:    s.deployment.preview,
+			Preview:    s.deployment.opts.DryRun,
 		})
 		if err != nil {
 			if resp.Status != resource.StatusPartialFailure {
@@ -617,7 +617,7 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			NewInputs:     s.new.Inputs,
 			Timeout:       s.new.CustomTimeouts.Update,
 			IgnoreChanges: s.ignoreChanges,
-			Preview:       s.deployment.preview,
+			Preview:       s.deployment.opts.DryRun,
 		})
 
 		s.new.Lock.Lock()

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -96,13 +96,14 @@ type incomingChain struct {
 type stepExecutor struct {
 	// The deployment currently being executed.
 	deployment *Deployment
-	// The options for this current deployment.
-	opts Options
-	// Whether or not we are doing a preview.
-	preview bool
 	// Resources that have been created but are pending a RegisterResourceOutputs.
 	pendingNews gsync.Map[resource.URN, Step]
-	// True if we want to ignore any errors and continue executing steps.
+
+	// True if errors should be ignored completely, without any handling or
+	// reporting. This is used in the case of imports and refreshes. It is _not_
+	// the same as ContinueOnError, which allows execution to continue in the face
+	// of errors that may occur during updates. If both ignoreErrors and
+	// ContinueOnError are set, ignoreErrors takes precedence.
 	ignoreErrors bool
 
 	// Lock protecting the running of workers. This can be used to synchronize with step executor.
@@ -262,7 +263,7 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 	reg.New().Lock.Unlock()
 
 	// If we're generating plans save these new outputs to the plan
-	if se.opts.GeneratePlan {
+	if se.deployment.opts.GeneratePlan {
 		if resourcePlan, ok := se.deployment.newPlans.get(urn); ok {
 			resourcePlan.Goal.OutputDiff = NewPlanDiff(oldOuts.Diff(outs))
 			resourcePlan.Outputs = outs
@@ -273,7 +274,7 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 	}
 
 	// If there is an event subscription for finishing the resource, execute them.
-	if e := se.opts.Events; e != nil {
+	if e := se.deployment.events; e != nil {
 		if eventerr := e.OnResourceOutputs(reg); eventerr != nil {
 			se.log(synchronousWorkerID, "register resource outputs failed: %s", eventerr)
 
@@ -366,13 +367,15 @@ func (se *stepExecutor) cancelDueToError(err error, step Step) {
 	if !set {
 		logging.V(10).Infof("StepExecutor already recorded an error then saw: %v", err)
 	}
-	if se.opts.ContinueOnError {
+	if se.ignoreErrors {
+		// Do nothing.
+	} else if se.deployment.opts.ContinueOnError {
 		step.Fail()
 		// Record the failure, but allow the deployment to continue.
 		se.erroredStepLock.Lock()
 		defer se.erroredStepLock.Unlock()
 		se.erroredSteps = append(se.erroredSteps, step)
-	} else if !se.ignoreErrors {
+	} else {
 		se.cancel()
 	}
 }
@@ -392,7 +395,7 @@ func (se *stepExecutor) cancelDueToError(err error, step Step) {
 // false if it was not.
 func (se *stepExecutor) executeStep(workerID int, step Step) error {
 	var payload interface{}
-	events := se.opts.Events
+	events := se.deployment.events
 	if events != nil {
 		var err error
 		payload, err = events.OnResourceStepPre(step)
@@ -402,8 +405,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 		}
 	}
 
-	se.log(workerID, "applying step %v on %v (preview %v)", step.Op(), step.URN(), se.preview)
-	status, stepComplete, err := step.Apply(se.preview)
+	se.log(workerID, "applying step %v on %v (preview %v)", step.Op(), step.URN(), se.deployment.opts.DryRun)
+	status, stepComplete, err := step.Apply(se.deployment.opts.DryRun)
 
 	if err == nil {
 		// If we have a state object, and this is a create or update, remember it, as we may need to update it later.
@@ -477,7 +480,7 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 		}
 
 		// If we're generating plans update the resource's outputs in the generated plan.
-		if se.opts.GeneratePlan {
+		if se.deployment.opts.GeneratePlan {
 			if resourcePlan, ok := se.deployment.newPlans.get(newState.URN); ok {
 				resourcePlan.Outputs = newState.Outputs
 			}
@@ -572,14 +575,14 @@ func (se *stepExecutor) worker(workerID int, launchAsync bool) {
 	}
 }
 
-func newStepExecutor(ctx context.Context, cancel context.CancelFunc, deployment *Deployment, opts Options,
-	preview, ignoreErrors bool,
+func newStepExecutor(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	deployment *Deployment,
+	ignoreErrors bool,
 ) *stepExecutor {
-	contract.Assertf(!(ignoreErrors && opts.ContinueOnError), "ignoreErrors and ContinueOnError are mutually exclusive")
 	exec := &stepExecutor{
 		deployment:     deployment,
-		opts:           opts,
-		preview:        preview,
 		ignoreErrors:   ignoreErrors,
 		incomingChains: make(chan incomingChain),
 		ctx:            ctx,
@@ -588,14 +591,14 @@ func newStepExecutor(ctx context.Context, cancel context.CancelFunc, deployment 
 
 	// If we're being asked to run as parallel as possible, spawn a single worker that launches chain executions
 	// asynchronously.
-	if opts.InfiniteParallelism() {
+	if deployment.opts.InfiniteParallelism() {
 		exec.workers.Add(1)
 		go exec.worker(infiniteWorkerID, true /*launchAsync*/)
 		return exec
 	}
 
 	// Otherwise, launch a worker goroutine for each degree of parallelism.
-	fanout := opts.DegreeOfParallelism()
+	fanout := deployment.opts.DegreeOfParallelism()
 	for i := 0; i < fanout; i++ {
 		exec.workers.Add(1)
 		go exec.worker(i, false /*launchAsync*/)

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -103,6 +103,7 @@ func TestStepExecutor(t *testing.T) {
 
 			se := &stepExecutor{
 				deployment: &Deployment{
+					opts: &Options{},
 					plan: &Plan{},
 				},
 				pendingNews: gsync.Map[resource.URN, Step]{},
@@ -117,10 +118,10 @@ func TestStepExecutor(t *testing.T) {
 			t.Parallel()
 
 			se := &stepExecutor{
-				opts: Options{
-					GeneratePlan: true,
-				},
 				deployment: &Deployment{
+					opts: &Options{
+						GeneratePlan: true,
+					},
 					newPlans: &resourcePlans{},
 				},
 				pendingNews: gsync.Map[resource.URN, Step]{},
@@ -139,16 +140,15 @@ func TestStepExecutor(t *testing.T) {
 				cancel: func() {
 					cancelCalled = true
 				},
-				opts: Options{
-					Events: &mockEvents{
-						OnResourceOutputsF: func(step Step) error {
-							return errors.New("expected error")
-						},
-					},
-				},
 				deployment: &Deployment{
 					ctx: &plugin.Context{
 						Diag: &deploytest.NoopSink{},
+					},
+					opts: &Options{},
+					events: &mockEvents{
+						OnResourceOutputsF: func(step Step) error {
+							return errors.New("expected error")
+						},
 					},
 				},
 				pendingNews: gsync.Map[resource.URN, Step]{},
@@ -168,16 +168,15 @@ func TestStepExecutor(t *testing.T) {
 
 			expectedErr := errors.New("expected error")
 			se := &stepExecutor{
-				opts: Options{
-					Events: &mockEvents{
-						OnResourceStepPreF: func(step Step) (interface{}, error) {
-							return nil, expectedErr
-						},
-					},
-				},
 				deployment: &Deployment{
 					ctx: &plugin.Context{
 						Diag: &deploytest.NoopSink{},
+					},
+					opts: &Options{},
+					events: &mockEvents{
+						OnResourceStepPreF: func(step Step) (interface{}, error) {
+							return nil, expectedErr
+						},
 					},
 				},
 				pendingNews: gsync.Map[resource.URN, Step]{},
@@ -192,8 +191,12 @@ func TestStepExecutor(t *testing.T) {
 
 			expectedErr := errors.New("expected error")
 			se := &stepExecutor{
-				opts: Options{
-					Events: &mockEvents{
+				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+					opts: &Options{},
+					events: &mockEvents{
 						OnResourceStepPreF: func(step Step) (interface{}, error) {
 							return nil, nil
 						},
@@ -202,11 +205,6 @@ func TestStepExecutor(t *testing.T) {
 						) error {
 							return expectedErr
 						},
-					},
-				},
-				deployment: &Deployment{
-					ctx: &plugin.Context{
-						Diag: &deploytest.NoopSink{},
 					},
 					goals: &gsync.Map[resource.URN, *resource.Goal]{},
 				},

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -491,11 +491,12 @@ func TestGenerateAliases(t *testing.T) {
 			}
 
 			sg := newStepGenerator(&Deployment{
+				opts: &Options{},
 				target: &Target{
 					Name: stack,
 				},
 				source: NewNullSource(project),
-			}, Options{}, NewUrnTargets(nil), NewUrnTargets(nil))
+			})
 
 			if tt.parentAlias != nil {
 				sg.aliases = map[resource.URN]resource.URN{
@@ -547,10 +548,12 @@ func TestStepGenerator(t *testing.T) {
 
 		// Arrange.
 		sg := &stepGenerator{
-			opts: Options{
-				TargetDependents: false,
-				Targets: UrnTargets{
-					literals: []resource.URN{"b"},
+			deployment: &Deployment{
+				opts: &Options{
+					TargetDependents: false,
+					Targets: UrnTargets{
+						literals: []resource.URN{"b"},
+					},
 				},
 			},
 			targetsActual: UrnTargets{
@@ -668,10 +671,12 @@ func TestStepGenerator(t *testing.T) {
 		assert.NoError(t, err)
 
 		sg := &stepGenerator{
-			opts: Options{
-				TargetDependents: true,
-				Targets: UrnTargets{
-					literals: []resource.URN{"c"},
+			deployment: &Deployment{
+				opts: &Options{
+					TargetDependents: true,
+					Targets: UrnTargets{
+						literals: []resource.URN{"c"},
+					},
 				},
 			},
 			targetsActual: UrnTargets{
@@ -809,11 +814,14 @@ func TestStepGenerator(t *testing.T) {
 					"urn:pulumi:stack::::::": true,
 				},
 				deployment: &Deployment{
+					ctx: &plugin.Context{
+						Diag: &deploytest.NoopSink{},
+					},
+					opts: &Options{},
 					target: &Target{
 						Name: tokens.MustParseStackName("stack"),
 					},
 					source: &nullSource{},
-					ctx:    &plugin.Context{Diag: &deploytest.NoopSink{}},
 				},
 			}
 			_, err := sg.GenerateReadSteps(&readResourceEvent{})

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -157,7 +157,9 @@ func TestCreateStep(t *testing.T) {
 					new: &resource.State{
 						Custom: true,
 					},
-					deployment: &Deployment{},
+					deployment: &Deployment{
+						opts: &Options{},
+					},
 					provider: &deploytest.Provider{
 						CreateF: func(
 							urn resource.URN, inputs resource.PropertyMap,
@@ -179,7 +181,9 @@ func TestCreateStep(t *testing.T) {
 					new: &resource.State{
 						Custom: true,
 					},
-					deployment: &Deployment{},
+					deployment: &Deployment{
+						opts: &Options{},
+					},
 					provider: &deploytest.Provider{
 						CreateF: func(
 							urn resource.URN, inputs resource.PropertyMap,
@@ -204,7 +208,9 @@ func TestCreateStep(t *testing.T) {
 					new: &resource.State{
 						Custom: true,
 					},
-					deployment: &Deployment{},
+					deployment: &Deployment{
+						opts: &Options{},
+					},
 					provider: &deploytest.Provider{
 						CreateF: func(
 							urn resource.URN, inputs resource.PropertyMap,
@@ -385,7 +391,9 @@ func TestUpdateStep(t *testing.T) {
 					// Use denydefaultprovider ID to ensure failure.
 					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
 				},
-				deployment: &Deployment{},
+				deployment: &Deployment{
+					opts: &Options{},
+				},
 				provider: &deploytest.Provider{
 					UpdateF: func(
 						urn resource.URN, id resource.ID,
@@ -409,7 +417,9 @@ func TestUpdateStep(t *testing.T) {
 					// Use denydefaultprovider ID to ensure failure.
 					Provider: "urn:pulumi:stack::project::pulumi:providers:aws::default_5_42_0::denydefaultprovider",
 				},
-				deployment: &Deployment{},
+				deployment: &Deployment{
+					opts: &Options{},
+				},
 				provider: &deploytest.Provider{
 					UpdateF: func(
 						urn resource.URN, id resource.ID,


### PR DESCRIPTION
# Description

There are a number of parts of the deployment process that require context about and configuration for the operation being executed. For instance:

* Source evaluation -- evaluating programs in order to emit resource registrations
* Step generation -- processing resource registrations in order to generate steps (create this, update that, delete the other, etc.)
* Step execution -- executing steps in order to action a deployment.

Presently, these pieces all take some form of `Options` struct or pass explicit arguments. This is problematic for a couple of reasons:

* It could be possible for different parts of the codebase to end up operating in different contexts/with different configurations, whether due to different values being passed explicitly or due to missed copying/instantiation.
* Some parts need less context/configuration than others, but still accept full `Options`, making it hard to discern what information is actually necessary in any given part of the process.

This commit attempts to clean things up by moving deployment options directly into the `Deployment` itself. Since step generation and execution already refer to a `Deployment`, they get a consistent view of the options for free. For source evaluation, we introduce an `EvalSourceOptions` struct for configuring just the options necessary there. At the top level, the engine configures a single set of options to flow through the deployment steps later on.

As part of this work, a few other things have been changed:

* Preview/dry-run parameters have been incorporated into options. This lets up lop off another argument and mitigate a bit of "boolean blindness". We don't appear to flip this flag within a deployment process (indeed, all options seem to be immutable) and so having it as a separate flag doesn't seem to buy us anything.
* Several methods representing parts of the deployment process have lost arguments in favour of state that is already being carried on (or can be carried on) their receiver. For instance, `deployment.run` no longer takes actions or preview configuration. While doing so means that a `deployment` could be run multiple times with different actions/preview arguments, we don't currently exploit this fact anywhere, so moving this state to the point of construction both simplifies things considerably and reduces the possibility for error (e.g. passing different values of `preview` when instantiating a `deployment` and subsequently calling `run`).
* Event handlers have been split out of the options object and attached to `Deployment` separately. This means we can talk about options at a higher level without having to `nil` out/worry about this field and mutate it correctly later on.
* Options are no longer mutated during deployment. Presently there appears to be only one case of this -- when handling `ContinueOnError` in the presence of `IgnoreChanges` (e.g. when performing a refresh). This case has been refactored so that the mutation is no longer necessary.

# Notes

* This change is in preparation for #16146, where we'd like to add an environment variable to control behaviour and having a single unified `Options` struct would make it easier to pass this configuration down with introducing (more) global state into deployments. Indeed, this change should make it easier to factor global state into `Options` so that it can be controlled and tested more easily/is less susceptible to bugs, race conditions, etc.
* I've tweaked/extended some comments while I'm here and have learned things the hard way (e.g. `Refresh` vs `isRefresh`). Feedback welcome on this if we'd rather not conflate.
* This change does mean that if in future we wanted e.g. to be able to run a `Deployment` in multiple different ways with multiple sets of actions, we'd have to refactor. Pushing state to the point of object construction reduces the flexibility of the code. However, since we are not presently using that flexibility (nor is there an obvious [to my mind] use case in the near future), this seems like a good trade-off to guard against bugs/make it simpler to move that state around.
* I've left some other review comments in the code around questions/changes that might be a bad idea; happy to receive feedback on it all though!