### PR TITLE
Show a fully qualified stack name in `pulumi stack --show-name -Q`

### DIFF
--- a/changelog/pending/20240624--cli-display--print-a-fully-qualified-stack-name-on-pulumi-stack-show-name-fully-qualify-stack-names.yaml
+++ b/changelog/pending/20240624--cli-display--print-a-fully-qualified-stack-name-on-pulumi-stack-show-name-fully-qualify-stack-names.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Print a fully qualified stack name on `pulumi stack --show-name --fully-qualify-stack-names`

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -103,7 +103,11 @@ func newStackCmd() *cobra.Command {
 
 func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
 	if args.showStackName {
-		fmt.Fprintln(out, s.Ref().Name())
+		if args.fullyQualifyStackNames {
+			fmt.Fprintln(out, s.Ref().String())
+		} else {
+			fmt.Fprintln(out, s.Ref().Name())
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Make `pulumi stack --show-name -Q` print a full stack name including the org and project names:

```
pulumi stack --show-name -Q
mikhail-pulumi-corp/tmp3/dev
```

The actual change is very simple (see the second commit) but I needed to refactor the entire command to be able to easily mock inputs and outputs. Let me know if that makes things worse and I should just do the one-line change without the refactoring.

Fixes https://github.com/pulumi/pulumi/issues/16445