### PR TITLE
Fix slice bounds out of range panic in fixupPath

### DIFF
--- a/changelog/pending/20240703--sdk-go--fix-slice-bounds-out-of-range-panic-in-fixuppath.yaml
+++ b/changelog/pending/20240703--sdk-go--fix-slice-bounds-out-of-range-panic-in-fixuppath.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix out-of-range panic when sanitizing env vars

--- a/changelog/pending/20240703--sdk-go--fix-slice-bounds-out-of-range-panic-in-fixuppath.yaml
+++ b/changelog/pending/20240703--sdk-go--fix-slice-bounds-out-of-range-panic-in-fixuppath.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: sdk/go
-  description: Fix out-of-range panic when sanitizing env vars
+  description: Fix out-of-range panic when sanitizing PATH env var

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -321,7 +321,7 @@ func fixupPath(env []string, pulumiBin string) []string {
 	pathIndex := -1
 	for i, e := range env {
 		// Case-insensitive compare, as Windows will normally be "Path", not "PATH".
-		if strings.EqualFold(e[0:5], "PATH=") {
+		if len(e) >= 5 && strings.EqualFold(e[0:5], "PATH=") {
 			pathIndex = i
 			break
 		}

--- a/sdk/go/auto/cmd_test.go
+++ b/sdk/go/auto/cmd_test.go
@@ -151,7 +151,7 @@ func TestNoGlobalPulumi(t *testing.T) {
 func TestFixupPath(t *testing.T) {
 	t.Parallel()
 
-	env := fixupPath([]string{"FOO=bar"}, "/pulumi-root/bin")
+	env := fixupPath([]string{"FOO=bar", "V=1"}, "/pulumi-root/bin")
 
 	require.Contains(t, env, "PATH=/pulumi-root/bin")
 }


### PR DESCRIPTION
I noticed that sst currently panics if an environment variable's name is shorter than 5 characters. This fixes the root cause.

```
V=1 sst deploy --stage=dev 
SST ❍ ion 0.0.416  ready!

➜  App:        myapp
   Stage:      dev

~  Deploying

panic: runtime error: slice bounds out of range [:5] with length 3

goroutine 1 [running]:
github.com/pulumi/pulumi/sdk/v3/go/auto.fixupPath({0x140018ec408, 0xb1, 0x1400013dfc0?}, {0x1400013dfc0, 0x32})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/cmd.go:324 +0x270
github.com/pulumi/pulumi/sdk/v3/go/auto.pulumiCommand.Run({{0x3, 0x73, 0x2, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, {0x1400013dfc0, ...}}, ...)
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/cmd.go:273 +0x394
github.com/pulumi/pulumi/sdk/v3/go/auto.(*LocalWorkspace).runPulumiInputCmdSync(0x14001494000, {0x106fb2b28, 0x1400061c0f0}, {0x0, 0x0}, {0x14000aeba00, 0x4, 0x4})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/local_workspace.go:776 +0x1f4
github.com/pulumi/pulumi/sdk/v3/go/auto.(*LocalWorkspace).runPulumiCmdSync(...)
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/local_workspace.go:790
github.com/pulumi/pulumi/sdk/v3/go/auto.(*LocalWorkspace).SelectStack(0x14001494000, {0x106fb2b28, 0x1400061c0f0}, {0x16b392623, 0x3})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/local_workspace.go:568 +0x160
github.com/pulumi/pulumi/sdk/v3/go/auto.SelectStack({0x106fb2b28?, 0x1400061c0f0?}, {0x16b392623, 0x3}, {0x106fcd6e0, 0x14001494000})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/stack.go:179 +0x5c
github.com/pulumi/pulumi/sdk/v3/go/auto.UpsertStack({0x106fb2b28, 0x1400061c0f0}, {0x16b392623, 0x3}, {0x106fcd6e0, 0x14001494000})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.2/go/auto/stack.go:191 +0x34
github.com/sst/ion/pkg/project.(*stack).Run(0x14000a42058, {0x106fb2b28, 0x1400061c0f0}, 0x140000bbcc0)
        /home/runner/work/ion/ion/pkg/project/stack.go:283 +0x1cf4
main.init.func3(0x14000064550)
        /home/runner/work/ion/ion/cmd/sst/main.go:458 +0x2c8
main.run()
        /home/runner/work/ion/ion/cmd/sst/main.go:160 +0x6cc
main.main()
        /home/runner/work/ion/ion/cmd/sst/main.go:52 +0x12c
```