### PR TITLE
Make pulumi install work for policy packs

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -7,7 +7,7 @@ scopes:
   backend: [diy, service]
   build: []
   ci: []
-  cli: [about, config, display, engine, import, new, plugin, package, state]
+  cli: [about, config, display, engine, import, install, new, plugin, package, state]
   components: [dotnet, go, java, nodejs, python, yaml]
   docs: []
   engine: []

--- a/changelog/pending/20240621--cli-install--make-pulumi-install-work-for-policy-packs.yaml
+++ b/changelog/pending/20240621--cli-install--make-pulumi-install-work-for-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/install
+  description: Make pulumi install work for policy packs

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -50,19 +50,22 @@ func newInstallCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			cwd, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("getting the working directory: %w", err)
-			}
-
-			// Check if we are in a policy pack project and install the policy pack dependencies if so.
-			policyPackPath, err := workspace.DetectPolicyPackPathFrom(cwd)
-			if err == nil && policyPackPath != "" {
-				proj, _, root, err := readPolicyProject(policyPackPath)
+			projectPath, err := workspace.DetectProjectPath()
+			if err != nil || projectPath == "" {
+				// No project found, check if we are in a policy pack project and install the policy
+				// pack dependencies if so.
+				cwd, err := os.Getwd()
 				if err != nil {
-					return err
+					return fmt.Errorf("getting the working directory: %w", err)
 				}
-				return installPolicyPackDependencies(ctx, root, proj)
+				policyPackPath, err := workspace.DetectPolicyPackPathFrom(cwd)
+				if err == nil && policyPackPath != "" {
+					proj, _, root, err := readPolicyProject(policyPackPath)
+					if err != nil {
+						return err
+					}
+					return installPolicyPackDependencies(ctx, root, proj)
+				}
 			}
 
 			// Load the project

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -50,6 +50,21 @@ func newInstallCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting the working directory: %w", err)
+			}
+
+			// Check if we are in a policy pack project and install the policy pack dependencies if so.
+			policyPackPath, err := workspace.DetectPolicyPackPathFrom(cwd)
+			if err == nil && policyPackPath != "" {
+				proj, _, root, err := readPolicyProject(policyPackPath)
+				if err != nil {
+					return err
+				}
+				return installPolicyPackDependencies(ctx, root, proj)
+			}
+
 			// Load the project
 			proj, root, err := readProject()
 			if err != nil {

--- a/pkg/cmd/pulumi/install.go
+++ b/pkg/cmd/pulumi/install.go
@@ -40,10 +40,10 @@ func newInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Args:  cmdutil.NoArgs,
-		Short: "Install packages and plugins for the current program",
-		Long: "Install packages and plugins for the current program.\n" +
+		Short: "Install packages and plugins for the current program or policy pack.",
+		Long: "Install packages and plugins for the current program or policy pack.\n" +
 			"\n" +
-			"This command is used to manually install packages and plugins required by your program.",
+			"This command is used to manually install packages and plugins required by your program or policy pack.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			displayOpts := display.Options{

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -24,11 +24,8 @@ import (
 
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -183,30 +180,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 
 	// Install dependencies.
 	if !args.generateOnly {
-		span := opentracing.SpanFromContext(ctx)
-		// Bit of a hack here. Creating a plugin context requires a "program project", but we've only got a
-		// policy project. Ideally we should be able to make a plugin context without any related project. But
-		// fow now this works.
-		projinfo := &engine.Projinfo{Proj: &workspace.Project{
-			Main:    proj.Main,
-			Runtime: proj.Runtime,
-		}, Root: root}
-		_, main, pluginCtx, err := engine.ProjectInfoContext(
-			projinfo,
-			nil,
-			cmdutil.Diag(),
-			cmdutil.Diag(),
-			false,
-			span,
-			nil,
-		)
-		if err != nil {
-			return err
-		}
-
-		defer pluginCtx.Close()
-
-		if err := installPolicyPackDependencies(pluginCtx, proj, main); err != nil {
+		if err := installPolicyPackDependencies(ctx, root, proj); err != nil {
 			return err
 		}
 	}
@@ -218,25 +192,6 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	fmt.Println()
 
 	printPolicyPackNextSteps(proj, root, args.generateOnly, opts)
-
-	return nil
-}
-
-func installPolicyPackDependencies(ctx *plugin.Context,
-	proj *workspace.PolicyPackProject, main string,
-) error {
-	// First make sure the language plugin is present.  We need this to load the required resource plugins.
-	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, proj.Runtime.Options())
-	lang, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), programInfo)
-	if err != nil {
-		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
-	}
-
-	if err = lang.InstallDependencies(programInfo); err != nil {
-		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
-			"then run `pulumi up` to perform an initial deployment: %w", err)
-	}
 
 	return nil
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1208,3 +1208,44 @@ func TestPolicyPluginExtraArguments(t *testing.T) {
 		"--policy-pack", "python_policy_pack", "--tracing", "file:/trace.log")
 	require.NoError(t, err)
 }
+
+//nolint:paralleltest // uses parallel programtest
+func TestPolicyPackNewGenerateOnly(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	require.False(t, e.PathExists("venv"))
+	stdout, _ := e.RunCommand("pulumi", "policy", "new", "aws-python", "--force", "--generate-only")
+	require.Contains(t, stdout, "To install dependencies for the Policy Pack, run `pulumi install`")
+	require.False(t, e.PathExists("venv"))
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestPolicyPackNew(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	require.False(t, e.PathExists("venv"))
+	stdout, _ := e.RunCommand("pulumi", "policy", "new", "aws-python", "--force")
+	require.NotContains(t, stdout, "To install dependencies for the Policy Pack, run `pulumi install`")
+	require.Contains(t, stdout, "Finished creating virtual environment")
+	require.Contains(t, stdout, "Finished installing dependencies")
+	require.True(t, e.PathExists("venv"))
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestPolicyPackInstallDependencies(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	e.ImportDirectory("policy/python_policy_pack")
+	require.False(t, e.PathExists("venv"))
+	stdout, _ := e.RunCommand("pulumi", "install")
+	require.Contains(t, stdout, "Finished creating virtual environment")
+	require.Contains(t, stdout, "Finished installing dependencies")
+	require.True(t, e.PathExists("venv"))
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestProjectInstallDependencies(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	e.ImportDirectory("single_resource")
+	require.False(t, e.PathExists("node_modules"))
+	stdout, _ := e.RunCommand("pulumi", "install")
+	require.Contains(t, stdout, "Finished installing dependencies")
+	require.True(t, e.PathExists("node_modules"))
+}


### PR DESCRIPTION
With https://github.com/pulumi/pulumi/pull/16411 we removed the manual
instructions telling users how to create virtual environments and
installing dependencies after generating a project with
`--generate-only`. Instead users are instructed to call `pulumi
install`.

However, this also removed the manual installation instructions for
Policy Packs, but `pulumi install` did not know how to deal with Policy
Packs. This PR makes `pulumi install` work for Policy Packs.

Fixes https://github.com/pulumi/pulumi/issues/16437
