### PR TITLE
[go/program-gen] Do not emit index module for resources without a schema

### DIFF
--- a/changelog/pending/20240705--programgen-go--do-not-emit-index-module-for-resources-without-a-schema.yaml
+++ b/changelog/pending/20240705--programgen-go--do-not-emit-index-module-for-resources-without-a-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Do not emit index module for resources without a schema

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -758,8 +758,8 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 				if r.Schema != nil {
 					panic(err)
 				}
-				// for unknown resources, make a best guess
-				vPath = "/v1"
+				// for unknown resources, don't create a versioned import
+				vPath = ""
 			}
 
 			g.addPulumiImport(pkg, vPath, mod, name)
@@ -776,8 +776,8 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 					tokenRange := tokenArg.SyntaxNode().Range()
 					pkg, mod, name, diagnostics := pcl.DecomposeToken(token, tokenRange)
 					if call.Type() == model.DynamicType {
-						// then this is an unknown function, create a dummy import for it
-						dummyVersionPath := "/v1"
+						// then this is an unknown function, create a dummy import for it without a version
+						dummyVersionPath := ""
 						g.addPulumiImport(pkg, dummyVersionPath, mod, name)
 						return call, nil
 					}
@@ -1048,7 +1048,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		mod = ""
 		typ = "Provider"
 	}
-	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
+	if mod == "" || strings.HasPrefix(mod, "/") || mod == IndexToken {
 		originalMod = mod
 		mod = pkg
 	}

--- a/tests/testdata/codegen/unknown-invoke-pp/go/unknown-invoke.go
+++ b/tests/testdata/codegen/unknown-invoke-pp/go/unknown-invoke.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown"
-	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown/eks"
+	"github.com/pulumi/pulumi-unknown/sdk/go/unknown"
+	"github.com/pulumi/pulumi-unknown/sdk/go/unknown/eks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
+++ b/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown"
-	"github.com/pulumi/pulumi-unknown/sdk/v1/go/unknown/eks"
+	"github.com/pulumi/pulumi-unknown/sdk/go/unknown"
+	"github.com/pulumi/pulumi-unknown/sdk/go/unknown/eks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -12,7 +12,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		main, err := index.NewMain(ctx, "main", &index.MainArgs{
+		main, err := unknown.NewMain(ctx, "main", &unknown.MainArgs{
 			First: "hello",
 			Second: map[string]interface{}{
 				"foo": "bar",


### PR DESCRIPTION
For resources that don't have a schema, we emit a best guess for how they are declared and how imports should be emitted. For these resources we emit `index.{ResourceName}` if that resource is from the index module, however this is not how resources are usually generated, instead we should generate `{packageName}.{ResourceName}` for resources from the index module which is what this PR resolves. 

Fixes #16461 