### PR TITLE
Fix usage of getters and setters in Lambda callback functions

### DIFF
--- a/changelog/pending/20240702--sdk-nodejs--fix-creating-a-closure-with-object-getters-and-setters.yaml
+++ b/changelog/pending/20240702--sdk-nodejs--fix-creating-a-closure-with-object-getters-and-setters.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix creating a closure with object getters and setters

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -543,6 +543,8 @@ function computeCapturedVariableNames(file: typescript.SourceFile): CapturedVari
             case ts.SyntaxKind.CatchClause:
                 return visitCatchClause(<typescript.CatchClause>node);
             case ts.SyntaxKind.MethodDeclaration:
+            case ts.SyntaxKind.GetAccessor:
+            case ts.SyntaxKind.SetAccessor:
                 return visitMethodDeclaration(<typescript.MethodDeclaration>node);
             case ts.SyntaxKind.MetaProperty:
                 // don't walk down an es6 metaproperty (i.e. "new.target").  It doesn't

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/176-getter/index.ts
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/176-getter/index.ts
@@ -1,0 +1,53 @@
+// Copyright 2024-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const description = "getter and setter";
+
+function Queue(initial = []) {
+    let xs = initial.slice();
+    let index = 0;
+
+    return {
+        get length() {
+            return xs.length - index;
+        },
+    };
+}
+
+const outsideConstant = "outsideConstant";
+const outsideVariable = 1;
+const outsideArrowFunctionExpression = () => 1;
+function outsideFunctionDeclaration() {
+    return outsideArrowFunctionExpression()
+}
+
+export const func = async () => {
+    Queue();
+
+    const obj = {
+        objectFieldValue: "objectField",
+        get objectField() {
+            return this.objectFieldValue;
+        },
+        get outsideConstant() {
+            return outsideConstant;
+        },
+        get outsideFunctionDeclaration() {
+            return outsideFunctionDeclaration()
+        },
+        set outsideVariable(value: number) {
+            console.log(outsideVariable, value)
+        },
+    };
+};

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/176-getter/snapshot.txt
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/cases/176-getter/snapshot.txt
@@ -1,0 +1,86 @@
+exports.handler = __f0;
+
+function __f1(__0, __1, __2, __3) {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __Queue() {
+  return (function() {
+    with({ Queue: __Queue, this: undefined, arguments: undefined }) {
+
+return function /*Queue*/(initial = []) {
+    let xs = initial.slice();
+    let index = 0;
+    return {
+        get length() {
+            return xs.length - index;
+        },
+    };
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f2() {
+  return (function() {
+    with({ this: undefined, arguments: undefined }) {
+
+return () => 1;
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __outsideFunctionDeclaration() {
+  return (function() {
+    with({ outsideArrowFunctionExpression: __f2, outsideFunctionDeclaration: __outsideFunctionDeclaration, this: undefined, arguments: undefined }) {
+
+return function /*outsideFunctionDeclaration*/() {
+    return outsideArrowFunctionExpression();
+};
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ __awaiter: __f1, Queue: __Queue, outsideConstant: "outsideConstant", outsideFunctionDeclaration: __outsideFunctionDeclaration, outsideVariable: 1, this: undefined, arguments: undefined }) {
+
+return () => __awaiter(void 0, void 0, void 0, function* () {
+    Queue();
+    const obj = {
+        objectFieldValue: "objectField",
+        get objectField() {
+            return this.objectFieldValue;
+        },
+        get outsideConstant() {
+            return outsideConstant;
+        },
+        get outsideFunctionDeclaration() {
+            return outsideFunctionDeclaration();
+        },
+        set outsideVariable(value) {
+            console.log(outsideVariable, value);
+        },
+    };
+});
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}


### PR DESCRIPTION
Fixes #16541 

Hi,

this is an attempt to fix #16541 , feedback is greatly appreciated!

I was not able to test if the result works as expected, I just adjusted the code and manually created a test snapshot from the mocha console output until I thought it looked right.

Could someone tell me...
1. how to actually build the `@pulumi/pulumi` package and how to test the fixes quickly?
2. how to create a snapshot for a new closure test?
3. if there is a quick way to write the TypeScript code in this project, set breakpoints and run tests against it?
   - I plan to investigate the pnpm bundling bug of the `CallbackFunction` but working on this and testing the code is extremely tedious right now as I do not know your secrets (yet 😀)
   - I didn't find these infos in the `CONTRIBUTING.md` and other READMEs
   - I am very familiar with TypeScript and the nodejs tooling, but no clue how everything is stitched together in this repo
   - feel free to send me a Slack message in the Pulumi Community or suggesting another communication channel



Thanks!

fyi @julienp 

