### PR TITLE
Use latest patch version of go in CI

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
           cache: true
           cache-dependency-path: |
             pkg/go.sum

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
           # golangci-lint-action handles all the caching for Go.
           cache: false
 
@@ -61,6 +62,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
       - name: Run go mod tidy
         run: make tidy
       - name: Fail if go mod not tidy
@@ -82,6 +84,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
       - name: Run make gen
         run: cd sdk/go && make gen
       - name: Fail if there are changes
@@ -114,6 +117,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
       - name: Set up Python ${{ fromJson(inputs.version-set).python }}
         uses: actions/setup-python@v5
         with:
@@ -163,5 +167,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
       - run: |
           make lint_actions

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -159,6 +159,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
           cache: true
           cache-dependency-path: |
             pkg/go.sum

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ fromJson(needs.matrix.outputs.version-set).go }}
+          check-latest: true
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/changelog/pending/20240710--ci--use-latest-patch-version-of-go-in-ci.yaml
+++ b/changelog/pending/20240710--ci--use-latest-patch-version-of-go-in-ci.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Use latest patch version of go in CI

--- a/changelog/pending/20240710--ci--use-latest-patch-version-of-go-in-ci.yaml
+++ b/changelog/pending/20240710--ci--use-latest-patch-version-of-go-in-ci.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: ci
-  description: Use latest patch version of go in CI
+  description: Use latest patch version of Go in CI


### PR DESCRIPTION
We pass a version like `1.22.x` for go, which results in the setup-go
action using a cached version, even if there is a more recent release
available. Set `check-latest: true` to ensure we're always using the latest
release, picking up any security fixes.

Unblocks https://github.com/pulumi/pulumi/pull/16608