### PR TITLE
[autmation/nodejs] Implement Stack.import() to specify and import resources into a stack

### DIFF
--- a/changelog/pending/20240710--auto-nodejs--implement-stack-import-in-automation-api-to-specify-and-import-resources-into-a-stack.yaml
+++ b/changelog/pending/20240710--auto-nodejs--implement-stack-import-in-automation-api-to-specify-and-import-resources-into-a-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Implement Stack.import() in automation API to specify and import resources into a stack

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -626,6 +626,7 @@ Event: ${line}\n${e.toString()}`);
                     //   converterArgs: "./tfstate.json"
                     // }
                     // would be equivalent to `pulumi import --from terraform ./tfstate.json`
+                    args.push("--");
                     args.push(...options.converterArgs);
                 }
             }

--- a/sdk/nodejs/tests/automation/data/import/Pulumi.yaml
+++ b/sdk/nodejs/tests/automation/data/import/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: import
+runtime: nodejs

--- a/sdk/nodejs/tests/automation/data/import/expected_generated_code.txt
+++ b/sdk/nodejs/tests/automation/data/import/expected_generated_code.txt
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+const randomPassword = new random.RandomPassword("randomPassword", {
+    length: 11,
+    lower: true,
+    number: true,
+    numeric: true,
+    special: true,
+    upper: true,
+});

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -16,6 +16,7 @@ import assert from "assert";
 import * as semver from "semver";
 import * as tmp from "tmp";
 import * as upath from "upath";
+import * as fs from "fs";
 
 import {
     CommandResult,
@@ -1168,6 +1169,58 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     });
+
+    it("can import resources into a stack using resource definitions", async () => {
+        const workDir = upath.joinSafe(__dirname, "data", "import");
+        const stackName = `int_test${getTestSuffix()}`;
+        const stack = await LocalWorkspace.createStack({ workDir, stackName });
+        const pulumiRandomVersion = "4.16.3";
+        await stack.workspace.installPlugin("random", pulumiRandomVersion);
+        const result = await stack.import({
+            protect: false,
+            resources: [
+                {
+                    type: "random:index/randomPassword:RandomPassword",
+                    name: "randomPassword",
+                    id: "supersecret",
+                },
+            ],
+        });
+        assert.strictEqual(result.summary.kind, "update");
+        assert.strictEqual(result.summary.result, "succeeded");
+
+        const expectedGeneratedCode = fs.readFileSync(upath.joinSafe(workDir, "expected_generated_code.txt"), "utf8");
+        assert.strictEqual(result.generatedCode, expectedGeneratedCode);
+        await stack.destroy();
+        await stack.workspace.removeStack(stackName);
+        await stack.workspace.removePlugin("random", pulumiRandomVersion);
+    });
+
+    it("can import resources into a stack without generating code", async () => {
+        const workDir = upath.joinSafe(__dirname, "data", "import");
+        const stackName = `int_test${getTestSuffix()}`;
+        const stack = await LocalWorkspace.createStack({ workDir, stackName });
+        const pulumiRandomVersion = "4.16.3";
+        await stack.workspace.installPlugin("random", pulumiRandomVersion);
+        const result = await stack.import({
+            protect: false,
+            generateCode: false,
+            resources: [
+                {
+                    type: "random:index/randomPassword:RandomPassword",
+                    name: "randomPassword",
+                    id: "supersecret",
+                },
+            ],
+        });
+        assert.strictEqual(result.summary.kind, "update");
+        assert.strictEqual(result.summary.result, "succeeded");
+        assert.strictEqual(result.generatedCode, "");
+        await stack.destroy();
+        await stack.workspace.removeStack(stackName);
+        await stack.workspace.removePlugin("random", pulumiRandomVersion);
+    });
+
     it(`sets pulumi version`, async () => {
         const ws = await LocalWorkspace.create({});
         assert(ws.pulumiVersion);


### PR DESCRIPTION
Addressing https://github.com/pulumi/pulumi/issues/8237 starting with NodeJS

This PR implements `Stack.import(...)` in NodeJS automation API and allows the user to specify resources and other import options to perform the import. Here is an example of how it looks like from the user's perspective:
```ts
// importing resources from a list of import definitions
// can also specify nameTable: { ... }
const result = await stack.import({
    protect: false,
    resources: [
        {  
            type: "random:index/randomPassword:RandomPassword",
            name: "randomPassword",
            id: "supersecret"
        }
    ]
})

// see the generated code from the import
console.log(result.generatedCode)
```
In addition to specifying resources, we can also specify a converter to import resources with:
```ts
// pulumi import --from terraform ./tfstate.json
const result = await stack.import({
    converter: "terraform",
    converterArgs: "./tfstate.json" 
})
```

> I've used `converter` and `converterArgs` as opposed to `from` and `fromArgs` because `fromArgs` sounds a bit weird and `converter` makes sense because we are using a converter. We could say `fromConverter` and `fromConverterArgs` but that sounds like a mouthful 