### PR TITLE
Implement `dependsOn` for invokes in the NodeJS SDK

### DIFF
--- a/changelog/pending/20240703--sdk-nodejs--add-dependson-to-invokeoptions-in-the-nodejs-sdk.yaml
+++ b/changelog/pending/20240703--sdk-nodejs--add-dependson-to-invokeoptions-in-the-nodejs-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add `dependsOn` to `InvokeOptions` in the NodeJS SDK

--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Input } from "./output";
 import { ProviderResource, Resource } from "./resource";
 
 /*
@@ -51,4 +52,9 @@ export interface InvokeOptions {
      * time.
      */
     async?: boolean;
+
+    /**
+     * An optional set of additional explicit dependencies on other resources.
+     */
+    dependsOn?: Input<Input<Resource>[]> | Input<Resource>;
 }

--- a/sdk/nodejs/runtime/dependsOn.ts
+++ b/sdk/nodejs/runtime/dependsOn.ts
@@ -1,0 +1,54 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getAllResources, Input, Output } from "../output";
+import { Resource } from "../resource";
+
+/**
+ * Gathers explicit dependent Resources from a list of Resources (possibly Promises and/or Outputs).
+ *
+ * @internal
+ */
+export async function gatherExplicitDependencies(
+    dependsOn: Input<Input<Resource>[]> | Input<Resource> | undefined,
+): Promise<Resource[]> {
+    if (dependsOn) {
+        if (Array.isArray(dependsOn)) {
+            const dos: Resource[] = [];
+            for (const d of dependsOn) {
+                dos.push(...(await gatherExplicitDependencies(d)));
+            }
+            return dos;
+        } else if (dependsOn instanceof Promise) {
+            return gatherExplicitDependencies(await dependsOn);
+        } else if (Output.isInstance(dependsOn)) {
+            // Recursively gather dependencies, await the promise, and append the output's dependencies.
+            const dos = (dependsOn as Output<Input<Resource>[] | Input<Resource>>).apply((v) =>
+                gatherExplicitDependencies(v),
+            );
+            const urns = await dos.promise();
+            const dosResources = await getAllResources(dos);
+            const implicits = await gatherExplicitDependencies([...dosResources]);
+            return (urns ?? []).concat(implicits);
+        } else {
+            if (!Resource.isInstance(dependsOn)) {
+                throw new Error("'dependsOn' was passed a value that was not a Resource.");
+            }
+
+            return [dependsOn];
+        }
+    }
+
+    return [];
+}

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ import * as grpc from "@grpc/grpc-js";
 
 import { AsyncIterable } from "@pulumi/query/interfaces";
 
+import { gatherExplicitDependencies } from "./dependsOn";
 import { InvokeOptions } from "../invoke";
 import * as log from "../log";
 import { Inputs, Output } from "../output";
@@ -99,6 +100,9 @@ export async function streamInvoke(
     // Wait for all values to be available, and then perform the RPC.
     const done = rpcKeepAlive();
     try {
+        // Wait for any explicit dependencies to complete before proceeding.
+        await gatherExplicitDependencies(opts.dependsOn);
+
         const serialized = await serializeProperties(`streamInvoke:${tok}`, props);
         log.debug(
             `StreamInvoke RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``,
@@ -142,6 +146,9 @@ async function invokeAsync(tok: string, props: Inputs, opts: InvokeOptions): Pro
     // Wait for all values to be available, and then perform the RPC.
     const done = rpcKeepAlive();
     try {
+        // Wait for any explicit dependencies to complete before proceeding.
+        await gatherExplicitDependencies(opts.dependsOn);
+
         const serialized = await serializeProperties(`invoke:${tok}`, props);
         log.debug(
             `Invoke RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``,

--- a/sdk/nodejs/tests/runtime/langhost/cases/043.depends_on_non_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/043.depends_on_non_resource/index.js
@@ -1,4 +1,4 @@
-// This tests the creation of ten propertyless resources.
+// This tests that resources cannot depend on things which are not resources.
 
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/075.invoke_depends_on/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/075.invoke_depends_on/index.js
@@ -1,0 +1,30 @@
+// Test the dependsOn invoke option.
+
+const assert = require("assert");
+const pulumi = require("../../../../../");
+
+const dependency = { resolved: false };
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name) {
+        super("test:index:MyResource", name);
+    }
+}
+
+const dependsOn = pulumi.output(
+    new Promise((resolve) =>
+        setTimeout(() => {
+            dependency.resolved = true;
+            resolve(new MyResource("dependency"));
+        }),
+    ),
+);
+
+// By the time we serialise the arguments of the invoke, dependency.resolved
+// should be true due to dependsOn awaiting the setTimeout promise resolution
+// above. Without dependsOn, the invoke will be serialised before promise
+// resolution (since promises [microtasks] happen before timeout events
+// [macrotasks]).
+pulumi.runtime.invoke("test:index:echo", { dependency }, { dependsOn }).then((result) => {
+    assert.strictEqual(result.dependency.resolved, true);
+});

--- a/sdk/nodejs/tests/runtime/langhost/cases/076.invoke_depends_on_non_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/076.invoke_depends_on_non_resource/index.js
@@ -1,0 +1,6 @@
+// This tests that invokes cannot depend on things which are not resources.
+
+let pulumi = require("../../../../../");
+
+const dependsOn = pulumi.output(Promise.resolve([Promise.resolve(1)]));
+pulumi.runtime.invoke("test:index:echo", {}, { dependsOn });

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -51,6 +51,7 @@
         "runtime/asyncIterableUtil.ts",
         "runtime/config.ts",
         "runtime/debuggable.ts",
+        "runtime/dependsOn.ts",
         "runtime/invoke.ts",
         "runtime/mocks.ts",
         "runtime/resource.ts",


### PR DESCRIPTION
This commit adds support for passing `dependsOn` to invokes (whether streamed or not) in the NodeJS SDK. This allows programs to ensure that certain invokes are executed after things they depend on, even if that dependency is not implicitly captured with an input-output relationship.

Part of #14243