### PR TITLE
state_move: add more tests and a couple of fixes

### DIFF
--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -125,7 +125,7 @@ func (cmd *stateMoveCmd) Run(
 		}
 	}
 
-	// We want to move there resources in the order they appear in the source snapshot,
+	// We want to move the resources in the order they appear in the source snapshot,
 	// resources with relationships are in the right order.
 	var resourcesToMoveOrdered []*resource.State
 	for _, res := range sourceSnapshot.Resources {

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -126,7 +126,7 @@ func (cmd *stateMoveCmd) Run(
 	}
 
 	// We want to move the resources in the order they appear in the source snapshot,
-	// resources with relationships are in the right order.
+	// so that resources with relationships are in the right order.
 	var resourcesToMoveOrdered []*resource.State
 	for _, res := range sourceSnapshot.Resources {
 		if _, ok := resourcesToMove[string(res.URN)]; ok {


### PR DESCRIPTION
Add more tests for moving children, and for breaking dependencies/property dependencies/deleted with attributes.

This also fixes a couple of bugs that were discovered while testing.

Depends on: https://github.com/pulumi/pulumi/pull/16527