### PR TITLE
Skip the inspect step for community PRs

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -50,6 +50,7 @@ jobs:
   # if they're not necessary.
   inspect:
     name: Inspect changed files
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
This will fail because we don't have the repo checked out. We don't
require this to pass for community PRs (tests are run "manually" via a
maintainer command), so skip it to keep things tidyer.
