### PR TITLE
[sdk/nodejs] Allow missing package.json dependencies

### DIFF
--- a/changelog/pending/20240621--sdk-nodejs--avoid-an-unhandled-error-when-dependencies-is-missing-from-package-json-during-closure-serialization.yaml
+++ b/changelog/pending/20240621--sdk-nodejs--avoid-an-unhandled-error-when-dependencies-is-missing-from-package-json-during-closure-serialization.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Avoid an unhandled error when `dependencies` is missing from `package.json` during closure serialization

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -257,8 +257,10 @@ async function allFoldersForPackages(
     // and should not be uploaded.
     const referencedPackages = new Set<string>(includedPackages);
     const packageJSON = computeDependenciesDirectlyFromPackageFile(upath.join(workingDir, "package.json"), logResource);
-    for (const depName of Object.keys(packageJSON.dependencies)) {
-        referencedPackages.add(depName);
+    if (packageJSON.dependencies) {
+        for (const depName of Object.keys(packageJSON.dependencies)) {
+            referencedPackages.add(depName);
+        }
     }
 
     // Find the workspace root, fallback to current working directory if we are not in a workspaces setup.

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1604,6 +1604,15 @@ func TestCodePathsWorkspaceTSC(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestCodePathsNoDependencies(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("nodejs", "codepaths-no-dependencies"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+	})
+}
+
 // Test that the resource stopwatch doesn't contain a negative time.
 func TestNoNegativeTimingsOnRefresh(t *testing.T) {
 	if runtime.GOOS == WindowsOS {

--- a/tests/integration/nodejs/codepaths-no-dependencies/Pulumi.yaml
+++ b/tests/integration/nodejs/codepaths-no-dependencies/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: codepaths-no-dependencies
+runtime: nodejs
+description: Basic test case for codepaths with no dependencies in package.json

--- a/tests/integration/nodejs/codepaths-no-dependencies/index.ts
+++ b/tests/integration/nodejs/codepaths-no-dependencies/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as runtime from "@pulumi/pulumi/runtime";
+
+(async function() {
+    const deps = await runtime.computeCodePaths();
+
+    const actual = JSON.stringify([...deps.keys()]);
+    const expected = "[]";
+
+    if (actual !== expected) {
+        throw new Error(`Got '${actual}' expected '${expected}'`);
+    }
+})()

--- a/tests/integration/nodejs/codepaths-no-dependencies/package.json
+++ b/tests/integration/nodejs/codepaths-no-dependencies/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "test-codepaths-no-dependencies",
+    "description": "Basic test case for codepaths where there is no dependencies in package.json",
+    "main": "index.ts"
+}

--- a/tests/integration/nodejs/codepaths-no-dependencies/tsconfig.json
+++ b/tests/integration/nodejs/codepaths-no-dependencies/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2016",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": ["index.ts"]
+}


### PR DESCRIPTION
Avoid an unhandled error when `dependencies` is missing from `package.json` during closure serialization.

Fixes #16076