### PR TITLE
Fix a panic when ignoring wildcard values with arrays of different length

### DIFF
--- a/changelog/pending/20240614--engine--fix-a-panic-when-ignoring-wildcard-values-with-arrays-of-different-length.yaml
+++ b/changelog/pending/20240614--engine--fix-a-panic-when-ignoring-wildcard-values-with-arrays-of-different-length.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a panic when ignoring wildcard values with arrays of different length

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -459,6 +459,11 @@ func (p PropertyPath) reset(old, new PropertyValue, oldIsSecret, newIsSecret boo
 			} else if old.IsArray() && new.IsArray() {
 				oldArray := old.ArrayValue()
 				newArray := new.ArrayValue()
+				// If arrays are of different length then this is a path failure because we can't
+				// continue the search of this path down each PropertyValue.
+				if len(oldArray) != len(newArray) {
+					return false
+				}
 
 				for i := range oldArray {
 					if !p[1:].reset(oldArray[i], newArray[i], oldIsSecret, newIsSecret) {

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -750,6 +750,30 @@ func TestReset(t *testing.T) {
 			nil,
 		},
 		{
+			"Nested wildcard, old array is longer fails",
+			PropertyPath{"root", "*", 0},
+			PropertyMap{"root": NewProperty([]PropertyValue{
+				NewProperty(1.0),
+				NewProperty(2.0),
+			})},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(3.0),
+			}))},
+			nil,
+		},
+		{
+			"Nested wildcard, new array is longer fails",
+			PropertyPath{"root", "*", 0},
+			PropertyMap{"root": NewProperty([]PropertyValue{
+				NewProperty(1.0),
+			})},
+			PropertyMap{"root": MakeSecret(NewProperty([]PropertyValue{
+				NewProperty(3.0),
+				NewProperty(4.0),
+			}))},
+			nil,
+		},
+		{
 			"Nested path, secret old",
 			PropertyPath{"root", "secret"},
 			PropertyMap{"root": MakeSecret(NewProperty(PropertyMap{"secret": NewProperty(1.0)}))},


### PR DESCRIPTION
The panic occurred during pulumi preview while calculating values for ignored changes with a `*` wildcard

```
{ignoreChanges: ["defaultActions[*].forward.targetGroups[*].weight"]}
```

when compared arrays had different length. We weren't checking the array boundaries carefully, and thus panicing when going out of bounds.

After the fix, the same repro in the issue leads to a preview error

> cannot ignore changes to the following properties because one or more elements of the path are missing: "defaultActions[*].forward.targetGroups[*].weight"

This seems consistent with other code branches and tests, where `reset` returns false for non-matching shapes. User's expectation may be that we succeed in this case - curious to get a take from ones who implemented the wildcard feature in the past.

Fixes #16403
