### PR TITLE
Skip TestTokenSourceWithQuicklyExpiringInitialToken

### DIFF
--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -64,6 +64,8 @@ func TestTokenSource(t *testing.T) {
 }
 
 func TestTokenSourceWithQuicklyExpiringInitialToken(t *testing.T) {
+	// TODO[pulumi/pulumi#16500] fix flaky test and unskip
+	t.Skip("Skipping flaky test: TODO[pulumi/pulumi#16500] to unskip")
 	if runtime.GOOS == "windows" {
 		t.Skip("Flaky on Windows CI workers due to the use of timer+Sleep")
 	}


### PR DESCRIPTION
`TestTokenSourceWithQuicklyExpiringInitialToken` is flaking like `TestTokenSource`. Skip it like we did in #16501.