### PR TITLE
Update pu/pu to support deployment run command

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1896,7 +1896,7 @@ const pulumiOperationHeader = "Pulumi operation"
 
 func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.StackReference,
 	req apitype.CreateDeploymentRequest, opts display.Options, deploymentInitiator string,
-	streamDeploymentLogs bool,
+	suppressStreamLogs bool,
 ) error {
 	stackID, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
@@ -1917,7 +1917,7 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 				colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n"), resp.ConsoleURL)
 	}
 
-	if !streamDeploymentLogs {
+	if suppressStreamLogs {
 		return nil
 	}
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -173,7 +173,7 @@ type Backend interface {
 	Client() *client.Client
 
 	RunDeployment(ctx context.Context, stackRef backend.StackReference, req apitype.CreateDeploymentRequest,
-		opts display.Options, deploymentInitiator string) error
+		opts display.Options, deploymentInitiator string, streamDeploymentLogs bool) error
 
 	// Queries the backend for resources based on the given query parameters.
 	Search(
@@ -1896,6 +1896,7 @@ const pulumiOperationHeader = "Pulumi operation"
 
 func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.StackReference,
 	req apitype.CreateDeploymentRequest, opts display.Options, deploymentInitiator string,
+	streamDeploymentLogs bool,
 ) error {
 	stackID, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
@@ -1914,6 +1915,10 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 		fmt.Printf(opts.Color.Colorize(
 			colors.SpecHeadline+"View Live: "+
 				colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n"), resp.ConsoleURL)
+	}
+
+	if !streamDeploymentLogs {
+		return nil
 	}
 
 	token := ""

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -41,6 +41,7 @@ type MockHTTPBackend struct {
 		req apitype.CreateDeploymentRequest,
 		opts display.Options,
 		deploymentInitiator string,
+		streamDeploymentLogs bool,
 	) error
 }
 
@@ -74,8 +75,9 @@ func (b *MockHTTPBackend) RunDeployment(
 	req apitype.CreateDeploymentRequest,
 	opts display.Options,
 	deploymentInitiator string,
+	streamDeploymentLogs bool,
 ) error {
-	return b.FRunDeployment(ctx, stackRef, req, opts, deploymentInitiator)
+	return b.FRunDeployment(ctx, stackRef, req, opts, deploymentInitiator, streamDeploymentLogs)
 }
 
 func (b *MockHTTPBackend) Search(

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -41,7 +41,7 @@ type MockHTTPBackend struct {
 		req apitype.CreateDeploymentRequest,
 		opts display.Options,
 		deploymentInitiator string,
-		streamDeploymentLogs bool,
+		suppressStreamLogs bool,
 	) error
 }
 
@@ -75,9 +75,9 @@ func (b *MockHTTPBackend) RunDeployment(
 	req apitype.CreateDeploymentRequest,
 	opts display.Options,
 	deploymentInitiator string,
-	streamDeploymentLogs bool,
+	suppressStreamLogs bool,
 ) error {
-	return b.FRunDeployment(ctx, stackRef, req, opts, deploymentInitiator, streamDeploymentLogs)
+	return b.FRunDeployment(ctx, stackRef, req, opts, deploymentInitiator, suppressStreamLogs)
 }
 
 func (b *MockHTTPBackend) Search(

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -128,7 +128,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				return errResult
 			}
 
-			return runDeployment(cmd, ctx, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+			return runDeployment(ctx, cmd, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -77,7 +77,7 @@ func newDeploymentRunCmd() *cobra.Command {
 	remoteArgs := RemoteArgs{}
 
 	var stack string
-	var suppressPermalink string
+	var suppressPermalink bool
 
 	cmd := &cobra.Command{
 		Use:   "run <operation> [url]",
@@ -101,7 +101,7 @@ func newDeploymentRunCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 				// we only suppress permalinks if the user passes true. the default is an empty string
 				// which we pass as 'false'
-				SuppressPermalink: suppressPermalink == "true",
+				SuppressPermalink: suppressPermalink,
 			}
 
 			project, _, err := readProject()
@@ -128,15 +128,15 @@ func newDeploymentRunCmd() *cobra.Command {
 				return errResult
 			}
 
-			return runDeployment(ctx, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+			return runDeployment(cmd, ctx, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
 		}),
 	}
 
 	// Remote flags
 	remoteArgs.applyFlagsForDeploymentCommand(cmd)
 
-	cmd.PersistentFlags().StringVar(
-		&suppressPermalink, "suppress-permalink", "",
+	cmd.PersistentFlags().BoolVar(
+		&suppressPermalink, "suppress-permalink", false,
 		"Suppress display of the state permalink")
 
 	cmd.PersistentFlags().StringVarP(

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -77,7 +77,6 @@ func newDeploymentRunCmd() *cobra.Command {
 	remoteArgs := RemoteArgs{}
 
 	var stack string
-	var jsonDisplay bool
 	var suppressPermalink string
 
 	cmd := &cobra.Command{
@@ -99,8 +98,7 @@ func newDeploymentRunCmd() *cobra.Command {
 			}
 
 			display := display.Options{
-				Color:       cmdutil.GetGlobalColorization(),
-				JSONDisplay: jsonDisplay,
+				Color: cmdutil.GetGlobalColorization(),
 				// we only suppress permalinks if the user passes true. the default is an empty string
 				// which we pass as 'false'
 				SuppressPermalink: suppressPermalink == "true",
@@ -144,10 +142,6 @@ func newDeploymentRunCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-
-	cmd.Flags().BoolVarP(
-		&jsonDisplay, "json", "j", false,
-		"Serialize the update diffs, operations, and overall output as JSON")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
@@ -66,6 +67,87 @@ func newDeploymentCmd() *cobra.Command {
 		"Override the file name where the deployment settings are specified. Default is Pulumi.[stack].deploy.yaml")
 
 	cmd.AddCommand(newDeploymentSettingsCmd())
+	cmd.AddCommand(newDeploymentRunCmd())
+
+	return cmd
+}
+
+func newDeploymentRunCmd() *cobra.Command {
+	// Flags for remote operations.
+	remoteArgs := RemoteArgs{}
+
+	var stack string
+	var jsonDisplay bool
+	var suppressPermalink string
+
+	cmd := &cobra.Command{
+		Use:   "run <operation> [url]",
+		Short: "Launch a deployment job on Pulumi Cloud",
+		Long:  "",
+		Args:  cmdutil.RangeArgs(1, 2),
+		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
+
+			operation, err := apitype.ParsePulumiOperation(args[0])
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			var url string
+			if len(args) > 1 {
+				url = args[1]
+			}
+
+			display := display.Options{
+				Color:       cmdutil.GetGlobalColorization(),
+				JSONDisplay: jsonDisplay,
+				// we only suppress permalinks if the user passes true. the default is an empty string
+				// which we pass as 'false'
+				SuppressPermalink: suppressPermalink == "true",
+			}
+
+			project, _, err := readProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return result.FromError(err)
+			}
+
+			currentBe, err := currentBackend(ctx, project, display)
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			if !currentBe.SupportsDeployments() {
+				return result.FromError(fmt.Errorf("backends of this type %q do not support deployments",
+					currentBe.Name()))
+			}
+
+			s, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, display)
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			if errResult := validateDeploymentFlags(url, remoteArgs); errResult != nil {
+				return errResult
+			}
+
+			return runDeployment(ctx, display, operation, s.Ref().FullyQualifiedName().String(), url, remoteArgs)
+		}),
+	}
+
+	// Remote flags
+	remoteArgs.applyFlagsForDeploymentCommand(cmd)
+
+	cmd.PersistentFlags().StringVar(
+		&suppressPermalink, "suppress-permalink", "",
+		"Suppress display of the state permalink")
+
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	cmd.Flags().BoolVarP(
+		&jsonDisplay, "json", "j", false,
+		"Serialize the update diffs, operations, and overall output as JSON")
 
 	return cmd
 }
@@ -196,6 +278,10 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		}),
 	}
 
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
 	return cmd
 }
 
