### PR TITLE
also show stdout and stderr when listing tests fails

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -186,7 +186,7 @@ def run_list_tests(pkg_dir: str, tags: List[str]) -> List[str]:
             text=True,
         )
     except sp.CalledProcessError as err:
-        message=f"Failed to list tests in package dir '{pkg_dir}', usually this implies a Go compilation error. Check that `make lint` succeeds."
+        message=f"Failed to list tests in package dir '{pkg_dir}', usually this implies a Go compilation error. Check that `make lint` succeeds.\nstdout: {cmd.stdout}\nstderr: {cmd.stderr}"
         print(f"::error {message}", file=sys.stderr)
         raise Exception(message) from err
 


### PR DESCRIPTION
Listing tests sometimes fails for reasons that are hard to understand. Also show stdout and stderr in the CI output to make it easier to track down why it failed.

I can't for the life of me figure out what's going on in https://github.com/pulumi/pulumi/pull/16493, and I think this might help.