### PR TITLE
Protect access to transport.UnsupportedCapabilities inside repo.FetchContext

### DIFF
--- a/changelog/pending/20240628--auto--protect-access-to-transport-unsupportedcapabilities-inside-repo-fetchcontext.yaml
+++ b/changelog/pending/20240628--auto--protect-access-to-transport-unsupportedcapabilities-inside-repo-fetchcontext.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto
+  description: Protect access to transport.UnsupportedCapabilities inside repo.FetchContext


### PR DESCRIPTION
repo.FetchContext reads transport.UnsupportedCapabilities, which we modify, leading to a potential data race in oncurrent calls to setupGitRepo.
Wrap the call to repo.FetchContext with the global transportMutex.

Fixes https://github.com/pulumi/pulumi/issues/16516
