### PR TITLE
Add packagemanager prompt to pulumi new for nodejs

### DIFF
--- a/changelog/pending/20240618--cli-new--add-packagemanager-prompt-to-pulumi-new-for-nodejs.yaml
+++ b/changelog/pending/20240618--cli-new--add-packagemanager-prompt-to-pulumi-new-for-nodejs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Add packagemanager prompt to pulumi new for nodejs

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -179,7 +179,7 @@ func (pack *cloudPolicyPack) Publish(
 	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	runtime := op.PolicyPack.Runtime.Name()
 	if strings.EqualFold(runtime, "nodejs") {
-		packTarball, err = npm.Pack(ctx, op.PlugCtx.Pwd, os.Stderr)
+		packTarball, err = npm.Pack(ctx, npm.AutoPackageManager, op.PlugCtx.Pwd, os.Stderr)
 		if err != nil {
 			return result.FromError(fmt.Errorf("could not publish policies because of error running npm pack: %w", err))
 		}
@@ -307,7 +307,7 @@ func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadClos
 }
 
 func completeNodeJSInstall(ctx context.Context, finalDir string) error {
-	if bin, err := npm.Install(ctx, finalDir, false /*production*/, nil, os.Stderr); err != nil {
+	if bin, err := npm.Install(ctx, npm.AutoPackageManager, finalDir, false /*production*/, nil, os.Stderr); err != nil {
 		return fmt.Errorf("failed to install dependencies of policy pack; you may need to re-run `%s install` "+
 			"in %q before this policy pack works"+": %w", bin, finalDir, err)
 	}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -241,4 +243,26 @@ func AssertHTTPResultWithRetry(
 	}
 	// Verify it matches expectations
 	return check(string(body))
+}
+
+func CheckRuntimeOptions(t *testing.T, root string, expected map[string]interface{}) {
+	t.Helper()
+
+	var config struct {
+		Runtime struct {
+			Name    string                 `yaml:"name"`
+			Options map[string]interface{} `yaml:"options"`
+		} `yaml:"runtime"`
+	}
+	yamlFile, err := os.ReadFile(filepath.Join(root, "Pulumi.yaml"))
+	if err != nil {
+		t.Logf("could not read Pulumi.yaml in %s", root)
+		t.FailNow()
+	}
+	if err := yaml.Unmarshal(yamlFile, &config); err != nil {
+		t.Logf("could not parse Pulumi.yaml in %s", root)
+		t.FailNow()
+	}
+
+	require.Equal(t, expected, config.Runtime.Options)
 }

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1467,7 +1467,7 @@ func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginCon
 		switch runtime {
 		case "nodejs":
 			var b bytes.Buffer
-			if _, err := npm.Install(ctx, finalDir, true /* production */, &b, &b); err != nil {
+			if _, err := npm.Install(ctx, npm.AutoPackageManager, finalDir, true /* production */, &b, &b); err != nil {
 				os.Stderr.Write(b.Bytes())
 				return fmt.Errorf("installing plugin dependencies: %w", err)
 			}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -906,8 +906,8 @@ func (host *nodeLanguageHost) RuntimeOptionsPrompts(ctx context.Context,
 			PromptType:  pulumirpc.RuntimeOptionPrompt_STRING,
 			Choices: []*pulumirpc.RuntimeOptionPrompt_RuntimeOptionValue{
 				{StringValue: "npm", PromptType: pulumirpc.RuntimeOptionPrompt_STRING},
-				{StringValue: "yarn", PromptType: pulumirpc.RuntimeOptionPrompt_STRING},
 				{StringValue: "pnpm", PromptType: pulumirpc.RuntimeOptionPrompt_STRING},
+				{StringValue: "yarn", PromptType: pulumirpc.RuntimeOptionPrompt_STRING},
 			},
 			Default: &pulumirpc.RuntimeOptionPrompt_RuntimeOptionValue{
 				PromptType:  pulumirpc.RuntimeOptionPrompt_STRING,

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -90,18 +90,18 @@ func TestResolvePackageManager(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		pm        PackageManagerType
-		exepcted  string
 		lockFiles []string
+		expected  string
 	}{
-		{"defaults to npm", AutoPackageManager, "npm", []string{}},
-		{"picks npm", NpmPackageManager, "npm", []string{}},
-		{"picks yarn", YarnPackageManager, "yarn", []string{}},
-		{"picks pnpm", PnpmPackageManager, "pnpm", []string{}},
-		{"picks npm based on lockfile", AutoPackageManager, "npm", []string{"npm"}},
-		{"picks yarn based on lockfile", AutoPackageManager, "yarn", []string{"yarn"}},
-		{"picks pnpm based on lockfile", AutoPackageManager, "pnpm", []string{"pnpm"}},
-		{"yarn > pnpm > npm", AutoPackageManager, "yarn", []string{"yarn", "pnpm", "npm"}},
-		{"pnpm > npm", AutoPackageManager, "pnpm", []string{"pnpm", "npm"}},
+		{"defaults to npm", AutoPackageManager, []string{}, "npm"},
+		{"picks npm", NpmPackageManager, []string{}, "npm"},
+		{"picks yarn", YarnPackageManager, []string{}, "yarn"},
+		{"picks pnpm", PnpmPackageManager, []string{}, "pnpm"},
+		{"picks npm based on lockfile", AutoPackageManager, []string{"npm"}, "npm"},
+		{"picks yarn based on lockfile", AutoPackageManager, []string{"yarn"}, "yarn"},
+		{"picks pnpm based on lockfile", AutoPackageManager, []string{"pnpm"}, "pnpm"},
+		{"yarn > pnpm > npm", AutoPackageManager, []string{"yarn", "pnpm", "npm"}, "yarn"},
+		{"pnpm > npm", AutoPackageManager, []string{"pnpm", "npm"}, "pnpm"},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestResolvePackageManager(t *testing.T) {
 			}
 			pm, err := ResolvePackageManager(tt.pm, dir)
 			require.NoError(t, err)
-			require.Equal(t, tt.exepcted, pm.Name())
+			require.Equal(t, tt.expected, pm.Name())
 		})
 	}
 }

--- a/tests/integration/integration_nodejs_acceptance_test.go
+++ b/tests/integration/integration_nodejs_acceptance_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 )
 
 // TestEmptyNodeJS simply tests that we can run an empty NodeJS project.
@@ -192,4 +193,47 @@ func TestConstructComponentConfigureProviderNode(t *testing.T) {
 		},
 	})
 	integration.ProgramTest(t, &opts)
