### PR TITLE
Fix Python program generation for remote assets

### DIFF
--- a/changelog/pending/20240702--programgen-python--fix-python-program-generation-for-remote-assets.yaml
+++ b/changelog/pending/20240702--programgen-python--fix-python-program-generation-for-remote-assets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/python
+  description: Fix Python program generation for remote assets

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -299,7 +299,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "stringAsset":
 		g.Fgenf(w, "pulumi.StringAsset(%.v)", expr.Args[0])
 	case "remoteAsset":
-		g.Fgenf(w, "pulumi.remoteAsset(%.v)", expr.Args[0])
+		g.Fgenf(w, "pulumi.RemoteAsset(%.v)", expr.Args[0])
 	case "filebase64":
 		g.Fgenf(w, "(lambda path: base64.b64encode(open(path).read().encode()).decode())(%.v)", expr.Args[0])
 	case "filebase64sha256":

--- a/tests/testdata/codegen/assets-archives-pp/python/assets-archives.py
+++ b/tests/testdata/codegen/assets-archives-pp/python/assets-archives.py
@@ -10,7 +10,7 @@ test_string_asset = aws.s3.BucketObject("testStringAsset",
     source=pulumi.StringAsset("<h1>File contents</h1>"))
 test_remote_asset = aws.s3.BucketObject("testRemoteAsset",
     bucket=site_bucket.id,
-    source=pulumi.remoteAsset("https://pulumi.test"))
+    source=pulumi.RemoteAsset("https://pulumi.test"))
 test_file_archive = aws.lambda_.Function("testFileArchive",
     role=site_bucket.arn,
     code=pulumi.FileArchive("file.tar.gz"))
@@ -22,13 +22,13 @@ test_asset_archive = aws.lambda_.Function("testAssetArchive",
     code=pulumi.AssetArchive({
         "file.txt": pulumi.FileAsset("file.txt"),
         "string.txt": pulumi.StringAsset("<h1>File contents</h1>"),
-        "remote.txt": pulumi.remoteAsset("https://pulumi.test"),
+        "remote.txt": pulumi.RemoteAsset("https://pulumi.test"),
         "file.tar": pulumi.FileArchive("file.tar.gz"),
         "remote.tar": pulumi.RemoteArchive("https://pulumi.test/foo.tar.gz"),
         ".nestedDir": pulumi.AssetArchive({
             "file.txt": pulumi.FileAsset("file.txt"),
             "string.txt": pulumi.StringAsset("<h1>File contents</h1>"),
-            "remote.txt": pulumi.remoteAsset("https://pulumi.test"),
+            "remote.txt": pulumi.RemoteAsset("https://pulumi.test"),
             "file.tar": pulumi.FileArchive("file.tar.gz"),
             "remote.tar": pulumi.RemoteArchive("https://pulumi.test/foo.tar.gz"),
         }),


### PR DESCRIPTION
This commit fixes Python code generation (specifically, program generation) whereby we were previously emitting calls to the non-existent `remoteAsset` function/constructor. We now use the (correct) `RemoteAsset` constructor, in line with other asset types exposed by the Python SDK.