### PR TITLE
fix race condition when registering stack transform

### DIFF
--- a/changelog/pending/20240621--sdk-nodejs--fix-race-condition-when-registering-stack-transforms.yaml
+++ b/changelog/pending/20240621--sdk-nodejs--fix-race-condition-when-registering-stack-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix race condition when registering stack transforms

--- a/sdk/nodejs/runtime/callbacks.ts
+++ b/sdk/nodejs/runtime/callbacks.ts
@@ -373,12 +373,16 @@ export class CallbackServer implements ICallbackServer {
         this.registerTransform(transform)
             .then(
                 (req) => {
-                    this._monitor.registerStackTransform(req, (err, _) => {
-                        if (err !== null) {
-                            // Remove this from the list of callbacks given we didn't manage to actually register it.
-                            this._callbacks.delete(req.getToken());
-                            return;
-                        }
+                    return new Promise((resolve, reject) => {
+                        this._monitor.registerStackTransform(req, (err, _) => {
+                            if (err !== null) {
+                                // Remove this from the list of callbacks given we didn't manage to actually register it.
+                                this._callbacks.delete(req.getToken());
+                                reject();
+                            } else {
+                                resolve();
+                            }
+                        });
                     });
                 },
                 (err) => log.error(`failed to register stack transform: ${err}`),


### PR DESCRIPTION
When registering a stack transform we want to make sure it is finished before any of the subsequent resource registrations are being run.  We try to do this with a `.then`/`.finally` construct.  However the callback that's passed to the `registerStackTransform` function is called asynchronously, and thus the `.finally` may run before the stack transform is actually finished.

Fix this by creating a new promise, and only resolving/rejecting it when the callback has finished running.

Fixes https://github.com/pulumi/pulumi/issues/15639