### PR TITLE
fail fast whenever a job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ on:
         default: false
         required: false
         type: boolean
+      fail-fast:
+        description: "Fail all workflows whenever one of them fails"
+        default: false
+        require: false
+        type: boolean
     secrets:
       PULUMI_BOT_TOKEN:
         required: true
@@ -268,7 +273,7 @@ jobs:
     if: ${{ inputs.lint }}
     uses: ./.github/workflows/ci-lint.yml
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
     with:
       ref: ${{ inputs.ref }}
       version-set: ${{ needs.matrix.outputs.version-set }}
@@ -277,7 +282,7 @@ jobs:
     name: build binaries
     needs: [matrix]
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml
@@ -298,7 +303,7 @@ jobs:
     needs: [matrix]
     uses: ./.github/workflows/ci-build-binaries.yml
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
@@ -313,7 +318,7 @@ jobs:
     needs: [matrix]
     uses: ./.github/workflows/ci-build-sdks.yml
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
@@ -332,7 +337,7 @@ jobs:
     needs: [matrix, lint]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJson(needs.matrix.outputs.unit-test-matrix) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:
@@ -357,7 +362,7 @@ jobs:
     needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJson(needs.matrix.outputs.integration-test-matrix) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:
@@ -408,7 +413,7 @@ jobs:
     if: ${{ needs.matrix.outputs.acceptance-test-matrix-macos != '{}' }}
     # alow jobs to fail if the platform contains windows
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJson(needs.matrix.outputs.acceptance-test-matrix-macos) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:
@@ -485,7 +490,7 @@ jobs:
     needs: [matrix, unit-test, integration-test, acceptance-test-win, acceptance-test-macos]
     if: ${{ inputs.enable-coverage }}
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ on:
 jobs:
   matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -265,6 +267,8 @@ jobs:
     needs: [matrix]
     if: ${{ inputs.lint }}
     uses: ./.github/workflows/ci-lint.yml
+    strategy:
+      fail-fast: true
     with:
       ref: ${{ inputs.ref }}
       version-set: ${{ needs.matrix.outputs.version-set }}
@@ -273,9 +277,7 @@ jobs:
     name: build binaries
     needs: [matrix]
     strategy:
-      # To avoid tying up macOS runners:
-      # If using IDE, ignore yaml-schema error: 'Incorrect type. Expected "boolean"'
-      fail-fast: ${{ contains(needs.matrix.outputs.build-targets, 'macos') }}
+      fail-fast: true
       matrix:
         target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml
@@ -295,6 +297,8 @@ jobs:
     name: build display WASM module
     needs: [matrix]
     uses: ./.github/workflows/ci-build-binaries.yml
+    strategy:
+      fail-fast: true
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
@@ -308,6 +312,8 @@ jobs:
     name: Build SDKs
     needs: [matrix]
     uses: ./.github/workflows/ci-build-sdks.yml
+    strategy:
+      fail-fast: true
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
@@ -326,7 +332,7 @@ jobs:
     needs: [matrix, lint]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
-      fail-fast: ${{ contains(needs.matrix.outputs.unit-test-matrix, 'macos') }}
+      fail-fast: true
       matrix: ${{ fromJson(needs.matrix.outputs.unit-test-matrix) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:
@@ -351,7 +357,7 @@ jobs:
     needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
-      fail-fast: ${{ contains(needs.matrix.outputs.integration-test-matrix, 'macos') }}
+      fail-fast: true
       matrix: ${{ fromJson(needs.matrix.outputs.integration-test-matrix) }}
     uses: ./.github/workflows/ci-run-test.yml
     with:
@@ -479,9 +485,7 @@ jobs:
     needs: [matrix, unit-test, integration-test, acceptance-test-win, acceptance-test-macos]
     if: ${{ inputs.enable-coverage }}
     strategy:
-      # To avoid tying up macOS runners:
-      # If using IDE, ignore yaml-schema error: 'Incorrect type. Expected "boolean"'
-      fail-fast: ${{ contains(needs.matrix.outputs.build-targets, 'macos') }}
+      fail-fast: true
       matrix:
         target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
   matrix:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ on:
         required: false
         type: boolean
       fail-fast:
-        description: "Fail all workflows whenever one of them fails"
+        required: false
         default: false
-        require: false
+        description: "Fail all workflows whenever one of them fails"
         type: boolean
     secrets:
       PULUMI_BOT_TOKEN:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -40,6 +40,7 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       enable-coverage: true
+      fail-fast: true
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
Whenever anything fails in CI, we don't want to continue the rest of the CI builds to save time and resources.  Setting the fail-fast property should abort the jobs when anything fails.
