### PR TITLE
[cli/plugin] Fix plugin install command when plugin type is tool

### DIFF
--- a/changelog/pending/20240616--cli-plugin--fix-plugin-install-command-when-plugin-type-is-tool.yaml
+++ b/changelog/pending/20240616--cli-plugin--fix-plugin-install-command-when-plugin-type-is-tool.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix plugin install command when plugin type is tool

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -31,12 +31,6 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginSpec) bool {
 		return false
 	}
 
-	// Zaid's arm and bicep converters so that `pulumi convert --from arm/bicep` just works.
-	if spec.Kind == apitype.ConverterPlugin && (spec.Name == "arm" || spec.Name == "bicep") {
-		spec.PluginDownloadURL = "github://api.github.com/Zaid-Ajaj"
-		return true
-	}
-
 	pulumiversePlugins := []string{
 		"acme",
 		"aquasec",

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -367,6 +367,15 @@ func newGithubSource(url *url.URL, name string, kind apitype.PluginKind) (*githu
 			repository = "pulumi-yaml"
 		}
 	}
+
+	if kind == apitype.ToolPlugin {
+		// Convention for tool plugins is to have them in a repository named "pulumi-tool-<name>".
+		if !strings.HasPrefix(name, "pulumi-tool-") {
+			// if it is not already fully qualified, we will prefix it with "pulumi-tool-"
+			repository = "pulumi-tool-" + name
+		}
+	}
+
 	if len(parts) == 2 {
 		repository = parts[1]
 	}


### PR DESCRIPTION
# Description

When trying to install a plugin of type `tool` from GitHub, the Pulumi convention is to have these plugins available in repositories named `pulumi-tool-<name>` so that we can install them via the CLI as follows:
```
pulumi plugin install tool <name>
```
However, today this fails because we don't prefix the repository name correctly with `"pulumi-tool-"`. This PR fixes that. Tested against [Zaid-Ajaj/pulumi-tool-importer](https://github.com/Zaid-Ajaj/pulumi-tool-importer)

Also removes hardcoded plugin download URL for known converter plugins of mine. These are moved to the `pulumi` organisation and no longer require a separate URL.

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
