### PR TITLE
Add conformance tests for remote assets

### DIFF
--- a/cmd/pulumi-test-language/l2resourceasset_test.go
+++ b/cmd/pulumi-test-language/l2resourceasset_test.go
@@ -310,6 +310,33 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 		return nil, fmt.Errorf("could not register resource: %w", err)
 	}
 
+	remoteass, err := resource.NewURIAsset(
+		"https://raw.githubusercontent.com/pulumi/pulumi/master" +
+			"/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create remote asset: %w", err)
+	}
+
+	mremoteass, err := plugin.MarshalAsset(remoteass, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal remote asset: %w", err)
+	}
+
+	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+		Type:   "asset-archive:index:AssetResource",
+		Custom: true,
+		Name:   "remoteass",
+		Object: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"value": mremoteass,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register resource: %w", err)
+	}
+
 	return &pulumirpc.RunResponse{}, nil
 }
 

--- a/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
+++ b/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/subdir/main.pp
@@ -18,3 +18,7 @@ resource "assarc" "asset-archive:index:ArchiveResource" {
         "archive": fileArchive("../archive.tar"),
     })
 }
+
+resource "remoteass" "asset-archive:index:AssetResource" {
+    value = remoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/master/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt")
+}

--- a/cmd/pulumi-test-language/tests.go
+++ b/cmd/pulumi-test-language/tests.go
@@ -362,7 +362,7 @@ var languageTests = map[string]languageTest{
 					requireStackResource(l, res, changes)
 
 					// Check we have the the asset, archive, and folder resources in the snapshot, the provider and the stack.
-					require.Len(l, snap.Resources, 6, "expected 6 resources in snapshot")
+					require.Len(l, snap.Resources, 7, "expected 7 resources in snapshot")
 
 					provider := snap.Resources[1]
 					assert.Equal(l, "pulumi:providers:asset-archive", provider.Type.String(), "expected asset-archive provider")
@@ -387,7 +387,11 @@ var languageTests = map[string]languageTest{
 
 					assarc, ok := resources["assarc"]
 					require.True(l, ok, "expected asset archive resource")
-					assert.Equal(l, "asset-archive:index:ArchiveResource", folder.Type.String(), "expected archive resource")
+					assert.Equal(l, "asset-archive:index:ArchiveResource", assarc.Type.String(), "expected archive resource")
+
+					remoteass, ok := resources["remoteass"]
+					require.True(l, ok, "expected remote asset resource")
+					assert.Equal(l, "asset-archive:index:AssetResource", remoteass.Type.String(), "expected asset resource")
 
 					main := filepath.Join(projectDirectory, "subdir")
 
@@ -441,6 +445,23 @@ var languageTests = map[string]languageTest{
 
 					assert.Equal(l, want, assarc.Inputs, "expected inputs to be {value: %v}", assarcValue)
 					assert.Equal(l, assarc.Inputs, assarc.Outputs, "expected inputs and outputs to match")
+
+					remoteassValue, err := resource.NewURIAsset(
+						"https://raw.githubusercontent.com/pulumi/pulumi/master" +
+							"/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt",
+					)
+					require.NoError(l, err)
+
+					want = resource.NewPropertyMapFromMap(map[string]any{
+						"value": remoteassValue,
+					})
+
+					assert.Equal(l, want, remoteass.Inputs, "expected inputs to be {value: %v}", remoteassValue)
+					assert.Equal(l, remoteass.Inputs, remoteass.Outputs, "expected inputs and outputs to match")
+					bs, err := remoteassValue.Bytes()
+					require.NoError(l, err)
+					assert.Equal(l, "text", string(bs))
+					assert.Equal(l, "982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1", remoteassValue.Hash)
 				},
 			},
 		},

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsc/projects/l2-resource-asset-archive/subdir/index.ts
@@ -10,3 +10,4 @@ const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.as
     folder: new pulumi.asset.FileArchive("../folder"),
     archive: new pulumi.asset.FileArchive("../archive.tar"),
 })});
+const remoteass = new asset_archive.AssetResource("remoteass", {value: new pulumi.asset.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/master/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt")});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
@@ -10,3 +10,4 @@ const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.as
     folder: new pulumi.asset.FileArchive("../folder"),
     archive: new pulumi.asset.FileArchive("../archive.tar"),
 })});
+const remoteass = new asset_archive.AssetResource("remoteass", {value: new pulumi.asset.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/master/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt")});

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -10,3 +10,4 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
     "folder": pulumi.FileArchive("../folder"),
     "archive": pulumi.FileArchive("../archive.tar"),
 }))
+remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/master/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt"))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -10,3 +10,4 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
     "folder": pulumi.FileArchive("../folder"),
     "archive": pulumi.FileArchive("../archive.tar"),
 }))
+remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/master/cmd/pulumi-test-language/testdata/l2-resource-asset-archive/test.txt"))


### PR DESCRIPTION
Conformance tests allow us to test functionality regardless of programming language used, by setting up a test program using PCL and making assertions about program state before and after various operations. This commit adds a set of conformance tests for remote assets (that is, assets that must be retrieved from some URI), which have until now been untested in this regard.