### PR TITLE
implement skeleton command for `pulumi state move`

### DIFF
--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -56,6 +56,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateUnprotectCommand())
 	cmd.AddCommand(newStateRenameCommand())
 	cmd.AddCommand(newStateUpgradeCommand())
+	//	cmd.AddCommand(newStateMoveCommand())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -56,7 +56,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateUnprotectCommand())
 	cmd.AddCommand(newStateRenameCommand())
 	cmd.AddCommand(newStateUpgradeCommand())
-	//	cmd.AddCommand(newStateMoveCommand())
+	cmd.AddCommand(newStateMoveCommand())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -1,0 +1,213 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+)
+
+type stateMoveCmd struct{}
+
+// func newStateMoveCommand() *cobra.Command {
+// 	var sourceStackName string
+// 	var destStackName string
+// 	stateMove := &stateMoveCmd{}
+// 	cmd := &cobra.Command{
+// 		Use:   "move",
+// 		Short: "Move resources from one stack to another",
+// 		Long: `Move resources from one stack to another
+
+// This command can be used to move resources from one stack to another. This can be useful when
+// splitting a stack into multiple stacks or when merging multiple stacks into one.`,
+// 		Args: cmdutil.MinimumNArgs(1),
+// 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+// 			ctx := cmd.Context()
+
+// 			if sourceStackName == "" && destStackName == "" {
+// 				return errors.New("at least one of --source or --dest must be provided")
+// 			}
+// 			// TODO: make sure to load the source stack even if it is from a different project
+// 			sourceStack, err := requireStack(ctx, sourceStackName, stackLoadOnly, display.Options{
+// 				Color:         cmdutil.GetGlobalColorization(),
+// 				IsInteractive: true,
+// 			})
+// 			if err != nil {
+// 				return err
+// 			}
+// 			// TODO: make sure to load the dest stack even if it is from a different project.
+// 			destStack, err := requireStack(ctx, destStackName, stackLoadOnly, display.Options{
+// 				Color:         cmdutil.GetGlobalColorization(),
+// 				IsInteractive: true,
+// 			})
+// 			if err != nil {
+// 				return err
+// 			}
+
+// 			return stateMove.Run(ctx, sourceStack, destStack, args)
+// 		}),
+// 	}
+
+// 	cmd.Flags().StringVarP(&sourceStackName, "source", "", "", "The name of the stack to move resources from")
+// 	cmd.Flags().StringVarP(&destStackName, "dest", "", "", "The name of the stack to move resources to")
+
+// 	return cmd
+// }
+
+func resourceMatches(res *resource.State, args []string) bool {
+	for _, arg := range args {
+		if string(res.URN) == arg {
+			return true
+		}
+	}
+	return false
+}
+
+func breakDependencies(res *resource.State, resourcesToMove map[string]*resource.State) {
+	j := 0
+	for _, dep := range res.Dependencies {
+		if _, ok := resourcesToMove[string(dep)]; !ok {
+			res.Dependencies[j] = dep
+			j++
+		}
+	}
+	res.Dependencies = res.Dependencies[:j]
+	for k, propDeps := range res.PropertyDependencies {
+		j = 0
+		for _, propDep := range propDeps {
+			if _, ok := resourcesToMove[string(propDep)]; !ok {
+				propDeps[j] = propDep
+				j++
+			}
+		}
+		res.PropertyDependencies[k] = propDeps[:j]
+	}
+	if _, ok := resourcesToMove[string(res.DeletedWith)]; !ok {
+		res.DeletedWith = ""
+	}
+}
+
+func rewriteURNs(res *resource.State, dest backend.Stack) {
+	// TODO: rewrite project name
+	res.URN = res.URN.RenameStack(dest.Ref().Name())
+	if res.Provider != "" {
+		res.Provider = string(urn.URN(res.Provider).RenameStack(dest.Ref().Name()))
+	}
+	for k, dep := range res.Dependencies {
+		res.Dependencies[k] = dep.RenameStack(dest.Ref().Name())
+	}
+	for k, propDeps := range res.PropertyDependencies {
+		for j, propDep := range propDeps {
+			res.PropertyDependencies[k][j] = propDep.RenameStack(dest.Ref().Name())
+		}
+	}
+	if res.DeletedWith != "" {
+		res.DeletedWith = res.DeletedWith.RenameStack(dest.Ref().Name())
+	}
+}
+
+func (cmd *stateMoveCmd) Run(ctx context.Context, source backend.Stack, dest backend.Stack, args []string) error {
+	sourceSnapshot, err := source.Snapshot(ctx, stack.DefaultSecretsProvider)
+	if err != nil {
+		return err
+	}
+	destSnapshot, err := dest.Snapshot(ctx, stack.DefaultSecretsProvider)
+	if err != nil {
+		return err
+	}
+
+	resourcesToMove := make(map[string]*resource.State)
+	providersToCopy := make(map[string]bool)
+	remainingResources := make(map[string]*resource.State)
+	for _, res := range sourceSnapshot.Resources {
+		if resourceMatches(res, args) {
+			resourcesToMove[string(res.URN)] = res
+			providersToCopy[res.Provider] = true
+		} else {
+			remainingResources[string(res.URN)] = res
+		}
+	}
+
+	sourceDepGraph := graph.NewDependencyGraph(sourceSnapshot.Resources)
+
+	// include all children in the list of resources to move
+	for _, res := range resourcesToMove {
+		for _, dep := range sourceDepGraph.ChildrenOf(res) {
+			resourcesToMove[string(dep.URN)] = dep
+			providersToCopy[dep.Provider] = true
+		}
+	}
+
+	// run through the source snapshot and find all the providers
+	// that need to be copied, remove all the resources that need
+	// to be removed, and break the dependencies that are no
+	// longer valid.
+	var providers []*resource.State
+	i := 0
+	for _, res := range sourceSnapshot.Resources {
+		// Find providers that need to be copied
+		if _, ok := resourcesToMove[string(res.URN)]; ok {
+			continue
+		}
+		if providersToCopy[string(res.URN)+"::"+string(res.ID)] {
+			providers = append(providers, res)
+		}
+
+		sourceSnapshot.Resources[i] = res
+		i++
+		breakDependencies(res, resourcesToMove)
+	}
+	sourceSnapshot.Resources = sourceSnapshot.Resources[:i]
+
+	for _, res := range providers {
+		// Providers stay in the source stack, so we need a copy of the provider to be able to
+		// rewrite the URNs of the resource.
+		copy := res.Copy()
+		rewriteURNs(copy, dest)
+		destSnapshot.Resources = append(destSnapshot.Resources, copy)
+	}
+
+	for _, res := range resourcesToMove {
+		breakDependencies(res, remainingResources)
+		rewriteURNs(res, dest)
+		if _, ok := resourcesToMove[string(res.Parent)]; !ok {
+			rootStack, err := stack.GetRootStackResource(destSnapshot)
+			if err != nil {
+				return err
+			}
+			res.Parent = rootStack.URN
+		}
+
+		destSnapshot.Resources = append(destSnapshot.Resources, res)
+	}
+
+	err = destSnapshot.VerifyIntegrity()
+	if err != nil {
+		return fmt.Errorf("failed to verify integrity of destination snapshot: %w", err)
+	}
+
+	err = sourceSnapshot.VerifyIntegrity()
+	if err != nil {
+		return fmt.Errorf("failed to verify integrity of source snapshot: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -16,61 +16,65 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
 )
 
 type stateMoveCmd struct{}
 
-// func newStateMoveCommand() *cobra.Command {
-// 	var sourceStackName string
-// 	var destStackName string
-// 	stateMove := &stateMoveCmd{}
-// 	cmd := &cobra.Command{
-// 		Use:   "move",
-// 		Short: "Move resources from one stack to another",
-// 		Long: `Move resources from one stack to another
+func newStateMoveCommand() *cobra.Command {
+	var sourceStackName string
+	var destStackName string
+	stateMove := &stateMoveCmd{}
+	cmd := &cobra.Command{
+		Use:   "move",
+		Short: "Move resources from one stack to another",
+		Long: `Move resources from one stack to another
 
-// This command can be used to move resources from one stack to another. This can be useful when
-// splitting a stack into multiple stacks or when merging multiple stacks into one.`,
-// 		Args: cmdutil.MinimumNArgs(1),
-// 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-// 			ctx := cmd.Context()
+This command can be used to move resources from one stack to another. This can be useful when
+splitting a stack into multiple stacks or when merging multiple stacks into one.`,
+		Args: cmdutil.MinimumNArgs(1),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 
-// 			if sourceStackName == "" && destStackName == "" {
-// 				return errors.New("at least one of --source or --dest must be provided")
-// 			}
-// 			// TODO: make sure to load the source stack even if it is from a different project
-// 			sourceStack, err := requireStack(ctx, sourceStackName, stackLoadOnly, display.Options{
-// 				Color:         cmdutil.GetGlobalColorization(),
-// 				IsInteractive: true,
-// 			})
-// 			if err != nil {
-// 				return err
-// 			}
-// 			// TODO: make sure to load the dest stack even if it is from a different project.
-// 			destStack, err := requireStack(ctx, destStackName, stackLoadOnly, display.Options{
-// 				Color:         cmdutil.GetGlobalColorization(),
-// 				IsInteractive: true,
-// 			})
-// 			if err != nil {
-// 				return err
-// 			}
+			if sourceStackName == "" && destStackName == "" {
+				return errors.New("at least one of --source or --dest must be provided")
+			}
+			// TODO: make sure to load the source stack even if it is from a different project
+			sourceStack, err := requireStack(ctx, sourceStackName, stackLoadOnly, display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
+				IsInteractive: true,
+			})
+			if err != nil {
+				return err
+			}
+			// TODO: make sure to load the dest stack even if it is from a different project.
+			destStack, err := requireStack(ctx, destStackName, stackLoadOnly, display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
+				IsInteractive: true,
+			})
+			if err != nil {
+				return err
+			}
 
-// 			return stateMove.Run(ctx, sourceStack, destStack, args)
-// 		}),
-// 	}
+			return stateMove.Run(ctx, sourceStack, destStack, args)
+		}),
+	}
 
-// 	cmd.Flags().StringVarP(&sourceStackName, "source", "", "", "The name of the stack to move resources from")
-// 	cmd.Flags().StringVarP(&destStackName, "dest", "", "", "The name of the stack to move resources to")
+	cmd.Flags().StringVarP(&sourceStackName, "source", "", "", "The name of the stack to move resources from")
+	cmd.Flags().StringVarP(&destStackName, "dest", "", "", "The name of the stack to move resources to")
 
-// 	return cmd
-// }
+	return cmd
+}
 
 func resourceMatches(res *resource.State, args []string) bool {
 	for _, arg := range args {

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -151,9 +151,9 @@ func (cmd *stateMoveCmd) Run(
 	for _, res := range providers {
 		// Providers stay in the source stack, so we need a copy of the provider to be able to
 		// rewrite the URNs of the resource.
-		copy := res.Copy()
-		rewriteURNs(copy, dest)
-		destSnapshot.Resources = append(destSnapshot.Resources, copy)
+		r := res.Copy()
+		rewriteURNs(r, dest)
+		destSnapshot.Resources = append(destSnapshot.Resources, r)
 	}
 
 	for _, res := range resourcesToMove {

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -41,8 +41,13 @@ func newStateMoveCommand() *cobra.Command {
 		Long: `Move resources from one stack to another
 
 This command can be used to move resources from one stack to another. This can be useful when
-splitting a stack into multiple stacks or when merging multiple stacks into one.`,
+splitting a stack into multiple stacks or when merging multiple stacks into one.
+
+EXPERIMENTAL: this feature is currently in development.
+`,
 		Args: cmdutil.MinimumNArgs(1),
+		// TODO: this command should be hidden until it is fully implemented
+		Hidden: true,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createStackWithResources(t *testing.T, b diy.Backend, stackName string, resources []*resource.State) backend.Stack {
+	sm := b64.NewBase64SecretsManager()
+
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+	ctx := context.Background()
+
+	sdep, err := stack.SerializeDeployment(ctx, snap, false /* showSecrets */)
+	assert.NoError(t, err)
+
+	data, err := encoding.JSON.Marshal(sdep)
+	assert.NoError(t, err)
+
+	udep := &apitype.UntypedDeployment{
+		Version:    3,
+		Deployment: json.RawMessage(data),
+	}
+
+	ref, err := b.ParseStackReference(stackName)
+	require.NoError(t, err)
+
+	s, err := b.CreateStack(ctx, ref, "", nil)
+	require.NoError(t, err)
+
+	err = b.ImportDeployment(ctx, s, udep)
+	require.NoError(t, err)
+
+	return s
+}
+
+func TestMoveLeafResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// urn:pulumi:stack2::pulumi-test-moves::pulumi:providers:aws::default_5_43_0::4b0fb629-cd65-4914-a34b-23a258996f7b
+
+	providerURN := resource.NewURN("sourceStack", "test", "pulumi:providers:d", "a_provider", "1.0.0")
+	sourceResources := []*resource.State{
+		{
+			URN:  providerURN,
+			Type: "pulumi:providers:d",
+			ID:   "provider_id",
+		},
+		{
+			URN:  resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type: "a:b:c",
+			Inputs: resource.PropertyMap{
+				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
+			},
+			Provider: string(providerURN),
+		},
+	}
+	tmpDir := t.TempDir()
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destResources := []*resource.State{}
+	destStackName := "organization/test/destStack"
+	destStack := createStackWithResources(t, b, destStackName, destResources)
+
+	stateMoveCmd := stateMoveCmd{}
+	stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[0].URN)})
+
+	// mp := &secrets.MockProvider{}
+	// mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+	// 	return b64.NewBase64SecretsManager(), nil
+	// })
+
+	// TODO: Check that the state on disk also reflects this state
+	// sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	// assert.NoError(t, err)
+	// assert.Equal(t, 0, len(sourceSnapshot.Resources))
+
+	// destSnapshot, err := destStack.Snapshot(ctx, mp)
+	// assert.NoError(t, err)
+	// assert.Equal(t, 1, len(destSnapshot.Resources))
+}

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -35,7 +35,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createStackWithResources(t *testing.T, b diy.Backend, stackName string, resources []*resource.State) backend.Stack {
+func createStackWithResources(
+	t *testing.T, b diy.Backend, stackName string, resources []*resource.State,
+) backend.Stack {
 	sm := b64.NewBase64SecretsManager()
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -279,6 +279,7 @@ func (dg *DependencyGraph) TransitiveDependenciesOf(r *resource.State) mapset.Se
 	return dependencies
 }
 
+// ChildrenOf returns a slice containing all resources that are children of the given resource.
 func (dg *DependencyGraph) ChildrenOf(res *resource.State) []*resource.State {
 	children := make([]*resource.State, 0)
 	for _, childIndex := range dg.childrenOf[res.URN] {

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -279,6 +279,14 @@ func (dg *DependencyGraph) TransitiveDependenciesOf(r *resource.State) mapset.Se
 	return dependencies
 }
 
+func (dg *DependencyGraph) ChildrenOf(res *resource.State) []*resource.State {
+	children := make([]*resource.State, 0)
+	for _, childIndex := range dg.childrenOf[res.URN] {
+		children = append(children, dg.resources[childIndex])
+	}
+	return children
+}
+
 // Mark a resource and its provider, parent, dependencies, property
 // dependencies, and deletion dependencies, as a dependency. This is a helper
 // function for `TransitiveDependenciesOf`.

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -162,6 +162,6 @@ func CreateRootStackResource(stackName tokens.QName, projectName tokens.PackageN
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
 	urn := resource.NewURN(stackName, projectName, "", typ, name)
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
-		nil, false, nil, nil, nil, "", false, "", nil, nil, "")
+		nil, false, nil, nil, nil, "", false, "", nil, nil, "", nil)
 	return state
 }

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -156,3 +156,12 @@ func GetRootStackResource(snap *deploy.Snapshot) (*resource.State, error) {
 	}
 	return nil, nil
 }
