### PR TITLE
unflake TestConfigEnvAddCmd/no_effects

### DIFF
--- a/pkg/cmd/pulumi/config_env_add_test.go
+++ b/pkg/cmd/pulumi/config_env_add_test.go
@@ -118,7 +118,9 @@ aws:region  us-west-2
 			"Without at least one of these properties, the environment will not affect the stack's behavior.\n\n\n" +
 			"Save? No\n"
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		out := strings.ReplaceAll(cleanStdout(stdout.String()), "Save? ▸Yes  No", "")
+
+		assert.Equal(t, expectedOut, out)
 
 		assert.Equal(t, "", newStackYAML)
 	})


### PR DESCRIPTION
In this test we're trying to test the console output, when saving properties. We do so by passing "n" to stdin, which then denies the request.  However this is somewhat flaky, because the library sending the confirmation prompt may be able to print the prompt in full before recognizing the character we send on stdin.

There's nothing really wrong with that other than it makes the test flake.  So let's clean the extra output from stdout in case it happens, as it either happening or not happening is just fine.

Fixes https://github.com/pulumi/pulumi/issues/15965

This should hopefully allow us to merge https://github.com/pulumi/pulumi/pull/15960