### PR TITLE
Fix --continue-on-error running indefinitely when a resource fails to be created or updated

### DIFF
--- a/changelog/pending/20240612--cli-engine--fix-continue-on-error-running-indefinitely-when-a-resource-fails-to-be-created-or-updated.yaml
+++ b/changelog/pending/20240612--cli-engine--fix-continue-on-error-running-indefinitely-when-a-resource-fails-to-be-created-or-updated.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/engine
+  description: Fix --continue-on-error running indefinitely when a resource fails to be created or updated

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -324,10 +324,14 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	}
 
 	complete := func() { s.reg.Done(&RegisterResult{State: s.new}) }
-	if resourceError == nil {
-		return resourceStatus, complete, nil
+
+	if resourceError != nil {
+		// If we have a failure, we should return an empty complete function
+		// and let the Fail method handle the registration.
+		return resourceStatus, nil, resourceError
 	}
-	return resourceStatus, complete, resourceError
+
+	return resourceStatus, complete, nil
 }
 
 func (s *CreateStep) Fail() {
@@ -647,10 +651,13 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 
 	// Finally, mark this operation as complete.
 	complete := func() { s.reg.Done(&RegisterResult{State: s.new}) }
-	if resourceError == nil {
-		return resourceStatus, complete, nil
+
+	if resourceError != nil {
+		// If we have a failure, we should return an empty complete function
+		// and let the Fail method handle the registration.
+		return resourceStatus, nil, resourceError
 	}
-	return resourceStatus, complete, resourceError
+	return resourceStatus, complete, nil
 }
 
 func (s *UpdateStep) Fail() {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR ensures that we only run the `StepCompleteFunc` if the step is successful. If not, we should use the step's `Fail` method to register the result. Previously, when a user runs a pulumi up operation with `--continue-on-error`, the engine would register the result twice, once in https://github.com/pulumi/pulumi/blob/ee6ec150d8237d472196da9e87265b6b0f24e6af/pkg/resource/deploy/step_executor.go#L342 and if a failure occurs, it is re-registered in https://github.com/pulumi/pulumi/blob/ee6ec150d8237d472196da9e87265b6b0f24e6af/pkg/resource/deploy/step_executor.go#L373
I suspect that the double registration is the cause of the user facing error. Since this would only occur for create and update steps, it also explains why the error doesn't occur during deletions.

Testing:

- Manually ran the repro identified in #16373 and https://github.com/pulumi/pulumi-command/issues/435#issuecomment-2114250614 against a locally built CLI with this fix.
- Extended existing lifecycle tests to account for the different code branches of `CreateStep.Apply()` and `UpdateStep.Apply()`

Fixes #16373

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [x] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
