### PR TITLE
Temporarily skip flaky TestTokenSource test

### DIFF
--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestTokenSource(t *testing.T) {
+	// TODO[pulumi/pulumi#16500] fix flaky test and unskip
+	t.Skip("Skipping flaky test: TODO[pulumi/pulumi#16500] to unskip")
 	if runtime.GOOS == "windows" {
 		t.Skip("Flaky on Windows CI workers due to the use of timer+Sleep")
 	}


### PR DESCRIPTION
We attempted to adjust the numbers to help address the flakiness in #16495, but still seeing occurrences of this even with that change. Temporarily skip the test to help unblock merges.