### PR TITLE
New Deployment Settings commands to init, update and clear the config

### DIFF
--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -144,6 +144,9 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 				DeploymentSettings: apitype.DeploymentSettings{
 					SourceContext: &apitype.SourceContext{
 						Git: &apitype.SourceContextGit{
+							// Setting this by default to be included in the deployment file
+							// so it is easier to manually change by users. This will be completed
+							// by the user when this gets converted to a wizard.
 							RepoDir: ".",
 						},
 					},
@@ -164,6 +167,9 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 			}
 
 			if vcsInfo, err := gitutil.TryGetVCSInfo(remoteURL); err == nil {
+				// If it is a GitHub repo, we will configure it to be used with the App. Otherwise, we will
+				// configure it as a barebone git repository (we wont be configuring credentials at this point
+				// users can use the `set` command to configure those afterwards).
 				if vcsInfo.Kind == gitutil.GitHubHostName {
 					newStackDeployment.DeploymentSettings.GitHub = &apitype.DeploymentSettingsGitHub{
 						Repository:          fmt.Sprintf("%s/%s", vcsInfo.Owner, vcsInfo.Repo),

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -174,7 +174,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 					newStackDeployment.DeploymentSettings.SourceContext.Git.RepoURL = remoteURL
 				}
 			} else {
-				return fmt.Errorf("detecting VCS info for stack tags for remote %v: %w", remoteURL, err)
+				return fmt.Errorf("detecting VCS info from stack tags for remote %v: %w", remoteURL, err)
 			}
 
 			if h.Name().IsBranch() {

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -100,7 +100,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		Use:        "init",
 		SuggestFor: []string{"new", "create"},
 		Args:       cmdutil.ExactArgs(0),
-		Short:      "Initializes the stack deployment settings file",
+		Short:      "Initialize the stack's deployment.yaml file",
 		Long:       "",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -205,7 +205,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull",
 		Args:  cmdutil.ExactArgs(0),
-		Short: "Pulls the stack's deployment settings from Pulumi Cloud and updates the deployment yaml file",
+		Short: "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
 		Long:  "",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -264,7 +264,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 		Aliases:    []string{"update"},
 		SuggestFor: []string{"apply", "deploy", "push"},
 		Args:       cmdutil.ExactArgs(0),
-		Short:      "Updates the stack's deployment settings with the data in the deployment yaml file",
+		Short:      "Update stack deployment settings from deployment.yaml",
 		Long:       "",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -319,7 +319,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 		Aliases:    []string{"down", "dn"},
 		SuggestFor: []string{"delete", "kill", "remove", "rm", "stop"},
 		Args:       cmdutil.ExactArgs(0),
-		Short:      "Deletes all the stack deployment settings",
+		Short:      "Delete all the stack's deployment settings",
 		Long:       "",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()


### PR DESCRIPTION
New set of commands to manage the stack's deployment settings:
- deployment settings init: initializes the deployment file with information from the environment for the current stack
- deployment settings update: overrides the deployment settings in pulumi cloud with the ones in the deployment file
- deployment settings destroy: clears the deployment settings for the current stack

Fixes # https://github.com/pulumi/pulumi-service/issues/20379