### PR TITLE
Fix NodeJS SDK mocking of custom resource reads

### DIFF
--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -155,17 +155,12 @@ export class MockMonitor {
 
     public async readResource(req: any, callback: (err: any, innterResponse: any) => void) {
         try {
-            let custom = false;
-            if (typeof req.getCustom === "function") {
-                custom = req.getCustom();
-            }
-
             const result: MockResourceResult = await this.mocks.newResource({
                 type: req.getType(),
                 name: req.getName(),
                 inputs: deserializeProperties(req.getProperties()),
                 provider: req.getProvider(),
-                custom: custom,
+                custom: true,
                 id: req.getId(),
             });
 

--- a/sdk/nodejs/tests_with_mocks/mocks.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/mocks.spec.ts
@@ -83,6 +83,15 @@ class Instance extends pulumi.CustomResource {
 
 class MyCustom extends pulumi.CustomResource {
     instance!: pulumi.Output<Instance>;
+    static get(
+        name: string,
+        id: pulumi.Input<pulumi.ID>,
+        state?: Record<string, any>,
+        opts?: pulumi.CustomResourceOptions,
+    ): MyCustom {
+        return new MyCustom(name, state, { ...opts, id });
+    }
+
     constructor(name: string, props?: Record<string, any>, opts?: CustomResourceOptions) {
         super("pkg:index:MyCustom", name, props, opts);
     }
@@ -104,6 +113,7 @@ setups.forEach(([test, isAsyncNewResource, isAsyncCall]) => {
         let component: MyComponent;
         let instance: Instance;
         let custom: MyCustom;
+        let read: MyCustom;
         let invokeResult: Promise<number>;
         let remoteComponent: MyRemoteComponent;
 
@@ -127,6 +137,7 @@ setups.forEach(([test, isAsyncNewResource, isAsyncCall]) => {
             component = new MyComponent("mycomponent", "hello");
             instance = new Instance("instance");
             custom = new MyCustom("mycustom", { instance: instance });
+            read = MyCustom.get("mycustom", "read");
             invokeResult = invoke();
             remoteComponent = new MyRemoteComponent("myremotecomponent", pulumi.interpolate`hello: ${instance.id}`);
         });
@@ -159,6 +170,13 @@ setups.forEach(([test, isAsyncNewResource, isAsyncCall]) => {
 
             it("mycustom has expected output value", (done) => {
                 custom.instance.apply((_) => {
+                    done();
+                });
+            });
+
+            it("can be read with get", (done) => {
+                read.id.apply((id) => {
+                    assert.strictEqual(id, "read");
                     done();
                 });
             });


### PR DESCRIPTION
This commit incorporates the tests introduced by @henriiik in #8585 into the existing test suite for the NodeJS SDK mocks. SDK mocks provide a means for users wishing to unit test their Pulumi programs to stub out various bits of Pulumi behaviour. Previously, those wanting to stub out resource reads (through `.get` static methods) would encounter crashes or use untested code paths. With the crashes fixed in previous commits, this commit adds some tests. Moreover, we fix an error whereby mock reads force a non-custom (component) resource, when in reality it should be the other way around (since reads don't make sense for component resources).

Closes #8585