@@ -254,11 +340,16 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 		}),
 	}
 
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
 	return cmd
 }
 
 func newDeploymentSettingsUpdateCmd() *cobra.Command {
 	var stack string
+
 	cmd := &cobra.Command{
 		Use:        "up",
 		Aliases:    []string{"update"},
@@ -309,11 +400,16 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 		}),
 	}
 
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
 	return cmd
 }
 
 func newDeploymentSettingsDestroyCmd() *cobra.Command {
 	var stack string
+
 	cmd := &cobra.Command{
 		Use:        "destroy",
 		Aliases:    []string{"down", "dn"},
@@ -358,6 +454,10 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 			return nil
 		}),
 	}
+
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -161,7 +161,7 @@ func newDestroyCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
+				return runDeployment(cmd, ctx, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -161,7 +161,7 @@ func newDestroyCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(cmd, ctx, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
+				return runDeployment(ctx, cmd, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -157,6 +157,10 @@ func newDestroyCmd() *cobra.Command {
 					url = args[0]
 				}
 
+				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+					return errResult
+				}
+
 				return runDeployment(ctx, opts.Display, apitype.Destroy, stackName, url, remoteArgs)
 			}
 

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -338,6 +338,10 @@ func newPreviewCmd() *cobra.Command {
 					url = args[0]
 				}
 
+				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+					return errResult
+				}
+
 				return runDeployment(ctx, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -342,7 +342,7 @@ func newPreviewCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(cmd, ctx, displayOpts, apitype.Preview, stackName, url, remoteArgs)
+				return runDeployment(ctx, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(displayOpts)

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -342,7 +342,7 @@ func newPreviewCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, displayOpts, apitype.Preview, stackName, url, remoteArgs)
+				return runDeployment(cmd, ctx, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(displayOpts)

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -154,7 +154,7 @@ func newRefreshCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+				return runDeployment(cmd, ctx, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -150,6 +150,10 @@ func newRefreshCmd() *cobra.Command {
 					url = args[0]
 				}
 
+				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+					return errResult
+				}
+
 				return runDeployment(ctx, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -154,7 +154,7 @@ func newRefreshCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(cmd, ctx, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+				return runDeployment(ctx, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -510,7 +510,7 @@ func newUpCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(cmd, ctx, opts.Display, apitype.Update, stackName, url, remoteArgs)
+				return runDeployment(ctx, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -510,7 +510,7 @@ func newUpCmd() *cobra.Command {
 					return errResult
 				}
 
-				return runDeployment(ctx, opts.Display, apitype.Update, stackName, url, remoteArgs)
+				return runDeployment(cmd, ctx, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
 
 			isDIYBackend, err := isDIYBackend(opts.Display)

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -505,6 +505,11 @@ func newUpCmd() *cobra.Command {
 				if len(args) > 0 {
 					url = args[0]
 				}
+
+				if errResult := validateRemoteDeploymentFlags(url, remoteArgs); errResult != nil {
+					return errResult
+				}
+
 				return runDeployment(ctx, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
 

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -362,7 +362,7 @@ func validateDeploymentFlags(url string, args RemoteArgs) result.Result {
 }
 
 // runDeployment kicks off a remote deployment.
-func runDeployment(cmd *cobra.Command, ctx context.Context, opts display.Options,
+func runDeployment(ctx context.Context, cmd *cobra.Command, opts display.Options,
 	operation apitype.PulumiOperation, stack, url string, args RemoteArgs,
 ) result.Result {
 	// Parse and validate the environment args.

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -154,6 +154,7 @@ func validateUnsupportedRemoteFlags(
 type RemoteArgs struct {
 	remote                   bool
 	inheritSettings          bool
+	streamLogs               bool
 	envVars                  []string
 	secretEnvVars            []string
 	preRunCommands           []string
@@ -171,6 +172,65 @@ type RemoteArgs struct {
 	executorImagePassword    string
 }
 
+func (r *RemoteArgs) applyFlagsForDeploymentCommand(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(
+		&r.inheritSettings, "inherit-settings", true,
+		"Inherit deployment settings from the current stack")
+	cmd.PersistentFlags().BoolVar(
+		&r.streamLogs, "stream-logs", false,
+		"Suppress log streaming of the deployment job")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.envVars, "env", []string{},
+		"Environment variables to use in the remote operation of the form NAME=value "+
+			"(e.g. `--env FOO=bar`)")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.secretEnvVars, "env-secret", []string{},
+		"Environment variables with secret values to use in the remote operation of the form "+
+			"NAME=secretvalue (e.g. `--env FOO=secret`)")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.preRunCommands, "pre-run-command", []string{},
+		"Commands to run before the remote operation")
+	cmd.PersistentFlags().BoolVar(
+		&r.skipInstallDependencies, "skip-install-dependencies", false,
+		"Whether to skip the default dependency installation step")
+	cmd.PersistentFlags().StringVar(
+		&r.gitBranch, "git-branch", "",
+		"Git branch to deploy; this is mutually exclusive with --git-commit; "+
+			"either value needs to be specified")
+	cmd.PersistentFlags().StringVar(
+		&r.gitCommit, "git-commit", "",
+		"Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
+			"this is mutually exclusive with --git-branch; either value needs to be specified")
+	cmd.PersistentFlags().StringVar(
+		&r.gitRepoDir, "git-repo-dir", "",
+		"The directory to work from in the project's source repository "+
+			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthAccessToken, "git-auth-access-token", "",
+		"Git personal access token")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthSSHPrivateKey, "git-auth-ssh-private-key", "",
+		"Git SSH private key; use --git-auth-password for the password, if needed")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthSSHPrivateKeyPath, "git-auth-ssh-private-key-path", "",
+		"Git SSH private key path; use --git-auth-password for the password, if needed")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthPassword, "git-auth-password", "",
+		"Git password; for use with username or with an SSH private key")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthUsername, "git-auth-username", "",
+		"Git username")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImage, "executor-image", "",
+		"The Docker image to use for the executor")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImageUsername, "executor-image-username", "",
+		"The username for the credentials with access to the Docker image to use for the executor")
+	cmd.PersistentFlags().StringVar(
+		&r.executorImagePassword, "executor-image-password", "",
+		"The password for the credentials with access to the Docker image to use for the executor")
+}
+
 // Add flags to support remote operations
 func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 	if !remoteSupported() {
@@ -180,6 +240,9 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&r.remote, "remote", false,
 		"[EXPERIMENTAL] Run the operation remotely")
+	cmd.PersistentFlags().BoolVar(
+		&r.streamLogs, "stream-logs", true,
+		"[EXPERIMENTAL] Suppress log streaming of the deployment job")
 	cmd.PersistentFlags().BoolVar(
 		&r.inheritSettings, "remote-inherit-settings", false,
 		"[EXPERIMENTAL] Inherit deployment settings from the current stack")
@@ -235,10 +298,7 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor")
 }
 
-// runDeployment kicks off a remote deployment.
-func runDeployment(ctx context.Context, opts display.Options, operation apitype.PulumiOperation, stack, url string,
-	args RemoteArgs,
-) result.Result {
+func validateRemoteDeploymentFlags(url string, args RemoteArgs) result.Result {
 	// Validate args.
 	if url == "" && !args.inheritSettings {
 		return result.FromError(errors.New("the url arg must be specified if not passing --remote-inherit-settings"))
@@ -264,6 +324,42 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 			"must both be specified"))
 	}
 
+	return nil
+}
+
+func validateDeploymentFlags(url string, args RemoteArgs) result.Result {
+	// Validate args.
+	if url == "" && !args.inheritSettings {
+		return result.FromError(errors.New("the url arg must be specified if not passing --inherit-settings"))
+	}
+	if args.gitBranch != "" && args.gitCommit != "" {
+		return result.FromError(errors.New("`--git-branch` and `--git-commit` cannot both be specified"))
+	}
+	if args.gitBranch == "" && args.gitCommit == "" && !args.inheritSettings {
+		return result.FromError(errors.New("either `--git-branch` or `--git-commit` is required " +
+			"if not passing --inherit-settings"))
+	}
+	if args.gitAuthSSHPrivateKey != "" && args.gitAuthSSHPrivateKeyPath != "" {
+		return result.FromError(errors.New("`--git-auth-ssh-private-key` and " +
+			"`--git-auth-ssh-private-key-path` cannot both be specified"))
+	}
+	if args.executorImage == "" && (args.executorImageUsername != "" || args.executorImagePassword != "") {
+		return result.FromError(errors.New("`--executor-image-username` and `--executor-image-password` " +
+			"cannot be specified without `--executor-image`"))
+	}
+	if (args.executorImagePassword != "" && args.executorImageUsername == "") ||
+		(args.executorImageUsername != "" && args.executorImagePassword == "") {
+		return result.FromError(errors.New("`--executor-image-username` and `--executor-image-password` " +
+			"must both be specified"))
+	}
+
+	return nil
+}
+
+// runDeployment kicks off a remote deployment.
+func runDeployment(ctx context.Context, opts display.Options, operation apitype.PulumiOperation, stack, url string,
+	args RemoteArgs,
+) result.Result {
 	// Parse and validate the environment args.
 	env := map[string]apitype.SecretValue{}
 	for i, e := range append(args.envVars, args.secretEnvVars...) {
@@ -398,7 +494,7 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 	// to "automation-api".
 	// In the future, we may want to expose initiating deployments from the CLI, in which case we would need to
 	// pass this value in from the CLI as a flag or environment variable.
-	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/)
+	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/, args.streamLogs)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -154,7 +154,7 @@ func validateUnsupportedRemoteFlags(
 type RemoteArgs struct {
 	remote                   bool
 	inheritSettings          bool
-	streamLogs               bool
+	supressStreamLogs        bool
 	envVars                  []string
 	secretEnvVars            []string
 	preRunCommands           []string
@@ -177,7 +177,7 @@ func (r *RemoteArgs) applyFlagsForDeploymentCommand(cmd *cobra.Command) {
 		&r.inheritSettings, "inherit-settings", true,
 		"Inherit deployment settings from the current stack")
 	cmd.PersistentFlags().BoolVar(
-		&r.streamLogs, "stream-logs", false,
+		&r.supressStreamLogs, "suppress-stream-logs", true,
 		"Suppress log streaming of the deployment job")
 	cmd.PersistentFlags().StringArrayVar(
 		&r.envVars, "env", []string{},
@@ -241,7 +241,7 @@ func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
 		&r.remote, "remote", false,
 		"[EXPERIMENTAL] Run the operation remotely")
 	cmd.PersistentFlags().BoolVar(
-		&r.streamLogs, "stream-logs", true,
+		&r.supressStreamLogs, "suppress-stream-logs", false,
 		"[EXPERIMENTAL] Suppress log streaming of the deployment job")
 	cmd.PersistentFlags().BoolVar(
 		&r.inheritSettings, "remote-inherit-settings", false,
@@ -494,7 +494,7 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 	// to "automation-api".
 	// In the future, we may want to expose initiating deployments from the CLI, in which case we would need to
 	// pass this value in from the CLI as a flag or environment variable.
-	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/, args.streamLogs)
+	err = cb.RunDeployment(ctx, stackRef, req, opts, "automation-api" /*deploymentInitiator*/, args.supressStreamLogs)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -543,7 +543,7 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.11.0 h1:Jw9gBvyfmfOMq/EkYDm9+zGPxsDAA8jfeMpHmtZ+1oA=
 github.com/pulumi/pulumi-java/pkg v0.11.0/go.mod h1:sXAk25P47AQVQL6ilAbFmRNgZykC7og/+87ihnqzFTc=
-github.com/pulumi/pulumi-yaml v1.8.0 h1:iVScFkRbslUAxxmu0n8Y15y7hnIwcUeIzBU/oHJQTFI=
+github.com/pulumi/pulumi-yaml v1.8.0 h1:bhmidiCMMuzsJao5FE0UR69iF3WVKPCFrRkzjotFNn4=
 github.com/pulumi/pulumi-yaml v1.8.0/go.mod h1:pCfYHSRmdl+5dM/7eT2uDQS528YOhAhiqbn9pwRzW20=
 github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -543,7 +543,7 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/pulumi-java/pkg v0.11.0 h1:Jw9gBvyfmfOMq/EkYDm9+zGPxsDAA8jfeMpHmtZ+1oA=
 github.com/pulumi/pulumi-java/pkg v0.11.0/go.mod h1:sXAk25P47AQVQL6ilAbFmRNgZykC7og/+87ihnqzFTc=
-github.com/pulumi/pulumi-yaml v1.8.0 h1:bhmidiCMMuzsJao5FE0UR69iF3WVKPCFrRkzjotFNn4=
+github.com/pulumi/pulumi-yaml v1.8.0 h1:iVScFkRbslUAxxmu0n8Y15y7hnIwcUeIzBU/oHJQTFI=
 github.com/pulumi/pulumi-yaml v1.8.0/go.mod h1:pCfYHSRmdl+5dM/7eT2uDQS528YOhAhiqbn9pwRzW20=
 github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlRM=
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -149,14 +149,14 @@ type SourceContext struct {
 }
 
 type SourceContextGit struct {
-	RepoURL string `json:"repoURL" yaml:"repoURL"`
+	RepoURL string `json:"repoURL" yaml:"repoURL,omitempty"`
 
 	Branch string `json:"branch" yaml:"branch"`
 
 	// (optional) RepoDir is the directory to work from in the project's source repository
 	// where Pulumi.yaml is located. It is used in case Pulumi.yaml is not
 	// in the project source root.
-	RepoDir string `json:"repoDir,omitempty" yaml:"repoDir"`
+	RepoDir string `json:"repoDir,omitempty" yaml:"repoDir,omitempty"`
 
 	// (optional) Commit is the hash of the commit to deploy. If used, HEAD will be in detached mode. This
 	// is mutually exclusive with the Branch setting. Either value needs to be specified.
@@ -205,13 +205,13 @@ type OperationContext struct {
 	// PreRunCommands is an optional list of arbitrary commands to run before Pulumi
 	// is invoked.
 	// ref: https://github.com/pulumi/pulumi/issues/9397
-	PreRunCommands []string `json:"preRunCommands" yaml:"preRunCommands"`
+	PreRunCommands []string `json:"preRunCommands" yaml:"preRunCommands,omitempty"`
 
 	// Operation is what we plan on doing.
-	Operation PulumiOperation `json:"operation" yaml:"operation"`
+	Operation PulumiOperation `json:"operation"`
 
 	// EnvironmentVariables contains environment variables to be applied during the execution.
-	EnvironmentVariables map[string]SecretValue `json:"environmentVariables" yaml:"environmentVariables"`
+	EnvironmentVariables map[string]SecretValue `json:"environmentVariables" yaml:"environmentVariables,omitempty"`
 
 	// Options is a bag of settings to specify or override default behavior
 	Options *OperationContextOptions `json:"options,omitempty" yaml:"options,omitempty"`
@@ -221,7 +221,7 @@ type OperationContext struct {
 type OperationContextOptions struct {
 	SkipInstallDependencies     bool   `json:"skipInstallDependencies" yaml:"skipInstallDependencies"`
 	SkipIntermediateDeployments bool   `json:"skipIntermediateDeployments" yaml:"skipIntermediateDeployments"`
-	Shell                       string `json:"shell" yaml:"shell"`
+	Shell                       string `json:"shell" yaml:"shell,omitempty"`
 	DeleteAfterDestroy          bool   `json:"deleteAfterDestroy" yaml:"deleteAfterDestroy"`
 	RemediateIfDriftDetected    bool   `json:"remediateIfDriftDetected" yaml:"remediateIfDriftDetected"`
 }

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -73,6 +73,20 @@ type CreateDeploymentRequest struct {
 
 	// Operation defines the options that the executor will use to run the Pulumi commands.
 	Operation *OperationContext `json:"operationContext,omitempty"`
+
+	AgentPoolID *AgentPoolIDMarshaller `json:"agentPoolID,omitempty"`
+}
+
+type AgentPoolIDMarshaller string
+
+func (d *AgentPoolIDMarshaller) MarshalJSON() ([]byte, error) {
+	if d == nil {
+		return json.Marshal([]byte{})
+	}
+	if *d != "" {
+		return json.Marshal(*d)
+	}
+	return json.Marshal(nil)
 }
 
 type DeploymentSettings struct {

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -80,9 +80,6 @@ type CreateDeploymentRequest struct {
 type AgentPoolIDMarshaller string
 
 func (d *AgentPoolIDMarshaller) MarshalJSON() ([]byte, error) {
-	if d == nil {
-		return json.Marshal([]byte{})
-	}
 	if *d != "" {
 		return json.Marshal(*d)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add new deployment run command

Fixes https://github.com/pulumi/pulumi-service/issues/20500

## Checklist

- [ ] I have run `make tidy` to update any new dependencies
- [ ] I have run `make lint` to verify my code passes the lint check
  - [ ] I have formatted my code using `gofumpt`

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Cloud,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
