### PR TITLE
Set the --continue-on-error flag with PULUMI_CONTINUE_ON_ERROR environment variable

### DIFF
--- a/changelog/pending/20240621--cli--set-the-continue-on-error-flag-with-pulumi_continue_on_error-environment-variable.yaml
+++ b/changelog/pending/20240621--cli--set-the-continue-on-error-flag-with-pulumi_continue_on_error-environment-variable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Set the --continue-on-error flag with PULUMI_CONTINUE_ON_ERROR environment variable

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -393,8 +393,9 @@ func newDestroyCmd() *cobra.Command {
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVar(
-		&continueOnError, "continue-on-error", false,
-		"Continue to perform the destroy operation despite the occurrence of errors")
+		&continueOnError, "continue-on-error", cmdutil.IsTruthy(os.Getenv("PULUMI_CONTINUE_ON_ERROR")),
+		"Continue to perform the destroy operation despite the occurrence of errors "+
+			"(can also be set with PULUMI_CONTINUE_ON_ERROR env var)")
 
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -393,7 +394,7 @@ func newDestroyCmd() *cobra.Command {
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVar(
-		&continueOnError, "continue-on-error", cmdutil.IsTruthy(os.Getenv("PULUMI_CONTINUE_ON_ERROR")),
+		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
 		"Continue to perform the destroy operation despite the occurrence of errors "+
 			"(can also be set with PULUMI_CONTINUE_ON_ERROR env var)")
 

--- a/pkg/cmd/pulumi/flags_test.go
+++ b/pkg/cmd/pulumi/flags_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContinueOnErrorEnvVar(t *testing.T) {
+	commands := []func() *cobra.Command{
+		newUpCmd,
+		newDestroyCmd,
+	}
+	testCases := []struct {
+		EnvVarValue string
+		Expected    bool
+	}{
+		{
+			EnvVarValue: "true",
+			Expected:    true,
+		},
+		{
+			EnvVarValue: "1",
+			Expected:    true,
+		},
+		{
+			EnvVarValue: "false",
+			Expected:    false,
+		},
+		{
+			EnvVarValue: "0",
+			Expected:    false,
+		},
+		{
+			EnvVarValue: "",
+			Expected:    false,
+		},
+	}
+
+	for _, command := range commands {
+		for _, test := range testCases {
+			os.Setenv("PULUMI_CONTINUE_ON_ERROR", test.EnvVarValue)
+			cmd := command()
+			f, err := cmd.PersistentFlags().GetBool("continue-on-error")
+			assert.Nil(t, err)
+			assert.Equal(t, test.Expected, f)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/flags_test.go
+++ b/pkg/cmd/pulumi/flags_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -56,7 +55,7 @@ func TestContinueOnErrorEnvVar(t *testing.T) {
 
 	for _, command := range commands {
 		for _, test := range testCases {
-			os.Setenv("PULUMI_CONTINUE_ON_ERROR", test.EnvVarValue)
+			t.Setenv("PULUMI_CONTINUE_ON_ERROR", test.EnvVarValue)
 			cmd := command()
 			f, err := cmd.PersistentFlags().GetBool("continue-on-error")
 			assert.Nil(t, err)

--- a/pkg/cmd/pulumi/flags_test.go
+++ b/pkg/cmd/pulumi/flags_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint:paralleltest // Changes environment variables
 func TestContinueOnErrorEnvVar(t *testing.T) {
 	commands := []func() *cobra.Command{
 		newUpCmd,

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -631,7 +632,7 @@ func newUpCmd() *cobra.Command {
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")
 	cmd.PersistentFlags().BoolVar(
-		&continueOnError, "continue-on-error", cmdutil.IsTruthy(os.Getenv("PULUMI_CONTINUE_ON_ERROR")),
+		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
 		"Continue updating resources even if an error is encountered "+
 			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
 

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -631,8 +631,9 @@ func newUpCmd() *cobra.Command {
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")
 	cmd.PersistentFlags().BoolVar(
-		&continueOnError, "continue-on-error", false,
-		"Continue updating resources even if an error is encountered")
+		&continueOnError, "continue-on-error", cmdutil.IsTruthy(os.Getenv("PULUMI_CONTINUE_ON_ERROR")),
+		"Continue updating resources even if an error is encountered "+
+			"(can also be set with PULUMI_CONTINUE_ON_ERROR env var)")
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -633,7 +633,7 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&continueOnError, "continue-on-error", cmdutil.IsTruthy(os.Getenv("PULUMI_CONTINUE_ON_ERROR")),
 		"Continue updating resources even if an error is encountered "+
-			"(can also be set with PULUMI_CONTINUE_ON_ERROR env var)")
+			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -88,6 +88,9 @@ var ErrorOnDependencyCycles = env.Bool("ERROR_ON_DEPENDENCY_CYCLES",
 var SkipVersionCheck = env.Bool("AUTOMATION_API_SKIP_VERSION_CHECK",
 	"If set skip validating the version number reported by the CLI.")
 
+var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
+	"Continue to perform the update/destroy operation despite the occurrence of errors.")
+
 // Environment variables that affect the DIY backend.
 var (
 	DIYBackendNoLegacyWarning = env.Bool("DIY_BACKEND_NO_LEGACY_WARNING",


### PR DESCRIPTION
If the `PULUMI_CONTINUE_ON_ERROR` environment variable is set to a truthy value, it will have the effect of `--continue-on-error` for `up` and `destroy` commands. This helps streamline setting the flag, including through Automation API and Deployments.

Part of #16405 but only for `--continue-on-error` that was specifically requested by a customer. If this lands, we can apply the same pattern elsewhere.