### PR TITLE
Improve TypeDocs for `sdk/nodejs/automation`

### DIFF
--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -25,7 +25,9 @@ import { createCommandError } from "./errors";
 
 const SKIP_VERSION_CHECK_VAR = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK";
 
-/** @internal */
+/**
+ * @internal
+ */
 export class CommandResult {
     stdout: string;
     stderr: string;

--- a/sdk/nodejs/automation/config.ts
+++ b/sdk/nodejs/automation/config.ts
@@ -13,15 +13,21 @@
 // limitations under the License.
 
 /**
- * ConfigValue is the input/output of a `pulumi config` command.
- * It has a plaintext value, and an option boolean indicating secretness.
+ * An input to/output from a `pulumi config` command.
  */
 export interface ConfigValue {
+    /**
+     * The underlying configuration value.
+     */
     value: string;
+
+    /**
+     * True if and only if this configuration value is a secret.
+     */
     secret?: boolean;
 }
 
 /**
- * ConfigMap is a map of string to ConfigValue
+ * A map of configuration values.
  */
 export type ConfigMap = { [key: string]: ConfigValue };

--- a/sdk/nodejs/automation/errors.ts
+++ b/sdk/nodejs/automation/errors.ts
@@ -15,7 +15,8 @@
 import { CommandResult } from "./cmd";
 
 /**
- * CommandError is an error resulting from invocation of a Pulumi Command.
+ * An error resulting from the invocation of a Pulumi command.
+ *
  * @alpha
  */
 export class CommandError extends Error {
@@ -27,7 +28,8 @@ export class CommandError extends Error {
 }
 
 /**
- * ConcurrentUpdateError is thrown when attempting to update a stack that already has an update in progress.
+ * An error thrown when attempting to update a stack that is already being
+ * updated.
  */
 export class ConcurrentUpdateError extends CommandError {
     /** @internal */
@@ -38,7 +40,7 @@ export class ConcurrentUpdateError extends CommandError {
 }
 
 /**
- * StackNotFoundError is thrown when attempting to select a stack that does not exist.
+ * An error thrown when attempting to select a stack that does not exist.
  */
 export class StackNotFoundError extends CommandError {
     /** @internal */
@@ -49,7 +51,7 @@ export class StackNotFoundError extends CommandError {
 }
 
 /**
- * StackAlreadyExistsError is thrown when attempting to create a stack that already exists.
+ * An error thrown when attempting to create a stack that already exists.
  */
 export class StackAlreadyExistsError extends CommandError {
     /** @internal */
@@ -64,7 +66,9 @@ const alreadyExistsRegex = new RegExp("stack.*already exists");
 const conflictText = "[409] Conflict: Another update is currently in progress.";
 const diyBackendConflictText = "the stack is currently locked by";
 
-/** @internal */
+/**
+ * @internal
+ */
 export function createCommandError(result: CommandResult): CommandError {
     const stderr = result.stderr;
     return notFoundRegex.test(stderr)

--- a/sdk/nodejs/automation/events.ts
+++ b/sdk/nodejs/automation/events.ts
@@ -24,8 +24,8 @@ import { OpMap, OpType } from "./stack";
 export type CancelEvent = {};
 
 /**
- * StdoutEngineEvent is emitted whenever a generic message is written, for example warnings
- * from the pulumi CLI itself. Less common than DiagnosticEvent
+ * An event emitted whenever a generic message is written, for example warnings
+ * from the pulumi CLI itself. Less common than {@link DiagnosticEvent}
  */
 export interface StdoutEngineEvent {
     message: string;
@@ -33,7 +33,7 @@ export interface StdoutEngineEvent {
 }
 
 /**
- * DiagnosticEvent is emitted whenever a diagnostic message is provided, for example errors from
+ * An event emitted whenever a diagnostic message is provided, for example errors from
  * a cloud resource provider while trying to create or update a resource.
  */
 export interface DiagnosticEvent {
@@ -47,7 +47,7 @@ export interface DiagnosticEvent {
 }
 
 /**
- * PolicyEvent is emitted whenever there is a Policy violation.
+ * An event emitted whenever there is a policy violation.
  */
 export interface PolicyEvent {
     resourceUrn?: string;
@@ -61,35 +61,37 @@ export interface PolicyEvent {
 }
 
 /**
- * PreludeEvent is emitted at the start of an update.
+ * An event emitted at the start of an update.
  */
 export interface PreludeEvent {
     /**
-     * config contains the keys and values for the update.
-     * Encrypted configuration values may be blinded.
+     * Configuration values that will be used during the update.
      */
     config: Record<string, string>;
 }
 
 /**
- * SummaryEvent is emitted at the end of an update, with a summary of the changes made.
+ * An event emitted at the end of an update, with a summary of the changes made.
  */
 export interface SummaryEvent {
     /**
-     * maybeCorrupt is set if one or more of the resources is in an invalid state.
+     * True if one or more of the resources are in an invalid state.
      */
     maybeCorrupt: boolean;
+
     /**
-     * duration is the number of seconds the update was executing.
+     * The number of seconds the update took to execute.
      */
     durationSeconds: number;
+
     /**
-     * resourceChanges contains the count for resource change by type. The keys are deploy.StepOp,
-     * which is not exported in this package.
+     * The count for resource changes by type.
      */
     resourceChanges: OpMap;
+
     /**
-     * policyPacks run during update. Maps PolicyPackName -> version.
+     * The policy packs that were run during the update. Maps PolicyPackName -> version.
+     *
      * Note: When this field was initially added, we forgot to add the JSON tag
      * and are now locked into using PascalCase for this field to maintain backwards
      * compatibility. For older clients this will map to the version, while for newer ones
@@ -98,63 +100,84 @@ export interface SummaryEvent {
     policyPacks: Record<string, string>;
 }
 
+/**
+ * A {@link DiffKind} describes the kind of difference between two values
+ * reported in a diff.
+ */
 export enum DiffKind {
     /**
-     * add indicates that the property was added.
+     * Indicates that the property was added.
      */
     add = "add",
+
     /**
-     * addReplace indicates that the property was added and requires that the resource be replaced.
+     * Indicates that the property was added and requires that the resource be replaced.
      */
     addReplace = "add-replace",
+
     /**
-     * delete indicates that the property was deleted.
+     * Indicates that the property was deleted.
      */
     delete = "delete",
+
     /**
-     * deleteReplace indicates that the property was deleted and requires that the resource be replaced.
+     * Indicates that the property was deleted and requires that the resource be replaced.
      */
     deleteReplace = "delete-replace",
+
     /**
-     * update indicates that the property was updated.
+     * Indicates that the property was updated.
      */
     update = "update",
+
     /**
-     * updateReplace indicates that the property was updated and requires that the resource be replaced.
+     * Indicates that the property was updated and requires that the resource be replaced.
      */
     updateReplace = "update-replace",
 }
 
 /**
- * PropertyDiff describes the difference between a single property's old and new values.
+ * A {@link PropertyDiff} describes the difference between a single property's old and new values.
  */
 export interface PropertyDiff {
     /**
      * diffKind is the kind of difference.
      */
     diffKind: DiffKind;
+
     /**
-     * inputDiff is true if this is a difference between old and new inputs rather than old state and new inputs.
+     * inputDiff is true if this is a difference between old and new inputs
+     * rather than old state and new inputs.
      */
     inputDiff: boolean;
 }
 
 /**
- * StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
- * to migrate a set of cloud resources from one state to another.
+ * {@link StepEventMetadata} describes a "step" within the Pulumi engine, which
+ * is any concrete action to migrate a set of cloud resources from one state to
+ * another.
  */
 export interface StepEventMetadata {
     /**
-     * Op is the operation being performed.
+     * The type of operation being performed.
      */
     op: OpType;
+
+    /**
+     * The URN of the resource being operated on.
+     */
     urn: string;
+
+    /**
+     * The type of the resource being operated on.
+     */
     type: string;
 
     /**
      * Old is the state of the resource before performing the step.
      */
     old?: StepEventStateMetadata;
+
     /**
      * New is the state of the resource after performing the step.
      */
@@ -164,18 +187,22 @@ export interface StepEventMetadata {
      * Keys causing a replacement (only applicable for "create" and "replace" Ops).
      */
     keys?: string[];
+
     /**
      * Keys that changed with this step.
      */
     diffs?: string[];
+
     /**
      * The diff for this step as a list of property paths and difference types.
      */
     detailedDiff?: Record<string, PropertyDiff>;
+
     /**
      * Logical is set if the step is a logical operation in the program.
      */
     logical?: boolean;
+
     /**
      * Provider actually performing the step.
      */
@@ -183,50 +210,66 @@ export interface StepEventMetadata {
 }
 
 /**
- * StepEventStateMetadata is the more detailed state information for a resource as it relates to
+ * {@link StepEventStateMetadata} is the more detailed state information for a resource as it relates to
  * a step(s) being performed.
  */
 export interface StepEventStateMetadata {
+    /**
+     * The type of the resource being operated on.
+     */
     type: string;
+
+    /**
+     * The URN of the resource being operated on.
+     */
     urn: string;
 
     /**
      * Custom indicates if the resource is managed by a plugin.
      */
     custom?: boolean;
+
     /**
      * Delete is true when the resource is pending deletion due to a replacement.
      */
     delete?: boolean;
+
     /**
      * ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
      */
     id: string;
+
     /**
      * Parent is an optional parent URN that this resource belongs to.
      */
     parent: string;
+
     /**
      * Protect is true to "protect" this resource (protected resources cannot be deleted).
      */
     protect?: boolean;
+
     /**
      * RetainOnDelete is true if the resource is not physically deleted when it is logically deleted.
      */
     retainOnDelete?: boolean;
+
     /**
      * Inputs contains the resource's input properties (as specified by the program). Secrets have
      * filtered out, and large assets have been replaced by hashes as applicable.
      */
     inputs: Record<string, any>;
+
     /**
      * Outputs contains the resource's complete output state (as returned by the resource provider).
      */
     outputs: Record<string, any>;
+
     /**
      * Provider is the resource's provider reference
      */
     provider: string;
+
     /**
      * InitErrors is the set of errors encountered in the process of initializing resource.
      */
@@ -234,41 +277,56 @@ export interface StepEventStateMetadata {
 }
 
 /**
- * ResourcePreEvent is emitted before a resource is modified.
+ * An event emitted before a resource is modified.
  */
 export interface ResourcePreEvent {
+    /**
+     * Metadata for the event.
+     */
     metadata: StepEventMetadata;
+
     planning?: boolean;
 }
 
 /**
- * ResOutputsEvent is emitted when a resource is finished being provisioned.
+ * An event emitted when a resource is finished being provisioned.
  */
 export interface ResOutputsEvent {
+    /**
+     * Metadata for the event.
+     */
     metadata: StepEventMetadata;
+
     planning?: boolean;
 }
 
 /**
- * ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is
- * emitted before this event, indicating the root cause of the error.
+ * An event emitted when a resource operation fails. Typically a
+ * {@link DiagnosticEvent} is emitted before this event, indicating the root
+ * cause of the error.
  */
 export interface ResOpFailedEvent {
+    /**
+     * Metadata for the event.
+     */
     metadata: StepEventMetadata;
+
     status: number;
+
     steps: number;
 }
 
 /**
- * EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
- * message. EngineEvent is a discriminated union of all possible event types, and exactly one
- * field will be non-nil.
+ * A Pulumi engine event, such as a change to a resource or diagnostic message.
+ * This is intended to capture a discriminated union -- exactly one event field
+ * will be non-nil.
  */
 export interface EngineEvent {
     /**
-     * Sequence is a unique, and monotonically increasing number for each engine event sent to the
-     * Pulumi Service. Since events may be sent concurrently, and/or delayed via network routing,
-     * the sequence number is to ensure events can be placed into a total ordering.
+     * A unique, and monotonically increasing number for each engine event sent
+     * to the Pulumi Service. Since events may be sent concurrently, and/or
+     * delayed via network routing, the sequence number is to ensure events can
+     * be placed into a total ordering.
      *
      * - No two events can have the same sequence number.
      * - Events with a lower sequence number must have been emitted before those with a higher
@@ -281,13 +339,52 @@ export interface EngineEvent {
      */
     timestamp: number;
 
+    /**
+     * A cancellation event, if this engine event represents a cancellation.
+     */
     cancelEvent?: CancelEvent;
+
+    /**
+     * A stdout event, if this engine event represents a message written to stdout.
+     */
     stdoutEvent?: StdoutEngineEvent;
+
+    /**
+     * A diagnostic event, if this engine event represents a diagnostic message.
+     */
     diagnosticEvent?: DiagnosticEvent;
+
+    /**
+     * A prelude event, if this engine event represents the start of an
+     * operation.
+     */
     preludeEvent?: PreludeEvent;
+
+    /**
+     * A summary event, if this engine event represents the end of an operation.
+     */
     summaryEvent?: SummaryEvent;
+
+    /**
+     * A resource pre-event, if this engine event represents a resource
+     * about to be modified.
+     */
     resourcePreEvent?: ResourcePreEvent;
+
+    /**
+     * A resource outputs event, if this engine event represents a resource
+     * that has been modified.
+     */
     resOutputsEvent?: ResOutputsEvent;
+
+    /**
+     * A resource operation failed event, if this engine event represents a resource
+     * operation that failed.
+     */
     resOpFailedEvent?: ResOpFailedEvent;
+
+    /**
+     * A policy event, if this engine event represents a policy violation.
+     */
     policyEvent?: PolicyEvent;
 }

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -31,34 +31,44 @@ import { Deployment, PluginInfo, PulumiFn, StackSummary, WhoAmIResult, Workspace
 const SKIP_VERSION_CHECK_VAR = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK";
 
 /**
- * LocalWorkspace is a default implementation of the Workspace interface.
- * A Workspace is the execution context containing a single Pulumi project, a program,
- * and multiple stacks. Workspaces are used to manage the execution environment,
- * providing various utilities such as plugin installation, environment configuration
- * ($PULUMI_HOME), and creation, deletion, and listing of Stacks.
- * LocalWorkspace relies on Pulumi.yaml and Pulumi.<stack>.yaml as the intermediate format
- * for Project and Stack settings. Modifying ProjectSettings will
- * alter the Workspace Pulumi.yaml file, and setting config on a Stack will modify the Pulumi.<stack>.yaml file.
- * This is identical to the behavior of Pulumi CLI driven workspaces.
+ * {@link LocalWorkspace} is a default implementation of the {@link Workspace} interface.
+ *
+ * A {@link Workspace} is the execution context containing a single Pulumi
+ * project, a program, and multiple stacks. Workspaces are used to manage the
+ * execution environment, providing various utilities such as plugin
+ * installation, environment configuration (`$PULUMI_HOME`), and creation,
+ * deletion, and listing of Stacks.
+ *
+ * {@link LocalWorkspace} relies on `Pulumi.yaml` and `Pulumi.<stack>.yaml` as
+ * the intermediate format for Project and Stack settings. Modifying the
+ * workspace's {@link ProjectSettings} will alter the workspace's `Pulumi.yaml`
+ * file, and setting config on a Stack will modify the relevant
+ * `Pulumi.<stack>.yaml` file. This is identical to the behavior of Pulumi CLI
+ * driven workspaces.
  *
  * @alpha
  */
 export class LocalWorkspace implements Workspace {
     /**
-     * The working directory to run Pulumi CLI commands
+     * The working directory to run Pulumi CLI commands in.
      */
     readonly workDir: string;
+
     /**
-     * The directory override for CLI metadata if set.
-     * This customizes the location of $PULUMI_HOME where metadata is stored and plugins are installed.
+     * The directory override for CLI metadata if set. This customizes the
+     * location of `$PULUMI_HOME` where metadata is stored and plugins are
+     * installed.
      */
     readonly pulumiHome?: string;
+
     /**
      * The secrets provider to use for encryption and decryption of stack secrets.
      * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     readonly secretsProvider?: string;
+
     private _pulumiCommand?: PulumiCommand;
+
     /**
      * The underlying Pulumi CLI.
      */
@@ -68,18 +78,23 @@ export class LocalWorkspace implements Workspace {
         }
         return this._pulumiCommand;
     }
+
     /**
-     *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
-     *  If none is specified, the stack will refer to ProjectSettings for this information.
+     * The inline program {@link PulumiFn} to be used for preview/update
+     * operations if any. If none is specified, the stack will refer to
+     * {@link ProjectSettings} for this information.
      */
     program?: PulumiFn;
+
     /**
      * Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
      */
     envVars: { [key: string]: string };
+
     private _pulumiVersion?: semver.SemVer;
+
     /**
-     * The version of the underlying Pulumi CLI/Engine.
+     * The version of the underlying Pulumi CLI/engine.
      *
      * @returns A string representation of the version, if available. `null` otherwise.
      */
@@ -89,10 +104,11 @@ export class LocalWorkspace implements Workspace {
         }
         return this._pulumiVersion.toString();
     }
+
     private ready: Promise<any[]>;
 
     /**
-     * Whether the workspace is a remote workspace.
+     * True if the workspace is a remote workspace.
      */
     private remote?: boolean;
 
@@ -132,23 +148,36 @@ export class LocalWorkspace implements Workspace {
         await ws.ready;
         return ws;
     }
+
     /**
-     * Creates a Stack with a LocalWorkspace utilizing the local Pulumi CLI program from the specified workDir.
-     * This is a way to create drivers on top of pre-existing Pulumi programs. This Workspace will pick up
-     * any available Settings files (Pulumi.yaml, Pulumi.<stack>.yaml).
+     * Creates a {@link Stack} with a {@link LocalWorkspace} utilizing the local
+     * Pulumi CLI program from the specified working directory. This is a way to
+     * create drivers on top of pre-existing Pulumi programs. This workspace
+     * will pick up any available settings files (`Pulumi.yaml`,
+     * `Pulumi.<stack>.yaml`).
      *
-     * @param args A set of arguments to initialize a Stack with a pre-configured Pulumi CLI program that already exists on disk.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a stack with a pre-configured Pulumi
+     *  CLI program that already exists on disk.
+     *
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createStack(args: LocalProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
+
     /**
-     * Creates a Stack with a LocalWorkspace utilizing the specified inline (in process) Pulumi program.
-     * This program is fully debuggable and runs in process. If no Project option is specified, default project settings
-     * will be created on behalf of the user. Similarly, unless a `workDir` option is specified, the working directory
+     * Creates a {@link Stack} with a {@link LocalWorkspace} utilizing the
+     * specified inline (in process) Pulumi program. This program is fully
+     * debuggable and runs in process. If no Project option is specified,
+     * default project settings will be created on behalf of the user.
+     * Similarly, unless a `workDir` option is specified, the working directory
      * will default to a new temporary directory provided by the OS.
      *
-     * @param args A set of arguments to initialize a Stack with and inline `PulumiFn` program that runs in process.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a stack with and an inline
+     *  {@link PulumiFn} program that runs in process.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createStack(args: InlineProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
     static async createStack(args: InlineProgramArgs | LocalProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack> {
@@ -159,23 +188,35 @@ export class LocalWorkspace implements Workspace {
         }
         throw new Error(`unexpected args: ${args}`);
     }
+
     /**
-     * Selects a Stack with a LocalWorkspace utilizing the local Pulumi CLI program from the specified workDir.
-     * This is a way to create drivers on top of pre-existing Pulumi programs. This Workspace will pick up
-     * any available Settings files (Pulumi.yaml, Pulumi.<stack>.yaml).
+     * Selects a {@link Stack} with a {@link LocalWorkspace} utilizing the local
+     * Pulumi CLI program from the specified working directory. This is a way to
+     * create drivers on top of pre-existing Pulumi programs. This Workspace
+     * will pick up any available Settings files (`Pulumi.yaml`,
+     * `Pulumi.<stack>.yaml`).
      *
-     * @param args A set of arguments to initialize a Stack with a pre-configured Pulumi CLI program that already exists on disk.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a stack with a pre-configured Pulumi
+     *  CLI program that already exists on disk.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async selectStack(args: LocalProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
+
     /**
-     * Selects an existing Stack with a LocalWorkspace utilizing the specified inline (in process) Pulumi program.
-     * This program is fully debuggable and runs in process. If no Project option is specified, default project settings
-     * will be created on behalf of the user. Similarly, unless a `workDir` option is specified, the working directory
+     * Selects an existing {@link Stack} with a {@link LocalWorkspace} utilizing
+     * the specified inline (in process) Pulumi program. This program is fully
+     * debuggable and runs in process. If no Project option is specified,
+     * default project settings will be created on behalf of the user.
+     * Similarly, unless a `workDir` option is specified, the working directory
      * will default to a new temporary directory provided by the OS.
      *
-     * @param args A set of arguments to initialize a Stack with and inline `PulumiFn` program that runs in process.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a Stack with and inline `PulumiFn`
+     *  program that runs in process.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async selectStack(args: InlineProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
     static async selectStack(args: InlineProgramArgs | LocalProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack> {
@@ -186,24 +227,36 @@ export class LocalWorkspace implements Workspace {
         }
         throw new Error(`unexpected args: ${args}`);
     }
+
     /**
-     * Creates or selects an existing Stack with a LocalWorkspace utilizing the specified inline (in process) Pulumi CLI program.
-     * This program is fully debuggable and runs in process. If no Project option is specified, default project settings
-     * will be created on behalf of the user. Similarly, unless a `workDir` option is specified, the working directory
-     * will default to a new temporary directory provided by the OS.
+     * Creates or selects an existing {@link Stack} with a {@link LocalWorkspace}
+     * utilizing the specified inline (in process) Pulumi CLI program. This
+     * program is fully debuggable and runs in process. If no project is
+     * specified, default project settings will be created on behalf of the
+     * user. Similarly, unless a `workDir` option is specified, the working
+     * directory will default to a new temporary directory provided by the OS.
      *
-     * @param args A set of arguments to initialize a Stack with a pre-configured Pulumi CLI program that already exists on disk.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a Stack with a pre-configured Pulumi
+     *  CLI program that already exists on disk.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createOrSelectStack(args: LocalProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
+
     /**
-     * Creates or selects an existing Stack with a LocalWorkspace utilizing the specified inline Pulumi CLI program.
-     * This program is fully debuggable and runs in process. If no Project option is specified, default project settings will be created
-     * on behalf of the user. Similarly, unless a `workDir` option is specified, the working directory will default
-     * to a new temporary directory provided by the OS.
+     * Creates or selects an existing {@link Stack} with a {@link
+     * LocalWorkspace} utilizing the specified inline Pulumi CLI program. This
+     * program is fully debuggable and runs in process. If no Project option is
+     * specified, default project settings will be created on behalf of the
+     * user. Similarly, unless a `workDir` option is specified, the working
+     * directory will default to a new temporary directory provided by the OS.
      *
-     * @param args A set of arguments to initialize a Stack with and inline `PulumiFn` program that runs in process.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a Stack with and inline `PulumiFn`
+     *  program that runs in process.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createOrSelectStack(args: InlineProgramArgs, opts?: LocalWorkspaceOptions): Promise<Stack>;
     static async createOrSelectStack(
@@ -217,6 +270,7 @@ export class LocalWorkspace implements Workspace {
         }
         throw new Error(`unexpected args: ${args}`);
     }
+
     private static async localSourceStackHelper(
         args: LocalProgramArgs,
         initFn: StackInitializer,
@@ -232,6 +286,7 @@ export class LocalWorkspace implements Workspace {
 
         return await initFn(args.stackName, ws);
     }
+
     private static async inlineSourceStackHelper(
         args: InlineProgramArgs,
         initFn: StackInitializer,
@@ -265,6 +320,10 @@ export class LocalWorkspace implements Workspace {
 
         return await initFn(args.stackName, ws);
     }
+
+    /**
+     * Constructs a new {@link LocalWorkspace}.
+     */
     private constructor(opts?: LocalWorkspaceOptions) {
         let dir = "";
         let envs = {};
@@ -334,20 +393,25 @@ export class LocalWorkspace implements Workspace {
 
         this.ready = Promise.all(readinessPromises);
     }
+
     /**
      * Returns the settings object for the current project if any
-     * LocalWorkspace reads settings from the Pulumi.yaml in the workspace.
-     * A workspace can contain only a single project at a time.
+     * {@link LocalWorkspace} reads settings from the `Pulumi.yaml`
+     * in the workspace. A workspace can contain only a single project at a
+     * time.
      */
     async projectSettings(): Promise<ProjectSettings> {
         return loadProjectSettings(this.workDir);
     }
+
     /**
-     * Overwrites the settings object in the current project.
-     * There can only be a single project per workspace. Fails if new project name does not match old.
-     * LocalWorkspace writes this value to a Pulumi.yaml file in Workspace.WorkDir().
+     * Overwrites the settings object in the current project. There can only be
+     * a single project per workspace. Fails if new project name does not match
+     * old. {@link LocalWorkspace} writes this value to a `Pulumi.yaml` file in
+     * `Workspace.WorkDir()`.
      *
-     * @param settings The settings object to save to the Workspace.
+     * @param settings
+     *  The settings object to save to the Workspace.
      */
     async saveProjectSettings(settings: ProjectSettings): Promise<void> {
         let foundExt = ".yaml";
@@ -367,11 +431,14 @@ export class LocalWorkspace implements Workspace {
         }
         return fs.writeFileSync(path, contents);
     }
+
     /**
-     * Returns the settings object for the stack matching the specified stack name if any.
-     * LocalWorkspace reads this from a Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * Returns the settings object for the stack matching the specified stack
+     * name if any. {@link LocalWorkspace} reads this from a
+     * `Pulumi.<stack>.yaml` file in `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to retrieve settings from.
+     * @param stackName
+     *  The stack to retrieve settings from.
      */
     async stackSettings(stackName: string): Promise<StackSettings> {
         const stackSettingsName = getStackSettingsName(stackName);
@@ -399,12 +466,16 @@ export class LocalWorkspace implements Workspace {
         }
         throw new Error(`failed to find stack settings file in workdir: ${this.workDir}`);
     }
+
     /**
-     * Overwrites the settings object for the stack matching the specified stack name.
-     * LocalWorkspace writes this value to a Pulumi.<stack>.yaml file in Workspace.WorkDir()
+     * Overwrites the settings object for the stack matching the specified stack
+     * name. {@link LocalWorkspace} writes this value to a `Pulumi.<stack>.yaml`
+     * file in `Workspace.WorkDir()`
      *
-     * @param stackName The stack to operate on.
-     * @param settings The settings object to save.
+     * @param stackName
+     *  The stack to operate on.
+     * @param settings
+     *  The settings object to save.
      */
     async saveStackSettings(stackName: string, settings: StackSettings): Promise<void> {
         const stackSettingsName = getStackSettingsName(stackName);
@@ -435,8 +506,10 @@ export class LocalWorkspace implements Workspace {
         }
         return fs.writeFileSync(path, contents);
     }
+
     /**
-     * Creates and sets a new stack with the stack name, failing if one already exists.
+     * Creates and sets a new stack with the stack name, failing if one already
+     * exists.
      *
      * @param stackName The stack to create.
      */
@@ -450,8 +523,10 @@ export class LocalWorkspace implements Workspace {
         }
         await this.runPulumiCmd(args);
     }
+
     /**
-     * Selects and sets an existing stack matching the stack name, failing if none exists.
+     * Selects and sets an existing stack matching the stack name, failing if
+     * none exists.
      *
      * @param stackName The stack to select.
      */
@@ -466,6 +541,7 @@ export class LocalWorkspace implements Workspace {
 
         await this.runPulumiCmd(args);
     }
+
     /**
      * Deletes the stack and all associated configuration and history.
      *
@@ -486,13 +562,17 @@ export class LocalWorkspace implements Workspace {
 
         await this.runPulumiCmd(args);
     }
+
     /**
-     * Adds environments to the end of a stack's import list. Imported environments are merged in order
-     * per the ESC merge rules. The list of environments behaves as if it were the import list in an anonymous
+     * Adds environments to the end of a stack's import list. Imported
+     * environments are merged in order per the ESC merge rules. The list of
+     * environments behaves as if it were the import list in an anonymous
      * environment.
      *
-     * @param stackName The stack to operate on
-     * @param environments The names of the environments to add to the stack's configuration
+     * @param stackName
+     *  The stack to operate on
+     * @param environments
+     *  The names of the environments to add to the stack's configuration
      */
     async addEnvironments(stackName: string, ...environments: string[]): Promise<void> {
         let ver = this._pulumiVersion;
@@ -508,6 +588,7 @@ export class LocalWorkspace implements Workspace {
 
         await this.runPulumiCmd(["config", "env", "add", ...environments, "--stack", stackName, "--yes"]);
     }
+
     /**
      * Returns the list of environments associated with the specified stack name.
      *
@@ -528,11 +609,14 @@ export class LocalWorkspace implements Workspace {
         const result = await this.runPulumiCmd(["config", "env", "ls", "--stack", stackName, "--json"]);
         return JSON.parse(result.stdout);
     }
+
     /**
      * Removes an environment from a stack's import list.
      *
-     * @param stackName The stack to operate on
-     * @param environment The name of the environment to remove from the stack's configuration
+     * @param stackName
+     *  The stack to operate on
+     * @param environment
+     *  The name of the environment to remove from the stack's configuration
      */
     async removeEnvironment(stackName: string, environment: string): Promise<void> {
         let ver = this._pulumiVersion;
@@ -548,13 +632,18 @@ export class LocalWorkspace implements Workspace {
 
         await this.runPulumiCmd(["config", "env", "rm", environment, "--stack", stackName, "--yes"]);
     }
+
     /**
      * Returns the value associated with the specified stack name and key,
-     * scoped to the current workspace. LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
+     * scoped to the current workspace. {@link LocalWorkspace} reads this config
+     * from the matching `Pulumi.stack.yaml` file.
      *
-     * @param stackName The stack to read config from
-     * @param key The key to use for the config lookup
-     * @param path The key contains a path to a property in a map or list to get
+     * @param stackName
+     *  The stack to read config from
+     * @param key
+     *  The key to use for the config lookup
+     * @param path
+     *  The key contains a path to a property in a map or list to get
      */
     async getConfig(stackName: string, key: string, path?: boolean): Promise<ConfigValue> {
         const args = ["config", "get"];
@@ -565,24 +654,33 @@ export class LocalWorkspace implements Workspace {
         const result = await this.runPulumiCmd(args);
         return JSON.parse(result.stdout);
     }
+
     /**
-     * Returns the config map for the specified stack name, scoped to the current workspace.
-     * LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
+     * Returns the config map for the specified stack name, scoped to the
+     * current workspace. {@link LocalWorkspace} reads this config from the
+     * matching `Pulumi.stack.yaml` file.
      *
-     * @param stackName The stack to read config from
+     * @param stackName
+     *  The stack to read config from
      */
     async getAllConfig(stackName: string): Promise<ConfigMap> {
         const result = await this.runPulumiCmd(["config", "--show-secrets", "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
+
     /**
-     * Sets the specified key-value pair on the provided stack name.
-     * LocalWorkspace writes this value to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * Sets the specified key-value pair on the provided stack name. {@link
+     * LocalWorkspace} writes this value to the matching `Pulumi.<stack>.yaml`
+     * file in `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to operate on
-     * @param key The config key to set
-     * @param value The value to set
-     * @param path The key contains a path to a property in a map or list to set
+     * @param stackName
+     *  The stack to operate on
+     * @param key
+     *  The config key to set
+     * @param value
+     *  The value to set
+     * @param path
+     *  The key contains a path to a property in a map or list to set
      */
     async setConfig(stackName: string, key: string, value: ConfigValue, path?: boolean): Promise<void> {
         const args = ["config", "set"];
@@ -593,13 +691,18 @@ export class LocalWorkspace implements Workspace {
         args.push(key, "--stack", stackName, secretArg, "--non-interactive", "--", value.value);
         await this.runPulumiCmd(args);
     }
+
     /**
      * Sets all values in the provided config map for the specified stack name.
-     * LocalWorkspace writes the config to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * {@link LocalWorkspace} writes the config to the matching
+     * `Pulumi.<stack>.yaml` file in `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to operate on
-     * @param config The `ConfigMap` to upsert against the existing config
-     * @param path The keys contain a path to a property in a map or list to set
+     * @param stackName
+     *  The stack to operate on
+     * @param config
+     *  The {@link ConfigMap} to upsert against the existing config
+     * @param path
+     *  The keys contain a path to a property in a map or list to set
      */
     async setAllConfig(stackName: string, config: ConfigMap, path?: boolean): Promise<void> {
         const args = ["config", "set-all", "--stack", stackName];
@@ -613,13 +716,18 @@ export class LocalWorkspace implements Workspace {
 
         await this.runPulumiCmd(args);
     }
+
     /**
-     * Removes the specified key-value pair on the provided stack name.
-     * It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * Removes the specified key-value pair on the provided stack name. Will
+     * remove any matching values in the `Pulumi.<stack>.yaml` file in
+     * `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to operate on
-     * @param key The config key to remove
-     * @param path The key contains a path to a property in a map or list to remove
+     * @param stackName
+     *  The stack to operate on
+     * @param key
+     *  The config key to remove
+     * @param path
+     *  The key contains a path to a property in a map or list to remove
      */
     async removeConfig(stackName: string, key: string, path?: boolean): Promise<void> {
         const args = ["config", "rm", key, "--stack", stackName];
@@ -628,14 +736,18 @@ export class LocalWorkspace implements Workspace {
         }
         await this.runPulumiCmd(args);
     }
+
     /**
-     *
      * Removes all values in the provided key list for the specified stack name
-     * It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * Will remove any matching values in the `Pulumi.<stack>.yaml` file in
+     * `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to operate on
-     * @param keys The list of keys to remove from the underlying config
-     * @param path The keys contain a path to a property in a map or list to remove
+     * @param stackName
+     *  The stack to operate on
+     * @param keys
+     *  The list of keys to remove from the underlying config
+     * @param path
+     *  The keys contain a path to a property in a map or list to remove
      */
     async removeAllConfig(stackName: string, keys: string[], path?: boolean): Promise<void> {
         const args = ["config", "rm-all", "--stack", stackName];
@@ -645,57 +757,74 @@ export class LocalWorkspace implements Workspace {
         args.push(...keys);
         await this.runPulumiCmd(args);
     }
+
     /**
-     * Gets and sets the config map used with the last update for Stack matching stack name.
-     * It will overwrite all configuration in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
+     * Gets and sets the config map used with the last update for the stack
+     * matching the given name. This will overwrite all configuration in the
+     * `Pulumi.<stack>.yaml` file in `Workspace.WorkDir()`.
      *
-     * @param stackName The stack to refresh
+     * @param stackName
+     *  The stack to refresh
      */
     async refreshConfig(stackName: string): Promise<ConfigMap> {
         await this.runPulumiCmd(["config", "refresh", "--force", "--stack", stackName]);
         return this.getAllConfig(stackName);
     }
+
     /**
      * Returns the value associated with the specified stack name and key,
-     * scoped to the LocalWorkspace.
+     * scoped to the {@link LocalWorkspace.}
      *
-     * @param stackName The stack to read tag metadata from.
-     * @param key The key to use for the tag lookup.
+     * @param stackName
+     *  The stack to read tag metadata from.
+     * @param key
+     *  The key to use for the tag lookup.
      */
     async getTag(stackName: string, key: string): Promise<string> {
         const result = await this.runPulumiCmd(["stack", "tag", "get", key, "--stack", stackName]);
         return result.stdout.trim();
     }
+
     /**
-     * Sets the specified key-value pair on the provided stack name.
+     * Sets the specified key-value pair on the stack with the given name.
      *
-     * @param stackName The stack to operate on.
-     * @param key The tag key to set.
-     * @param value The tag value to set.
+     * @param stackName
+     *  The stack to operate on.
+     * @param key
+     *  The tag key to set.
+     * @param value
+     *  The tag value to set.
      */
     async setTag(stackName: string, key: string, value: string): Promise<void> {
         await this.runPulumiCmd(["stack", "tag", "set", key, value, "--stack", stackName]);
     }
+
     /**
-     * Removes the specified key-value pair on the provided stack name.
+     * Removes the specified key-value pair on the stack with the given name.
      *
-     * @param stackName The stack to operate on.
-     * @param key The tag key to remove.
+     * @param stackName
+     *  The stack to operate on.
+     * @param key
+     *  The tag key to remove.
      */
     async removeTag(stackName: string, key: string): Promise<void> {
         await this.runPulumiCmd(["stack", "tag", "rm", key, "--stack", stackName]);
     }
+
     /**
-     * Returns the tag map for the specified tag name, scoped to the current LocalWorkspace.
+     * Returns the tag map for the specified stack, scoped to the current
+     * {@link LocalWorkspace.}
      *
-     * @param stackName The stack to read tag metadata from.
+     * @param stackName
+     *  The stack to read tag metadata from.
      */
     async listTags(stackName: string): Promise<TagMap> {
         const result = await this.runPulumiCmd(["stack", "tag", "ls", "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
+
     /**
-     * Returns the currently authenticated user.
+     * Returns information about the currently authenticated user.
      */
     async whoAmI(): Promise<WhoAmIResult> {
         let ver = this._pulumiVersion;
@@ -713,6 +842,7 @@ export class LocalWorkspace implements Workspace {
             return { user: result.stdout.trim() };
         }
     }
+
     /**
      * Returns a summary of the currently selected stack, if any.
      */
@@ -725,11 +855,14 @@ export class LocalWorkspace implements Workspace {
         }
         return undefined;
     }
+
     /**
-     * Returns all Stacks from the underlying backend based on the provided options.
-     * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     * Returns all stacks from the underlying backend based on the provided
+     * options. This queries the underlying backend and may return stacks not
+     * present in the workspace as `Pulumi.<stack>.yaml` files.
      *
-     * @param opts Options to customize the behavior of the list.
+     * @param opts
+     *  Options to customize the behavior of the list.
      */
     async listStacks(opts?: ListOptions): Promise<StackSummary[]> {
         const args = ["stack", "ls", "--json"];
@@ -741,33 +874,46 @@ export class LocalWorkspace implements Workspace {
         const result = await this.runPulumiCmd(args);
         return JSON.parse(result.stdout);
     }
+
     /**
-     * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
+     * Installs a plugin in the workspace, for example to use cloud providers
+     * like AWS or GCP.
      *
-     * @param name the name of the plugin.
-     * @param version the version of the plugin e.g. "v1.0.0".
-     * @param kind the kind of plugin, defaults to "resource"
+     * @param name
+     *  The name of the plugin.
+     * @param version
+     *  The version of the plugin e.g. "v1.0.0".
+     * @param kind
+     *  The kind of plugin, defaults to "resource"
      */
     async installPlugin(name: string, version: string, kind = "resource"): Promise<void> {
         await this.runPulumiCmd(["plugin", "install", kind, name, version]);
     }
+
     /**
-     * Installs a plugin in the Workspace, from a third party server.
+     * Installs a plugin in the workspace from a third party server.
      *
-     * @param name the name of the plugin.
-     * @param version the version of the plugin e.g. "v1.0.0".
-     * @param server the server to install the plugin from
+     * @param name
+     *  The name of the plugin.
+     * @param version
+     *  The version of the plugin e.g. "v1.0.0".
+     * @param server
+     *  The server to install the plugin from
      */
     async installPluginFromServer(name: string, version: string, server: string): Promise<void> {
         await this.runPulumiCmd(["plugin", "install", "resource", name, version, "--server", server]);
     }
+
     /**
-     * Removes a plugin from the Workspace matching the specified name and version.
+     * Removes a plugin from the workspace matching the specified name and version.
      *
-     * @param name the optional name of the plugin.
-     * @param versionRange optional semver range to check when removing plugins matching the given name
-     *  e.g. "1.0.0", ">1.0.0".
-     * @param kind he kind of plugin, defaults to "resource".
+     * @param name
+     *  The optional name of the plugin.
+     * @param versionRange
+     *  An optional semver range to check when removing plugins matching the
+     *  given name e.g. "1.0.0", ">1.0.0".
+     * @param kind
+     *  The kind of plugin, defaults to "resource".
      */
     async removePlugin(name?: string, versionRange?: string, kind = "resource"): Promise<void> {
         const args = ["plugin", "rm", kind];
@@ -780,8 +926,9 @@ export class LocalWorkspace implements Workspace {
         args.push("--yes");
         await this.runPulumiCmd(args);
     }
+
     /**
-     * Returns a list of all plugins installed in the Workspace.
+     * Returns a list of all plugins installed in the workspace.
      */
     async listPlugins(): Promise<PluginInfo[]> {
         const result = await this.runPulumiCmd(["plugin", "ls", "--json"]);
@@ -792,22 +939,29 @@ export class LocalWorkspace implements Workspace {
             return value;
         });
     }
+
     /**
-     * exportStack exports the deployment state of the stack.
-     * This can be combined with Workspace.importStack to edit a stack's state (such as recovery from failed deployments).
+     * Exports the deployment state of the stack. This can be combined with
+     * {@link importStack} to edit a stack's state (such as recovery from failed
+     * deployments).
      *
-     * @param stackName the name of the stack.
+     * @param stackName
+     *  The name of the stack.
      */
     async exportStack(stackName: string): Promise<Deployment> {
         const result = await this.runPulumiCmd(["stack", "export", "--show-secrets", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
+
     /**
-     * importStack imports the specified deployment state into a pre-existing stack.
-     * This can be combined with Workspace.exportStack to edit a stack's state (such as recovery from failed deployments).
+     * Imports the given deployment state into a pre-existing stack. This can be
+     * combined with {@link exportStack} to edit a stack's state (such as
+     * recovery from failed deployments).
      *
-     * @param stackName the name of the stack.
-     * @param state the stack state to import.
+     * @param stackName
+     *  The name of the stack.
+     * @param state
+     *  The stack state to import.
      */
     async importStack(stackName: string, state: Deployment): Promise<void> {
         const randomSuffix = Math.floor(100000 + Math.random() * 900000);
@@ -817,9 +971,11 @@ export class LocalWorkspace implements Workspace {
         await this.runPulumiCmd(["stack", "import", "--file", filepath, "--stack", stackName]);
         fs.unlinkSync(filepath);
     }
+
     /**
-     * Gets the current set of Stack outputs from the last Stack.up().
-     * @param stackName the name of the stack.
+     * Gets the current set of Stack outputs from the last {@link Stack.up}.
+     *
+     * @param stackName The name of the stack.
      */
     async stackOutputs(stackName: string): Promise<OutputMap> {
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
@@ -845,24 +1001,26 @@ export class LocalWorkspace implements Workspace {
     }
 
     /**
-     * serializeArgsForOp is hook to provide additional args to every CLI commands before they are executed.
-     * Provided with stack name,
-     * returns a list of args to append to an invoked command ["--config=...", ]
-     * LocalWorkspace does not utilize this extensibility point.
+     * A hook to provide additional args to every CLI commands before they are
+     * executed. Provided with stack name, this function returns a list of
+     * arguments to append to an invoked command (e.g. `["--config=...", ...]`)
+     * Presently, {@link LocalWorkspace} does not utilize this extensibility
+     * point.
      */
     async serializeArgsForOp(_: string): Promise<string[]> {
-        // LocalWorkspace does not utilize this extensibility point.
         return [];
     }
+
     /**
-     * postCommandCallback is a hook executed after every command. Called with the stack name.
-     * An extensibility point to perform workspace cleanup (CLI operations may create/modify a Pulumi.stack.yaml)
-     * LocalWorkspace does not utilize this extensibility point.
+     * A hook executed after every command. Called with the stack name. An
+     * extensibility point to perform workspace cleanup (CLI operations may
+     * create/modify a `Pulumi.stack.yaml`) {@link LocalWorkspace} does not
+     * utilize this extensibility point.
      */
     async postCommandCallback(_: string): Promise<void> {
-        // LocalWorkspace does not utilize this extensibility point.
         return;
     }
+
     private async checkRemoteSupport() {
         const optOut = !!this.envVars[SKIP_VERSION_CHECK_VAR] || !!process.env[SKIP_VERSION_CHECK_VAR];
         // If remote was specified, ensure the CLI supports it.
@@ -875,6 +1033,7 @@ export class LocalWorkspace implements Workspace {
             }
         }
     }
+
     private async runPulumiCmd(args: string[]): Promise<CommandResult> {
         let envs: { [key: string]: string } = {};
         if (this.pulumiHome) {
@@ -886,11 +1045,17 @@ export class LocalWorkspace implements Workspace {
         envs = { ...envs, ...this.envVars };
         return this.pulumiCommand.run(args, this.workDir, envs);
     }
-    /** @internal */
+
+    /**
+     * @internal
+     */
     get isRemote(): boolean {
         return !!this.remote;
     }
-    /** @internal */
+
+    /**
+     * @internal
+     */
     remoteArgs(): string[] {
         const args: string[] = [];
         if (!this.isRemote) {
@@ -964,15 +1129,17 @@ export class LocalWorkspace implements Workspace {
  */
 export interface InlineProgramArgs {
     /**
-     * The name of the associated Stack
+     * The associated stack name.
      */
     stackName: string;
+
     /**
-     * The name of the associated project
+     * The associated project name.
      */
     projectName: string;
+
     /**
-     * The inline (in process) Pulumi program to use with Update and Preview operations.
+     * The inline (in-process) Pulumi program to use with update and preview operations.
      */
     program: PulumiFn;
 }
@@ -981,79 +1148,101 @@ export interface InlineProgramArgs {
  * Description of a stack backed by pre-existing local Pulumi CLI program.
  */
 export interface LocalProgramArgs {
+    /**
+     * The associated stack name.
+     */
     stackName: string;
+
+    /**
+     * The working directory of the program.
+     */
     workDir: string;
 }
 
 /**
- * Extensibility options to configure a LocalWorkspace; e.g: settings to seed
- * and environment variables to pass through to every command.
+ * Extensibility options to configure a {@link LocalWorkspace;} e.g: settings to
+ * seed and environment variables to pass through to every command.
  */
 export interface LocalWorkspaceOptions {
     /**
-     * The directory to run Pulumi commands and read settings (Pulumi.yaml and Pulumi.<stack>.yaml).
+     * The directory to run Pulumi commands and read settings (`Pulumi.yaml` and
+     * `Pulumi.<stack>.yaml`).
      */
     workDir?: string;
+
     /**
      * The directory to override for CLI metadata
      */
     pulumiHome?: string;
+
     /**
      * The underlying Pulumi CLI.
      */
     pulumiCommand?: PulumiCommand;
+
     /**
-     *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
-     *  If none is specified, the stack will refer to ProjectSettings for this information.
+     * The inline program {@link PulumiFn} to be used for preview/update
+     * operations, if any. If none is specified, the stack will refer to
+     * {@link ProjectSettings} for this information.
      */
     program?: PulumiFn;
+
     /**
      * Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
      */
     envVars?: { [key: string]: string };
+
     /**
      * The secrets provider to use for encryption and decryption of stack secrets.
      * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     secretsProvider?: string;
+
     /**
      * The settings object for the current project.
      */
     projectSettings?: ProjectSettings;
+
     /**
-     * A map of Stack names and corresponding settings objects.
+     * A map of stack names and corresponding settings objects.
      */
     stackSettings?: { [key: string]: StackSettings };
+
     /**
-     * Indicates that the workspace is a remote workspace.
+     * True if workspace is a remote workspace.
      *
      * @internal
      */
     remote?: boolean;
+
     /**
      * The remote Git source info.
      *
      * @internal
      */
     remoteGitProgramArgs?: RemoteGitProgramArgs;
+
     /**
      * An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
      *
      * @internal
      */
     remotePreRunCommands?: string[];
+
     /**
      * The environment variables to pass along when running remote Pulumi operations.
      *
      * @internal
      */
     remoteEnvVars?: { [key: string]: string | { secret: string } };
+
     /**
      * Whether to skip the default dependency installation step.
      *
      * @internal
      */
     remoteSkipInstallDependencies?: boolean;
+
     /**
      * Whether to inherit deployment settings from the stack.
      *
@@ -1063,18 +1252,20 @@ export interface LocalWorkspaceOptions {
 }
 
 /**
- * Returns true if the provided `args` object satisfies the `LocalProgramArgs` interface.
+ * Returns true if the provided arguments satisfy the {@link LocalProgramArgs} interface.
  *
- * @param args The args object to evaluate
+ * @param args
+ *  The args object to evaluate
  */
 function isLocalProgramArgs(args: LocalProgramArgs | InlineProgramArgs): args is LocalProgramArgs {
     return (args as LocalProgramArgs).workDir !== undefined;
 }
 
 /**
- * Returns true if the provided `args` object satisfies the `InlineProgramArgs` interface.
+ * Returns true if the provided arguments satisfy the {@link InlineProgramArgs} interface.
  *
- * @param args The args object to evaluate
+ * @param args
+ *  The args object to evaluate
  */
 function isInlineProgramArgs(args: LocalProgramArgs | InlineProgramArgs): args is InlineProgramArgs {
     return (args as InlineProgramArgs).projectName !== undefined && (args as InlineProgramArgs).program !== undefined;

--- a/sdk/nodejs/automation/minimumVersion.ts
+++ b/sdk/nodejs/automation/minimumVersion.ts
@@ -14,5 +14,7 @@
 
 import * as semver from "semver";
 
-/** @internal */
+/**
+ * @internal
+ */
 export const minimumVersion = new semver.SemVer("v3.2.0-alpha");

--- a/sdk/nodejs/automation/projectSettings.ts
+++ b/sdk/nodejs/automation/projectSettings.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 /**
- * A Pulumi project manifest. It describes metadata applying to all sub-stacks created from the project.
+ * A Pulumi project manifest. It describes metadata applying to all sub-stacks
+ * created from the project.
  */
 export interface ProjectSettings {
     name: string;
@@ -29,7 +30,7 @@ export interface ProjectSettings {
 }
 
 /**
- * A description of the Project's program runtime and associated metadata.
+ * A description of the project's program runtime and associated metadata.
  */
 export interface ProjectRuntimeInfo {
     name: string;

--- a/sdk/nodejs/automation/remoteStack.ts
+++ b/sdk/nodejs/automation/remoteStack.ts
@@ -18,11 +18,13 @@ import { DestroyResult, OutputMap, PreviewResult, RefreshResult, Stack, UpdateSu
 import { Deployment } from "./workspace";
 
 /**
- * RemoteStack is an isolated, independencly configurable instance of a Pulumi program that is
- * operated on remotely (up/preview/refresh/destroy).
+ * {@link RemoteStack} is an isolated, independently configurable instance of a
+ * Pulumi program that is operated on remotely.
  */
 export class RemoteStack {
-    /** @internal */
+    /**
+     * @internal
+     */
     static create(stack: Stack): RemoteStack {
         return new RemoteStack(stack);
     }
@@ -42,58 +44,64 @@ export class RemoteStack {
     }
 
     /**
-     * Creates or updates the resources in a stack by executing the program in the Workspace.
-     * https://www.pulumi.com/docs/cli/commands/pulumi_up/
-     * This operation runs remotely.
+     * Creates or updates the resources in a stack by executing the program in
+     * the Workspace. This operation runs remotely.
      *
-     * @param opts Options to customize the behavior of the update.
+     * @param opts
+     *  Options to customize the behavior of the update.
+     *
+     * @see https://www.pulumi.com/docs/cli/commands/pulumi_up/
      */
     up(opts?: RemoteUpOptions): Promise<UpResult> {
         return this.stack.up(opts);
     }
 
     /**
-     * Performs a dry-run update to a stack, returning pending changes.
-     * https://www.pulumi.com/docs/cli/commands/pulumi_preview/
-     * This operation runs remotely.
+     * Performs a dry-run update to a stack, returning pending changes. This
+     * operation runs remotely.
      *
-     * @param opts Options to customize the behavior of the preview.
+     * @param opts
+     *  Options to customize the behavior of the preview.
+     *
+     * @see https://www.pulumi.com/docs/cli/commands/pulumi_preview/
      */
     preview(opts?: RemotePreviewOptions): Promise<PreviewResult> {
         return this.stack.preview(opts);
     }
 
     /**
-     * Compares the current stack’s resource state with the state known to exist in the actual
-     * cloud provider. Any such changes are adopted into the current stack.
-     * This operation runs remotely.
+     * Compares the current stack’s resource state with the state known to exist
+     * in the actual cloud provider. Any such changes are adopted into the
+     * current stack. This operation runs remotely.
      *
-     * @param opts Options to customize the behavior of the refresh.
+     * @param opts
+     *  Options to customize the behavior of the refresh.
      */
     refresh(opts?: RemoteRefreshOptions): Promise<RefreshResult> {
         return this.stack.refresh(opts);
     }
 
     /**
-     * Destroy deletes all resources in a stack, leaving all history and configuration intact.
-     * This operation runs remotely.
+     * Deletes all resources in a stack, leaving all history and configuration
+     * intact. This operation runs remotely.
      *
-     * @param opts Options to customize the behavior of the destroy.
+     * @param opts
+     *  Options to customize the behavior of the destroy.
      */
     destroy(opts?: RemoteDestroyOptions): Promise<DestroyResult> {
         return this.stack.destroy(opts);
     }
 
     /**
-     * Gets the current set of Stack outputs from the last Stack.up().
+     * Gets the current set of stack outputs from the last {@link Stack.up}.
      */
     outputs(): Promise<OutputMap> {
         return this.stack.outputs();
     }
 
     /**
-     * Returns a list summarizing all previous and current results from Stack lifecycle operations
-     * (up/preview/refresh/destroy).
+     * Returns a list summarizing all previous and current results from Stack
+     * lifecycle operations (up/preview/refresh/destroy).
      */
     history(pageSize?: number, page?: number): Promise<UpdateSummary[]> {
         // TODO: Find a way to allow showSecrets as an option that doesn't require loading the project.
@@ -101,28 +109,32 @@ export class RemoteStack {
     }
 
     /**
-     * Cancel stops a stack's currently running update. It returns an error if no update is currently running.
-     * Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
-     * if a resource operation was pending when the update was canceled.
-     * This command is not supported for diy backends.
+     * Stops a stack's currently running update. It returns an error if no
+     * update is currently running. Note that this operation is _very
+     * dangerous_, and may leave the stack in an inconsistent state if a
+     * resource operation was pending when the update was canceled. This command
+     * is not supported for DIY backends.
      */
     cancel(): Promise<void> {
         return this.stack.cancel();
     }
 
     /**
-     * exportStack exports the deployment state of the stack.
-     * This can be combined with Stack.importStack to edit a stack's state (such as recovery from failed deployments).
+     * Exports the deployment state of the stack. This can be combined with
+     * {@link Stack.importStack} to edit a stack's state (such as recovery from
+     * failed deployments).
      */
     exportStack(): Promise<Deployment> {
         return this.stack.exportStack();
     }
 
     /**
-     * importStack imports the specified deployment state into a pre-existing stack.
-     * This can be combined with Stack.exportStack to edit a stack's state (such as recovery from failed deployments).
+     * Imports the specified deployment state into a pre-existing stack. This
+     * can be combined with {@link Stack.exportStack} to edit a stack's state
+     * (such as recovery from failed deployments).
      *
-     * @param state the stack state to import.
+     * @param state
+     *  The stack state to import.
      */
     importStack(state: Deployment): Promise<void> {
         return this.stack.importStack(state);
@@ -130,7 +142,7 @@ export class RemoteStack {
 }
 
 /**
- * Options controlling the behavior of a RemoteStack.up() operation.
+ * Options controlling the behavior of a {@link RemoteStack.up} operation.
  */
 export interface RemoteUpOptions {
     onOutput?: (out: string) => void;
@@ -138,7 +150,7 @@ export interface RemoteUpOptions {
 }
 
 /**
- * Options controlling the behavior of a RemoteStack.preview() operation.
+ * Options controlling the behavior of a {@link RemoteStack.preview} operation.
  */
 export interface RemotePreviewOptions {
     onOutput?: (out: string) => void;
@@ -146,7 +158,7 @@ export interface RemotePreviewOptions {
 }
 
 /**
- * Options controlling the behavior of a RemoteStack.refresh() operation.
+ * Options controlling the behavior of a {@link RemoteStack.refresh} operation.
  */
 export interface RemoteRefreshOptions {
     onOutput?: (out: string) => void;
@@ -154,7 +166,7 @@ export interface RemoteRefreshOptions {
 }
 
 /**
- * Options controlling the behavior of a RemoteStack.destroy() operation.
+ * Options controlling the behavior of a {@link RemoteStack.destroy} operation.
  */
 export interface RemoteDestroyOptions {
     onOutput?: (out: string) => void;

--- a/sdk/nodejs/automation/remoteWorkspace.ts
+++ b/sdk/nodejs/automation/remoteWorkspace.ts
@@ -17,15 +17,20 @@ import { RemoteStack } from "./remoteStack";
 import { Stack } from "./stack";
 
 /**
- * RemoteWorkspace is the execution context containing a single remote Pulumi project.
+ * {@link RemoteWorkspace} is the execution context containing a single remote
+ * Pulumi project.
  */
 export class RemoteWorkspace {
     /**
-     * PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
-     * Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     * Creates a stack backed by a {@link RemoteWorkspace} with source code from
+     * the specified Git repository. Pulumi operations on the stack (preview,
+     * update, refresh, and destroy) are performed remotely.
      *
-     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a {@link RemoteStack} with a remote
+     *  Pulumi program from a Git repository.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
         const ws = await createLocalWorkspace(args, opts);
@@ -34,11 +39,15 @@ export class RemoteWorkspace {
     }
 
     /**
-     * PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
-     * repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     * Selects an existing stack backed by a {@link RemoteWorkspace} with source
+     * code from the specified Git repository. Pulumi operations on the stack
+     * (preview, update, refresh, and destroy) are performed remotely.
      *
-     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a {@link RemoteStack} with a remote
+     *  Pulumi program from a Git repository.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async selectStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
         const ws = await createLocalWorkspace(args, opts);
@@ -46,11 +55,14 @@ export class RemoteWorkspace {
         return RemoteStack.create(stack);
     }
     /**
-     * PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
-     * Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     * Creates or selects an existing stack backed by a {@link RemoteWorkspace}
+     * with source code from the specified Git repository. Pulumi operations on
+     * the stack (preview, update, refresh, and destroy) are performed remotely.
      *
-     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
-     * @param opts Additional customizations to be applied to the Workspace.
+     * @param args
+     *  A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+     * @param opts
+     *  Additional customizations to be applied to the Workspace.
      */
     static async createOrSelectStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
         const ws = await createLocalWorkspace(args, opts);
@@ -66,7 +78,7 @@ export class RemoteWorkspace {
  */
 export interface RemoteGitProgramArgs {
     /**
-     * The name of the associated Stack
+     * The associated stack name.
      */
     stackName: string;
 
@@ -76,12 +88,12 @@ export interface RemoteGitProgramArgs {
     url?: string;
 
     /**
-     * Optional path relative to the repo root specifying location of the Pulumi program.
+     * An optional path relative to the repo root specifying location of the Pulumi program.
      */
     projectPath?: string;
 
     /**
-     * Optional branch to checkout.
+     * An optional branch to checkout.
      */
     branch?: string;
 
@@ -97,62 +109,70 @@ export interface RemoteGitProgramArgs {
 }
 
 /**
- * Authentication options for the repository that can be specified for a private Git repo.
+ * Authentication options that can be specified for a private Git repository.
  * There are three different authentication paths:
- *  - Personal accesstoken
- *  - SSH private key (and its optional password)
- *  - Basic auth username and password
+ *
+ *  - A Personal access token
+ *  - An SSH private key (and its optional passphrase)
+ *  - Username and password (basic authentication)
  *
  * Only one authentication path is valid.
  */
 export interface RemoteGitAuthArgs {
     /**
-     * The absolute path to a private key for access to the git repo.
+     * The absolute path to a private key to be used for access to the Git repository.
      */
     sshPrivateKeyPath?: string;
 
     /**
-     * The (contents) private key for access to the git repo.
+     * A string containing the contents of a private key to be used for access
+     * to the Git repository.
      */
     sshPrivateKey?: string;
 
     /**
-     * The password that pairs with a username or as part of an SSH Private Key.
+     * The password that pairs with a username as part of basic authentication,
+     * or the passphrase to be used with an SSH private key.
      */
     password?: string;
 
     /**
-     * PersonalAccessToken is a Git personal access token in replacement of your password.
+     * A Git personal access token, to be used in replacement of a password.
      */
     personalAccessToken?: string;
 
     /**
-     * Username is the username to use when authenticating to a git repository
+     * The username to use when authenticating to a Git repository with basic
+     * authentication.
      */
     username?: string;
 }
 
 /**
- * Extensibility options to configure a RemoteWorkspace.
+ * Extensibility options to configure a {@link RemoteWorkspace.}
  */
 export interface RemoteWorkspaceOptions {
     /**
-     * Environment values scoped to the remote workspace. These will be passed to remote operations.
+     * Environment values scoped to the remote workspace. These will be passed
+     * to remote operations.
      */
     envVars?: { [key: string]: string | { secret: string } };
 
     /**
-     * An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+     * An optional list of arbitrary commands to run before a remote Pulumi
+     * operation is invoked.
      */
     preRunCommands?: string[];
 
     /**
-     * Whether to skip the default dependency installation step. Defaults to false.
+     * Whether to skip the default dependency installation step. Defaults to
+     * false.
      */
     skipInstallDependencies?: boolean;
 
     /**
-     * Whether to inherit the deployment settings set on the stack. Defaults to false.
+     * Whether to inherit the deployment settings set on the stack. Defaults to
+     * false.
      */
     inheritSettings?: boolean;
 }
@@ -191,7 +211,10 @@ async function createLocalWorkspace(
     return await LocalWorkspace.create(localOpts);
 }
 
-/** @internal exported only so it can be tested */
+/**
+ * @internal
+ *  Exported only so it can be tested.
+ */
 export function isFullyQualifiedStackName(stackName: string): boolean {
     if (!stackName) {
         return false;

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -24,11 +24,16 @@ import * as localState from "../runtime/state";
 import * as langproto from "../proto/language_pb";
 import * as plugproto from "../proto/plugin_pb";
 
-// maxRPCMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
-/** @internal */
+/**
+ * Raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb).
+ *
+ * @internal
+ */
 export const maxRPCMessageSize: number = 1024 * 1024 * 400;
 
-/** @internal */
+/**
+ * @internal
+ */
 export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
     readonly program: () => Promise<T>;
 
@@ -40,7 +45,8 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
     }
 
     onPulumiExit(hasError: boolean) {
-        // check for leaks once the CLI exits but skip if the program otherwise errored to keep error output clean
+        // Check for leaks once the CLI exits but skip if the program otherwise
+        // errored to keep error output clean
         if (!hasError) {
             const [leaks, leakMessage] = debuggable.leakedPromises();
             if (leaks.size !== 0) {

--- a/sdk/nodejs/automation/stackSettings.ts
+++ b/sdk/nodejs/automation/stackSettings.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * A description of the Stack's configuration and encryption metadata.
+ * A description of a {@link Stack}'s configuration and encryption metadata.
  */
 export interface StackSettings {
     secretsProvider?: string;
@@ -23,18 +23,20 @@ export interface StackSettings {
 }
 
 /**
- * Stack configuration entry
+ * A stack configuration entry.
  */
 export type StackSettingsConfigValue = string | StackSettingsSecureConfigValue | any;
 
 /**
- * A secret Stack config entry
+ * A secret stack configuration entry.
  */
 export interface StackSettingsSecureConfigValue {
     secure: string;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export const stackSettingsSerDeKeys = [
     ["secretsprovider", "secretsProvider"],
     ["encryptedkey", "encryptedKey"],

--- a/sdk/nodejs/automation/tag.ts
+++ b/sdk/nodejs/automation/tag.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /**
- * TagMap is a key-value map of tag metadata associated with a stack.
+ * A {@link TagMap} is a key-value map of tag metadata associated with a
+ * {@link Stack}.
  */
 export type TagMap = { [key: string]: string };

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -21,268 +21,377 @@ import { StackSettings } from "./stackSettings";
 import { TagMap } from "./tag";
 
 /**
- * Workspace is the execution context containing a single Pulumi project, a program, and multiple stacks.
- * Workspaces are used to manage the execution environment, providing various utilities such as plugin
- * installation, environment configuration ($PULUMI_HOME), and creation, deletion, and listing of Stacks.
+ * {@link Workspace} is the execution context containing a single Pulumi
+ * project, a program, and multiple {@link Stack}s. Workspaces are used to
+ * manage the execution environment, providing various utilities such as plugin
+ * installation, environment configuration (`$PULUMI_HOME`), and creation,
+ * deletion, and listing of Stacks.
  *
  * @alpha
  */
 export interface Workspace {
     /**
-     * The working directory to run Pulumi CLI commands
+     * The working directory to run Pulumi CLI commands.
      */
     readonly workDir: string;
+
     /**
-     * The directory override for CLI metadata if set.
-     * This customizes the location of $PULUMI_HOME where metadata is stored and plugins are installed.
+     * The directory override for CLI metadata if set. This customizes the
+     * location of `$PULUMI_HOME` where metadata is stored and plugins are
+     * installed.
      */
     readonly pulumiHome?: string;
+
     /**
-     * The secrets provider to use for encryption and decryption of stack secrets.
-     * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
+     * The secrets provider to use for encryption and decryption of stack
+     * secrets.
+     *
+     * @see https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     readonly secretsProvider?: string;
+
     /**
-     * The version of the underlying Pulumi CLI/Engine.
+     * The version of the underlying Pulumi CLI/engine.
      */
     readonly pulumiVersion: string;
+
     /**
      * The underlying Pulumi CLI.
      */
     readonly pulumiCommand: PulumiCommand;
+
     /**
-     *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
-     *  If none is specified, the stack will refer to ProjectSettings for this information.
+     * The inline program {@link PulumiFn} to be used for preview/update
+     * operations, if any. If none is specified, the stack will refer to {@link
+     * ProjectSettings} for this information.
      */
     program?: PulumiFn;
+
     /**
-     * Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
+     * Environment values scoped to the current workspace. These will be
+     * supplied to every Pulumi command.
      */
     envVars: { [key: string]: string };
+
     /**
-     * Returns the settings object for the current project if any.
+     * Returns the settings object for the current project, if any.
      */
     projectSettings(): Promise<ProjectSettings>;
 
     /**
-     * Overwrites the settings object in the current project.
-     * There can only be a single project per workspace. Fails is new project name does not match old.
+     * Overwrites the settings object in the current project. There can only be
+     * a single project per workspace. Fails if the new project name does not
+     * match the old one.
      *
-     * @param settings The settings object to save.
+     * @param settings
+     *  The settings object to save.
      */
     saveProjectSettings(settings: ProjectSettings): Promise<void>;
+
     /**
-     * Returns the settings object for the stack matching the specified stack name if any.
+     * Returns the settings object for the stack matching the specified stack
+     * name, if any.
      *
-     * @param stackName The name of the stack.
+     * @param stackName
+     *  The name of the stack.
      */
     stackSettings(stackName: string): Promise<StackSettings>;
+
     /**
-     * overwrites the settings object for the stack matching the specified stack name.
+     * Overwrites the settings object for the stack matching the specified stack
+     * name.
      *
-     * @param stackName The name of the stack to operate on.
-     * @param settings The settings object to save.
+     * @param stackName
+     *  The name of the stack to operate on.
+     * @param settings
+     *  The settings object to save.
      */
     saveStackSettings(stackName: string, settings: StackSettings): Promise<void>;
+
     /**
-     * serializeArgsForOp is hook to provide additional args to every CLI commands before they are executed.
-     * Provided with stack name,
-     * returns a list of args to append to an invoked command ["--config=...", ]
-     * LocalWorkspace does not utilize this extensibility point.
+     * A hook to provide additional arguments to every CLI command before they
+     * are executed. Provided with the stack name, this should return a list of
+     * arguments to append to an invoked command (e.g. `["--config=...", ...]`).
      */
     serializeArgsForOp(stackName: string): Promise<string[]>;
+
     /**
-     * postCommandCallback is a hook executed after every command. Called with the stack name.
-     * An extensibility point to perform workspace cleanup (CLI operations may create/modify a Pulumi.stack.yaml)
-     * LocalWorkspace does not utilize this extensibility point.
+     * A hook executed after every command. Called with the stack name. An
+     * extensibility point to perform workspace cleanup (CLI operations may
+     * create/modify a `Pulumi.stack.yaml`)
      */
     postCommandCallback(stackName: string): Promise<void>;
+
     /**
-     * Adds environments to the end of a stack's import list. Imported environments are merged in order
-     * per the ESC merge rules. The list of environments behaves as if it were the import list in an anonymous
+     * Adds environments to the end of a stack's import list. Imported
+     * environments are merged in order per the ESC merge rules. The list of
+     * environments behaves as if it were the import list in an anonymous
      * environment.
      *
-     * @param stackName The stack to operate on
-     * @param environments The names of the environments to add to the stack's configuration
+     * @param stackName
+     *  The stack to operate on
+     * @param environments
+     *  The names of the environments to add to the stack's configuration
      */
     addEnvironments(stackName: string, ...environments: string[]): Promise<void>;
+
     /**
-     * Returns the list of environments associated with the specified stack name.
+     * Returns the list of environments associated with the specified stack
+     * name.
      *
-     * @param stackName The stack to operate on
+     * @param stackName
+     *  The stack to operate on
      */
     listEnvironments(stackName: string): Promise<string[]>;
+
     /**
      * Removes an environment from a stack's import list.
      *
-     * @param stackName The stack to operate on
-     * @param environment The name of the environment to remove from the stack's configuration
+     * @param stackName
+     *  The stack to operate on
+     * @param environment
+     *  The name of the environment to remove from the stack's configuration
      */
     removeEnvironment(stackName: string, environment: string): Promise<void>;
+
     /**
      * Returns the value associated with the specified stack name and key,
      * scoped to the Workspace.
      *
-     * @param stackName The stack to read config from
-     * @param key The key to use for the config lookup
-     * @param path The key contains a path to a property in a map or list to get
+     * @param stackName
+     *  The stack to read config from
+     * @param key
+     *  The key to use for the config lookup
+     * @param path
+     *  The key contains a path to a property in a map or list to get
      */
     getConfig(stackName: string, key: string, path?: boolean): Promise<ConfigValue>;
+
     /**
-     * Returns the config map for the specified stack name, scoped to the current Workspace.
+     * Returns the config map for the specified stack name, scoped to the
+     * current Workspace.
      *
-     * @param stackName The stack to read config from
+     * @param stackName
+     *  The stack to read config from
      */
     getAllConfig(stackName: string): Promise<ConfigMap>;
+
     /**
      * Sets the specified key-value pair on the provided stack name.
      *
-     * @param stackName The stack to operate on
-     * @param key The config key to set
-     * @param value The value to set
-     * @param path The key contains a path to a property in a map or list to set
+     * @param stackName
+     *  The stack to operate on
+     * @param key
+     *  The config key to set
+     * @param value
+     *  The value to set
+     * @param path
+     *  The key contains a path to a property in a map or list to set
      */
     setConfig(stackName: string, key: string, value: ConfigValue, path?: boolean): Promise<void>;
+
     /**
      * Sets all values in the provided config map for the specified stack name.
      *
-     * @param stackName The stack to operate on
-     * @param config The `ConfigMap` to upsert against the existing config
-     * @param path The keys contain a path to a property in a map or list to set
+     * @param stackName
+     *  The stack to operate on
+     * @param config
+     *  The {@link ConfigMap} to upsert against the existing config
+     * @param path
+     *  The keys contain a path to a property in a map or list to set
      */
     setAllConfig(stackName: string, config: ConfigMap, path?: boolean): Promise<void>;
+
     /**
      * Removes the specified key-value pair on the provided stack name.
      *
-     * @param stackName The stack to operate on
-     * @param key The config key to remove
-     * @param path The key contains a path to a property in a map or list to remove
+     * @param stackName
+     *  The stack to operate on
+     * @param key
+     *  The config key to remove
+     * @param path
+     *  The key contains a path to a property in a map or list to remove
      */
     removeConfig(stackName: string, key: string, path?: boolean): Promise<void>;
+
     /**
-     *
      * Removes all values in the provided key list for the specified stack name.
      *
-     * @param stackName The stack to operate on
-     * @param keys The list of keys to remove from the underlying config
-     * @param path The keys contain a path to a property in a map or list to remove
+     * @param stackName
+     *  The stack to operate on
+     * @param keys
+     *  The list of keys to remove from the underlying config
+     * @param path
+     *  The keys contain a path to a property in a map or list to remove
      */
     removeAllConfig(stackName: string, keys: string[], path?: boolean): Promise<void>;
+
     /**
-     * Gets and sets the config map used with the last update for Stack matching stack name.
+     * Gets and sets the config map used with the last update for Stack matching
+     * stack name.
      *
-     * @param stackName The stack to refresh
+     * @param stackName
+     *  The stack to refresh
      */
     refreshConfig(stackName: string): Promise<ConfigMap>;
+
     /**
      * Returns the value associated with the specified stack name and key,
-     * scoped to the Workspace.
+     * scoped to the {@link Workspace}.
      *
-     * @param stackName The stack to read tag metadata from.
-     * @param key The key to use for the tag lookup.
+     * @param stackName
+     *  The stack to read tag metadata from.
+     * @param key
+     *  The key to use for the tag lookup.
      */
     getTag(stackName: string, key: string): Promise<string>;
+
     /**
      * Sets the specified key-value pair on the provided stack name.
      *
-     * @param stackName The stack to operate on.
-     * @param key The tag key to set.
-     * @param value The tag value to set.
+     * @param stackName
+     *  The stack to operate on.
+     * @param key
+     *  The tag key to set.
+     * @param value
+     *  The tag value to set.
      */
     setTag(stackName: string, key: string, value: string): Promise<void>;
+
     /**
      * Removes the specified key-value pair on the provided stack name.
      *
-     * @param stackName The stack to operate on.
-     * @param key The tag key to remove.
+     * @param stackName
+     *  The stack to operate on.
+     * @param key
+     *  The tag key to remove.
      */
     removeTag(stackName: string, key: string): Promise<void>;
+
     /**
-     * Returns the tag map for the specified tag name, scoped to the current Workspace.
+     * Returns the tag map for the specified tag name, scoped to the current
+     * {@link Workspace.}
      *
-     * @param stackName The stack to read tag metadata from.
+     * @param stackName
+     *  The stack to read tag metadata from.
      */
     listTags(stackName: string): Promise<TagMap>;
+
     /**
-     * Returns the currently authenticated user.
+     * Returns information about the currently authenticated user.
      */
     whoAmI(): Promise<WhoAmIResult>;
+
     /**
      * Returns a summary of the currently selected stack, if any.
      */
     stack(): Promise<StackSummary | undefined>;
+
     /**
-     * Creates and sets a new stack with the stack name, failing if one already exists.
+     * Creates and sets a new stack with the stack name, failing if one already
+     * exists.
      *
-     * @param stackName The stack to create.
+     * @param stackName
+     *  The stack to create.
      */
     createStack(stackName: string): Promise<void>;
+
     /**
-     * Selects and sets an existing stack matching the stack name, failing if none exists.
+     * Selects and sets an existing stack matching the stack name, failing if
+     * none exists.
      *
-     * @param stackName The stack to select.
+     * @param stackName
+     *  The stack to select.
      */
     selectStack(stackName: string): Promise<void>;
     /**
      * Deletes the stack and all associated configuration and history.
      *
-     * @param stackName The stack to remove
+     * @param stackName
+     *  The stack to remove
      */
     removeStack(stackName: string, opts?: RemoveOptions): Promise<void>;
     /**
-     * Returns all Stacks from the underlying backend based on the provided options.
-     * This queries backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
+     * Returns all stacks from the underlying backend based on the provided
+     * options. This queries backend and may return stacks not present in the
+     * {@link Workspace} as `Pulumi.<stack>.yaml` files.
      *
-     * @param opts Options to customize the behavior of the list.
+     * @param opts
+     *  Options to customize the behavior of the list.
      */
     listStacks(opts?: ListOptions): Promise<StackSummary[]>;
+
     /**
-     * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
+     * Installs a plugin in the workspace, for example to use cloud providers
+     * like AWS or GCP.
      *
-     * @param name the name of the plugin.
-     * @param version the version of the plugin e.g. "v1.0.0".
-     * @param server the server to install the plugin into
+     * @param name
+     *  The name of the plugin.
+     * @param version
+     *  The version of the plugin e.g. "v1.0.0".
+     * @param server
+     *  The server to install the plugin into
      */
     installPluginFromServer(name: string, version: string, server: string): Promise<void>;
+
     /**
-     * Installs a plugin in the Workspace from a remote server, for example a third party plugin.
+     * Installs a plugin in the workspace from a remote server, for example a
+     * third-party plugin.
      *
-     * @param name the name of the plugin.
-     * @param version the version of the plugin e.g. "v1.0.0".
-     * @param kind the kind of plugin e.g. "resource"
+     * @param name
+     *  The name of the plugin.
+     * @param version
+     *  The version of the plugin e.g. "v1.0.0".
+     * @param kind
+     *  The kind of plugin e.g. "resource"
      */
     installPlugin(name: string, version: string, kind?: string): Promise<void>;
+
     /**
-     * Removes a plugin from the Workspace matching the specified name and version.
+     * Removes a plugin from the workspace matching the specified name and
+     * version.
      *
-     * @param name the optional name of the plugin.
-     * @param versionRange optional semver range to check when removing plugins matching the given name
-     *  e.g. "1.0.0", ">1.0.0".
-     * @param kind he kind of plugin e.g. "resource"
+     * @param name
+     *  The optional name of the plugin.
+     * @param versionRange
+     *  An optional semver range to check when removing plugins matching the
+     *  given name e.g. "1.0.0", ">1.0.0".
+     * @param kind
+     *  The kind of plugin e.g. "resource"
      */
     removePlugin(name?: string, versionRange?: string, kind?: string): Promise<void>;
+
     /**
-     * Returns a list of all plugins installed in the Workspace.
+     * Returns a list of all plugins installed in the workspace.
      */
     listPlugins(): Promise<PluginInfo[]>;
+
     /**
-     * exportStack exports the deployment state of the stack.
-     * This can be combined with Workspace.importStack to edit a stack's state (such as recovery from failed deployments).
+     * Exports the deployment state of the stack. This can be combined with
+     * {@link Workspace.importStack} to edit a stack's state (such as recovery
+     * from failed deployments).
      *
      * @param stackName the name of the stack.
      */
     exportStack(stackName: string): Promise<Deployment>;
+
     /**
-     * importStack imports the specified deployment state into a pre-existing stack.
-     * This can be combined with Workspace.exportStack to edit a stack's state (such as recovery from failed deployments).
+     * Imports the specified deployment state into a pre-existing stack. This
+     * can be combined with {@link Workspace.exportStack} to edit a stack's
+     * state (such as recovery from failed deployments).
      *
-     * @param stackName the name of the stack.
-     * @param state the stack state to import.
+     * @param stackName
+     *  The name of the stack.
+     * @param state
+     *  The stack state to import.
      */
     importStack(stackName: string, state: Deployment): Promise<void>;
+
     /**
-     * Gets the current set of Stack outputs from the last Stack.up().
-     * @param stackName the name of the stack.
+     * Gets the current set of Stack outputs from the last {@link Stack.up}.
+     *
+     * @param stackName
+     *  The name of the stack.
      */
     stackOutputs(stackName: string): Promise<OutputMap>;
 }
@@ -307,6 +416,7 @@ export interface Deployment {
      * Version indicates the schema of the encoded deployment.
      */
     version: number;
+
     /**
      * The pulumi deployment.
      */


### PR DESCRIPTION
This commit improves the TypeScript TypeDocs for `automation` modules in the NodeJS SDK. Specifically:

* It adds documentation to interfaces, properties, etc. that are missing it.

* It transforms would-be TypeDoc comments erroneously written using either `/*` (a single asterisk) or `//` (a normal line comment) to actual TypeDoc comments.

* It standardises on TypeDoc's `{@link Name}` syntax for linking identifiers, as opposed to the mixture of backticks and square brackets we have today. This helps IDEs as well as (hopefully) improving any rendered documentation.

* It fixes typos and generally cleans up the formatting here and there, as well as introducing more consistency where the same concepts crop up in multiple places.

![image](https://github.com/pulumi/pulumi/assets/163793/b6ab94cf-74d7-4c6d-a2e1-df737c184794)
![image](https://github.com/pulumi/pulumi/assets/163793/783dd060-67a1-487a-a683-2c8a94ac3d86)