### PR TITLE
Disable default Cobra completion commands

### DIFF
--- a/changelog/pending/20240701--cli--disable-default-cobra-completions-in-the-cli.yaml
+++ b/changelog/pending/20240701--cli--disable-default-cobra-completions-in-the-cli.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Disable default Cobra completions in the CLI

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -417,6 +417,11 @@ func NewPulumiCmd() *cobra.Command {
 		contract.IgnoreError(err)
 	}
 
+	// Since we define a custom command for generating shell completions
+	// (`gen-completion` / `newGenCompletionCmd`), we disable Cobra's default
+	// completion command as a recommended best practice.
+	cmd.CompletionOptions.DisableDefaultCmd = true
+
 	return cmd
 }
 


### PR DESCRIPTION
The Pulumi CLI provides a customised shell completion command, `gen-completion`, that can be used to generate scripts that enable tab completion in shells such as Bash and Zsh. When providing custom generation commands, Cobra (the library we use to build the Pulumi CLI) [recommends disabling the default completion command](https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md#adapting-the-default-completion-command). This commit rebases @EthanOrlander's work in #7842 on `master` and disables the default command in the recommended manner.

This is technically a breaking change in the interface of the CLI, but since we'd (presumably) rather that users were only using the officially supported completions that Pulumi itself maintains, this feels like us fixing a bug/the right thing to do.

Fixes #7841
Closes #7842