### PR TITLE
Update `upload-artifact` and `download-artifact` actions

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -130,7 +130,7 @@ jobs:
           cat .goreleaser.yml \
             | go run github.com/t0yv0/goreleaser-filter@v0.3.0 -goos ${{ inputs.os }} -goarch ${{ inputs.arch }} \
             | goreleaser release -f - -p 5 --skip-validate --clean --snapshot
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.os != 'js' }}
         with:
           name: artifacts-cli-${{ inputs.os }}-${{ inputs.arch }}

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -134,6 +134,7 @@ jobs:
         if: ${{ inputs.os != 'js' }}
         with:
           name: artifacts-cli-${{ inputs.os }}-${{ inputs.arch }}
+          overwrite: true
           retention-days: 1
           path: |
             goreleaser/*.tar.gz

--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -68,7 +68,7 @@ jobs:
           python -m pip install wheel setuptools
           python setup.py build bdist_wheel --python-tag py3
       - name: Upload pulumi.whl
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts-python-sdk
           path: sdk/python/lib/dist/*.whl
@@ -118,7 +118,7 @@ jobs:
           cd sdk/nodejs/bin
           npm pack
       - name: Upload pulumi-node-sdk.tgz
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts-nodejs-sdk
           path: sdk/nodejs/bin/*.tgz

--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           mkdir -p artifacts.tmp
       - name: Download artifacts from previous step
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts.tmp
       - name: Move artifacts to the right place
@@ -191,7 +191,7 @@ jobs:
         run: |
           mkdir -p artifacts.tmp
       - name: Download artifacts from previous step
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts.tmp
       - name: Move artifacts to the right place
@@ -235,7 +235,7 @@ jobs:
         run: |
           mkdir -p artifacts.tmp
       - name: Download artifacts from previous step
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts.tmp
       - name: Flatten artifact directories

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -61,7 +61,7 @@ jobs:
           SHA=$(git rev-parse HEAD)
           ./.github/scripts/set-output sha "$SHA"
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts.tmp
       - name: Rename SDKs

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -96,18 +96,8 @@ jobs:
       - name: Write test started file
         shell: bash
         run: |
-          HASH=$(echo '${{ inputs.test-name }}' | git hash-object --literally --stdin | awk '{ print $1 }')
+          HASH=$(echo '${{ inputs.test-name }}-${{ inputs.is-integration-test && 'integration' || 'unit' }}' | git hash-object --literally --stdin | awk '{ print $1 }')
           echo "TEST_HASH_ID=${HASH}" >> "$GITHUB_ENV"
-          echo "TEST_STATUS_FILE=status/test-${HASH}.txt" >> "$GITHUB_ENV"
-      # Consume env.TEST_STATUS_FILE to ensure it's able to be successfully used later.
-      - shell: bash
-        run: |
-          mkdir status
-          echo "incomplete" > "${{ env.TEST_STATUS_FILE }}"
-      - name: Register test started.
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.TEST_STATUS_FILE }}
       - name: "Windows cache workaround"
         # https://github.com/actions/cache/issues/752#issuecomment-1222415717
         # but only modify the path by adding tar.exe
@@ -273,7 +263,7 @@ jobs:
       # Integration test only steps:
       - name: Download pulumi-${{ steps.goenv.outputs.cli-target }}
         if: ${{ inputs.is-integration-test }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: artifacts-cli-${{ steps.goenv.outputs.cli-target }}
           path: artifacts/cli
@@ -362,20 +352,13 @@ jobs:
             go tool covdata textfmt -i="$GOCOVERDIR" -o="$PULUMI_TEST_COVERAGE_PATH/integration.$TS.cov"
           fi
       - name: Upload code coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.enable-coverage }}
         with:
           name: coverage-${{ env.TEST_HASH_ID }}
           path: |
             coverage/*
             !coverage/.gitkeep
-      - name: Register test OK.
-        shell: bash
-        run: mkdir status; echo "OK" > "${{ env.TEST_STATUS_FILE }}"
-      - name: Register test successful.
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.TEST_STATUS_FILE }}
       - name: Summarize Test Time by Package
         continue-on-error: true
         env:
@@ -399,7 +382,7 @@ jobs:
                       if [[ $? -eq 141 ]]; then true; else exit $?; fi
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: gotestsum-test-results
+          name: gotestsum-test-results-${{ env.TEST_HASH_ID }}
           path: test-results/*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
       - name: Check tests completed successfully.
         run: |
           JSON='${{ toJson(needs) }}'
-          if test -z "$(echo $JSON | jq -r '.[] | .outputs | .result' | grep -v 'success')"; then
+          if test -z "$(echo $JSON | jq -r '.[] | .result' | grep -v 'success')"; then
               echo "Tests OK!"
           else
               echo "Test Failure.. skipping CodeCov upload."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,8 @@ jobs:
       # Check that there are no failed tests.
       - name: Check tests completed successfully.
         run: |
-          # turn this into an if
-          if test -z "$(echo ${{ toJson(needs) }} | jq -r '.[] | .outputs | .result' | grep -v 'success')"; then
+          JSON='${{ toJson(needs) }}'
+          if test -z "$(echo $JSON | jq -r '.[] | .outputs | .result' | grep -v 'success')"; then
               echo "Tests OK!"
           else
               echo "Test Failure.. skipping CodeCov upload."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,10 +429,11 @@ jobs:
           path: test-results
           key: gotestsum-timing-${{ github.run_number }}
           restore-keys: gotestsum-timing-
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: gotestsum-test-results
+          pattern: gotestsum-test-results-*
+          merge-multiple: true
           path: test-results
       - name: List and clean up test results
         continue-on-error: true
@@ -444,14 +445,11 @@ jobs:
     if: ${{ inputs.enable-coverage }}
     runs-on: ubuntu-latest
     steps:
-      - name: Retrieve code coverage statuses
-        uses: actions/download-artifact@v3
-        with:
-          path: status
-      # Check that there are no incomplete tests.
+      # Check that there are no failed tests.
       - name: Check tests completed successfully.
         run: |
-          if test -z "$(grep -rl 'incomplete' ./status)"; then
+          # turn this into an if
+          if test -z "$(echo ${{ toJson(needs) }} | jq -r '.[] | .outputs | .result' | grep -v 'success')"; then
               echo "Tests OK!"
           else
               echo "Test Failure.. skipping CodeCov upload."
@@ -462,8 +460,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Retrieve code coverage reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
+          pattern: coverage-*
+          merge-multiple: true
           path: coverage
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts.tmp
       - name: Rename SDKs
@@ -113,7 +113,7 @@ jobs:
           # flatten to a single directory to upload:
           mv sums.tmp/* sigs.tmp
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts-signatures
           retention-days: 1


### PR DESCRIPTION
v2 of `actions/upload-artifact` and `actions/download-artifact` will be deprecated on June 30, 2024. This commit bumps the versions of these actions to v4. The main breaking change between v2/v3 and v4 is that artifacts are now immutable, so multiple uploads to artifacts with the same name will fail by default. In this case there are two options -- use different names, and recollect the artifacts later with a modified `download-artifact` instantiation, or pass `overwrite: true` to calls which will happen later to first delete the artifact and create a new one in its place. It _appears_ that we only fall foul of repeated uploads in one place, and that for this case we can use `overwrite`, so that is the approach this commit takes.