+}
+
+func TestNewNodejsUsesNpmByDefault(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "new", "typescript", "--force", "--non-interactive", "--yes", "--generate-only")
+
+	expected := map[string]interface{}{
+		"packagemanager": "npm",
+	}
+	integration.CheckRuntimeOptions(t, e.RootPath, expected)
+}
+
+func TestNewNodejsRuntimeOptions(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "new", "typescript", "--force", "--non-interactive", "--yes", "--generate-only",
+		"--name", "test_project",
+		"--description", "Testing that the packagemanager option is set correctly",
+		"--stack", "test",
+		"--runtime-options", "packagemanager=pnpm",
+	)
+
+	expected := map[string]interface{}{
+		"packagemanager": "pnpm",
+	}
+	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -426,7 +425,7 @@ func TestNewPythonUsesPip(t *testing.T) {
 		"toolchain":  "pip",
 		"virtualenv": "venv",
 	}
-	checkRuntimeOptions(t, e.RootPath, expected)
+	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
 //nolint:paralleltest // Modifies env
@@ -458,7 +457,7 @@ func TestNewPythonChoosePoetry(t *testing.T) {
 	expected := map[string]interface{}{
 		"toolchain": "poetry",
 	}
-	checkRuntimeOptions(t, e.RootPath, expected)
+	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
 func TestNewPythonRuntimeOptions(t *testing.T) {
@@ -483,7 +482,7 @@ func TestNewPythonRuntimeOptions(t *testing.T) {
 		"toolchain":  "pip",
 		"virtualenv": "mytestenv",
 	}
-	checkRuntimeOptions(t, e.RootPath, expected)
+	integration.CheckRuntimeOptions(t, e.RootPath, expected)
 }
 
 func TestNewPythonConvertRequirementsTxt(t *testing.T) {
@@ -515,26 +514,4 @@ in-project = true`
 
 	require.True(t, e.PathExists("pyproject.toml"), "pyproject.toml was created")
 	require.False(t, e.PathExists("requirements.txt"), "requirements.txt was removed")
-}
-
-func checkRuntimeOptions(t *testing.T, root string, expected map[string]interface{}) {
-	t.Helper()
-
-	var config struct {
-		Runtime struct {
-			Name    string                 `yaml:"name"`
-			Options map[string]interface{} `yaml:"options"`
-		} `yaml:"runtime"`
-	}
-	yamlFile, err := os.ReadFile(filepath.Join(root, "Pulumi.yaml"))
-	if err != nil {
-		t.Logf("could not read Pulumi.yaml in %s", root)
-		t.FailNow()
-	}
-	if err := yaml.Unmarshal(yamlFile, &config); err != nil {
-		t.Logf("could not parse Pulumi.yaml in %s", root)
-		t.FailNow()
-	}
-
-	require.Equal(t, expected, config.Runtime.Options)
 }


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/16346 introduced the capability to query the language runtime for additional prompts. We use this to let the user pick a package manager among npm, yarn and pnpm during `pulumi new` when using the nodejs runtime.

When there is no explicitly configured package manager, we re-use the previous behaviour for determining the package manager (check `PULUMI_PREFER_YARN` env variable, look for lock files).

Defaults to `npm` when running `new` in non-interactive mode.
