### PR TITLE
Change parameterization in schemas to base64 strings

### DIFF
--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -160,9 +160,7 @@
                 },
                 "parameter": {
                     "type": "string",
-                    "media": {
-                        "binaryEncoding": "base64"
-                    }
+                    "contentEncoding": "base64"
                 }
             },
             "additionalProperties": false

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -159,7 +159,10 @@
                     "additionalProperties": false
                 },
                 "parameter": {
-
+                    "type": "string",
+                    "media": {
+                        "binaryEncoding": "base64"
+                    }
                 }
             },
             "additionalProperties": false

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -592,7 +592,7 @@ type BaseProvider struct {
 type Parameterization struct {
 	BaseProvider BaseProvider
 	// Parameter is the parameter for the provider.
-	Parameter interface{}
+	Parameter []byte
 }
 
 // Package describes a Pulumi package.
@@ -1969,10 +1969,7 @@ type ParameterizationSpec struct {
 	// The base provider to parameterize.
 	BaseProvider BaseProviderSpec `json:"baseProvider" yaml:"baseProvider"`
 	// The parameter to apply to the base provider.
-	//
-	// Parameter can be any type round-tripable through [json.Marshal]/[json.Unmarshal] and
-	// [yaml.Marshal]/[yaml.Unmarshal].
-	Parameter interface{} `json:"parameter" yaml:"parameter"`
+	Parameter []byte `json:"parameter" yaml:"parameter"`
 }
 
 // PackageSpec is the serializable description of a Pulumi package.


### PR DESCRIPTION
Follow on to https://github.com/pulumi/pulumi/pull/16606. Allow the schema to express any bytes value.