### PR TITLE
error out on duplicate providers/resources

### DIFF
--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -213,8 +213,6 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot.Resources = append(destSnapshot.Resources, r)
 	}
 
-	// TODO: conflict on resources that are already on the destination stack
-
 	var brokenDestDependencies []brokenDependency
 	for _, res := range resourcesToMoveOrdered {
 		if _, ok := resourcesToMove[string(res.Parent)]; !ok {

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -192,6 +192,11 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot.Resources = append([]*resource.State{rootStack}, destSnapshot.Resources...)
 	}
 
+	destResMap := make(map[urn.URN]bool)
+	for _, res := range destSnapshot.Resources {
+		destResMap[res.URN] = true
+	}
+
 	for _, res := range providers {
 		// Providers stay in the source stack, so we need a copy of the provider to be able to
 		// rewrite the URNs of the resource.
@@ -200,6 +205,11 @@ func (cmd *stateMoveCmd) Run(
 		if err != nil {
 			return err
 		}
+
+		if _, ok := destResMap[r.URN]; ok {
+			return fmt.Errorf("provider %s already exists in destination stack", r.URN)
+		}
+
 		destSnapshot.Resources = append(destSnapshot.Resources, r)
 	}
 
@@ -219,6 +229,10 @@ func (cmd *stateMoveCmd) Run(
 		err = rewriteURNs(res, dest)
 		if err != nil {
 			return err
+		}
+
+		if _, ok := destResMap[res.URN]; ok {
+			return fmt.Errorf("resource %s already exists in destination stack", res.URN)
 		}
 
 		destSnapshot.Resources = append(destSnapshot.Resources, res)

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -273,3 +273,127 @@ func TestMoveResourceWithDependencies(t *testing.T) {
 		destSnapshot.Resources[2].URN)
 	assert.Equal(t, 0, len(destSnapshot.Resources[2].Dependencies))
 }
+
+func TestMoveWithExistingProvider(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+		},
+		{
+			URN:      resource.NewURN("destStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+	}
+
+	destResources := []*resource.State{
+		{
+			URN:    resource.NewURN("destStack", "test", "", "pulumi:providers:a", "default_1_0_0"),
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "other_provider_id",
+			Custom: true,
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destStackName := "organization/test/destStack"
+	destStack := createStackWithResources(t, b, destStackName, destResources)
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp)
+	assert.ErrorContains(t, err, "provider urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0 "+
+		"already exists in destination stack")
+}
+
+func TestMoveWithExistingResource(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+	}
+
+	otherProviderURN := resource.NewURN("destStack", "test", "", "pulumi:providers:a", "default_1_0_1")
+	destResources := []*resource.State{
+		{
+			URN:    otherProviderURN,
+			Type:   "pulumi:providers:a::default_1_0_1",
+			ID:     "other_provider_id",
+			Custom: true,
+		},
+		{
+			URN:      resource.NewURN("destStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(otherProviderURN) + "::other_provider_id",
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destStackName := "organization/test/destStack"
+	destStack := createStackWithResources(t, b, destStackName, destResources)
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp)
+	assert.ErrorContains(t, err, "resource urn:pulumi:destStack::test::d:e:f$a:b:c::name "+
+		"already exists in destination stack")
+}


### PR DESCRIPTION
When the user tries to move a resource that would end up being a duplicate in the destination stack, we need to prevent that, to avoid a broken state file.

Error out in this case.

Depends on: https://github.com/pulumi/pulumi/pull/16543