### PR TITLE
Don't incorrectly emit deprecated warnings

### DIFF
--- a/changelog/pending/20240614--sdk-python--dont-incorrectly-emit-deprecation-warnings-for-non-deprecated-properties.yaml
+++ b/changelog/pending/20240614--sdk-python--dont-incorrectly-emit-deprecation-warnings-for-non-deprecated-properties.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Don't incorrectly emit deprecation warnings for non-deprecated properties

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1527,14 +1527,13 @@ func (mod *modContext) genProperties(w io.Writer, properties []*schema.Property,
 		} else {
 			fmt.Fprintf(w, "%s    @pulumi.getter(name=%q)\n", indent, prop.Name)
 		}
+		if prop.DeprecationMessage != "" {
+			escaped := strings.ReplaceAll(prop.DeprecationMessage, `"`, `\"`)
+			fmt.Fprintf(w, "%s    @pulumi.deprecated(\"\"\"%s\"\"\")\n", indent, escaped)
+		}
 		fmt.Fprintf(w, "%s    def %s(self) -> %s:\n", indent, pname, ty)
 		if prop.Comment != "" {
 			printComment(w, prop.Comment, indent+"        ")
-		}
-		if prop.DeprecationMessage != "" {
-			escaped := strings.ReplaceAll(prop.DeprecationMessage, `"`, `\"`)
-			fmt.Fprintf(w, "%s        warnings.warn(\"\"\"%s\"\"\", DeprecationWarning)\n", indent, escaped)
-			fmt.Fprintf(w, "%s        pulumi.log.warn(\"\"\"%s is deprecated: %s\"\"\")\n\n", indent, pname, escaped)
 		}
 		fmt.Fprintf(w, "%s        return pulumi.get(self, %q)\n\n", indent, pname)
 

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -36,6 +36,10 @@ from .config import (
     ConfigTypeError,
 )
 
+from .deprecated import (
+    deprecated,
+)
+
 from .errors import (
     RunError,
 )
