### PR TITLE
Wrap call&construct of node provider server in AsyncLocalStorage

### DIFF
--- a/changelog/pending/20240626--sdk-nodejs--fix-construct-and-call-calls-in-the-node-js-sdk-sharing-state.yaml
+++ b/changelog/pending/20240626--sdk-nodejs--fix-construct-and-call-calls-in-the-node-js-sdk-sharing-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix Construct and Call calls in the Node.js SDK sharing state


### PR DESCRIPTION
In #16428 we parallelized the call&construct calls of the node provider server. It was wrongly assumed that the state of the settings are localized to the current call, but that is only done when running in `asyncLocalStorage.run`.
This change wraps the call&construct calls in `asyncLocalStorage.run` to correctly localize state.

Addresses https://github.com/pulumi/pulumi/pull/16428#issuecomment-2190932525
