### PR TITLE
make sure ci-ok is red even if there are skipped tests

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -134,8 +134,12 @@ jobs:
   ci-ok:
     name: ci-ok
     needs: [ci]
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: CI failed
+        if: ${{ needs.ci.result != 'success' }}
+        run: exit 1
       - name: CI succeeded
         run: exit 0
 


### PR DESCRIPTION
When there are skipped tests, any jobs depending on the skipped test will also be skipped.  This means ci-ok will be skipped in that case. For some reason GitHub believes this should mean "Go ahead ignoring this check" instead of treating it the same as a failed check.

Therefore when a test is skipped in the CI script because an earlier test failed, ci-ok is marked as Skipped and we still enqueue the PR, wasting time and resources.

The workaround is to make sure this check *always* runs, and checking the result of the scripts it depends on.  We do the same in the on-merge job.