### PR TITLE
ci: Set `GITHUB_TOKEN` when running tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -334,6 +334,7 @@ jobs:
           AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/application_default_credentials.json
           AWS_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_SECRET }}


### PR DESCRIPTION
#16521 deleted the top-level line that declared the `GITHUB_TOKEN` envvar in `ci-run-test.yml`. This has the downside that when running tests, the envvar isn't set, so when we try to do plugin acquisition, we quickly hit rate limits. This commit sets the envvar for the step running the tests.