### PR TITLE
Display an actionable error message when dependency installation fails

### DIFF
--- a/changelog/pending/20240626--sdk-nodejs-python--display-an-actionable-error-message-when-dependency-installation-fails.yaml
+++ b/changelog/pending/20240626--sdk-nodejs-python--display-an-actionable-error-message-when-dependency-installation-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,python
+  description: Display an actionable error message when dependency installation fails

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -966,6 +966,7 @@ func installDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 	}
 
 	if err = lang.InstallDependencies(programInfo); err != nil {
+		//revive:disable:error-strings // This error message is user facing.
 		return fmt.Errorf("installing dependencies failed: %w\nRun `pulumi install` to complete the installation.", err)
 	}
 

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -966,8 +966,7 @@ func installDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 	}
 
 	if err = lang.InstallDependencies(programInfo); err != nil {
-		return fmt.Errorf("installing dependencies failed; rerun manually to try again, "+
-			"then run `pulumi up` to perform an initial deployment: %w", err)
+		return fmt.Errorf("installing dependencies failed: %w\nRun `pulumi install` to complete the installation.", err)
 	}
 
 	return nil

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -872,7 +872,7 @@ func (host *nodeLanguageHost) InstallDependencies(
 
 	_, err = npm.Install(ctx, opts.packagemanager, workspaceRoot, false /*production*/, stdout, stderr)
 	if err != nil {
-		return fmt.Errorf("dependency installation failed: %w", err)
+		return err
 	}
 
 	stdout.Write([]byte("Finished installing dependencies\n\n"))

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -25,8 +25,7 @@ func newNPM() (*npmManager, error) {
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil, errors.New("Could not find `npm` executable.\n" +
-				"Install npm from https://docs.npmjs.com/downloading-and-installing-node-js-and-npm " +
-				"and make sure it is in your PATH.")
+				"Install npm and make sure it is in your PATH.")
 		}
 		return nil, err
 	}

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -24,8 +24,9 @@ func newNPM() (*npmManager, error) {
 	npmPath, err := exec.LookPath("npm")
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return nil, fmt.Errorf("Could not find `npm` executable.\n" +
-				"Install npm from https://docs.npmjs.com/downloading-and-installing-node-js-and-npm and make sure it is in your PATH.")
+			return nil, errors.New("Could not find `npm` executable.\n" +
+				"Install npm from https://docs.npmjs.com/downloading-and-installing-node-js-and-npm " +
+				"and make sure it is in your PATH.")
 		}
 		return nil, err
 	}

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -3,6 +3,7 @@ package npm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -21,10 +22,16 @@ var _ PackageManager = &npmManager{}
 
 func newNPM() (*npmManager, error) {
 	npmPath, err := exec.LookPath("npm")
-	instance := &npmManager{
-		executable: npmPath,
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("Could not find `npm` executable.\n" +
+				"Install npm from https://docs.npmjs.com/downloading-and-installing-node-js-and-npm and make sure it is in your PATH.")
+		}
+		return nil, err
 	}
-	return instance, err
+	return &npmManager{
+		executable: npmPath,
+	}, nil
 }
 
 func (node *npmManager) Name() string {

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -38,7 +38,7 @@ func newPnpm() (*pnpmManager, error) {
 	pnpmPath, err := exec.LookPath("pnpm")
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return nil, fmt.Errorf("Could not find `pnpm` executable.\n" +
+			return nil, errors.New("Could not find `pnpm` executable.\n" +
 				"Install pnpm from https://pnpm.io/installation and make sure it is in your PATH.")
 		}
 		return nil, err

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -17,6 +17,7 @@ package npm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,10 +36,16 @@ var _ PackageManager = &pnpmManager{}
 
 func newPnpm() (*pnpmManager, error) {
 	pnpmPath, err := exec.LookPath("pnpm")
-	instance := &pnpmManager{
-		executable: pnpmPath,
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("Could not find `pnpm` executable.\n" +
+				"Install pnpm from https://pnpm.io/installation and make sure it is in your PATH.")
+		}
+		return nil, err
 	}
-	return instance, err
+	return &pnpmManager{
+		executable: pnpmPath,
+	}, nil
 }
 
 func (pnpm *pnpmManager) Name() string {

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -39,7 +39,7 @@ func newPnpm() (*pnpmManager, error) {
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil, errors.New("Could not find `pnpm` executable.\n" +
-				"Install pnpm from https://pnpm.io/installation and make sure it is in your PATH.")
+				"Install pnpm and make sure it is in your PATH.")
 		}
 		return nil, err
 	}

