### PR TITLE
Fix provider `Delete`

### DIFF
--- a/changelog/pending/20240621--engine--fix-provider-delete-s-broken-by-16302.yaml
+++ b/changelog/pending/20240621--engine--fix-provider-delete-s-broken-by-16302.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: "Fix provider `Delete`s broken by #16302"

--- a/changelog/pending/20240621--engine--fix-provider-delete-s-broken-by-16302.yaml
+++ b/changelog/pending/20240621--engine--fix-provider-delete-s-broken-by-16302.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: engine
-  description: "Fix provider `Delete`s broken by #16302"
+  description: "Fix provider `Delete`s"

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1352,7 +1352,7 @@ func (p *provider) Delete(ctx context.Context, req DeleteRequest) (DeleteRespons
 	// We should never call delete at preview time, so we should never see unknowns here
 	contract.Assertf(pcfg.known, "Delete cannot be called if the configuration is unknown")
 
-	minputs, err := MarshalProperties(req.Outputs, MarshalOptions{
+	minputs, err := MarshalProperties(req.Inputs, MarshalOptions{
 		Label:              label,
 		ElideAssetContents: true,
 		KeepSecrets:        pcfg.acceptSecrets,


### PR DESCRIPTION
#16302 (78c48204e056d58217bda37c187e2ade5929c040) introduced a regression whereby outputs are mixed up with inputs for provider `Delete`s. This commit fixes the behaviour so that it matches that before the refactoring.

Fixes #16440