@@ -117,6 +121,8 @@ __all__ = [
     "Config",
     "ConfigMissingError",
     "ConfigTypeError",
+    # deprecated
+    "deprecated",
     # errors
     "RunError",
     # invoke

--- a/sdk/python/lib/pulumi/deprecated.py
+++ b/sdk/python/lib/pulumi/deprecated.py
@@ -1,0 +1,54 @@
+# Copyright 2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import warnings
+from typing import (
+    Callable,
+    TypeVar,
+    cast,
+)
+from .log import warn
+from ._types import _PULUMI_DEPRECATED_CALLABLE
+
+C = TypeVar("C", bound=Callable)
+
+
+def deprecated(message: str) -> Callable[[C], C]:
+    """
+    Decorator to indicate a function is deprecated.
+
+    As well as inserting appropriate statements to indicate that the function is
+    deprecated, this decorator also tags the function with a special attribute
+    so that Pulumi code can detect that it is deprecated and react appropriately
+    in certain situations.
+
+    message is the deprecation message that should be printed if the function is called.
+    """
+
+    def decorator(fn: C) -> C:
+        if not callable(fn):
+            raise TypeError("Expected fn to be callable")
+
+        @functools.wraps(fn)
+        def deprecated_fn(*args, **kwargs):
+            warnings.warn(message)
+            warn(f"{fn.__name__} is deprecated: {message}")
+
+            return fn(*args, **kwargs)
+
+        deprecated_fn.__dict__[_PULUMI_DEPRECATED_CALLABLE] = fn
+        return cast(C, deprecated_fn)
+
+    return decorator

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -1030,9 +1030,9 @@ class Resource:
             # providers map, so that it can be used for child resources.
             if provider_pkg in opts_providers:
                 message = f"There is a conflict between the `provider` field ({provider_pkg}) and a member of the `providers` map"
-                depreciation = "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details"
-                warnings.warn(f"{message} for resource {t}. " + depreciation)
-                log.warn(f"{message}. {depreciation}", resource=self)
+                deprecation = "This will become an error in a future version. See https://github.com/pulumi/pulumi/issues/8799 for more details"
+                warnings.warn(f"{message} for resource {t}. " + deprecation)
+                log.warn(f"{message}. {deprecation}", resource=self)
             else:
                 opts_providers[provider_pkg] = opts.provider
 

--- a/sdk/python/lib/test/test_deprecated.py
+++ b/sdk/python/lib/test/test_deprecated.py
@@ -1,0 +1,119 @@
+# Copyright 2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+import unittest
+import unittest.mock
+
+
+class Resource1(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self) -> str:
+        return "foo"
+
+    @property
+    @pulumi.getter
+    @pulumi.deprecated("bar is deprecated; use foo instead")
+    def bar(self) -> str:
+        return "bar"
+
+
+class DeprecatedTests(unittest.TestCase):
+    def test_deprecated_can_be_called(self):
+        # Arrange.
+        r = Resource1("test", "test", True)
+        expected = "bar"
+
+        # Act.
+        actual = r.bar
+
+        # Assert.
+        self.assertEqual(expected, actual)
+
+    def test_deprecated_can_be_called_by_prop(self):
+        # Arrange.
+        prop = Resource1.__dict__["bar"]
+        expected = "bar"
+
+        # Act.
+        actual = prop.fget(Resource1("test", "test", True))
+
+        # Assert.
+        self.assertEqual(expected, actual)
+
+    def test_deprecated_is_tagged(self):
+        # Arrange.
+        prop = Resource1.__dict__["bar"]
+
+        # Act.
+        f = prop.fget.__dict__.get("_pulumi_deprecated_callable")
+
+        # Assert.
+        self.assertIsNotNone(f)
+
+    def test_deprecated_can_passthrough(self):
+        # Arrange.
+        prop = Resource1.__dict__["bar"]
+        f = prop.fget.__dict__.get("_pulumi_deprecated_callable")
+        expected = "bar"
+
+        # Act.
+        actual = f(Resource1("test", "test", True))
+
+        # Assert.
+        self.assertEqual(expected, actual)
+
+    @unittest.mock.patch("warnings.warn")
+    def test_deprecated_prints_warnings(self, warnings_warn):
+        # Arrange.
+        prop = Resource1.__dict__["bar"]
+
+        # Act.
+        prop.fget(Resource1("test", "test", True))
+
+        # Assert.
+        warnings_warn.assert_called_once()
+
+    def test_non_deprecated_can_be_called(self):
+        # Arrange.
+        r = Resource1("test", "test", True)
+        expected = "foo"
+
+        # Act.
+        actual = r.foo
+
+        # Assert.
+        self.assertEqual(expected, actual)
+
+    def test_non_deprecated_can_be_called_by_prop(self):
+        # Arrange.
+        prop = Resource1.__dict__["foo"]
+        expected = "foo"
+
+        # Act.
+        actual = prop.fget(Resource1("test", "test", True))
+
+        # Assert.
+        self.assertEqual(expected, actual)
+
+    def test_non_deprecated_is_not_tagged(self):
+        # Arrange.
+        prop = Resource1.__dict__["foo"]
+
+        # Act.
+        f = prop.fget.__dict__.get("_pulumi_deprecated_callable")
+
+        # Assert.
+        self.assertIsNone(f)

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -57,10 +57,8 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
+    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def diameter(self) -> pulumi.Input['Diameter']:
-        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
-        pulumi.log.warn("""diameter is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
-
         return pulumi.get(self, "diameter")
 
     @diameter.setter
@@ -69,10 +67,8 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
+    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def type(self) -> pulumi.Input['RubberTreeVariety']:
-        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
-        pulumi.log.warn("""type is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
-
         return pulumi.get(self, "type")
 
     @type.setter
@@ -90,10 +86,8 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
+    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
-        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
-        pulumi.log.warn("""farm is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
-
         return pulumi.get(self, "farm")
 
     @farm.setter
@@ -102,10 +96,8 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
+    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def size(self) -> Optional[pulumi.Input['TreeSize']]:
-        warnings.warn("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""", DeprecationWarning)
-        pulumi.log.warn("""size is deprecated: Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
-
         return pulumi.get(self, "size")
 
     @size.setter


### PR DESCRIPTION
Presently, the Python SDK incorrectly emits deprecation warnings for properties even if user code does not reference them. This is due to various pieces of code in the SDK that enumerate properties e.g. for the purpose of serialisation/RPC calls. In enumerating properties, their getters are invoked, triggering the deprecation warnings.

There isn't currently a way for us to detect which properties may or may not be deprecated and handle them appropriately, so this commit introduces one. Deprecation messages are moved into a new decorator, `@pulumi.deprecated`. This decorator accepts a `Callable` and wraps it, making two changes:

* Before the decorated `Callable`'s execution, deprecation messages are printed.
* The returned `Callable` is tagged with a new reserved property, `_pulumi_deprecated_callable`, which references the wrapped `Callable` (that is, the original `Callable` whose invocation will _not_ produce deprecation warnings).

With this in place, we subsequently make the following two changes:

* We modify the SDK enumeration code (specifically that in `input_type_to_dict` to check for `_pulumi_deprecated_callable` properties and use them where appropriate to invoke getters without triggering deprecation warnings.
* We modify Python code generation so that instead of emitting statements to print deprecation warnings, we simply emit applications of the `@pulumi.deprecated` decorator instead.

This commit adds some Python unit tests to exercise the decorator and manual testing has been performed using the AWS Classic SDK.

Fixes #15894
