### PR TITLE
rewrite the URN when resources are being moved between projects

### DIFF
--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -234,7 +234,8 @@ func renameStackAndProject(urn urn.URN, stack backend.Stack) (urn.URN, error) {
 	if project, ok := stack.Ref().Project(); ok {
 		newURN = newURN.RenameProject(tokens.PackageName(project))
 	} else {
-		return "", errors.New("cannot get project name.  Please upgrade your project with `pulumi state upgrade` to solve this.")
+		return "", errors.New("cannot get project name.  " +
+			"Please upgrade your project with `pulumi state upgrade` to solve this.")
 	}
 	return newURN, nil
 }

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -234,7 +234,7 @@ func renameStackAndProject(urn urn.URN, stack backend.Stack) (urn.URN, error) {
 	if project, ok := stack.Ref().Project(); ok {
 		newURN = newURN.RenameProject(tokens.PackageName(project))
 	} else {
-		return "", errors.New("cannot get project name.  " +
+		return "", errors.New("cannot get project name. " +
 			"Please upgrade your project with `pulumi state upgrade` to solve this.")
 	}
 	return newURN, nil

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -234,7 +234,7 @@ func renameStackAndProject(urn urn.URN, stack backend.Stack) (urn.URN, error) {
 	if project, ok := stack.Ref().Project(); ok {
 		newURN = newURN.RenameProject(tokens.PackageName(project))
 	} else {
-		return "", errors.New("cannot get project name")
+		return "", errors.New("cannot get project name.  Please upgrade your project with `pulumi state upgrade` to solve this.")
 	}
 	return newURN, nil
 }

--- a/sdk/go/common/resource/urn/urn.go
+++ b/sdk/go/common/resource/urn/urn.go
@@ -191,8 +191,7 @@ func (urn URN) Rename(newName string) URN {
 	return New(
 		urn.Stack(),
 		urn.Project(),
-		// parent type is empty because
-		// assuming the qualified type already includes it
+		// parent type is empty because the qualified type already includes it
 		"",
 		urn.QualifiedType(),
 		newName,
@@ -204,8 +203,7 @@ func (urn URN) RenameStack(stack tokens.StackName) URN {
 	return New(
 		stack.Q(),
 		urn.Project(),
-		// parent type is empty because
-		// assuming the qualified type already includes it
+		// parent type is empty because the qualified type already includes it
 		"",
 		urn.QualifiedType(),
 		urn.Name(),
@@ -217,8 +215,7 @@ func (urn URN) RenameProject(project tokens.PackageName) URN {
 	return New(
 		urn.Stack(),
 		project,
-		// parent type is empty because
-		// assuming the qualified type already includes it
+		// parent type is empty because the qualified type already includes it
 		"",
 		urn.QualifiedType(),
 		urn.Name(),

--- a/sdk/go/common/resource/urn/urn.go
+++ b/sdk/go/common/resource/urn/urn.go
@@ -201,5 +201,26 @@ func (urn URN) Rename(newName string) URN {
 
 // Returns a new URN with an updated stack part
 func (urn URN) RenameStack(stack tokens.StackName) URN {
-	return New(stack.Q(), urn.Project(), urn.QualifiedType(), urn.Type(), urn.Name())
+	return New(
+		stack.Q(),
+		urn.Project(),
+		// parent type is empty because
+		// assuming the qualified type already includes it
+		"",
+		urn.QualifiedType(),
+		urn.Name(),
+	)
+}
+
+// Returns a new URN with an updated project part
+func (urn URN) RenameProject(project tokens.PackageName) URN {
+	return New(
+		urn.Stack(),
+		project,
+		// parent type is empty because
+		// assuming the qualified type already includes it
+		"",
+		urn.QualifiedType(),
+		urn.Name(),
+	)
 }

--- a/sdk/go/common/resource/urn/urn_test.go
+++ b/sdk/go/common/resource/urn/urn_test.go
@@ -337,3 +337,39 @@ func TestRename(t *testing.T) {
 		urn.New(stack, proj, parentType, typ, "a-better-resource"),
 		renamed)
 }
+
+func TestRenameStack(t *testing.T) {
+	t.Parallel()
+
+	stack := tokens.QName("stack")
+	proj := tokens.PackageName("foo/bar/baz")
+	parentType := tokens.Type("parent$type")
+	typ := tokens.Type("bang:boom/fizzle:MajorResource")
+	name := "a-swell-resource"
+
+	oldURN := urn.New(stack, proj, parentType, typ, name)
+	renamed := oldURN.RenameStack(tokens.MustParseStackName("a-better-stack"))
+
+	assert.NotEqual(t, oldURN, renamed)
+	assert.Equal(t,
+		urn.New("a-better-stack", proj, parentType, typ, name),
+		renamed)
+}
+
+func TestRenameProject(t *testing.T) {
+	t.Parallel()
+
+	stack := tokens.QName("stack")
+	proj := tokens.PackageName("foo/bar/baz")
+	parentType := tokens.Type("parent$type")
+	typ := tokens.Type("bang:boom/fizzle:MajorResource")
+	name := "a-swell-resource"
+
+	oldURN := urn.New(stack, proj, parentType, typ, name)
+	renamed := oldURN.RenameProject(tokens.PackageName("a-better-project"))
+
+	assert.NotEqual(t, oldURN, renamed)
+	assert.Equal(t,
+		urn.New(stack, "a-better-project", parentType, typ, name),
+		renamed)
+}


### PR DESCRIPTION
When a resource is moved between stacks in different projects we also need to rewrite project part of the URNs.  Do that here.  Moving between different projects already works by virtue of the requireStack function supporting that when providing the fully qualified name of the stack.

There is some awkwardness here as old diy backends may not return a project name, in which case we error out here.  Curious if anyone has thought about what to do here.  Is erroring out the best we can do?  What happens if we don't rewrite the project name in this case?