### PR TITLE
[docs/go-program-gen] Fix generating constructor syntax examples for kubernetes

### DIFF
--- a/changelog/pending/20240703--docs--fix-generating-constructor-syntax-examples-for-kubernetes.yaml
+++ b/changelog/pending/20240703--docs--fix-generating-constructor-syntax-examples-for-kubernetes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: docs
+  description: Fix generating constructor syntax examples for kubernetes

--- a/pkg/codegen/docs/constructor_syntax_generator.go
+++ b/pkg/codegen/docs/constructor_syntax_generator.go
@@ -123,7 +123,13 @@ func (g *constructorSyntaxGenerator) writeValue(
 				}
 
 				g.indent(buffer)
-				write("%s = ", p.Name)
+				propertyName := p.Name
+				// quote property names that start with a dollar sign: $ref => "$ref"
+				if strings.HasPrefix(propertyName, "$") {
+					propertyName = fmt.Sprintf("%q", propertyName)
+				}
+
+				write("%s = ", propertyName)
 				if p.ConstValue != nil {
 					// constant values used for discriminator properties of object need to be exact
 					// we write them out here as strings to generate correct programs

--- a/pkg/codegen/go/gen_program_ternaries.go
+++ b/pkg/codegen/go/gen_program_ternaries.go
@@ -60,7 +60,7 @@ func (g *generator) rewriteTernaries(
 	spiller *tempSpiller,
 ) (model.Expression, []*ternaryTemp, hcl.Diagnostics) {
 	spiller.temps = nil
-	x, diags := model.VisitExpression(x, spiller.spillExpression, nil)
+	x, diags := model.VisitExpression(x, nil, spiller.spillExpression)
 
 	return x, spiller.temps, diags
 }

--- a/tests/testdata/codegen/azure-native-pp/go/azure-native.go
+++ b/tests/testdata/codegen/azure-native-pp/go/azure-native.go
@@ -27,30 +27,30 @@ func main() {
 		_, err = cdn.NewEndpoint(ctx, "endpoint", &cdn.EndpointArgs{
 			Origins: cdn.DeepCreatedOriginArray{},
 			DeliveryPolicy: &cdn.EndpointPropertiesUpdateParametersDeliveryPolicyArgs{
-				Rules: []cdn.DeliveryRuleArgs{
-					{
+				Rules: cdn.DeliveryRuleArray{
+					&cdn.DeliveryRuleArgs{
 						Actions: pulumi.Array{
-							{
+							cdn.DeliveryRuleCacheExpirationAction{
 								Name: "CacheExpiration",
-								Parameters: {
+								Parameters: cdn.CacheExpirationActionParameters{
 									CacheBehavior: cdn.CacheBehaviorOverride,
 									CacheDuration: "10:10:09",
 									CacheType:     cdn.CacheTypeAll,
 									OdataType:     "#Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters",
 								},
 							},
-							{
+							cdn.DeliveryRuleResponseHeaderAction{
 								Name: "ModifyResponseHeader",
-								Parameters: {
+								Parameters: cdn.HeaderActionParameters{
 									HeaderAction: cdn.HeaderActionOverwrite,
 									HeaderName:   "Access-Control-Allow-Origin",
 									OdataType:    "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
 									Value:        "*",
 								},
 							},
-							{
+							cdn.DeliveryRuleRequestHeaderAction{
 								Name: "ModifyRequestHeader",
-								Parameters: {
+								Parameters: cdn.HeaderActionParameters{
 									HeaderAction: cdn.HeaderActionOverwrite,
 									HeaderName:   "Accept-Encoding",
 									OdataType:    "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
@@ -59,9 +59,9 @@ func main() {
 							},
 						},
 						Conditions: pulumi.Array{
-							{
+							cdn.DeliveryRuleRemoteAddressCondition{
 								Name: "RemoteAddress",
-								Parameters: {
+								Parameters: cdn.RemoteAddressMatchConditionParameters{
 									MatchValues: []string{
 										"192.168.1.0/24",
 										"10.0.0.0/24",

--- a/tests/testdata/codegen/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/tests/testdata/codegen/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -20,32 +20,32 @@ func main() {
 				},
 			},
 			Spec: &corev1.PodSpecArgs{
-				Containers: []corev1.ContainerArgs{
-					{
+				Containers: corev1.ContainerArray{
+					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx"),
 						Image: pulumi.String("nginx:1.14-alpine"),
 						Ports: corev1.ContainerPortArray{
-							{
+							&corev1.ContainerPortArgs{
 								ContainerPort: pulumi.Int(80),
 							},
 						},
-						Resources: {
-							Limits: {
+						Resources: &corev1.ResourceRequirementsArgs{
+							Limits: pulumi.StringMap{
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),
 							},
 						},
 					},
-					{
+					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx2"),
 						Image: pulumi.String("nginx:1.14-alpine"),
 						Ports: corev1.ContainerPortArray{
-							{
+							&corev1.ContainerPortArgs{
 								ContainerPort: pulumi.Int(80),
 							},
 						},
-						Resources: {
-							Limits: {
+						Resources: &corev1.ResourceRequirementsArgs{
+							Limits: pulumi.StringMap{
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),
 							},

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmap/_index.md
@@ -309,58 +309,58 @@ var configMapResource = new Kubernetes.Core.V1.ConfigMap("configMapResource", ne
 
 ```go
 example, err := corev1.NewConfigMap(ctx, "configMapResource", &corev1.ConfigMapArgs{
-ApiVersion: pulumi.String("string"),
-BinaryData: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-Data: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-Immutable: pulumi.Bool(false),
-Kind: pulumi.String("string"),
-Metadata: &metav1.ObjectMetaArgs{
-Annotations: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-ClusterName: pulumi.String("string"),
-CreationTimestamp: pulumi.String("string"),
-DeletionGracePeriodSeconds: pulumi.Int(0),
-DeletionTimestamp: pulumi.String("string"),
-Finalizers: pulumi.StringArray{
-pulumi.String("string"),
-},
-GenerateName: pulumi.String("string"),
-Generation: pulumi.Int(0),
-Labels: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-ManagedFields: metav1.ManagedFieldsEntryArray{
-&metav1.ManagedFieldsEntryArgs{
-ApiVersion: pulumi.String("string"),
-FieldsType: pulumi.String("string"),
-FieldsV1: pulumi.Any("{}"),
-Manager: pulumi.String("string"),
-Operation: pulumi.String("string"),
-Subresource: pulumi.String("string"),
-Time: pulumi.String("string"),
-},
-},
-Name: pulumi.String("string"),
-Namespace: pulumi.String("string"),
-OwnerReferences: metav1.OwnerReferenceArray{
-&metav1.OwnerReferenceArgs{
-ApiVersion: pulumi.String("string"),
-Kind: pulumi.String("string"),
-Name: pulumi.String("string"),
-Uid: pulumi.String("string"),
-BlockOwnerDeletion: pulumi.Bool(false),
-Controller: pulumi.Bool(false),
-},
-},
-ResourceVersion: pulumi.String("string"),
-SelfLink: pulumi.String("string"),
-Uid: pulumi.String("string"),
-},
+	ApiVersion: pulumi.String("string"),
+	BinaryData: pulumi.StringMap{
+		"string": pulumi.String("string"),
+	},
+	Data: pulumi.StringMap{
+		"string": pulumi.String("string"),
+	},
+	Immutable: pulumi.Bool(false),
+	Kind:      pulumi.String("string"),
+	Metadata: &metav1.ObjectMetaArgs{
+		Annotations: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ClusterName:                pulumi.String("string"),
+		CreationTimestamp:          pulumi.String("string"),
+		DeletionGracePeriodSeconds: pulumi.Int(0),
+		DeletionTimestamp:          pulumi.String("string"),
+		Finalizers: pulumi.StringArray{
+			pulumi.String("string"),
+		},
+		GenerateName: pulumi.String("string"),
+		Generation:   pulumi.Int(0),
+		Labels: pulumi.StringMap{
+			"string": pulumi.String("string"),
+		},
+		ManagedFields: metav1.ManagedFieldsEntryArray{
+			&metav1.ManagedFieldsEntryArgs{
+				ApiVersion:  pulumi.String("string"),
+				FieldsType:  pulumi.String("string"),
+				FieldsV1:    pulumi.Any("{}"),
+				Manager:     pulumi.String("string"),
+				Operation:   pulumi.String("string"),
+				Subresource: pulumi.String("string"),
+				Time:        pulumi.String("string"),
+			},
+		},
+		Name:      pulumi.String("string"),
+		Namespace: pulumi.String("string"),
+		OwnerReferences: metav1.OwnerReferenceArray{
+			&metav1.OwnerReferenceArgs{
+				ApiVersion:         pulumi.String("string"),
+				Kind:               pulumi.String("string"),
+				Name:               pulumi.String("string"),
+				Uid:                pulumi.String("string"),
+				BlockOwnerDeletion: pulumi.Bool(false),
+				Controller:         pulumi.Bool(false),
+			},
+		},
+		ResourceVersion: pulumi.String("string"),
+		SelfLink:        pulumi.String("string"),
+		Uid:             pulumi.String("string"),
+	},
 })
 ```
 

--- a/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/core/v1/configmaplist/_index.md
@@ -322,70 +322,70 @@ var configMapListResource = new Kubernetes.Core.V1.ConfigMapList("configMapListR
 
 ```go
 example, err := corev1.NewConfigMapList(ctx, "configMapListResource", &corev1.ConfigMapListArgs{
-Items: corev1.ConfigMapTypeArray{
-interface{}{
-ApiVersion: pulumi.String("v1"),
-BinaryData: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-Data: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-Immutable: pulumi.Bool(false),
-Kind: pulumi.String("ConfigMap"),
-Metadata: &metav1.ObjectMetaArgs{
-Annotations: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-ClusterName: pulumi.String("string"),
-CreationTimestamp: pulumi.String("string"),
-DeletionGracePeriodSeconds: pulumi.Int(0),
-DeletionTimestamp: pulumi.String("string"),
-Finalizers: pulumi.StringArray{
-pulumi.String("string"),
-},
-GenerateName: pulumi.String("string"),
-Generation: pulumi.Int(0),
-Labels: pulumi.StringMap{
-"string": pulumi.String("string"),
-},
-ManagedFields: metav1.ManagedFieldsEntryArray{
-&metav1.ManagedFieldsEntryArgs{
-ApiVersion: pulumi.String("string"),
-FieldsType: pulumi.String("string"),
-FieldsV1: pulumi.Any("{}"),
-Manager: pulumi.String("string"),
-Operation: pulumi.String("string"),
-Subresource: pulumi.String("string"),
-Time: pulumi.String("string"),
-},
-},
-Name: pulumi.String("string"),
-Namespace: pulumi.String("string"),
-OwnerReferences: metav1.OwnerReferenceArray{
-&metav1.OwnerReferenceArgs{
-ApiVersion: pulumi.String("string"),
-Kind: pulumi.String("string"),
-Name: pulumi.String("string"),
-Uid: pulumi.String("string"),
-BlockOwnerDeletion: pulumi.Bool(false),
-Controller: pulumi.Bool(false),
-},
-},
-ResourceVersion: pulumi.String("string"),
-SelfLink: pulumi.String("string"),
-Uid: pulumi.String("string"),
-},
-},
-},
-ApiVersion: pulumi.String("string"),
-Kind: pulumi.String("string"),
-Metadata: &metav1.ListMetaArgs{
-Continue: pulumi.String("string"),
-RemainingItemCount: pulumi.Int(0),
-ResourceVersion: pulumi.String("string"),
-SelfLink: pulumi.String("string"),
-},
+	Items: corev1.ConfigMapTypeArray{
+		&corev1.ConfigMapTypeArgs{
+			ApiVersion: pulumi.String("v1"),
+			BinaryData: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			Data: pulumi.StringMap{
+				"string": pulumi.String("string"),
+			},
+			Immutable: pulumi.Bool(false),
+			Kind:      pulumi.String("ConfigMap"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Annotations: pulumi.StringMap{
+					"string": pulumi.String("string"),
+				},
+				ClusterName:                pulumi.String("string"),
+				CreationTimestamp:          pulumi.String("string"),
+				DeletionGracePeriodSeconds: pulumi.Int(0),
+				DeletionTimestamp:          pulumi.String("string"),
+				Finalizers: pulumi.StringArray{
+					pulumi.String("string"),
+				},
+				GenerateName: pulumi.String("string"),
+				Generation:   pulumi.Int(0),
+				Labels: pulumi.StringMap{
+					"string": pulumi.String("string"),
+				},
+				ManagedFields: metav1.ManagedFieldsEntryArray{
+					&metav1.ManagedFieldsEntryArgs{
+						ApiVersion:  pulumi.String("string"),
+						FieldsType:  pulumi.String("string"),
+						FieldsV1:    pulumi.Any("{}"),
+						Manager:     pulumi.String("string"),
+						Operation:   pulumi.String("string"),
+						Subresource: pulumi.String("string"),
+						Time:        pulumi.String("string"),
+					},
+				},
+				Name:      pulumi.String("string"),
+				Namespace: pulumi.String("string"),
+				OwnerReferences: metav1.OwnerReferenceArray{
+					&metav1.OwnerReferenceArgs{
+						ApiVersion:         pulumi.String("string"),
+						Kind:               pulumi.String("string"),
+						Name:               pulumi.String("string"),
+						Uid:                pulumi.String("string"),
+						BlockOwnerDeletion: pulumi.Bool(false),
+						Controller:         pulumi.Bool(false),
+					},
+				},
+				ResourceVersion: pulumi.String("string"),
+				SelfLink:        pulumi.String("string"),
+				Uid:             pulumi.String("string"),
+			},
+		},
+	},
+	ApiVersion: pulumi.String("string"),
+	Kind:       pulumi.String("string"),
+	Metadata: &metav1.ListMetaArgs{
+		Continue:           pulumi.String("string"),
+		RemainingItemCount: pulumi.Int(0),
+		ResourceVersion:    pulumi.String("string"),
+		SelfLink:           pulumi.String("string"),
+	},
 })
 ```
 

--- a/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/helm/v3/release/_index.md
@@ -255,13 +255,13 @@ var releaseResource = new Kubernetes.Helm.V3.Release("releaseResource", new()
 
 ```go
 example, err := helmv3.NewRelease(ctx, "releaseResource", &helmv3.ReleaseArgs{
-Chart: pulumi.String("string"),
-ValueYamlFiles: pulumi.AssetOrArchiveArray{
-pulumi.NewStringAsset("content"),
-},
-Values: pulumi.Map{
-"string": pulumi.Any("any"),
-},
+	Chart: pulumi.String("string"),
+	ValueYamlFiles: pulumi.AssetOrArchiveArray{
+		pulumi.NewStringAsset("content"),
+	},
+	Values: pulumi.Map{
+		"string": pulumi.Any("any"),
+	},
 })
 ```
 

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/configgroup/_index.md
@@ -260,13 +260,13 @@ var kubernetesConfigGroupResource = new Kubernetes.Yaml.ConfigGroup("kubernetesC
 
 ```go
 example, err := yaml.NewConfigGroup(ctx, "kubernetesConfigGroupResource", &yaml.ConfigGroupArgs{
-Files: pulumi.Any("string"),
-Objs: nil,
-ResourcePrefix: pulumi.String("string"),
-Transformations: pulumi.Array{
-pulumi.Any("any"),
-},
-Yaml: pulumi.Any("string"),
+	Files:          pulumi.Any("string"),
+	Objs:           nil,
+	ResourcePrefix: pulumi.String("string"),
+	Transformations: pulumi.Array{
+		pulumi.Any("any"),
+	},
+	Yaml: pulumi.Any("string"),
 })
 ```
 

--- a/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
+++ b/tests/testdata/codegen/kubernetes20/docs/yaml/v2/configgroup/_index.md
@@ -251,10 +251,10 @@ var configGroupResource = new Kubernetes.Yaml.V2.ConfigGroup("configGroupResourc
 
 ```go
 example, err := yamlv2.NewConfigGroup(ctx, "configGroupResource", &yamlv2.ConfigGroupArgs{
-Files: pulumi.Any("string"),
-Objs: nil,
-ResourcePrefix: pulumi.String("string"),
-Yaml: pulumi.Any("string"),
+	Files:          pulumi.Any("string"),
+	Objs:           nil,
+	ResourcePrefix: pulumi.String("string"),
+	Yaml:           pulumi.Any("string"),
 })
 ```
 


### PR DESCRIPTION
In this PR we fix generating constructor syntax examples for Kubernetes. The problem initially was due to generating a PCL program with syntax errors for the kubernetes schema. The syntax error was happening because we emitted properties `$ref` and `$schema` which are not valid identifiers in PCL. Fixing this was simple enough, we only needed to quote these properties that start with dollar signs and we get a valid PCL program. 

Full PCL program for kubernetes: https://gist.github.com/Zaid-Ajaj/abe899430a0b5f99a428934dcac75d52

However, the valid PCL program wouldn't convert to Go with program-gen and it would hang without showing any errors or stack traces. I wrote a script to split the programs for each resource and convert each separately. This way I narrowed down the problem to this program:

```
resource "def" "kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition" {
  apiVersion = "string"
  kind = "string"
  spec = {
    versions = [{}]
  }
}
```

Debugging this in Go program-gen didn't show an obvious error and it kept on hanging. However I noticed that we lowering expressions twice: once for the entirety of resource inputs when generating resources and again when generating the expressions separately. Lowering expressions has been the source of many bugs and it seems to trip up program-gen a lot and suspected something wrong was going on here, so I simplified it to lower the expressions once when we generate resource inputs. This fixed the hang issue as well as a few of our test programs (see diffs for test programs and tests schemas) 

Tested this against the full kubernetes schema and we can now generate the full Go program:
https://gist.github.com/Zaid-Ajaj/3ac734536969a989edae92219968d51f

> The second time we lower expressions not only is redundant but also can generate invalid code if the lowered expressions have temporary variables because program-gen would just emit these variables inside inline expressions like objects and lists which gives invalid Go code.

Resolves part of #16463 