### PR TITLE
wait for RPCs to finish before registering stack transforms

### DIFF
--- a/changelog/pending/20240611--sdk-python--make-sure-no-resource-registrations-are-in-progress-while-stack-transforms-are-being-registered.yaml
+++ b/changelog/pending/20240611--sdk-python--make-sure-no-resource-registrations-are-in-progress-while-stack-transforms-are-being-registered.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Make sure no resource registrations are in progress while stack transforms are being registered

--- a/sdk/python/lib/pulumi/runtime/rpc_manager.py
+++ b/sdk/python/lib/pulumi/runtime/rpc_manager.py
@@ -81,8 +81,6 @@ class RPCManager:
 
             return result, exception
 
-        rpc_wrapper.is_rpc_wrapper = True
-
         return rpc_wrapper
 
     def clear(self) -> None:

--- a/sdk/python/lib/pulumi/runtime/rpc_manager.py
+++ b/sdk/python/lib/pulumi/runtime/rpc_manager.py
@@ -81,6 +81,8 @@ class RPCManager:
 
             return result, exception
 
+        rpc_wrapper.is_rpc_wrapper = True
+
         return rpc_wrapper
 
     def clear(self) -> None:

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -311,6 +311,11 @@ def register_stack_transform(t: ResourceTransform):
             "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
         )
 
+    loop = asyncio.get_event_loop()
+    pending = asyncio.all_tasks()
+    rpcs = {task for task in pending if task._coro.is_rpc_wrapper is True}
+    _sync_await(asyncio.gather(*rpcs))
+
     callbacks = _sync_await(_get_callbacks())
     if callbacks is None:
         raise Exception("No callback server registered.")

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -17,7 +17,7 @@ Support for automatic stack components.
 """
 import asyncio
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Awaitable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Awaitable, Optional, cast
 
 from .. import log
 from ..resource import (
@@ -311,9 +311,11 @@ def register_stack_transform(t: ResourceTransform):
             "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
         )
 
-    loop = asyncio.get_event_loop()
+    # We need to make sure all the current resource registrations are finished before
+    # registering the transforms.  Do so by waiting for all RPCs to complete, before
+    # we go ahead and register the transform.
     pending = asyncio.all_tasks()
-    rpcs = {task for task in pending if task._coro.is_rpc_wrapper is True}
+    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
     _sync_await(asyncio.gather(*rpcs))
 
     callbacks = _sync_await(_get_callbacks())


### PR DESCRIPTION
For transforms, we want to make sure all resources are registered before registering them, and that no resource registration happens while the transform is being registered in the engine.

The latter is already given, since `register_stack_transform` happens synchronously, so no new RegisterResource calls can be started while the transforms are registered.

For the former, we can make use of the event loop.  Since all of the rpc calls are being put on the event loop, we can make sure to wait for them to finish before re start registering the transforms.  Note that we can't just wait for all tasks to finish because there might be more than RPCs in flight.  However when the RPCs finished we can be certain that the resources are registered in the engine, and registering the stack transforms is now a valid operation.
