### PR TITLE
mark the whole CI workflow as fail-fast

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -32,6 +32,8 @@ jobs:
     name: CI
     needs: [info]
     uses: ./.github/workflows/ci.yml
+    strategy:
+      fail-fast: true
     permissions:
       contents: read
       # To sign artifacts.


### PR DESCRIPTION
This might actually kill all jobs instead of just the jobs related to the failed one.