### PR TITLE
Upgrade `codecov/codecov-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
           merge-multiple: true
           path: coverage
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: coverage/
           files: "*,!.gitkeep"


### PR DESCRIPTION
Upgrade the `codecov/codecov-action` to `v4` to avoid warnings (it supports Node 20):

https://github.com/pulumi/pulumi/actions/runs/9752874835

<img width="1257" alt="Screenshot 2024-07-01 at 7 26 07 PM" src="https://github.com/pulumi/pulumi/assets/710598/7156cdf9-b1e5-44f4-8758-18742dc86c68">
