### PR TITLE
Update pu/pu to support the new settings pull command + new deployment file

### DIFF
--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -74,7 +74,7 @@ func newDeploymentSettingsCmd() *cobra.Command {
 		Short: "Manages the stack's deployment settings",
 		Long: "Manages the stack's deployment settings\n" +
 			"\n" +
-			"Use this command to manage stack's deployment settings like\n" +
+			"Use this command to manage a stack's deployment settings like\n" +
 			"generating the deployment file, updating secrets or pushing the\n" +
 			"updated settings to Pulumi Cloud.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -93,7 +93,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull",
 		Args:  cmdutil.ExactArgs(0),
-		Short: "Pulls the stack's deployment settings and updates the deployment yaml file",
+		Short: "Pulls the stack's deployment settings from Pulumi Cloud and updates the deployment yaml file",
 		Long:  "",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -15,8 +15,14 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
 )
 
 var stackDeploymentConfigFile string
@@ -33,4 +39,157 @@ func saveProjectStackDeployment(psd *workspace.ProjectStackDeployment, stack bac
 		return workspace.SaveProjectStackDeployment(stack.Ref().Name().Q(), psd)
 	}
 	return psd.Save(stackDeploymentConfigFile)
+}
+
+func newDeploymentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deployment",
+		Short: "Manage stack deployments",
+		Long: "Manage stack deployments.\n" +
+			"\n" +
+			"Use this command to manage stack deployments, " +
+			"e.g. configuring deployment settings",
+		Args: cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			return nil
+		}),
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&stackConfigFile, "config-file", "",
+		"Use the configuration values in the specified file rather than detecting the file name")
+
+	cmd.AddCommand(newDeploymentSettingsCmd())
+
+	return cmd
+}
+
+func newDeploymentSettingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "settings",
+		Args:  cmdutil.ExactArgs(1),
+		Short: "Manages the stack's deployment settings",
+		Long:  "",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			return nil
+		}),
+	}
+
+	cmd.AddCommand(newDeploymentSettingsPullCmd())
+	cmd.AddCommand(newDeploymentSettingsUpdateCmd())
+
+	return cmd
+}
+
+func newDeploymentSettingsPullCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Args:  cmdutil.ExactArgs(0),
+		Short: "Pulls the stack's deployment settings and updates the deployment yaml file",
+		Long:  "",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			interactive := cmdutil.Interactive()
+
+			displayOpts := display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
+				IsInteractive: interactive,
+			}
+
+			project, _, err := readProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			currentBe, err := currentBackend(ctx, project, displayOpts)
+			if err != nil {
+				return err
+			}
+
+			if !currentBe.SupportsDeployments() {
+				return fmt.Errorf("backends of this type %q do not support deployments",
+					currentBe.Name())
+			}
+
+			s, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, displayOpts)
+			if err != nil {
+				return err
+			}
+
+			deploymentSettings, err := currentBe.GetStackDeploymentSettings(ctx, s)
+			if err != nil {
+				return err
+			}
+
+			newStackDeployment := &workspace.ProjectStackDeployment{
+				DeploymentSettings: *deploymentSettings,
+			}
+
+			err = saveProjectStackDeployment(newStackDeployment, s)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}),
+	}
+
+	return cmd
+}
+
+func newDeploymentSettingsUpdateCmd() *cobra.Command {
+	var stack string
+	cmd := &cobra.Command{
+		Use:        "up",
+		Aliases:    []string{"update"},
+		SuggestFor: []string{"apply", "deploy", "push"},
+		Args:       cmdutil.ExactArgs(0),
+		Short:      "Updates the stack's deployment settings with the data in the deployment yaml file",
+		Long:       "",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			interactive := cmdutil.Interactive()
+
+			displayOpts := display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
+				IsInteractive: interactive,
+			}
+
+			project, _, err := readProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			currentBe, err := currentBackend(ctx, project, displayOpts)
+			if err != nil {
+				return err
+			}
+
+			if !currentBe.SupportsDeployments() {
+				return fmt.Errorf("backends of this type %q do not support deployments",
+					currentBe.Name())
+			}
+
+			s, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, displayOpts)
+			if err != nil {
+				return err
+			}
+
+			sd, err := loadProjectStackDeployment(s)
+			if err != nil {
+				return err
+			}
+
+			err = currentBe.UpdateStackDeploymentSettings(ctx, s, sd.DeploymentSettings)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}),
+	}
+
+	return cmd
 }

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+var stackDeploymentConfigFile string
+
+func loadProjectStackDeployment(stack backend.Stack) (*workspace.ProjectStackDeployment, error) {
+	if stackDeploymentConfigFile == "" {
+		return workspace.DetectProjectStackDeployment(stack.Ref().Name().Q())
+	}
+	return workspace.LoadProjectStackDeployment(stackDeploymentConfigFile)
+}
+
+func saveProjectStackDeployment(psd *workspace.ProjectStackDeployment, stack backend.Stack) error {
+	if stackDeploymentConfigFile == "" {
+		return workspace.SaveProjectStackDeployment(stack.Ref().Name().Q(), psd)
+	}
+	return psd.Save(stackDeploymentConfigFile)
+}

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -60,7 +60,7 @@ func newDeploymentCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(
 		&stackDeploymentConfigFile, "config-file", "",
-		"Use the configuration values in the specified deployment file rather than detecting the file name")
+		"Override the file name where the deployment settings are specified. Default is Pulumi.[stack].deploy.yaml")
 
 	cmd.AddCommand(newDeploymentSettingsCmd())
 

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -59,7 +59,7 @@ func newDeploymentCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(
-		&stackConfigFile, "config-file", "",
+		&stackDeploymentConfigFile, "config-file", "",
 		"Use the configuration values in the specified deployment file rather than detecting the file name")
 
 	cmd.AddCommand(newDeploymentSettingsCmd())
