### PR TITLE
Add Paramaterization to the Pulumi schema

### DIFF
--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -187,12 +187,16 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 	}
 	diags = diags.Extend(typeDiags)
 
+	parameterization, parameterizationDiags := bindParameterization(spec.Parameterization)
+	diags = diags.Extend(parameterizationDiags)
+
 	pkg := types.pkg
 	pkg.Config = config
 	pkg.Types = typeList
 	pkg.Provider = provider
 	pkg.Resources = resources
 	pkg.Functions = functions
+	pkg.Parameterization = parameterization
 	pkg.resourceTable = types.resourceDefs
 	pkg.functionTable = types.functionDefs
 	pkg.typeTable = types.typeDefs
@@ -1324,6 +1328,34 @@ func bindMethods(path, resourceToken string, methods map[string]string,
 		})
 	}
 	return result, diags, nil
+}
+
+func bindParameterization(spec *ParameterizationSpec) (*Parameterization, hcl.Diagnostics) {
+	if spec == nil {
+		return nil, nil
+	}
+
+	if spec.BaseProvider.Name == "" {
+		return nil, hcl.Diagnostics{errorf(
+			"#/parameterization/baseProvider/name",
+			"provider name must be specified")}
+	}
+
+	ver, err := semver.Parse(spec.BaseProvider.Version)
+	if err != nil {
+		return nil, hcl.Diagnostics{errorf(
+			"#/parameterization/baseProvider/version",
+			"invalid version %q: %v", spec.BaseProvider.Version, err)}
+	}
+
+	return &Parameterization{
+		BaseProvider: BaseProvider{
+			Name:              spec.BaseProvider.Name,
+			Version:           ver,
+			PluginDownloadURL: spec.BaseProvider.PluginDownloadURL,
+		},
+		Parameter: spec.Parameter,
+	}, nil
 }
 
 func bindConfig(spec ConfigSpec, types *types) ([]*Property, hcl.Diagnostics, error) {

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -132,6 +132,37 @@
         "language": {
             "description": "Additional language-specific data about the package.",
             "type": "object"
+        },
+        "parameterization": {
+            "description": "An optional object to define parameterization for the package.",
+            "type": "object",
+            "properties": {
+                "baseProvider": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The unqualified name of the package (e.g. \"aws\", \"azure\", \"gcp\", \"kubernetes\", \"random\")",
+                            "type": "string",
+                            "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
+                        },
+                        "version": {
+                            "description": "The version of the package. The version must be valid semver.",
+                            "type": "string",
+                            "pattern": "^v?(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                        },
+                        "pluginDownloadURL": {
+                            "description": "The URL to use when downloading the provider plugin binary.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["name", "version"],
+                    "additionalProperties": false
+                },
+                "parameter": {
+
+                }
+            },
+            "additionalProperties": false
         }
     },
     "additionalProperties": false,

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -567,6 +567,22 @@ func (fun *Function) NeedsOutputVersion() bool {
 	return fun.ReturnType != nil
 }
 
+// BaseProvider
+type BaseProvider struct {
+	// Name is the name of the provider.
+	Name string
+	// Version is the version of the provider.
+	Version semver.Version
+	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
+	PluginDownloadURL string
+}
+
+type Parameterization struct {
+	BaseProvider BaseProvider
+	// Parameter is the parameter for the provider.
+	Parameter interface{}
+}
+
 // Package describes a Pulumi package.
 type Package struct {
 	// True if this package should be written in the new style to support pack and conformance testing.
@@ -619,6 +635,9 @@ type Package struct {
 	Functions []*Function
 	// Language specifies additional language-specific data about the package.
 	Language map[string]interface{}
+
+	// Parameterization is the optional parameterization for the package, if any.
+	Parameterization *Parameterization
 
 	resourceTable     map[string]*Resource
 	resourceTypeTable map[string]*ResourceType
@@ -943,6 +962,18 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 		}
 	}
 
+	var parameterization *ParameterizationSpec
+	if pkg.Parameterization != nil {
+		parameterization = &ParameterizationSpec{
+			BaseProvider: BaseProviderSpec{
+				Name:              pkg.Parameterization.BaseProvider.Name,
+				Version:           pkg.Parameterization.BaseProvider.Version.String(),
+				PluginDownloadURL: pkg.Parameterization.BaseProvider.PluginDownloadURL,
+			},
+			Parameter: pkg.Parameterization.Parameter,
+		}
+	}
+
 	spec = &PackageSpec{
 		Name:                pkg.Name,
 		Version:             version,
@@ -961,6 +992,7 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 		Resources:           map[string]ResourceSpec{},
 		Functions:           map[string]FunctionSpec{},
 		AllowedPackageNames: pkg.AllowedPackageNames,
+		Parameterization:    parameterization,
 	}
 
 	lang, err := marshalLanguage(pkg.Language)
@@ -1888,6 +1920,27 @@ type PackageInfoSpec struct {
 	Language map[string]RawMessage `json:"language,omitempty" yaml:"language,omitempty"`
 }
 
+// BaseProviderSpec is the serializable description of a Pulumi base provider.
+type BaseProviderSpec struct {
+	// The name of the base provider.
+	Name string `json:"name" yaml:"name"`
+	// The version of the base provider.
+	Version string `json:"version" yaml:"version"`
+	// The plugin download URL for the base provider.
+	PluginDownloadURL string `json:"pluginDownloadURL,omitempty" yaml:"pluginDownloadURL,omitempty"`
+}
+
+// ParameterizationSpec is the serializable description of a provider parameterization.
+type ParameterizationSpec struct {
+	// The base provider to parameterize.
+	BaseProvider BaseProviderSpec `json:"baseProvider" yaml:"baseProvider"`
+	// The parameter to apply to the base provider.
+	//
+	// Parameter can be any type round-tripable through [json.Marshal]/[json.Unmarshal] and
+	// [yaml.Marshal]/[yaml.Unmarshal].
+	Parameter interface{} `json:"parameter" yaml:"parameter"`
+}
+
 // PackageSpec is the serializable description of a Pulumi package.
 type PackageSpec struct {
 	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes", "random")
@@ -1941,6 +1994,9 @@ type PackageSpec struct {
 	Resources map[string]ResourceSpec `json:"resources,omitempty" yaml:"resources,omitempty"`
 	// Functions is a map from token to FunctionSpec that describes the set of functions defined by this package.
 	Functions map[string]FunctionSpec `json:"functions,omitempty" yaml:"functions,omitempty"`
+
+	// Parameterization is the optional parameterization for this package.
+	Parameterization *ParameterizationSpec `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
 }
 
 func (p *PackageSpec) Info() PackageInfoSpec {


### PR DESCRIPTION
This adds the parameterisation spec to the pulumi schema. This will allow providers to take a dependency on these types to start defining parameterized schemes from tfbridge.

They _should not_ be considered completely stable. We may still need to change things here as work continues.