### PR TITLE
Update current nodejs version to 22.x

### DIFF
--- a/changelog/pending/20240612--sdk-nodejs--update-current-nodejs-version-to-22-x.yaml
+++ b/changelog/pending/20240612--sdk-nodejs--update-current-nodejs-version-to-22-x.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Update current nodejs version to 22.x

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -129,7 +129,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
     "go": "1.22.x",
-    "nodejs": "21.x",
+    "nodejs": "22.x",
     "python": "3.12.x",
 }
 


### PR DESCRIPTION
# Description

The current nodejs version is 22.x https://nodejs.org/en/about/previous-releases

This might help us with GH actions failing on the node download step. The node-setup action will download LTS versions from https://github.com/actions/node-versions/blob/main/versions-manifest.json, and fallback to the official nodejs.org download if not found. Since we had node set to 21.x before, it was always downloading from nodejs.org, which seems to be fairly flakey.

This won't fix it once we test against 23.x though :/