### PR TITLE
fix potential concurrent map write in Go transforms

### DIFF
--- a/changelog/pending/20240621--sdk-go--fix-concurrent-map-write-when-registering-transform-callbacks.yaml
+++ b/changelog/pending/20240621--sdk-go--fix-concurrent-map-write-when-registering-transform-callbacks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix concurrent map write when registering transform callbacks


### PR DESCRIPTION
These callbacks can be registered concurrently in Goroutines during register resource calls, making it possible that we write to the map concurrently.  Introduce a lock to avoid that.

Fixes https://github.com/pulumi/pulumi/issues/16203