### PR TITLE
retry post requests that timeout during handshake

### DIFF
--- a/changelog/pending/20240703--backend-service--retry-post-requests-that-time-out-during-handshake-timeouts.yaml
+++ b/changelog/pending/20240703--backend-service--retry-post-requests-that-time-out-during-handshake-timeouts.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: Retry POST requests that time out during handshake timeouts

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -210,20 +210,18 @@ type defaultHTTPClient struct {
 }
 
 func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Response, error) {
-	if policy.shouldRetry(req) {
-		// Wait 1s before retrying on failure. Then increase by 2x until the
-		// maximum delay is reached. Stop after maxRetryCount requests have
-		// been made.
-		opts := httputil.RetryOpts{
-			Delay:    durationPtr(time.Second),
-			Backoff:  float64Ptr(2.0),
-			MaxDelay: durationPtr(30 * time.Second),
+	// Wait 1s before retrying on failure. Then increase by 2x until the
+	// maximum delay is reached. Stop after maxRetryCount requests have
+	// been made.
+	opts := httputil.RetryOpts{
+		Delay:    durationPtr(time.Second),
+		Backoff:  float64Ptr(2.0),
+		MaxDelay: durationPtr(30 * time.Second),
 
-			MaxRetryCount: intPtr(4),
-		}
-		return httputil.DoWithRetryOpts(req, c.client, opts)
+		MaxRetryCount:         intPtr(4),
+		HandshakeTimeoutsOnly: !policy.shouldRetry(req),
 	}
-	return c.client.Do(req)
+	return httputil.DoWithRetryOpts(req, c.client, opts)
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.

--- a/sdk/go/common/util/httputil/http.go
+++ b/sdk/go/common/util/httputil/http.go
@@ -17,6 +17,7 @@ package httputil
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -32,6 +33,9 @@ type RetryOpts struct {
 	MaxDelay *time.Duration
 
 	MaxRetryCount *int
+	// HandshakeTimeoutsOnly indicates whether we should only be retrying timeouts that occur during the TLS handshake.
+	// These timeouts are safe to retry even on POST requests, since we know the actual request hasn't been sent yet.
+	HandshakeTimeoutsOnly bool
 }
 
 // DoWithRetry calls client.Do, and in the case of an error, retries the operation again after a slight delay.
@@ -78,9 +82,18 @@ func doWithRetry(req *http.Request, client *http.Client, opts RetryOpts) (*http.
 			}
 
 			res, resErr := client.Do(req)
+			if opts.HandshakeTimeoutsOnly {
+				if resErr != nil && strings.Contains(resErr.Error(), "net/http: TLS handshake timeout") {
+					// If we have a handshake timeout, we can retry the request.
+					return false, nil, nil
+				} else {
+					return true, res, resErr
+				}
+			}
 			if resErr == nil && !inRange(res.StatusCode, 500, 599) {
 				return true, res, nil
 			}
+
 			if try >= (maxRetryCount - 1) {
 				return true, res, resErr
 			}

--- a/sdk/go/common/util/httputil/http.go
+++ b/sdk/go/common/util/httputil/http.go
@@ -86,9 +86,8 @@ func doWithRetry(req *http.Request, client *http.Client, opts RetryOpts) (*http.
 				if resErr != nil && strings.Contains(resErr.Error(), "net/http: TLS handshake timeout") {
 					// If we have a handshake timeout, we can retry the request.
 					return false, nil, nil
-				} else {
-					return true, res, resErr
 				}
+				return true, res, resErr
 			}
 			if resErr == nil && !inRange(res.StatusCode, 500, 599) {
 				return true, res, nil


### PR DESCRIPTION
We've had quite a few test flakes that happen because of TLS handshake timeouts to the service backend.  These are usually during stack creation (which happens a lot during tests), which are POST requests.

POST requests are not generally safe to retry, because the request could already have been sent to the backend and an action taken, but the client couldn't read the response.  However when there is a TLS handshake failure, the request can never have made it to the backend, so these errors are safe to retry.

This should hopefully help with https://github.com/pulumi/pulumi/issues/16529.