### PR TITLE
Add asset archive test to conformance tests

### DIFF
--- a/changelog/pending/20240624--engine--fix-an-issue-with-asset-archives-not-working-with-paths-outside-the-working-directory.yaml
+++ b/changelog/pending/20240624--engine--fix-an-issue-with-asset-archives-not-working-with-paths-outside-the-working-directory.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix an issue with asset archives not working with paths outside the working directory.

--- a/cmd/pulumi-test-language/l2resourceasset_test.go
+++ b/cmd/pulumi-test-language/l2resourceasset_test.go
@@ -276,6 +276,40 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 		return nil, fmt.Errorf("could not register resource: %w", err)
 	}
 
+	assarc, err := plugin.MarshalArchive(&resource.Archive{
+		Assets: map[string]interface{}{
+			"string": &resource.Asset{
+				Text: "file contents",
+			},
+			"file": &resource.Asset{
+				Path: "../test.txt",
+			},
+			"folder": &resource.Archive{
+				Path: "../folder",
+			},
+			"archive": &resource.Archive{
+				Path: "../archive.tar",
+			},
+		},
+	}, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal asset archive: %w", err)
+	}
+
+	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type:   "asset-archive:index:ArchiveResource",
+		Custom: true,
+		Name:   "assarc",
+		Object: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"value": assarc,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register resource: %w", err)
+	}
+
 	return &pulumirpc.RunResponse{}, nil
 }
 

--- a/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
+++ b/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
@@ -9,3 +9,12 @@ resource "arc" "asset-archive:index:ArchiveResource" {
 resource "dir" "asset-archive:index:ArchiveResource" {
     value = fileArchive("../folder")
 }
+
+resource "assarc" "asset-archive:index:ArchiveResource" {
+    value = assetArchive({
+        "string": stringAsset("file contents"),
+        "file": fileAsset("../test.txt"),
+        "folder": fileArchive("../folder"),
+        "archive": fileArchive("../archive.tar"),
+    })
+}

--- a/cmd/pulumi-test-language/tests.go
+++ b/cmd/pulumi-test-language/tests.go
@@ -336,7 +336,7 @@ var languageTests = map[string]languageTest{
 					requireStackResource(l, res, changes)
 
 					// Check we have the the asset, archive, and folder resources in the snapshot, the provider and the stack.
-					require.Len(l, snap.Resources, 5, "expected 5 resources in snapshot")
+					require.Len(l, snap.Resources, 6, "expected 6 resources in snapshot")
 
 					provider := snap.Resources[1]
 					assert.Equal(l, "pulumi:providers:asset-archive", provider.Type.String(), "expected asset-archive provider")
@@ -357,6 +357,10 @@ var languageTests = map[string]languageTest{
 
 					folder, ok := resources["dir"]
 					require.True(l, ok, "expected folder resource")
+					assert.Equal(l, "asset-archive:index:ArchiveResource", folder.Type.String(), "expected archive resource")
+
+					assarc, ok := resources["assarc"]
+					require.True(l, ok, "expected asset archive resource")
 					assert.Equal(l, "asset-archive:index:ArchiveResource", folder.Type.String(), "expected archive resource")
 
 					main := filepath.Join(projectDirectory, "subdir")
@@ -393,6 +397,24 @@ var languageTests = map[string]languageTest{
 
 					assert.Equal(l, want, folder.Inputs, "expected inputs to be {value: %v}", folderValue)
 					assert.Equal(l, folder.Inputs, folder.Outputs, "expected inputs and outputs to match")
+
+					stringAsset, err := resource.NewTextAsset("file contents")
+					require.NoError(l, err)
+
+					assarcValue, err := resource.NewAssetArchiveWithWD(map[string]interface{}{
+						"string":  stringAsset,
+						"file":    assetValue,
+						"folder":  folderValue,
+						"archive": archiveValue,
+					}, main)
+					require.NoError(l, err)
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"value": assarcValue,
+					})
+
+					assert.Equal(l, want, assarc.Inputs, "expected inputs to be {value: %v}", assarcValue)
+					assert.Equal(l, assarc.Inputs, assarc.Outputs, "expected inputs and outputs to match")
 				},
 			},
 		},

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -88,6 +88,10 @@ func NewAssetArchive(assets map[string]interface{}) (*Archive, error) {
 	return archive.FromAssets(assets)
 }
 
+func NewAssetArchiveWithWD(assets map[string]interface{}, wd string) (*Archive, error) {
+	return archive.FromAssetsWithWD(assets, wd)
+}
+
 func NewPathArchive(path string) (*Archive, error) {
 	return archive.FromPath(path)
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
@@ -4,3 +4,9 @@ import * as asset_archive from "@pulumi/asset-archive";
 const ass = new asset_archive.AssetResource("ass", {value: new pulumi.asset.FileAsset("../test.txt")});
 const arc = new asset_archive.ArchiveResource("arc", {value: new pulumi.asset.FileArchive("../archive.tar")});
 const dir = new asset_archive.ArchiveResource("dir", {value: new pulumi.asset.FileArchive("../folder")});
+const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.asset.AssetArchive({
+    string: new pulumi.asset.StringAsset("file contents"),
+    file: new pulumi.asset.FileAsset("../test.txt"),
+    folder: new pulumi.asset.FileArchive("../folder"),
+    archive: new pulumi.asset.FileArchive("../archive.tar"),
+})});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
@@ -4,3 +4,9 @@ import * as asset_archive from "@pulumi/asset-archive";
 const ass = new asset_archive.AssetResource("ass", {value: new pulumi.asset.FileAsset("../test.txt")});
 const arc = new asset_archive.ArchiveResource("arc", {value: new pulumi.asset.FileArchive("../archive.tar")});
 const dir = new asset_archive.ArchiveResource("dir", {value: new pulumi.asset.FileArchive("../folder")});
+const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.asset.AssetArchive({
+    string: new pulumi.asset.StringAsset("file contents"),
+    file: new pulumi.asset.FileAsset("../test.txt"),
+    folder: new pulumi.asset.FileArchive("../folder"),
+    archive: new pulumi.asset.FileArchive("../archive.tar"),
+})});

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -4,3 +4,9 @@ import pulumi_asset_archive as asset_archive
 ass = asset_archive.AssetResource("ass", value=pulumi.FileAsset("../test.txt"))
 arc = asset_archive.ArchiveResource("arc", value=pulumi.FileArchive("../archive.tar"))
 dir = asset_archive.ArchiveResource("dir", value=pulumi.FileArchive("../folder"))
+assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
+    "string": pulumi.StringAsset("file contents"),
+    "file": pulumi.FileAsset("../test.txt"),
+    "folder": pulumi.FileArchive("../folder"),
+    "archive": pulumi.FileArchive("../archive.tar"),
+}))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -4,3 +4,9 @@ import pulumi_asset_archive as asset_archive
 ass = asset_archive.AssetResource("ass", value=pulumi.FileAsset("../test.txt"))
 arc = asset_archive.ArchiveResource("arc", value=pulumi.FileArchive("../archive.tar"))
 dir = asset_archive.ArchiveResource("dir", value=pulumi.FileArchive("../folder"))
+assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
+    "string": pulumi.StringAsset("file contents"),
+    "file": pulumi.FileAsset("../test.txt"),
+    "folder": pulumi.FileArchive("../folder"),
+    "archive": pulumi.FileArchive("../archive.tar"),
+}))


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/16092.

Hopefully the really last part of the fixes started by https://github.com/pulumi/pulumi/pull/16100 and https://github.com/pulumi/pulumi/pull/16119. This fixes the working directory handling for asset archives.