--- a/sdk/nodejs/npm/yarn.go
+++ b/sdk/nodejs/npm/yarn.go
@@ -27,7 +27,7 @@ func newYarnClassic() (*yarnClassic, error) {
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil, errors.New("Could not find `yarn` executable.\n" +
-				"Install yarn from https://classic.yarnpkg.com/en/docs/install and make sure it is in your PATH.")
+				"Install yarn and make sure it is in your PATH.")
 		}
 		return nil, err
 	}

--- a/sdk/nodejs/npm/yarn.go
+++ b/sdk/nodejs/npm/yarn.go
@@ -3,6 +3,7 @@ package npm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,10 +24,16 @@ var _ PackageManager = &yarnClassic{}
 
 func newYarnClassic() (*yarnClassic, error) {
 	yarnPath, err := exec.LookPath("yarn")
-	yarn := &yarnClassic{
-		executable: yarnPath,
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("Could not find `yarn` executable.\n" +
+				"Install yarn from https://classic.yarnpkg.com/en/docs/install and make sure it is in your PATH.")
+		}
+		return nil, err
 	}
-	return yarn, err
+	return &yarnClassic{
+		executable: yarnPath,
+	}, nil
 }
 
 func (yarn *yarnClassic) Name() string {

--- a/sdk/nodejs/npm/yarn.go
+++ b/sdk/nodejs/npm/yarn.go
@@ -26,7 +26,7 @@ func newYarnClassic() (*yarnClassic, error) {
 	yarnPath, err := exec.LookPath("yarn")
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return nil, fmt.Errorf("Could not find `yarn` executable.\n" +
+			return nil, errors.New("Could not find `yarn` executable.\n" +
 				"Install yarn from https://classic.yarnpkg.com/en/docs/install and make sure it is in your PATH.")
 		}
 		return nil, err

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -32,7 +32,8 @@ var _ Toolchain = &poetry{}
 func newPoetry(directory string) (*poetry, error) {
 	poetryPath, err := exec.LookPath("poetry")
 	if err != nil {
-		return nil, fmt.Errorf("poetry not found on path: %w", err)
+		return nil, fmt.Errorf("Could not find `poetry` executable.\n" +
+			"Install poetry from https://python-poetry.org/ or set the toolchain option in Pulumi.yaml to `pip`.")
 	}
 	logging.V(9).Infof("Python toolchain: using poetry at %s in %s", poetryPath, directory)
 	return &poetry{

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -33,7 +33,7 @@ func newPoetry(directory string) (*poetry, error) {
 	poetryPath, err := exec.LookPath("poetry")
 	if err != nil {
 		return nil, errors.New("Could not find `poetry` executable.\n" +
-			"Install poetry from https://python-poetry.org/ or set the toolchain option in Pulumi.yaml to `pip`.")
+			"Install poetry and make sure is is in your PATH, or set the toolchain option in Pulumi.yaml to `pip`.")
 	}
 	logging.V(9).Infof("Python toolchain: using poetry at %s in %s", poetryPath, directory)
 	return &poetry{

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -32,7 +32,7 @@ var _ Toolchain = &poetry{}
 func newPoetry(directory string) (*poetry, error) {
 	poetryPath, err := exec.LookPath("poetry")
 	if err != nil {
-		return nil, fmt.Errorf("Could not find `poetry` executable.\n" +
+		return nil, errors.New("Could not find `poetry` executable.\n" +
 			"Install poetry from https://python-poetry.org/ or set the toolchain option in Pulumi.yaml to `pip`.")
 	}
 	logging.V(9).Infof("Python toolchain: using poetry at %s in %s", poetryPath, directory)


### PR DESCRIPTION
When the dependency installation fails because we could not find the
packagemanager executable, tell the user how to remedy the error and
finish the dependency installation.

Example:
```
The packagemangager to use for installing dependencies pnpm
Installing dependencies...

error: installing dependencies failed: Could not find `pnpm` executable.
Install pnpm from https://pnpm.io/installation and make sure it is in your PATH.
Run `pulumi install` to complete the installation.
```