### PR TITLE
Use default values for language specific prompts when using --yes

### DIFF
--- a/changelog/pending/20240708--cli-new--use-default-values-for-language-specific-prompts-when-using-yes.yaml
+++ b/changelog/pending/20240708--cli-new--use-default-values-for-language-specific-prompts-when-using-yes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Use default values for language specific prompts when using --yes

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -889,7 +889,7 @@ func promptRuntimeOptions(ctx *plugin.Context, info *workspace.ProjectRuntimeInf
 
 		surveycore.DisableColor = true
 		for _, optionPrompt := range prompts {
-			if !interactive {
+			if yes {
 				if optionPrompt.Default == nil {
 					return nil, fmt.Errorf("must provide a runtime option for '%s' in non-interactive mode", optionPrompt.Key)
 				}


### PR DESCRIPTION
When passing `yes` in interactive mode (or non-interactive mode), language specific options should use their deafult values without prompting the user.
