### PR TITLE
reduce the usage of PULUMI_BOT_TOKEN

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -102,9 +102,9 @@ jobs:
           # addressing the root cause of why GoReleaser v1.19.0 fails to read
           # the configuration.
           version: v1.18.2
-      - name: Set up bin dir
+      - name: Prepare bin dir for goreleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOS: ${{ inputs.os }}
           GOARCH: ${{ inputs.arch }}
         run: ./scripts/prep-for-goreleaser.sh local

--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -37,7 +37,7 @@ jobs:
       version: "${{ fromJSON(steps.version.outputs.version) }}"
       release-notes: "${{ fromJSON(steps.notes.outputs.release-notes) }}"
     env:
-      GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -61,7 +61,6 @@ defaults:
     shell: bash
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_VERSION: ${{ inputs.version }}
   PULUMI_TEST_OWNER: "moolumi"
   PULUMI_TEST_ORG: "moolumi"
@@ -223,18 +222,10 @@ jobs:
       - name: Set Go Dep path
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname "$(pwd)")" | tee -a "${GITHUB_ENV}"
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        with:
-          repo: pulumi/pulumictl
-          tag: v0.0.42
-          cache: enable
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: gotestyourself/gotestsum
           tag: v1.8.1
@@ -242,7 +233,7 @@ jobs:
       - name: Install goteststats
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: pulumi/goteststats
           tag: v0.0.7

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -85,19 +85,19 @@ jobs:
         with:
           path: pulumi
           ref: ${{ inputs.ref }}
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out pulumi-aws
         uses: actions/checkout@v4
         with:
           repository: pulumi/pulumi-aws
           path: pulumi-aws
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN}}
       - name: Check out pulumi-kubernetes
         uses: actions/checkout@v4
         with:
           repository: pulumi/pulumi-kubernetes
           path: pulumi-kubernetes
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out docs
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: pulumi/pulumictl
           tag: v0.0.46

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -111,10 +111,6 @@ jobs:
           uses: jaxxstorm/action-install-gh-release@v1.11.0
           with:
             repo: gotesttools/gotestfmt
-        - name: Install pulumictl
-          uses: jaxxstorm/action-install-gh-release@v1.11.0
-          with:
-            repo: pulumi/pulumictl
         - name: Check out source code
           uses: actions/checkout@v4
           with:


### PR DESCRIPTION
PULUMI_BOT_TOKEN is a shared resource across the company and we should be using it as little as possible.  This will hopefully help us bump into the API rate limit less.

Do this using a combination of
- not installing stuff we don't seem to need
- using `secrets.GITHUB_TOKEN` instead.  `secrets.GITHUB_TOKEN` is scoped per repository, so any excessive usage is solely on us to fix.

I'm not entirely sure if this is going to make things better or worse, but I've seen internal complaints about pulumi-bot getting rate limited, and this should help with that.