### PR TITLE
Connect settings init to pulumi new

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -454,7 +454,18 @@ func runNew(ctx context.Context, args newArgs) error {
 		fmt.Println(template.Quickstart)
 	}
 
-	return nil
+	configureDeployments := askForConfirmation("Do you want to set up deployments for this stack?",
+		opts.Color, true, args.yes)
+
+	if !configureDeployments {
+		return nil
+	}
+
+	d, err := initializeDeploymentSettings(ctx, "", args.yes)
+	if err != nil {
+		return err
+	}
+	return initStackDeploymentCmd(d, "")
 }
 
 // sanitizeTemplate strips sensitive data such as credentials and query strings from a template URL.


### PR DESCRIPTION
This makes pulumi new run settings init at the end. 

This will be on hold and will be merged whenever we are ready to release it