### PR TITLE
New deployment settings wizards and environment variables management comands

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -213,7 +213,7 @@ type Backend interface {
 	UpdateStackTags(ctx context.Context, stack Stack, tags map[apitype.StackTagName]string) error
 
 	// Encrypt secrets using the DS encryption key
-	EncryptStackDeploymentSettingsSecret(ctx context.Context, stack Stack, secret string) (string, error)
+	EncryptStackDeploymentSettingsSecret(ctx context.Context, stack Stack, secret string) (*apitype.SecretValue, error)
 	// UpdateStackDeploymentSettings updates the stacks's deployment settings.
 	UpdateStackDeploymentSettings(ctx context.Context, stack Stack, deployment apitype.DeploymentSettings) error
 	// Fetch deployment settings

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1356,9 +1356,9 @@ func (b *diyBackend) UpdateStackTags(ctx context.Context,
 
 func (b *diyBackend) EncryptStackDeploymentSettingsSecret(ctx context.Context,
 	stack backend.Stack, secret string,
-) (string, error) {
+) (*apitype.SecretValue, error) {
 	// The local backend does not support managing deployments.
-	return "", errors.New("stack deployments not supported with diy backends")
+	return nil, errors.New("stack deployments not supported with diy backends")
 }
 
 func (b *diyBackend) UpdateStackDeploymentSettings(ctx context.Context, stack backend.Stack,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1852,10 +1852,10 @@ func (b *cloudBackend) UpdateStackTags(ctx context.Context,
 
 func (b *cloudBackend) EncryptStackDeploymentSettingsSecret(ctx context.Context,
 	stack backend.Stack, secret string,
-) (string, error) {
+) (*apitype.SecretValue, error) {
 	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	return b.client.EncryptStackDeploymentSettingsSecret(ctx, stackID, secret)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1139,15 +1139,15 @@ func (pc *Client) UpdateStackDeploymentSettings(ctx context.Context, stack Stack
 
 func (pc *Client) EncryptStackDeploymentSettingsSecret(ctx context.Context,
 	stack StackIdentifier, secret string,
-) (string, error) {
+) (*apitype.SecretValue, error) {
 	request := apitype.SecretValue{Value: secret}
 	response := apitype.SecretValue{}
 	err := pc.restCall(ctx, "POST", getStackPath(stack, "deployments", "settings", "encrypt"), nil, &request, &response)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return response.Value, nil
+	return &response, nil
 }
 
 func (pc *Client) DestroyStackDeploymentSettings(ctx context.Context, stack StackIdentifier) error {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -62,7 +62,7 @@ type MockBackend struct {
 	UpdateStackTagsF                      func(context.Context, Stack, map[apitype.StackTagName]string) error
 	ExportDeploymentF                     func(context.Context, Stack) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF                     func(context.Context, Stack, *apitype.UntypedDeployment) error
-	EncryptStackDeploymentSettingsSecretF func(ctx context.Context, stack Stack, secret string) (string, error)
+	EncryptStackDeploymentSettingsSecretF func(ctx context.Context, stack Stack, secret string) (*apitype.SecretValue, error)
 	UpdateStackDeploymentSettingsF        func(context.Context, Stack, apitype.DeploymentSettings) error
 	DestroyStackDeploymentSettingsF       func(ctx context.Context, stack Stack) error
 	GetStackDeploymentSettingsF           func(context.Context, Stack) (*apitype.DeploymentSettings, error)
@@ -388,7 +388,7 @@ func (be *MockBackend) CancelCurrentUpdate(ctx context.Context, stackRef StackRe
 
 func (be *MockBackend) EncryptStackDeploymentSettingsSecret(
 	ctx context.Context, stack Stack, secret string,
-) (string, error) {
+) (*apitype.SecretValue, error) {
 	if be.EncryptStackDeploymentSettingsSecretF != nil {
 		return be.EncryptStackDeploymentSettingsSecretF(ctx, stack, secret)
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -62,12 +62,13 @@ type MockBackend struct {
 	UpdateStackTagsF                      func(context.Context, Stack, map[apitype.StackTagName]string) error
 	ExportDeploymentF                     func(context.Context, Stack) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF                     func(context.Context, Stack, *apitype.UntypedDeployment) error
-	EncryptStackDeploymentSettingsSecretF func(ctx context.Context, stack Stack, secret string) (*apitype.SecretValue, error)
-	UpdateStackDeploymentSettingsF        func(context.Context, Stack, apitype.DeploymentSettings) error
-	DestroyStackDeploymentSettingsF       func(ctx context.Context, stack Stack) error
-	GetStackDeploymentSettingsF           func(context.Context, Stack) (*apitype.DeploymentSettings, error)
-	CurrentUserF                          func() (string, []string, *workspace.TokenInformation, error)
-	PreviewF                              func(context.Context, Stack,
+	EncryptStackDeploymentSettingsSecretF func(ctx context.Context,
+		stack Stack, secret string) (*apitype.SecretValue, error)
+	UpdateStackDeploymentSettingsF  func(context.Context, Stack, apitype.DeploymentSettings) error
+	DestroyStackDeploymentSettingsF func(ctx context.Context, stack Stack) error
+	GetStackDeploymentSettingsF     func(context.Context, Stack) (*apitype.DeploymentSettings, error)
+	CurrentUserF                    func() (string, []string, *workspace.TokenInformation, error)
+	PreviewF                        func(context.Context, Stack,
 		UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
 	UpdateF func(context.Context, Stack,
 		UpdateOperation) (sdkDisplay.ResourceChanges, result.Result)

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -360,7 +360,8 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 			}
 
 			if !yes {
-				confirm, err := askForConfirmation("This action will override the stack's deployment settings, do you want to continue?", displayOpts.Color)
+				confirm, err := askForConfirmation("This action will override the stack's deployment settings, "+
+					"do you want to continue?", displayOpts.Color)
 				if err != nil {
 					return err
 				}
@@ -409,7 +410,8 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 			}
 
 			if !yes {
-				confirm, err := askForConfirmation("This action will clear the stack's deployment settings, do you want to continue?", displayOpts.Color)
+				confirm, err := askForConfirmation("This action will clear the stack's deployment settings, "+
+					"do you want to continue?", displayOpts.Color)
 				if err != nil {
 					return err
 				}
@@ -673,7 +675,8 @@ func configureGit(ctx context.Context, displayOpts *display.Options, be backend.
 		useGiHub := vcsInfo.Kind == gitutil.GitHubHostName
 
 		if useGiHub {
-			useGiHub, err = askForConfirmation("A GitHub repository was detected, do you want to use the Pulumi GitHub App?", displayOpts.Color)
+			useGiHub, err = askForConfirmation("A GitHub repository was detected, do you want to use the Pulumi GitHub App?",
+				displayOpts.Color)
 			if err != nil {
 				return err
 			}
@@ -1089,7 +1092,7 @@ func askForConfirmation(prompt string, color colors.Colorization) (bool, error) 
 	if err := survey.AskOne(&survey.Select{
 		Message: prompt,
 		Options: []string{yes, no},
-		Default: string(no),
+		Default: no,
 	}, &option, surveyIcons(color)); err != nil {
 		return false, errors.New("selection cancelled")
 	}

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -378,7 +378,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 
 			if !yes {
 				confirm, err := askForConfirmation("This action will override the stack's deployment settings, "+
-					"do you want to continue?", displayOpts.Color)
+					"do you want to continue?", displayOpts.Color, false)
 				if err != nil {
 					return err
 				}
@@ -428,7 +428,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 
 			if !yes {
 				confirm, err := askForConfirmation("This action will clear the stack's deployment settings, "+
-					"do you want to continue?", displayOpts.Color)
+					"do you want to continue?", displayOpts.Color, false)
 				if err != nil {
 					return err
 				}
@@ -692,7 +692,7 @@ func configureGit(ctx context.Context, displayOpts *display.Options, be backend.
 
 		if useGiHub {
 			useGiHub, err = askForConfirmation("A GitHub repository was detected, do you want to use the Pulumi GitHub App?",
-				displayOpts.Color)
+				displayOpts.Color, true)
 			if err != nil {
 				return err
 			}
@@ -1101,19 +1101,6 @@ func configureAdvancedSettings(displayOpts *display.Options, sd *workspace.Proje
 	return nil
 }
 
-func askForConfirmation(prompt string, color colors.Colorization) (bool, error) {
-	var option string
-	if err := survey.AskOne(&survey.Select{
-		Message: prompt,
-		Options: []string{opt_yes, opt_no},
-		Default: opt_no,
-	}, &option, surveyIcons(color)); err != nil {
-		return false, errors.New("selection cancelled")
-	}
-
-	return option == opt_yes, nil
-}
-
 func configureImageRepository(ctx context.Context, displayOpts *display.Options,
 	be backend.Backend, s backend.Stack, sd *workspace.ProjectStackDeployment,
 ) error {
@@ -1122,7 +1109,7 @@ func configureImageRepository(ctx context.Context, displayOpts *display.Options,
 	var password string
 	var err error
 
-	confirm, err := askForConfirmation("Do you want to use a custom executor image?", displayOpts.Color)
+	confirm, err := askForConfirmation("Do you want to use a custom executor image?", displayOpts.Color, false)
 	if err != nil {
 		return err
 	}
@@ -1194,4 +1181,21 @@ func configureImageRepository(ctx context.Context, displayOpts *display.Options,
 	}
 
 	return nil
+}
+
+func askForConfirmation(prompt string, color colors.Colorization, defaultValue bool) (bool, error) {
+	var option string
+	def := opt_no
+	if defaultValue {
+		def = opt_yes
+	}
+	if err := survey.AskOne(&survey.Select{
+		Message: prompt,
+		Options: []string{opt_yes, opt_no},
+		Default: def,
+	}, &option, surveyIcons(color)); err != nil {
+		return false, errors.New("selection cancelled")
+	}
+
+	return option == opt_yes, nil
 }

--- a/pkg/cmd/pulumi/deployment.go
+++ b/pkg/cmd/pulumi/deployment.go
@@ -36,21 +36,21 @@ import (
 )
 
 const (
-	opt_yes                           = "Yes"
-	opt_no                            = "No"
-	opt_oidc_aws                      = "Enable AWS integration"
-	opt_oidc_azure                    = "Enable Azure integration"
-	opt_oidc_gcp                      = "Enable Google Cloud integration"
-	opt_git                           = "Git"
-	opt_executor_image                = "Executor image"
-	opt_advanced_settings             = "Advanced settings"
-	opt_preview_pr                    = "Run previews for pull requests"
-	opt_update_pushes                 = "Run updates for pushed commits"
-	opt_pr_template                   = "Use this stack as a template for pull request stacks"
-	opt_user_pass                     = "Username/Password"
-	opt_ssh                           = "SSH key"
-	opt_skip_deps_install             = "Skip automatic dependency installation step"
-	opt_skip_intermediate_deployments = "Skip intermediate deployments"
+	optYes                         = "Yes"
+	optNo                          = "No"
+	optOidcAws                     = "Enable AWS integration"
+	optOidcAzure                   = "Enable Azure integration"
+	optOidcGcp                     = "Enable Google Cloud integration"
+	optGit                         = "Git"
+	optExecutorImage               = "Executor image"
+	optAdvancedSettings            = "Advanced settings"
+	optPreviewPr                   = "Run previews for pull requests"
+	optUpdatePushes                = "Run updates for pushed commits"
+	optPrTemplate                  = "Use this stack as a template for pull request stacks"
+	optUserPass                    = "Username/Password"
+	optSSH                         = "SSH key"
+	optSkipDepsInstall             = "Skip automatic dependency installation step"
+	optSkipIntermediateDeployments = "Skip intermediate deployments"
 )
 
 var stackDeploymentConfigFile string
@@ -272,22 +272,22 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 			if err := survey.AskOne(&survey.Select{
 				Message: "Do you want to configure an OpenID Connect integration?",
 				Options: []string{
-					opt_no,
-					opt_oidc_aws,
-					opt_oidc_azure,
-					opt_oidc_gcp,
+					optNo,
+					optOidcAws,
+					optOidcAzure,
+					optOidcGcp,
 				},
-				Default: opt_no,
+				Default: optNo,
 			}, &option, surveyIcons(display.Color)); err != nil {
 				return errors.New("selection cancelled")
 			}
 
 			switch option {
-			case opt_oidc_aws:
+			case optOidcAws:
 				err = configureOidcAws(newStackDeployment)
-			case opt_oidc_azure:
+			case optOidcAzure:
 				err = configureOidcAzure(newStackDeployment)
-			case opt_oidc_gcp:
+			case optOidcGcp:
 				err = configureOidcGCP(newStackDeployment)
 			}
 			if err != nil {
@@ -482,29 +482,29 @@ func newDeploymentSettingsSetCmd() *cobra.Command {
 			if err := survey.AskOne(&survey.Select{
 				Message: "Configure:",
 				Options: []string{
-					opt_git,
-					opt_executor_image,
-					opt_advanced_settings,
-					opt_oidc_aws,
-					opt_oidc_azure,
-					opt_oidc_gcp,
+					optGit,
+					optExecutorImage,
+					optAdvancedSettings,
+					optOidcAws,
+					optOidcAzure,
+					optOidcGcp,
 				},
 			}, &option, surveyIcons(displayOpts.Color)); err != nil {
 				return errors.New("selection cancelled")
 			}
 
 			switch option {
-			case opt_git:
+			case optGit:
 				err = configureGit(ctx, displayOpts, be, s, sd, gitSSHPrivateKeyPath)
-			case opt_executor_image:
+			case optExecutorImage:
 				err = configureImageRepository(ctx, displayOpts, be, s, sd)
-			case opt_advanced_settings:
+			case optAdvancedSettings:
 				err = configureAdvancedSettings(displayOpts, sd)
-			case opt_oidc_aws:
+			case optOidcAws:
 				err = configureOidcAws(sd)
-			case opt_oidc_azure:
+			case optOidcAzure:
 				err = configureOidcAzure(sd)
-			case opt_oidc_gcp:
+			case optOidcGcp:
 				err = configureOidcGCP(sd)
 			}
 			if err != nil {
@@ -727,23 +727,27 @@ func configureGitHubRepo(displayOpts *display.Options,
 	if err := survey.AskOne(&survey.MultiSelect{
 		Message: "What kind of authentication should it use?",
 		Options: []string{
-			opt_preview_pr,
-			opt_update_pushes,
-			opt_pr_template,
+			optPreviewPr,
+			optUpdatePushes,
+			optPrTemplate,
+		},
+		Default: []string{
+			optPreviewPr,
+			optUpdatePushes,
 		},
 	}, &options, surveyIcons(displayOpts.Color)); err != nil {
 		return errors.New("selection cancelled")
 	}
 
-	if slices.Contains(options, opt_preview_pr) {
+	if slices.Contains(options, optPreviewPr) {
 		sd.DeploymentSettings.GitHub.PreviewPullRequests = true
 	}
 
-	if slices.Contains(options, opt_update_pushes) {
+	if slices.Contains(options, optUpdatePushes) {
 		sd.DeploymentSettings.GitHub.DeployCommits = true
 	}
 
-	if slices.Contains(options, opt_pr_template) {
+	if slices.Contains(options, optPrTemplate) {
 		sd.DeploymentSettings.GitHub.PullRequestTemplate = true
 	}
 
@@ -760,16 +764,16 @@ func configureBareGitRepo(ctx context.Context, displayOpts *display.Options,
 	if err := survey.AskOne(&survey.Select{
 		Message: "What kind of authentication should it use?",
 		Options: []string{
-			opt_user_pass,
-			opt_ssh,
+			optUserPass,
+			optSSH,
 		},
 	}, &option, surveyIcons(displayOpts.Color)); err != nil {
 		return errors.New("selection cancelled")
 	}
 	switch option {
-	case opt_user_pass:
+	case optUserPass:
 		return configureGitPassword(ctx, be, s, sd)
-	case opt_ssh:
+	case optSSH:
 		return configureGitSSH(ctx, be, s, sd, gitSSHPrivateKeyPath)
 	}
 
@@ -1075,8 +1079,11 @@ func configureAdvancedSettings(displayOpts *display.Options, sd *workspace.Proje
 	if err := survey.AskOne(&survey.MultiSelect{
 		Message: "Advanced settings",
 		Options: []string{
-			opt_skip_deps_install,
-			opt_skip_intermediate_deployments,
+			optSkipIntermediateDeployments,
+			optSkipDepsInstall,
+		},
+		Default: []string{
+			optSkipIntermediateDeployments,
 		},
 	}, &options, surveyIcons(displayOpts.Color)); err != nil {
 		return errors.New("selection cancelled")
@@ -1090,11 +1097,11 @@ func configureAdvancedSettings(displayOpts *display.Options, sd *workspace.Proje
 		sd.DeploymentSettings.Operation.Options = &apitype.OperationContextOptions{}
 	}
 
-	if slices.Contains(options, opt_skip_deps_install) {
+	if slices.Contains(options, optSkipDepsInstall) {
 		sd.DeploymentSettings.Operation.Options.SkipInstallDependencies = true
 	}
 
-	if slices.Contains(options, opt_skip_intermediate_deployments) {
+	if slices.Contains(options, optSkipIntermediateDeployments) {
 		sd.DeploymentSettings.Operation.Options.SkipIntermediateDeployments = true
 	}
 
@@ -1185,17 +1192,17 @@ func configureImageRepository(ctx context.Context, displayOpts *display.Options,
 
 func askForConfirmation(prompt string, color colors.Colorization, defaultValue bool) (bool, error) {
 	var option string
-	def := opt_no
+	def := optNo
 	if defaultValue {
-		def = opt_yes
+		def = optYes
 	}
 	if err := survey.AskOne(&survey.Select{
 		Message: prompt,
-		Options: []string{opt_yes, opt_no},
+		Options: []string{optYes, optNo},
 		Default: def,
 	}, &option, surveyIcons(color)); err != nil {
 		return false, errors.New("selection cancelled")
 	}
 
-	return option == opt_yes, nil
+	return option == optYes, nil
 }

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -213,6 +213,8 @@ type BasicAuth struct {
 
 // OperationContext describes what to do.
 type OperationContext struct {
+	// OIDC contains the OIDC configuration for the operation.
+	OIDC *OperationContextOIDCConfiguration `json:"oidc,omitempty" yaml:"oidc,omitempty"`
 	// PreRunCommands is an optional list of arbitrary commands to run before Pulumi
 	// is invoked.
 	// ref: https://github.com/pulumi/pulumi/issues/9397
@@ -226,6 +228,50 @@ type OperationContext struct {
 
 	// Options is a bag of settings to specify or override default behavior
 	Options *OperationContextOptions `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+type OperationContextOIDCConfiguration struct {
+	// AWS contains AWS-specific configuration.
+	AWS *OperationContextAWSOIDCConfiguration `json:"aws,omitempty" yaml:"aws,omitempty"`
+	// Azure contains Azure-specific configuration.
+	Azure *OperationContextAzureOIDCConfiguration `json:"azure,omitempty" yaml:"azure,omitempty"`
+	// GCP contains GCP-specific configuration.
+	GCP *OperationContextGCPOIDCConfiguration `json:"gcp,omitempty" yaml:"gcp,omitempty"`
+}
+
+type OperationContextAWSOIDCConfiguration struct {
+	// Duration is the duration of the assume-role session.
+	Duration time.Duration `json:"duration,omitempty" yaml:"duration,omitempty"`
+	// PolicyARNs is an optional set of IAM policy ARNs that further restrict the assume-role session.
+	PolicyARNs []string `json:"policyArns,omitempty" yaml:"policyArns,omitempty"`
+	// The ARN of the role to assume using the OIDC token.
+	RoleARN string `json:"roleArn" yaml:"roleArn"`
+	// The name of the assume-role session.
+	SessionName string `json:"sessionName" yaml:"sessionName"`
+}
+
+type OperationContextAzureOIDCConfiguration struct {
+	// ClientID is the client ID of the federated workload identity.
+	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	// TenantID is the tenant ID of the federated workload identity.
+	TenantID string `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	// SubscriptionID is the subscription ID of the federated workload identity.
+	SubscriptionID string `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+}
+
+type OperationContextGCPOIDCConfiguration struct {
+	// ProjectID is the numerical ID of the GCP project.
+	ProjectID string `json:"projectId" yaml:"projectId"`
+	// Region is the region of the GCP project.
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+	// WorkloadPoolID is the ID of the workload pool to use.
+	WorkloadPoolID string `json:"workloadPoolId" yaml:"workloadPoolId"`
+	// ProviderID is the ID of the identity provider associated with the workload pool.
+	ProviderID string `json:"providerId" yaml:"providerId"`
+	// ServiceAccount is the email address of the service account to use.
+	ServiceAccount string `json:"serviceAccount" yaml:"serviceAccount"`
+	// TokenLifetime is the lifetime of the temporary credentials.
+	TokenLifetime time.Duration `json:"tokenLifetime,omitempty" yaml:"tokenLifetime,omitempty"`
 }
 
 // OperationContextOptions is a bag of settings to specify or override default behavior in a deployment

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -304,8 +304,8 @@ type DeploymentLogs struct {
 
 // A SecretValue describes a possibly-secret value.
 type SecretValue struct {
-	Value      string // Plaintext if Secret is false; ciphertext otherwise.
-	Ciphertext string // ciphertext
+	Value      string
+	Ciphertext string
 	Secret     bool
 }
 

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -219,7 +219,7 @@ type OperationContext struct {
 	PreRunCommands []string `json:"preRunCommands" yaml:"preRunCommands,omitempty"`
 
 	// Operation is what we plan on doing.
-	Operation PulumiOperation `json:"operation"`
+	Operation PulumiOperation `json:"operation" yaml:"-"`
 
 	// EnvironmentVariables contains environment variables to be applied during the execution.
 	EnvironmentVariables map[string]SecretValue `json:"environmentVariables" yaml:"environmentVariables,omitempty"`

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -75,6 +75,21 @@ func ReadConsole(prompt string) (string, error) {
 	return readConsoleFancy(os.Stdout, os.Stdin, prompt, false /* secret */)
 }
 
+// ReadConsoleWithDefault reads the console with the given prompt text with support for a default value.
+func ReadConsoleWithDefault(prompt string, defaultValue string) (string, error) {
+	promptMessage := fmt.Sprintf("%s [%s]", prompt, defaultValue)
+	value, err := ReadConsole(promptMessage)
+	if err != nil {
+		return "", err
+	}
+
+	if value == "" {
+		value = defaultValue
+	}
+
+	return value, nil
+}
+
 // readConsolePlain prints the given prompt (if any),
 // and reads the user's response from stdin.
 //

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -537,3 +537,61 @@ func TestParseAuthURL(t *testing.T) {
 		assert.Equal(t, "http-basic-auth - foo:<empty>", auth.String())
 	})
 }
+
+type mockDetectGitAccessors struct {
+	KnownDirectories map[string]*mockDetectGitFileInfo
+}
+
+func (a mockDetectGitAccessors) Stat(name string) (detectGitFileInfo, error) {
+	d, ok := a.KnownDirectories[name]
+
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return d, nil
+}
+
+type mockDetectGitFileInfo struct {
+	IsDirValue bool
+}
+
+func (m mockDetectGitFileInfo) IsDir() bool {
+	return m.IsDirValue
+}
+
+type mockFileDir struct {
+	KnownDirectories []string
+}
+
+func TestDetectGitRootDirectory(t *testing.T) {
+	t.Run("should return the parent directory that contains a .git directory", func(t *testing.T) {
+		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
+			KnownDirectories: map[string]*mockDetectGitFileInfo{
+				"/home/user/repos/git/.git": {IsDirValue: true},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "/home/user/repos/git", d)
+	})
+
+	t.Run("not git directory found", func(t *testing.T) {
+		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
+			KnownDirectories: map[string]*mockDetectGitFileInfo{},
+		})
+		assert.Error(t, err, ".git not found")
+		assert.Empty(t, d)
+	})
+
+	t.Run("there are git markers set", func(t *testing.T) {
+		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
+			KnownDirectories: map[string]*mockDetectGitFileInfo{
+				"/home/user/repos/git/HEAD":    {IsDirValue: false},
+				"/home/user/repos/git/objects": {IsDirValue: false},
+				"/home/user/repos/git/refs":    {IsDirValue: false},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "/home/user/repos/git", d)
+	})
+}

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -560,12 +560,10 @@ func (m mockDetectGitFileInfo) IsDir() bool {
 	return m.IsDirValue
 }
 
-type mockFileDir struct {
-	KnownDirectories []string
-}
-
 func TestDetectGitRootDirectory(t *testing.T) {
+	t.Parallel()
 	t.Run("should return the parent directory that contains a .git directory", func(t *testing.T) {
+		t.Parallel()
 		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
 			KnownDirectories: map[string]*mockDetectGitFileInfo{
 				"/home/user/repos/git/.git": {IsDirValue: true},
@@ -576,6 +574,7 @@ func TestDetectGitRootDirectory(t *testing.T) {
 	})
 
 	t.Run("not git directory found", func(t *testing.T) {
+		t.Parallel()
 		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
 			KnownDirectories: map[string]*mockDetectGitFileInfo{},
 		})
@@ -584,6 +583,7 @@ func TestDetectGitRootDirectory(t *testing.T) {
 	})
 
 	t.Run("there are git markers set", func(t *testing.T) {
+		t.Parallel()
 		d, err := detectGitRootDirectory("/home/user/repos/git/something/nested", mockDetectGitAccessors{
 			KnownDirectories: map[string]*mockDetectGitFileInfo{
 				"/home/user/repos/git/HEAD":    {IsDirValue: false},

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -176,8 +176,7 @@ func LoadProjectStackDeployment(path string) (*ProjectStackDeployment, error) {
 
 	b, err := readFileStripUTF8BOM(path)
 	if os.IsNotExist(err) {
-		defaultProjectStackDeployment := ProjectStackDeployment{}
-		return &defaultProjectStackDeployment, nil
+		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Turns `deployment settings init` command a wizard
- Adds new `deployment settings env` command to manage env variables (including secrets encryption)
- Adds new `deployment settings set` command to configure individual settings (including secrets encryption)

https://asciinema.org/a/QhuWHAvkmeAmVJkYqkCP0P6wb

Fix https://github.com/pulumi/pulumi-service/issues/20567
Fix https://github.com/pulumi/pulumi-service/issues/20576