### PR TITLE
Fix a typo in user prompt

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -902,7 +902,7 @@ func (host *nodeLanguageHost) RuntimeOptionsPrompts(ctx context.Context,
 	if _, hasPackagemanager := rawOpts["packagemanager"]; !hasPackagemanager {
 		prompts = append(prompts, &pulumirpc.RuntimeOptionPrompt{
 			Key:         "packagemanager",
-			Description: "The packagemangager to use for installing dependencies",
+			Description: "The package manager to use for installing dependencies",
 			PromptType:  pulumirpc.RuntimeOptionPrompt_STRING,
 			Choices: []*pulumirpc.RuntimeOptionPrompt_RuntimeOptionValue{
 				{StringValue: "npm", PromptType: pulumirpc.RuntimeOptionPrompt_STRING},


### PR DESCRIPTION
Fix a typo "packagemangager" -> "package manager"