### PR TITLE
Implement `depends_on` for invokes in the Python SDK

### DIFF
--- a/changelog/pending/20240709--sdk-python--add-depends_on-to-invokeoptions-in-the-python-sdk.yaml
+++ b/changelog/pending/20240709--sdk-python--add-depends_on-to-invokeoptions-in-the-python-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add `depends_on` to `InvokeOptions` in the Python SDK

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -32,7 +32,6 @@ from typing import (
     cast,
 )
 from . import _types
-from .metadata import get_project, get_stack
 from .runtime import known_types
 from .runtime.resource import (
     _pkg_from_type,
@@ -42,7 +41,6 @@ from .runtime.resource import (
     read_resource,
     collapse_alias_to_urn,
     create_urn as create_urn_internal,
-    convert_providers,
 )
 from .runtime.settings import get_root_resource
 from .output import _is_prompt, _map_input, _map2_input, T, Output

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -274,10 +274,12 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
     async def _transformation_resource_options(
         self, opts: ResourceOptions
     ) -> resource_pb2.TransformResourceOptions:
+        from .depends_on import (  # pylint: disable=import-outside-toplevel
+            resolve_depends_on_urns,
+        )
         from .resource import (  # pylint: disable=import-outside-toplevel
             _create_custom_timeouts,
             _create_provider_ref,
-            _resolve_depends_on_urns,
             create_alias_spec,
         )
         from ..resource import (  # pylint: disable=import-outside-toplevel
@@ -303,7 +305,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
         if opts.custom_timeouts is not None:
             custom_timeouts = _create_custom_timeouts(opts.custom_timeouts)
 
-        depends_on = await _resolve_depends_on_urns(opts)
+        depends_on = await resolve_depends_on_urns(opts._depends_on_list())
 
         ignore_changes = None
         if opts.ignore_changes:

--- a/sdk/python/lib/pulumi/runtime/depends_on.py
+++ b/sdk/python/lib/pulumi/runtime/depends_on.py
@@ -1,0 +1,49 @@
+# Copyright 2016-2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import TYPE_CHECKING, List, Optional, Set
+
+from ..output import Output
+from .rpc import _expand_dependencies
+
+if TYPE_CHECKING:
+    from ..output import Input
+    from ..resource import Resource
+
+
+async def resolve_depends_on_urns(
+    depends_on: "Input[List[Input[Resource]]]",
+    from_resource: Optional["Resource"] = None,
+) -> Set[str]:
+    """
+    Resolves the set of all dependent resources implied by
+    `depends_on`, either directly listed or implied in the Input
+    layer. Returns a deduplicated URN list.
+    """
+
+    if not depends_on:
+        return set()
+
+    outer = Output._from_input_shallow(depends_on)
+    all_deps = await outer.resources()
+    inner_list = await outer.future() or []
+
+    for i in inner_list:
+        inner = Output.from_input(i)
+        more_deps = await inner.resources()
+        all_deps = all_deps | more_deps
+        direct_dep = await inner.future()
+        if direct_dep is not None:
+            all_deps.add(direct_dep)
+
+    return await _expand_dependencies(all_deps, from_resource)

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -89,3 +89,7 @@ def test_invoke_empty_return(tok: str, version: str, empty: bool, expected) -> N
     props = {"empty": True} if empty else {}
     opts = pulumi.InvokeOptions(version=version) if version else None
     assert pulumi.runtime.invoke(tok, props, opts).value == expected
+
+@pulumi.runtime.test
+def test_invoke_depends_on():
+    assert True

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -69,7 +69,6 @@ def test_depends_on_accepts_outputs(dep_tracker):
 def test_depends_on_outputs_works_in_presence_of_unknowns(dep_tracker_preview):
     dep1 = MockResource(name="dep1")
     dep2 = MockResource(name="dep2")
-    dep3 = MockResource(name="dep3")
     known = output_depending_on_resource(dep1, isKnown=True).apply(lambda _: dep2)
     unknown = output_depending_on_resource(dep2, isKnown=False).apply(lambda _: dep2)
     res = MockResource(
@@ -154,7 +153,7 @@ def test_depends_on_typechecks_sync():
         res = MockResource(
             name="res", opts=pulumi.ResourceOptions(depends_on=["hello"])
         )
-        assert False, "should of failed"
+        assert False, "should have failed"
     except TypeError as e:
         assert (
             str(e) == "'depends_on' was passed a value hello that was not a Resource."
@@ -174,7 +173,7 @@ def test_depends_on_typechecks_async():
 
     try:
         test()
-        assert False, "should of failed"
+        assert False, "should have failed"
     except TypeError as e:
         assert (
             str(e) == "'depends_on' was passed a value goodbye that was not a Resource."
@@ -371,6 +370,6 @@ def test_bad_component_super_call():
 
     try:
         test()
-        assert False, "should of failed"
+        assert False, "should have failed"
     except TypeError as e:
         assert str(e) == "Expected resource properties to be a mapping"


### PR DESCRIPTION
This commit adds support for passing `depends_on` to invokes in the Python SDK. This allows programs to ensure that certain invokes are executed after things they depend on, even if that dependency is not implicitly captured with an input-output relationship.

Part of #14243