### PR TITLE
[engine] Support remapping envvars for providers

### DIFF
--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -176,7 +176,7 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 			return nil, err
 		}
 		// We assume this was a plugin and not a path, so load the plugin.
-		provider, err := host.Provider(tokens.Package(pkg), version)
+		provider, err := host.Provider(tokens.Package(pkg), version, nil)
 		if err != nil {
 			// There is an executable with the same name, so suggest that
 			if info, statErr := os.Stat(pkg); statErr == nil && isExecutable(info) {
@@ -205,7 +205,7 @@ func providerFromSource(packageSource string) (plugin.Provider, error) {
 					return nil, err
 				}
 
-				p, err := host.Provider(tokens.Package(pkg), version)
+				p, err := host.Provider(tokens.Package(pkg), version, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/codegen/convert/plugin_mapper.go
+++ b/pkg/codegen/convert/plugin_mapper.go
@@ -76,7 +76,7 @@ func (pc *hostManagedProvider) Close() error {
 // that uses the given plugin host to create providers.
 func ProviderFactoryFromHost(host plugin.Host) ProviderFactory {
 	return func(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-		provider, err := host.Provider(pkg, version)
+		provider, err := host.Provider(pkg, version, nil)
 		if err != nil {
 			desc := pkg.String()
 			if version != nil {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -297,7 +297,7 @@ func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]b
 }
 
 func (l *pluginLoader) loadPluginSchemaBytes(pkg string, version *semver.Version) ([]byte, plugin.Provider, error) {
-	provider, err := l.host.Provider(tokens.Package(pkg), version)
+	provider, err := l.host.Provider(tokens.Package(pkg), version, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -171,6 +171,10 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 		if err != nil {
 			return set, err
 		}
+		envVars, err := providers.GetProviderEnvVars(res.Inputs)
+		if err != nil {
+			return set, err
+		}
 		logging.V(preparePluginLog).Infof(
 			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", pkg, version, urn)
 		set.Add(workspace.PluginSpec{
@@ -179,6 +183,7 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 			Version:           version,
 			PluginDownloadURL: downloadURL,
 			Checksums:         checksums,
+			EnvVars:           envVars,
 		})
 	}
 	return set, nil

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -365,7 +365,11 @@ func (host *pluginHost) plugin(kind apitype.PluginKind, name string, version *se
 	return plug, nil
 }
 
-func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+func (host *pluginHost) Provider(
+	pkg tokens.Package,
+	version *semver.Version,
+	envVars map[string]plugin.ProviderEnvVar,
+) (plugin.Provider, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -74,6 +74,8 @@ type ParameterizeResponse struct {
 	Version *semver.Version
 }
 
+type ProviderEnvVar = workspace.ProviderEnvVar
+
 // Provider presents a simple interface for orchestrating resource create, read, update, and delete operations.  Each
 // provider understands how to handle all of the resource types within a single package.
 //

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -719,6 +719,12 @@ func (pp ProjectPlugin) Spec() PluginSpec {
 	}
 }
 
+// ProviderEnvVar represents an environment variable setting for a provider plugin.
+type ProviderEnvVar struct {
+	Value string // The value of the environment variable, if any.
+	From  string // If set, the name of the environment variable to copy from. Overrides Value.
+}
+
 // PluginSpec provides basic specification for a plugin.
 type PluginSpec struct {
 	Name              string             // the simple name of the plugin.
@@ -729,6 +735,9 @@ type PluginSpec struct {
 
 	// if set will be used to validate the plugin downloaded matches. This is keyed by "$os-$arch", e.g. "linux-x64".
 	Checksums map[string][]byte
+
+	// if set will be used to set environment variables.
+	EnvVars map[string]ProviderEnvVar
 }
 
 // Dir gets the expected plugin directory for this plugin.


### PR DESCRIPTION
These changes add support for remapping environment variables when launching providers. This allows users to work around problems with dynamic provider configuration that is stored in statefiles causing problems during refresh and destroy operations.

For a bit of background: `pulumi up` is distinctly different from `pulumi destroy` and `pulumi refresh` in that it involves running the Pulumi program associated with the stack's project. As it runs, the Pulumi program defines the desired state for resources--including provider resources--using values computed by the program in coordination with the Pulumi engine. When the program creates a provider resource, the inputs for the provider are either sourced from the program itself (i.e. from values provided by the program) or are read out-of-band by the provider plugin. The exact set of configuration that may be sourced from the environment is particular to each provider--for example, the Kubernetes provider uses the ambient `kubeconfig` by default, the AWS provider reads various AWS-specific environment variables, etc. Any _explicitly-provided inputs_ are written into the stack's statefile.

For example, consider the following program:

```typescript
import * as aws from "@pulumi/aws";

const usEast1 = new aws.Provider("us-east-1", { region: "us-east-1" });
const defaultRegion = new aws.Provider("default-region");
```

The `usEast1` provider's `region` is explicitly specified by the program, but the `defaultRegion` provider's `region` will be read from the environment (e.g. from the `AWS_REGION` environment variable). In the resulting statefile, the `usEast1` provider's state will include the `region` input, but the `defaultRegion` provider's state will not.

Because `pulumi refresh` and `pulumi destroy` do not run the Pulumi program associated with the stack's project, they are unable to recompute configuration values that were explicitly provided by the program, and must use the values stored in the statefile. Unfortunately, this may include credential information, which is what causes the errors described here. The current workaround--which is certainly not sufficient for explicitly-instantiated providers--is to use environment variables to provide credentials out-of-band.

The clearest/most complete solution here is to run the Pulumi program associated with a stack's project as part of `pulumi refresh` and `pulumi destroy`. Unfortunately, this is a _major_ behavioral change, and the exact semantics of the run are not clear.

These changes allow explicitly-instantiated providers to make use of the same workaround that is available to default providers: pass dynamic, environmentally-sourced provider configuration in environment variables rather than as provider inputs. The environment variable remapping allows users to replace the value for a provider environment variable with the value of a different environment variable before the provider is loaded. This allows users to place configuration in environment variables that the provider would not normally read and remap them to provider-supported envvars, which allows multiple distinct sets of environment variables for providers.

For the example above, this might look like so:

```typescript
import * as aws from "@pulumi/aws";

const usEast1 = new aws.Provider("us-east-1", {
    pluginEnvVars: { "AWS_REGION": { from: "US_EAST_1_REGION" } },
});
const defaultRegion = new aws.Provider("default-region");
```

Or, if the providers needed different credentials (much more common):

```typescript
import * as aws from "@pulumi/aws";

const usEast1 = new aws.Provider("us-east-1", {
    pluginEnvVars: {
	"AWS_ACCESS_KEY_ID": { from: "US_EAST_1_AWS_ACCESS_KEY_ID" },
	"AWS_SECRET_ACCESS_KEY": { from: "US_EAST_1_AWS_SECRET_ACCESS_KEY" },
	"AWS_SESSION_TOKEN": { from: "US_EAST_1_AWS_SESSION_TOKEN" },
    },
});
const defaultRegion = new aws.Provider("default-region");
```

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
