### PR TITLE
Fix TestTerminate_gracefulShutdown/python flake

### DIFF
--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -409,7 +409,7 @@ func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
 			t.Skipf("Skipping test: could not find python or python executable")
 			return nil
 		}
-		return exec.Command(pythonBin, append([]string{src}, p.args...)...)
+		return exec.Command(pythonBin, append([]string{src}, p.args...)...) //nolint:gosec
 
 	default:
 		t.Fatalf("unknown test program kind: %v", p.kind)

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -406,7 +406,7 @@ func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
 			}
 		}
 		if pythonBin == "" {
-			t.Skipf("Skipping test: could not find python or python executable")
+			t.Skipf("Skipping test: could not find python3 or python executable")
 			return nil
 		}
 		return exec.Command(pythonBin, append([]string{src}, p.args...)...) //nolint:gosec

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -393,7 +393,22 @@ func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
 		return exec.Command(nodeBin, append([]string{src}, p.args...)...)
 
 	case pythonTestProgram:
-		pythonBin := lookPathOrSkip(t, "python3")
+		pythonCmds := []string{"python3", "python"}
+		if runtime.GOOS == "windows" {
+			pythonCmds = []string{"python", "python3"}
+		}
+		pythonBin := ""
+		for _, bin := range pythonCmds {
+			bin, err := exec.LookPath(bin)
+			if err == nil {
+				pythonBin = bin
+				break
+			}
+		}
+		if pythonBin == "" {
+			t.Skipf("Skipping test: could not find python or python executable")
+			return nil
+		}
 		return exec.Command(pythonBin, append([]string{src}, p.args...)...)
 
 	default:

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -393,7 +393,7 @@ func (p testProgram) Build(t *testing.T) (cmd *exec.Cmd) {
 		return exec.Command(nodeBin, append([]string{src}, p.args...)...)
 
 	case pythonTestProgram:
-		pythonBin := lookPathOrSkip(t, "python")
+		pythonBin := lookPathOrSkip(t, "python3")
 		return exec.Command(pythonBin, append([]string{src}, p.args...)...)
 
 	default:

--- a/sdk/go/common/util/cmdutil/testdata/graceful.py
+++ b/sdk/go/common/util/cmdutil/testdata/graceful.py
@@ -2,9 +2,10 @@ import signal
 import sys
 import time
 
+signal_received = False
+
 def signal_handler(signal, frame):
-    print("exiting cleanly", flush=True)
-    sys.exit(0)
+    signal_received = True
 
 signal.signal(signal.SIGINT, signal_handler)
 if hasattr(signal, "SIGBREAK"):
@@ -17,6 +18,9 @@ print("ready", flush=True)
 # so we'll sleep in small increments.
 timeout = 3.0
 while timeout > 0:
+    if signal_received:
+        print("exiting cleanly", flush=True)
+        sys.exit(0)
     time.sleep(0.05)
     timeout -= 0.05
 

--- a/sdk/go/common/util/cmdutil/testdata/graceful.py
+++ b/sdk/go/common/util/cmdutil/testdata/graceful.py
@@ -1,10 +1,12 @@
 import signal
 import sys
 import time
+import os
 
 signal_received = False
 
 def signal_handler(signal, frame):
+    global signal_received
     signal_received = True
 
 signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
It is unsafe to call `print` in a Python signalhandler. Instead we set a
flag and check this in the main busy loop.

Fixes https://github.com/pulumi/pulumi/issues/16472