### PR TITLE
Provide installation instructions for the python typechecker

### DIFF
--- a/changelog/pending/20240701--sdk-python--provide-installation-instructions-for-the-python-typechecker.yaml
+++ b/changelog/pending/20240701--sdk-python--provide-installation-instructions-for-the-python-typechecker.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Provide installation instructions for the python typechecker

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -767,6 +767,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 				}
 				installCommand = fmt.Sprintf("Please add an entry for %s to requirements.txt and run `%s`", typechecker, pipCommand)
 			}
+			//revive:disable:error-strings // This error message is user facing.
 			return nil, fmt.Errorf("The typechecker option is set to %s, but %s is not installed. %s",
 				typechecker, typechecker, installCommand)
 		}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -759,15 +759,15 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		}
 		idx := slices.IndexFunc(packages, func(p toolchain.PythonPackage) bool { return p.Name == typechecker })
 		if idx < 0 {
-			installCommand := fmt.Sprintf("poetry add %s", typechecker)
+			installCommand := fmt.Sprintf("Please install it using `poetry add %s`.", typechecker)
 			if opts.Toolchain != toolchain.Poetry {
+				pipCommand := fmt.Sprintf("%s/bin/pip install -r requirements.txt", opts.Virtualenv)
 				if runtime.GOOS == "windows" {
-					installCommand = fmt.Sprintf("%s\\Scripts\\pip install %s", opts.Virtualenv, typechecker)
-				} else {
-					installCommand = fmt.Sprintf("%s/bin/pip install %s", opts.Virtualenv, typechecker)
+					pipCommand = fmt.Sprintf("%s\\Scripts\\pip install -r requirements.txt", opts.Virtualenv)
 				}
+				installCommand = fmt.Sprintf("Please add an entry for %s to requirements.txt and run `%s`", typechecker, pipCommand)
 			}
-			return nil, fmt.Errorf("The typechecker option is set to %s, but %s is not installed. Please install it using `%s`.",
+			return nil, fmt.Errorf("The typechecker option is set to %s, but %s is not installed. %s",
 				typechecker, typechecker, installCommand)
 		}
 

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -36,6 +36,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -758,9 +759,13 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		}
 		idx := slices.IndexFunc(packages, func(p toolchain.PythonPackage) bool { return p.Name == typechecker })
 		if idx < 0 {
-			installCommand := fmt.Sprintf("pip install %s", typechecker)
-			if opts.Toolchain == toolchain.Poetry {
-				installCommand = fmt.Sprintf("poetry add %s", typechecker)
+			installCommand := fmt.Sprintf("poetry add %s", typechecker)
+			if opts.Toolchain != toolchain.Poetry {
+				if runtime.GOOS == "windows" {
+					installCommand = fmt.Sprintf("%s\\Scripts\\pip install %s", opts.Virtualenv, typechecker)
+				} else {
+					installCommand = fmt.Sprintf("%s/bin/pip install %s", opts.Virtualenv, typechecker)
+				}
 			}
 			return nil, fmt.Errorf("The typechecker option is set to %s, but %s is not installed. Please install it using `%s`.",
 				typechecker, typechecker, installCommand)

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -761,9 +761,9 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		if idx < 0 {
 			installCommand := fmt.Sprintf("Please install it using `poetry add %s`.", typechecker)
 			if opts.Toolchain != toolchain.Poetry {
-				pipCommand := fmt.Sprintf("%s/bin/pip install -r requirements.txt", opts.Virtualenv)
+				pipCommand := opts.Virtualenv + "/bin/pip install -r requirements.txt"
 				if runtime.GOOS == "windows" {
-					pipCommand = fmt.Sprintf("%s\\Scripts\\pip install -r requirements.txt", opts.Virtualenv)
+					pipCommand = opts.Virtualenv + "\\Scripts\\pip install -r requirements.txt"
 				}
 				installCommand = fmt.Sprintf("Please add an entry for %s to requirements.txt and run `%s`", typechecker, pipCommand)
 			}

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -413,7 +413,8 @@ func TestTypecheckerMissingError(t *testing.T) {
 	validation := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		// Should get an event for the pyright failure.
 		found := false
-		expected := "The typechecker option is set to pyright, but pyright is not installed. Please add an entry for pyright to requirements.txt"
+		expected := "The typechecker option is set to pyright, but pyright is not installed." +
+			" Please add an entry for pyright to requirements.txt"
 		for _, event := range stack.Events {
 			if event.DiagnosticEvent != nil {
 				if strings.Contains(event.DiagnosticEvent.Message, expected) {

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -408,6 +408,30 @@ func TestPyrightSupport(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestTypecheckerMissingError(t *testing.T) {
+	validation := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		// Should get an event for the pyright failure.
+		found := false
+		expected := "The typechecker option is set to pyright, but pyright is not installed. Please add an entry for pyright to requirements.txt"
+		for _, event := range stack.Events {
+			if event.DiagnosticEvent != nil {
+				if strings.Contains(event.DiagnosticEvent.Message, expected) {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "Did not find expected pyright diagnostic event")
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                    filepath.Join("python", "pyright-missing"),
+		Quick:                  true,
+		ExpectFailure:          true,
+		ExtraRuntimeValidation: validation,
+	})
+}
+
 func TestNewPythonUsesPip(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration/python/pyright-missing/.gitignore
+++ b/tests/integration/python/pyright-missing/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/pyright-missing/Pulumi.yaml
+++ b/tests/integration/python/pyright-missing/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pulumi-python-pyright
+description: A simple Python Pulumi program that type checks with pyright but pyright is not installed.
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+    typechecker: pyright

--- a/tests/integration/python/pyright-missing/__main__.py
+++ b/tests/integration/python/pyright-missing/__main__.py
@@ -1,0 +1,8 @@
+# Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+"""An example program that type checks with pyright but pyright is not installed"""
+
+import pulumi
+
+# This export won't work because the first argument is a number, not a string
+pulumi.export(42, 'bar')

--- a/tests/integration/python/pyright-missing/requirements.txt
+++ b/tests/integration/python/pyright-missing/requirements.txt
@@ -1,0 +1,2 @@
+pulumi
+# pyright is intentionally not installed for this test


### PR DESCRIPTION
When the typechecker option is set, but the selected typechecker is not installed in the project's virtual environment, the pulumi operation will fail with an unhelpful message like `mypy failed: exit status 1`.

To make this more actionable, we check if the typechecker is installed, and if not, we provide installation instructions to remediate the issue.