### PR TITLE
Generate `@deprecated` decorators in Python SDKs

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1560,7 +1560,7 @@ func (mod *modContext) genProperties(w io.Writer, properties []*schema.Property,
 		}
 		if prop.DeprecationMessage != "" {
 			escaped := strings.ReplaceAll(prop.DeprecationMessage, `"`, `\"`)
-			fmt.Fprintf(w, "%s    @pulumi.deprecated(\"\"\"%s\"\"\")\n", indent, escaped)
+			fmt.Fprintf(w, "%s    @_utilities.deprecated(\"\"\"%s\"\"\")\n", indent, escaped)
 		}
 		fmt.Fprintf(w, "%s    def %s(self) -> %s:\n", indent, pname, ty)
 		if prop.Comment != "" {

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import functools
 import importlib.metadata
 import importlib.util
 import inspect
@@ -7,6 +8,7 @@ import json
 import os
 import sys
 import typing
+import warnings
 
 import pulumi
 import pulumi.runtime
@@ -14,6 +16,8 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+C = typing.TypeVar("C", bound=typing.Callable)
 
 
 def get_env(*args):
@@ -282,3 +286,34 @@ async def _await_output(o: pulumi.Output[typing.Any]) -> typing.Tuple[object, bo
         await o._is_secret,
         await o._resources,
     )
+
+
+# This is included to provide an upgrade path for users who are using a version
+# of the Pulumi SDK (<3.121.0) that does not include the `deprecated` decorator.
+def deprecated(message: str) -> typing.Callable[[C], C]:
+    """
+    Decorator to indicate a function is deprecated.
+
+    As well as inserting appropriate statements to indicate that the function is
+    deprecated, this decorator also tags the function with a special attribute
+    so that Pulumi code can detect that it is deprecated and react appropriately
+    in certain situations.
+
+    message is the deprecation message that should be printed if the function is called.
+    """
+
+    def decorator(fn: C) -> C:
+        if not callable(fn):
+            raise TypeError("Expected fn to be callable")
+
+        @functools.wraps(fn)
+        def deprecated_fn(*args, **kwargs):
+            warnings.warn(message)
+            pulumi.warn(f"{fn.__name__} is deprecated: {message}")
+
+            return fn(*args, **kwargs)
+
+        deprecated_fn.__dict__["_pulumi_deprecated_callable"] = fn
+        return typing.cast(C, deprecated_fn)
+
+    return decorator

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -57,7 +57,7 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+    @_utilities.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def diameter(self) -> pulumi.Input['Diameter']:
         return pulumi.get(self, "diameter")
 
@@ -67,7 +67,7 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+    @_utilities.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def type(self) -> pulumi.Input['RubberTreeVariety']:
         return pulumi.get(self, "type")
 
@@ -86,7 +86,7 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+    @_utilities.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
@@ -96,7 +96,7 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    @pulumi.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
+    @_utilities.deprecated("""Dear future maintainer, if there are changes here, make sure that this is printed before the value is set to the default or else this will always print.""")
     def size(self) -> Optional[pulumi.Input['TreeSize']]:
         return pulumi.get(self, "size")
 

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -4,6 +4,7 @@
 
 
 import asyncio
+import functools
 import importlib.metadata
 import importlib.util
 import inspect
@@ -11,6 +12,7 @@ import json
 import os
 import sys
 import typing
+import warnings
 
 import pulumi
 import pulumi.runtime
@@ -18,6 +20,8 @@ from pulumi.runtime.sync_await import _sync_await
 
 from semver import VersionInfo as SemverVersion
 from parver import Version as PEP440Version
+
+C = typing.TypeVar("C", bound=typing.Callable)
 
 
 def get_env(*args):
@@ -286,6 +290,37 @@ async def _await_output(o: pulumi.Output[typing.Any]) -> typing.Tuple[object, bo
         await o._is_secret,
         await o._resources,
     )
+
+
+# This is included to provide an upgrade path for users who are using a version
+# of the Pulumi SDK (<3.121.0) that does not include the `deprecated` decorator.
+def deprecated(message: str) -> typing.Callable[[C], C]:
+    """
+    Decorator to indicate a function is deprecated.
+
+    As well as inserting appropriate statements to indicate that the function is
+    deprecated, this decorator also tags the function with a special attribute
+    so that Pulumi code can detect that it is deprecated and react appropriately
+    in certain situations.
+
+    message is the deprecation message that should be printed if the function is called.
+    """
+
+    def decorator(fn: C) -> C:
+        if not callable(fn):
+            raise TypeError("Expected fn to be callable")
+
+        @functools.wraps(fn)
+        def deprecated_fn(*args, **kwargs):
+            warnings.warn(message)
+            pulumi.warn(f"{fn.__name__} is deprecated: {message}")
+
+            return fn(*args, **kwargs)
+
+        deprecated_fn.__dict__["_pulumi_deprecated_callable"] = fn
+        return typing.cast(C, deprecated_fn)
+
+    return decorator
 
 def get_plugin_download_url():
 	return "example.com/download"


### PR DESCRIPTION
The latest version of the core Pulumi SDK contains a decorator, `@deprecated`, that is used when generating SDK code in order to signify deprecated properties in a way that can be recognised by other SDK code. This is useful when writing generic Python code that e.g. traverses class properties without triggering deprecation warnings for those not explicitly mentioned in user code. The [original pull request](https://github.com/pulumi/pulumi/pull/16400) has more details.

Alas, we can't rely on the fact that a user will upgrade _both_ a particular (generated) provider SDK and the core Pulumi SDK at the same time. Thus, it's entirely possible that a user bumps their version of (say) `pulumi_aws`, whilst leaving their `pulumi` library at the same (compatible, according to specified bounds) version. In doing so they'd hit errors when the new SDK tried to import the `@deprecated` decorator, which doesn't exist in the old core SDK.

This commit thus fixes this by altering code generation so that each SDK receives its own inlined copy of the `@deprecated` decorator, which it can reference regardless of the version of the core SDK. This decorator applies the same `_pulumi_deprecated_callable` tag to functions it decorates, which a sufficiently modern SDK will recognise to avoid triggering e.g. https://github.com/pulumi/pulumi/issues/15894. Later on, we can hopefully find a way to avoid doing this and use only a version of `@deprecated` specified in the core SDK.

Codegen tests have been updated and the inlined decorator has manually been tested using the AWS Classic SDK.

Addresses https://github.com/pulumi/pulumi/pull/16400#discussion_r1646562455