### PR TITLE
add RegisterResourceTransform as alias for RegisterStackTransform

### DIFF
--- a/changelog/pending/20240621--sdk-go-nodejs-python--add-register-resource-transform-alias-for-register-stack-transform.yaml
+++ b/changelog/pending/20240621--sdk-go-nodejs-python--add-register-resource-transform-alias-for-register-stack-transform.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go,nodejs,python
+  description: Add register resource transform alias for register stack transform

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2113,13 +2113,15 @@ func (ctx *Context) Export(name string, value Input) {
 }
 
 // RegisterStackTransformation adds a transformation to all future resources constructed in this Pulumi stack.
+//
+// Deprecated: Use RegisterResourceTransform instead.
 func (ctx *Context) RegisterStackTransformation(t ResourceTransformation) error {
 	ctx.state.stack.addTransformation(t)
 	return nil
 }
 
-// RegisterStackTransform adds a transform to all future resources constructed in this Pulumi stack.
-func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
+// RegisterResourceTransform adds a transform to all future resources constructed in this Pulumi stack.
+func (ctx *Context) RegisterResourceTransform(t ResourceTransform) error {
 	cb, err := ctx.registerTransform(t)
 	if err != nil {
 		return err
@@ -2127,6 +2129,11 @@ func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
 
 	_, err = ctx.state.monitor.RegisterStackTransform(ctx.ctx, cb)
 	return err
+}
+
+// RegisterStackTransform adds a transform to all future resources constructed in this Pulumi stack.
+func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
+	return ctx.RegisterResourceTransform(t)
 }
 
 func (ctx *Context) newOutputState(elementType reflect.Type, deps ...Resource) *OutputState {

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2113,8 +2113,6 @@ func (ctx *Context) Export(name string, value Input) {
 }
 
 // RegisterStackTransformation adds a transformation to all future resources constructed in this Pulumi stack.
-//
-// Deprecated: Use RegisterResourceTransform instead.
 func (ctx *Context) RegisterStackTransformation(t ResourceTransformation) error {
 	ctx.state.stack.addTransformation(t)
 	return nil
@@ -2132,6 +2130,8 @@ func (ctx *Context) RegisterResourceTransform(t ResourceTransform) error {
 }
 
 // RegisterStackTransform adds a transform to all future resources constructed in this Pulumi stack.
+//
+// Deprecated: Use RegisterResourceTransform instead.
 func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
 	return ctx.RegisterResourceTransform(t)
 }

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -222,7 +222,7 @@ export function registerStackTransformation(t: ResourceTransformation) {
 /**
  * Add a transformation to all future resources constructed in this Pulumi stack.
  */
-export function registerResourceTransform(t: ResourceTransform) {
+export function registerResourceTransform(t: ResourceTransform): void {
     if (!getStore().supportsTransforms) {
         throw new Error("The Pulumi CLI does not support transforms. Please update the Pulumi CLI");
     }
@@ -241,7 +241,6 @@ export function registerResourceTransform(t: ResourceTransform) {
 export function registerStackTransform(t: ResourceTransform) {
     registerResourceTransform(t);
 }
-
 
 export function getStackResource(): Stack | undefined {
     return stateGetStackResource();

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -222,7 +222,7 @@ export function registerStackTransformation(t: ResourceTransformation) {
 /**
  * Add a transformation to all future resources constructed in this Pulumi stack.
  */
-export function registerStackTransform(t: ResourceTransform) {
+export function registerResourceTransform(t: ResourceTransform) {
     if (!getStore().supportsTransforms) {
         throw new Error("The Pulumi CLI does not support transforms. Please update the Pulumi CLI");
     }
@@ -232,6 +232,16 @@ export function registerStackTransform(t: ResourceTransform) {
     }
     callbacks.registerStackTransform(t);
 }
+
+/**
+ * Add a transformation to all future resources constructed in this Pulumi stack.
+ *
+ * @deprecated Use `registerResourceTransform` instead.
+ */
+export function registerStackTransform(t: ResourceTransform) {
+    registerResourceTransform(t);
+}
+
 
 export function getStackResource(): Stack | undefined {
     return stateGetStackResource();

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -46,6 +46,7 @@ from .stack import (
     run_in_stack,
     register_stack_transformation,
     register_stack_transform,
+    register_resource_transform,
 )
 
 from .invoke import (
@@ -88,6 +89,7 @@ __all__ = [
     "run_in_stack",
     "register_stack_transformation",
     "register_stack_transform",
+    "register_resource_transform",
     # invoke
     "invoke",
     "invoke_async",

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -302,7 +302,7 @@ def register_stack_transformation(t: ResourceTransformation):
         root_resource._transformations = root_resource._transformations + [t]
 
 
-def register_stack_transform(t: ResourceTransform):
+def register_resource_transform(t: ResourceTransform):
     """
     Add a transform to all future resources constructed in this Pulumi stack.
     """
@@ -322,3 +322,12 @@ def register_stack_transform(t: ResourceTransform):
     if callbacks is None:
         raise Exception("No callback server registered.")
     callbacks.register_stack_transform(t)
+
+
+def register_stack_transform(t: ResourceTransform):
+    """
+    Add a transform to all future resources constructed in this Pulumi stack.
+
+    Deprecated: use `register_resource_transform` instead.
+    """
+    register_resource_transform(t)

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -302,7 +302,7 @@ def register_stack_transformation(t: ResourceTransformation):
         root_resource._transformations = root_resource._transformations + [t]
 
 
-def register_resource_transform(t: ResourceTransform):
+def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
     """


### PR DESCRIPTION
In subsequent PRs we're going to introduce transforms for Calls, Invokes and Reads.  Add an alias to the current register stack transforms functions, and deprecate the old version.   This is both for consistency, and because it's a bit confusing that register stack transforms only works for register resource calls, and not other types of pulumi operations.

/xref https://github.com/pulumi/pulumi/issues/16171