+
+// CreateRootStackResource creates a new root stack resource with the given name
+func CreateRootStackResource(stackName tokens.QName, projectName tokens.PackageName) *resource.State {
+	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
+	urn := resource.NewURN(stackName, projectName, "", typ, name)
+	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
+		nil, false, nil, nil, nil, "", false, "", nil, nil, "")
+	return state
+}

--- a/sdk/go/common/resource/urn/urn.go
+++ b/sdk/go/common/resource/urn/urn.go
@@ -198,3 +198,7 @@ func (urn URN) Rename(newName string) URN {
 		newName,
 	)
 }
+
+func (urn URN) RenameStack(stack tokens.StackName) URN {
+	return New(stack.Q(), urn.Project(), urn.QualifiedType(), urn.Type(), urn.Name())
+}

--- a/sdk/go/common/resource/urn/urn.go
+++ b/sdk/go/common/resource/urn/urn.go
@@ -199,6 +199,7 @@ func (urn URN) Rename(newName string) URN {
 	)
 }
 
+// Returns a new URN with an updated stack part
 func (urn URN) RenameStack(stack tokens.StackName) URN {
 	return New(stack.Q(), urn.Project(), urn.QualifiedType(), urn.Type(), urn.Name())
 }


### PR DESCRIPTION
Implement a skeleton command for `pulumi state move`.  This can so far only more a single resource from one stack to another, including copying the provider it needs, and leave valid state files behind.

These state files are not written to the backend yet, nor is there any kind of UI.  Further PRs will build on top of this.

The command is intentionally commented out so this can be merged independently.

---

Based on discussions in the last retro, I'm trying something new here and try to split the PR up some more into chunks that can be individually merged, but are not completely ready yet.  The code added here is essentially dead code at this point, but provides a skeleton to incrementally add pieces.

To give an idea of where this is headed, the next things I'm planning to work on here are:
- Writing the state files to the backend
- Make sure this works with stacks from two different projects
- Add a preview phase that asks for user confirmation
- Add output for moved resources and warnings for dependencies that are being broken
- Implement `--include-parents` flag
- Implement convenience flags (`--yes`, `--skip-preview` etc.)

I'd love some early thoughts on this PR, and also meta thoughts on splitting PRs up this way.