### PR TITLE
Update `goreleaser/goreleaser-action`

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           ./scripts/versions.sh | tee -a "${GITHUB_ENV}"
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
           distribution: goreleaser-pro


### PR DESCRIPTION
Update `goreleaser/goreleaser-action` to address GitHub Action warnings.

<img width="1253" alt="Screenshot 2024-06-28 at 4 28 28 PM" src="https://github.com/pulumi/pulumi/assets/710598/0d1b365c-2850-4fcb-9b21-152f05597d7f">
