### PR TITLE
only retry tests when they are running in the merge queue

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -37,6 +37,11 @@ on:
         default: false
         required: false
         type: boolean
+      test-retries:
+        description: "How often tests are retried"
+        default: 0
+        required: false
+        type: number
 
       version-set:
         required: false
@@ -73,7 +78,7 @@ env:
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2
   GO_TEST_SHUFFLE: off
-  PULUMI_TEST_RETRIES: 2
+  PULUMI_TEST_RETRIES: ${{ inputs.test-retries }}
   DOTNET_CLI_TELEMETRY_OPTOUT: "true"
   DOTNET_ROLL_FORWARD: "Major"
   SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ on:
         default: false
         description: "Fail all workflows whenever one of them fails"
         type: boolean
+      test-retries:
+        required: false
+        default: 0
+        description: "Retry tests n times if there are failures"
+        type: number
     secrets:
       PULUMI_BOT_TOKEN:
         required: true
@@ -349,6 +354,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: false
       enable-coverage: ${{ inputs.enable-coverage }}
+      test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
@@ -374,6 +380,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
+      test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
@@ -399,6 +406,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
+      test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
@@ -425,6 +433,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
+      test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -43,6 +43,7 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       enable-coverage: true
       fail-fast: true
+      test-retries: 2
     secrets: inherit
 
   prepare-release:


### PR DESCRIPTION
We recently tried to remove the retry script from this repo.  However there were too many flaky tests, which made merging anything very difficult.  This was however a very useful exercise to remove some flaky tests, which would be useful to continue doing.

To compromise on that, run tests with retries in the merge queue, but don't do retries in other situations, such as PRs.  It's easier to retry tests manually there anyway, but flaky tests are still going to be more likely to be noticed.