@@ -83,7 +83,6 @@ func newDeploymentSettingsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newDeploymentSettingsPullCmd())
-	// cmd.AddCommand(newDeploymentSettingsUpdateCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -71,8 +71,8 @@ func newDeploymentSettingsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "settings",
 		Args:  cmdutil.ExactArgs(1),
-		Short: "Manages the stack's deployment settings",
-		Long: "Manages the stack's deployment settings\n" +
+		Short: "Manage stack deployment settings",
+		Long: "Manage stack deployment settings\n" +
 			"\n" +
 			"Use this command to manage a stack's deployment settings like\n" +
 			"generating the deployment file, updating secrets or pushing the\n" +

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -344,6 +344,7 @@ func NewPulumiCmd() *cobra.Command {
 				newLogoutCmd(),
 				newWhoAmICmd(),
 				newOrgCmd(),
+				newDeploymentCmd(),
 			},
 		},
 		{

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -166,6 +166,25 @@ func LoadProjectStack(project *Project, path string) (*ProjectStack, error) {
 	return LoadProjectStackBytes(project, b, path, marshaller)
 }
 
+func LoadProjectStackDeployment(path string) (*ProjectStackDeployment, error) {
+	contract.Requiref(path != "", "path", "must not be empty")
+
+	marshaller, err := marshallerForPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := readFileStripUTF8BOM(path)
+	if os.IsNotExist(err) {
+		defaultProjectStackDeployment := ProjectStackDeployment{}
+		return &defaultProjectStackDeployment, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return LoadProjectStackDeploymentBytes(b, path, marshaller)
+}
+
 // LoadProjectStack reads a stack definition from a byte slice.
 func LoadProjectStackBytes(
 	project *Project,
@@ -216,6 +235,20 @@ func LoadProjectStackBytes(
 
 	projectStack.raw = b
 	return &projectStack, nil
+}
+
+func LoadProjectStackDeploymentBytes(
+	b []byte,
+	path string,
+	marshaller encoding.Marshaler,
+) (*ProjectStackDeployment, error) {
+	var projectStackDeployment ProjectStackDeployment
+	err := marshaller.Unmarshal(b, &projectStackDeployment)
+	if err != nil {
+		return nil, err
+	}
+
+	return &projectStackDeployment, nil
 }
 
 // LoadPluginProject reads a plugin project definition from a file.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -110,19 +110,19 @@ func DetectProjectStackPath(stackName tokens.QName) (*Project, string, error) {
 	return proj, filepath.Join(filepath.Dir(projPath), fileName), nil
 }
 
-func DetectProjectStackDeploymentPath(stackName tokens.QName) (*Project, string, error) {
+func DetectProjectStackDeploymentPath(stackName tokens.QName) (string, error) {
 	proj, projPath, err := DetectProjectAndPath()
 	if err != nil {
-		return nil, "", err
+		return "", err
 	}
 
 	fileName := fmt.Sprintf("%s.%s.%s%s", ProjectFile, qnameFileName(stackName), DeploymentSuffix, filepath.Ext(projPath))
 
 	if proj.StackConfigDir != "" {
-		return proj, filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName), nil
+		return filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName), nil
 	}
 
-	return proj, filepath.Join(filepath.Dir(projPath), fileName), nil
+	return filepath.Join(filepath.Dir(projPath), fileName), nil
 }
 
 var ErrProjectNotFound = errors.New("no project file found")
@@ -180,7 +180,7 @@ func DetectProjectStack(stackName tokens.QName) (*ProjectStack, error) {
 }
 
 func DetectProjectStackDeployment(stackName tokens.QName) (*ProjectStackDeployment, error) {
-	_, path, err := DetectProjectStackDeploymentPath(stackName)
+	path, err := DetectProjectStackDeploymentPath(stackName)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func SaveProjectStack(stackName tokens.QName, stack *ProjectStack) error {
 }
 
 func SaveProjectStackDeployment(stackName tokens.QName, deployment *ProjectStackDeployment) error {
-	_, path, err := DetectProjectStackDeploymentPath(stackName)
+	path, err := DetectProjectStackDeploymentPath(stackName)
 	if err != nil {
 		return err
 	}

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -60,6 +60,8 @@ const (
 
 	// ProjectFile is the base name of a project file.
 	ProjectFile = "Pulumi"
+	// DeploymentSuffix base suffix for the deployment file
+	DeploymentSuffix = "deploy"
 	// RepoFile is the name of the file that holds information specific to the entire repository.
 	RepoFile = "settings.json"
 	// WorkspaceFile is the name of the file that holds workspace information.
@@ -100,6 +102,21 @@ func DetectProjectStackPath(stackName tokens.QName) (*Project, string, error) {
 	}
 
 	fileName := fmt.Sprintf("%s.%s%s", ProjectFile, qnameFileName(stackName), filepath.Ext(projPath))
+
+	if proj.StackConfigDir != "" {
+		return proj, filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName), nil
+	}
+
+	return proj, filepath.Join(filepath.Dir(projPath), fileName), nil
+}
+
+func DetectProjectStackDeploymentPath(stackName tokens.QName) (*Project, string, error) {
+	proj, projPath, err := DetectProjectAndPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	fileName := fmt.Sprintf("%s.%s.%s%s", ProjectFile, qnameFileName(stackName), DeploymentSuffix, filepath.Ext(projPath))
 
 	if proj.StackConfigDir != "" {
 		return proj, filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName), nil
@@ -162,6 +179,15 @@ func DetectProjectStack(stackName tokens.QName) (*ProjectStack, error) {
 	return LoadProjectStack(project, path)
 }
 
+func DetectProjectStackDeployment(stackName tokens.QName) (*ProjectStackDeployment, error) {
+	_, path, err := DetectProjectStackDeploymentPath(stackName)
+	if err != nil {
+		return nil, err
+	}
+
+	return LoadProjectStackDeployment(path)
+}
+
 // DetectProjectAndPath loads the closest package from the current working directory, or an error if not found.  It
 // also returns the path where the package was found.
 func DetectProjectAndPath() (*Project, string, error) {
@@ -194,6 +220,15 @@ func SaveProjectStack(stackName tokens.QName, stack *ProjectStack) error {
 	}
 
 	return stack.Save(path)
+}
+
+func SaveProjectStackDeployment(stackName tokens.QName, deployment *ProjectStackDeployment) error {
+	_, path, err := DetectProjectStackDeploymentPath(stackName)
+	if err != nil {
+		return err
+	}
+
+	return deployment.Save(path)
 }
 
 // isProject returns true if the path references what appears to be a valid project.  If problems are detected -- like

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -60,7 +60,7 @@ const (
 
 	// ProjectFile is the base name of a project file.
 	ProjectFile = "Pulumi"
-	// DeploymentSuffix base suffix for the deployment file
+	// DeploymentSuffix is the base suffix for deployment settings files (e.g. "Pulumi.<stack>.deploy.yaml").
 	DeploymentSuffix = "deploy"
 	// RepoFile is the name of the file that holds information specific to the entire repository.
 	RepoFile = "settings.json"

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -164,10 +164,7 @@ func TestDetectProjectStackDeploymentPath(t *testing.T) {
 	err = os.WriteFile(yamlDeployPath, []byte(yamlDeployContents), 0o600)
 	assert.NoError(t, err)
 
-	project, path, err := DetectProjectStackDeploymentPath("stack")
+	path, err := DetectProjectStackDeploymentPath("stack")
 	assert.NoError(t, err)
 	assert.Equal(t, yamlDeployPath, path)
-	assert.Equal(t, tokens.PackageName("some_project"), project.Name)
-	assert.Equal(t, "Some project", *project.Description)
-	assert.Equal(t, "nodejs", project.Runtime.name)
 }

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -153,7 +153,10 @@ func TestDetectProjectStackDeploymentPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	yamlPath := filepath.Join(tmpDir, "Pulumi.yaml")
-	yamlContents := "name: some_project\ndescription: Some project\nruntime: nodejs\n"
+	yamlContents := `
+name: some_project
+description: Some project
+runtime: nodejs`
 
 	err = os.WriteFile(yamlPath, []byte(yamlContents), 0o600)
 	assert.NoError(t, err)

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -143,7 +143,7 @@ func TestDetectProjectUnreadableParent(t *testing.T) {
 	assert.ErrorIs(t, err, ErrProjectNotFound)
 }
 
-//nolint:paralleltest // Theses test use and change the current working directory
+//nolint:paralleltest // These tests use and change the current working directory
 func TestDetectProjectStackDeploymentPath(t *testing.T) {
 	tmpDir := mkTempDir(t)
 	cwd, err := os.Getwd()

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pgavlin/fx"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -1015,6 +1016,16 @@ func (ps *ProjectStack) Save(path string) error {
 type ProjectRuntimeInfo struct {
 	name    string
 	options map[string]interface{}
+}
+
+type ProjectStackDeployment struct {
+	DeploymentSettings apitype.DeploymentSettings `json:"deploymentSettings" yaml:"deploymentSettings"`
+}
+
+func (psd *ProjectStackDeployment) Save(path string) error {
+	contract.Requiref(path != "", "path", "must not be empty")
+	contract.Requiref(psd != nil, "ps", "must not be nil")
+	return save(path, psd, true /*mkDirAll*/)
 }
 
 func NewProjectRuntimeInfo(name string, options map[string]interface{}) ProjectRuntimeInfo {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -1019,7 +1019,7 @@ type ProjectRuntimeInfo struct {
 }
 
 type ProjectStackDeployment struct {
-	DeploymentSettings apitype.DeploymentSettings `json:"deploymentSettings" yaml:"deploymentSettings"`
+	DeploymentSettings apitype.DeploymentSettings `json:"settings" yaml:"settings"`
 }
 
 func (psd *ProjectStackDeployment) Save(path string) error {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

- Add new deployment settings pull command: this command will pull the deployment settings from pulumi cloud and generate the new deployment file. For now it will be hidden until we have completed the whole feature.
- Add support for the new deployment file, this will contain all the deployment related information (for now just the settings), example:

```
settings:
  -executorContext: {}
    sourceContext:
      git:
        branch: main
        repoDir: .
    gitHub:
      repository: glena/test-action
      deployCommits: true
      previewPullRequests: false
    operationContext:
      preRunCommands: []
      operation: ""
      environmentVariables: {}
      options:
        skipInstallDependencies: false
        skipIntermediateDeployments: true
        shell: ""
        deleteAfterDestroy: false
        remediateIfDriftDetected: false
    agentPoolID: ...
```

Fixes https://github.com/pulumi/pulumi-service/issues/20306

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
