### PR TITLE
Hide expanded constructor syntax when language fails

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1750,24 +1750,18 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 				example = ""
 			}
 			creationExampleSyntax["typescript"] = example
-		} else {
-			creationExampleSyntax["typescript"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.python.resources[r.Token]; found {
 			if strings.Contains(example, "not_implemented") || strings.Contains(example, "PANIC") {
 				example = ""
 			}
 			creationExampleSyntax["python"] = example
-		} else {
-			creationExampleSyntax["python"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.csharp.resources[r.Token]; found {
 			if strings.Contains(example, "NotImplemented") || strings.Contains(example, "PANIC") {
 				example = ""
 			}
 			creationExampleSyntax["csharp"] = example
-		} else {
-			creationExampleSyntax["csharp"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.golang.resources[r.Token]; found {
 			modified := strings.ReplaceAll(example, "_, err =", "example, err :=")
@@ -1776,18 +1770,12 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 				modified = ""
 			}
 			creationExampleSyntax["go"] = modified
-		} else {
-			creationExampleSyntax["go"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.java.resources[r.Token]; found {
 			creationExampleSyntax["java"] = example
-		} else {
-			creationExampleSyntax["java"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.yaml.resources[collapseYAMLToken(r.Token)]; found {
 			creationExampleSyntax["yaml"] = example
-		} else {
-			creationExampleSyntax["yaml"] = ""
 		}
 	}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1747,47 +1747,47 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 	if !r.IsProvider && err == nil {
 		if example, found := dctx.constructorSyntaxData.typescript.resources[r.Token]; found {
 			if strings.Contains(example, "notImplemented") || strings.Contains(example, "PANIC") {
-				example = "Coming soon!"
+				example = ""
 			}
 			creationExampleSyntax["typescript"] = example
 		} else {
-			creationExampleSyntax["typescript"] = "Coming soon!"
+			creationExampleSyntax["typescript"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.python.resources[r.Token]; found {
 			if strings.Contains(example, "not_implemented") || strings.Contains(example, "PANIC") {
-				example = "Coming soon!"
+				example = ""
 			}
 			creationExampleSyntax["python"] = example
 		} else {
-			creationExampleSyntax["python"] = "Coming soon!"
+			creationExampleSyntax["python"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.csharp.resources[r.Token]; found {
 			if strings.Contains(example, "NotImplemented") || strings.Contains(example, "PANIC") {
-				example = "Coming soon!"
+				example = ""
 			}
 			creationExampleSyntax["csharp"] = example
 		} else {
-			creationExampleSyntax["csharp"] = "Coming soon!"
+			creationExampleSyntax["csharp"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.golang.resources[r.Token]; found {
 			modified := strings.ReplaceAll(example, "_, err =", "example, err :=")
 			modified = strings.ReplaceAll(modified, "_, err :=", "example, err :=")
 			if strings.Contains(modified, "notImplemented") || strings.Contains(modified, "PANIC") {
-				modified = "Coming soon!"
+				modified = ""
 			}
 			creationExampleSyntax["go"] = modified
 		} else {
-			creationExampleSyntax["go"] = "Coming soon!"
+			creationExampleSyntax["go"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.java.resources[r.Token]; found {
 			creationExampleSyntax["java"] = example
 		} else {
-			creationExampleSyntax["java"] = "Coming soon!"
+			creationExampleSyntax["java"] = ""
 		}
 		if example, found := dctx.constructorSyntaxData.yaml.resources[collapseYAMLToken(r.Token)]; found {
 			creationExampleSyntax["yaml"] = example
 		} else {
-			creationExampleSyntax["yaml"] = "Coming soon!"
+			creationExampleSyntax["yaml"] = ""
 		}
 	}
 

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -112,9 +112,10 @@ Resources are created with functions called constructors. To learn more about de
 </pulumi-choosable>
 </div>
 
-{{ if ne (len .CreationExampleSyntax) 0 }}
+{{ with .CreationExampleSyntax }}
+{{ if and (ne (len .) 0) (and (ne (index . "typescript") "") (ne (index . "python") "") (ne (index . "java") "") (ne (index . "go") "") (ne (index . "csharp") "") (ne (index . "yaml") "")) }}
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 
@@ -139,6 +140,7 @@ The following reference example uses placeholder values for all [input propertie
 </pulumi-choosable>
 </div>
 
+{{ end }}
 {{ end }}
 {{- end }}
 

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -112,8 +112,7 @@ Resources are created with functions called constructors. To learn more about de
 </pulumi-choosable>
 </div>
 
-{{ with .CreationExampleSyntax }}
-{{ if and (ne (len .) 0) (and (ne (index . "typescript") "") (ne (index . "python") "") (ne (index . "java") "") (ne (index . "go") "") (ne (index . "csharp") "") (ne (index . "yaml") "")) }}
+{{ if and (ne (len .CreationExampleSyntax) 0) (and (ne (index .CreationExampleSyntax "typescript") "") (ne (index .CreationExampleSyntax "python") "") (ne (index .CreationExampleSyntax "java") "") (ne (index .CreationExampleSyntax "go") "") (ne (index .CreationExampleSyntax "csharp") "") (ne (index .CreationExampleSyntax "yaml") "")) }}
 
 ### Constructor example
 
@@ -140,7 +139,6 @@ The following reference example uses placeholder values for all [input propertie
 </pulumi-choosable>
 </div>
 
-{{ end }}
 {{ end }}
 {{- end }}
 

--- a/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
+++ b/tests/testdata/codegen/assets-and-archives/docs/resourcewithassets/_index.md
@@ -218,7 +218,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/tests/testdata/codegen/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -547,7 +547,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/tests/testdata/codegen/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -220,7 +220,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/nursery/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -220,7 +220,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/overlay/overlay/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
+++ b/tests/testdata/codegen/docs-collision/docs/res-overlay/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
+++ b/tests/testdata/codegen/embedded-crd-types/docs/component/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
+++ b/tests/testdata/codegen/enum-reference/docs/myModule/iamresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/external-enum/docs/component/_index.md
+++ b/tests/testdata/codegen/external-enum/docs/component/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/cat/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/component/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
+++ b/tests/testdata/codegen/external-resource-schema/docs/workload/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/tests/testdata/codegen/hyphen-url/docs/registrygeoreplication/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
@@ -219,7 +219,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
@@ -220,7 +220,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
@@ -226,7 +226,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
+++ b/tests/testdata/codegen/legacy-names/docs/example_resource/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
+++ b/tests/testdata/codegen/methods-return-plain-resource/docs/configurer/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/maincomponent/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/mod/component2/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resource/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
+++ b/tests/testdata/codegen/naming-collisions/docs/resourceinput/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
+++ b/tests/testdata/codegen/nested-module/docs/nested/module/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/barresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/barresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/fooresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/otherresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/overlayresource/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/resource/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/other-owned/docs/typeuses/_index.md
@@ -218,7 +218,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
+++ b/tests/testdata/codegen/plain-and-default/docs/moduleresource/_index.md
@@ -229,7 +229,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/foo/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-defaults/docs/moduletest/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/foo/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/tests/testdata/codegen/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/tests/testdata/codegen/plain-schema-gh6957/docs/staticpage/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
+++ b/tests/testdata/codegen/provider-type-schema/docs/submod/provider/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/cat/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/dog/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/replace-on-change/docs/god/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/god/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/norecursive/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
+++ b/tests/testdata/codegen/replace-on-change/docs/toystore/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/person/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/resource-args-python/docs/person/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/person/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
+++ b/tests/testdata/codegen/resource-args-python/docs/pet/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
+++ b/tests/testdata/codegen/resource-property-overlap/docs/rec/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/secrets/docs/resource/_index.md
+++ b/tests/testdata/codegen/secrets/docs/resource/_index.md
@@ -221,7 +221,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/tests/testdata/codegen/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -220,7 +220,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
+++ b/tests/testdata/codegen/simple-methods-schema/docs/foo/_index.md
@@ -215,7 +215,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -224,7 +224,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
+++ b/tests/testdata/codegen/simple-plain-schema/docs/component/_index.md
@@ -225,7 +225,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/barresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/fooresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/otherresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/overlayresource/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-resource-schema/docs/typeuses/_index.md
@@ -218,7 +218,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev2/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
+++ b/tests/testdata/codegen/simple-resource-with-aliases/docs/basicresourcev3/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/otherresource/_index.md
@@ -217,7 +217,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/resource/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
+++ b/tests/testdata/codegen/simple-yaml-schema/docs/typeuses/_index.md
@@ -219,7 +219,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inline/docs/exampleserver/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
+++ b/tests/testdata/codegen/unions-inside-arrays/docs/exampleserver/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
+++ b/tests/testdata/codegen/urn-id-properties/docs/res/_index.md
@@ -219,7 +219,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>

--- a/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
+++ b/tests/testdata/codegen/using-shared-types-in-config/docs/user/_index.md
@@ -216,7 +216,7 @@ Resources are created with functions called constructors. To learn more about de
 
 
 
-### Example
+### Constructor example
 
 The following reference example uses placeholder values for all [input properties](#inputs).
 <div>


### PR DESCRIPTION
fixes: https://github.com/pulumi/registry/issues/4320
fixes: https://github.com/pulumi/registry/issues/4805

This PR hides the expanded constructor syntax if any of the languages are failing to generate. I also updated the heading to be `Constructor example` instead of `Example` to help avoid confusion with the other examples on the page.