### PR TITLE
Only look for main in package.json if no entyrpoint was set via Pulumi.yaml

### DIFF
--- a/changelog/pending/20240611--sdk-nodejs--only-look-for-main-in-package-json-if-no-entyrpoint-was-set-via-pulumi-yaml.yaml
+++ b/changelog/pending/20240611--sdk-nodejs--only-look-for-main-in-package-json-if-no-entyrpoint-was-set-via-pulumi-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Only look for main in package.json if no entyrpoint was set via Pulumi.yaml

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -277,6 +277,7 @@ export async function run(
         });
     }
 
+    const hasEntrypoint = argv._[0] !== ".";
     let program: string = argv._[0];
     if (!path.isAbsolute(program)) {
         // If this isn't an absolute path, make it relative to the working directory.
@@ -388,9 +389,9 @@ ${defaultMessage}`,
             const packageObject = packageObjectFromProjectRoot(packageRoot);
             let programExport: any;
 
-            // If the user provided an entrypoint, we use that file
-            // relative to the package directory.
-            if (packageObject["main"]) {
+            // If there is no entrypoint set in Pulumi.yaml via the main
+            // option, look for an entrypoint defined in package.json
+            if (!hasEntrypoint && packageObject["main"]) {
                 const packageMainPath = path.join(packageRoot, packageObject["main"]);
                 if (fs.existsSync(packageMainPath)) {
                     program = packageMainPath;

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1384,6 +1384,19 @@ func TestESMTSCompiled(t *testing.T) {
 }
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestMainOverridesPackageJSON(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("nodejs", "main-overrides-package-json"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stack.Outputs)
+			assert.Equal(t, "This is the entrypoint from Pulumi.yaml", stack.Outputs["text"])
+		},
+	})
+}
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestNpmWorkspace(t *testing.T) {
 	preparePropject := func(projinfo *engine.Projinfo) error {
 		// The default nodejs prepare uses yarn to link dependencies.

--- a/tests/integration/nodejs/main-overrides-package-json/Pulumi.yaml
+++ b/tests/integration/nodejs/main-overrides-package-json/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: main-overrides-package-json
+description: The main option from Pulumi.yaml overrides the main setting from package.json
+main: entrypoint.js
+runtime: nodejs

--- a/tests/integration/nodejs/main-overrides-package-json/entrypoint.js
+++ b/tests/integration/nodejs/main-overrides-package-json/entrypoint.js
@@ -1,0 +1,3 @@
+// Copyright 2024-2024, Pulumi Corporation.  All rights reserved.
+
+export const text = "This is the entrypoint from Pulumi.yaml"

--- a/tests/integration/nodejs/main-overrides-package-json/index.js
+++ b/tests/integration/nodejs/main-overrides-package-json/index.js
@@ -1,0 +1,3 @@
+// Copyright 2024-2024, Pulumi Corporation.  All rights reserved.
+
+export const text = "This is the entrypoint from package.json"

--- a/tests/integration/nodejs/main-overrides-package-json/package.json
+++ b/tests/integration/nodejs/main-overrides-package-json/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "main-overrides-package-json",
+    "license": "Apache-2.0",
+    "type": "module",
+    "main": "index.js",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
# Description

`main` in Pulumi.yaml is supposed to take precedence over `main` in `package.json`, but we inadvertently broke this in https://github.com/pulumi/pulumi/commit/cf1189bf2c9a31b7d0ca7aa280661af892029aa4

Fixes https://github.com/pulumi/pulumi/issues/16274

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`
