### PR TITLE
add Go support for invoke transforms

### DIFF
--- a/changelog/pending/20240710--sdk-go--add-support-for-invoke-transforms.yaml
+++ b/changelog/pending/20240710--sdk-go--add-support-for-invoke-transforms.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdk/go
-  description: Add support for invoke transforms
+  description: Add support for invoke stack transforms

--- a/changelog/pending/20240710--sdk-go--add-support-for-invoke-transforms.yaml
+++ b/changelog/pending/20240710--sdk-go--add-support-for-invoke-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add support for invoke transforms

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -61,15 +61,16 @@ type contextState struct {
 	callbacksLock sync.Mutex
 	callbacks     *callbackServer
 
-	keepResources       bool       // true if resources should be marshaled as strongly-typed references.
-	keepOutputValues    bool       // true if outputs should be marshaled as strongly-type output values.
-	supportsDeletedWith bool       // true if deletedWith supported by pulumi
-	supportsAliasSpecs  bool       // true if full alias specification is supported by pulumi
-	supportsTransforms  bool       // true if remote transforms are supported by pulumi
-	rpcs                int        // the number of outstanding RPC requests.
-	rpcsDone            *sync.Cond // an event signaling completion of RPCs.
-	rpcsLock            sync.Mutex // a lock protecting the RPC count and event.
-	rpcError            error      // the first error (if any) encountered during an RPC.
+	keepResources            bool       // true if resources should be marshaled as strongly-typed references.
+	keepOutputValues         bool       // true if outputs should be marshaled as strongly-type output values.
+	supportsDeletedWith      bool       // true if deletedWith supported by pulumi
+	supportsAliasSpecs       bool       // true if full alias specification is supported by pulumi
+	supportsTransforms       bool       // true if remote transforms are supported by pulumi
+	supportsInvokeTransforms bool       // true if remote invoke transforms are supported by pulumi
+	rpcs                     int        // the number of outstanding RPC requests.
+	rpcsDone                 *sync.Cond // an event signaling completion of RPCs.
+	rpcsLock                 sync.Mutex // a lock protecting the RPC count and event.
+	rpcError                 error      // the first error (if any) encountered during an RPC.
 
 	join workGroup // the waitgroup for non-RPC async work associated with this context
 }
@@ -162,18 +163,24 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 		return nil, err
 	}
 
+	supportsInvokeTransforms, err := supportsFeature("invokeTransforms")
+	if err != nil {
+		return nil, err
+	}
+
 	contextState := &contextState{
-		info:                info,
-		exports:             make(map[string]Input),
-		monitorConn:         monitorConn,
-		monitor:             monitor,
-		engineConn:          engineConn,
-		engine:              engine,
-		keepResources:       keepResources,
-		keepOutputValues:    keepOutputValues,
-		supportsDeletedWith: supportsDeletedWith,
-		supportsAliasSpecs:  supportsAliasSpecs,
-		supportsTransforms:  supportsTransforms,
+		info:                     info,
+		exports:                  make(map[string]Input),
+		monitorConn:              monitorConn,
+		monitor:                  monitor,
+		engineConn:               engineConn,
+		engine:                   engine,
+		keepResources:            keepResources,
+		keepOutputValues:         keepOutputValues,
+		supportsDeletedWith:      supportsDeletedWith,
+		supportsAliasSpecs:       supportsAliasSpecs,
+		supportsTransforms:       supportsTransforms,
+		supportsInvokeTransforms: supportsInvokeTransforms,
 	}
 	contextState.rpcsDone = sync.NewCond(&contextState.rpcsLock)
 	context := &Context{
@@ -493,6 +500,124 @@ func (ctx *Context) registerTransform(t ResourceTransform) (*pulumirpc.Callback,
 			}
 			rpcRes.Options.ReplaceOnChanges = opts.ReplaceOnChanges
 			rpcRes.Options.RetainOnDelete = opts.RetainOnDelete
+			rpcRes.Options.Version = opts.Version
+		}
+
+		return rpcRes, nil
+	}
+
+	err := func() error {
+		ctx.state.callbacksLock.Lock()
+		defer ctx.state.callbacksLock.Unlock()
+		if ctx.state.callbacks == nil {
+			c, err := newCallbackServer()
+			if err != nil {
+				return fmt.Errorf("creating callback server: %w", err)
+			}
+			ctx.state.callbacks = c
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	cb, err := ctx.state.callbacks.RegisterCallback(callback)
+	if err != nil {
+		return nil, fmt.Errorf("registering callback: %w", err)
+	}
+
+	return cb, nil
+}
+
+// registerTransform starts up a callback server if not already running and registers the given transform.
+func (ctx *Context) registerInvokeTransform(t InvokeTransform) (*pulumirpc.Callback, error) {
+	if !ctx.state.supportsInvokeTransforms {
+		return nil, errors.New("the Pulumi CLI does not support invoke transforms. Please update the Pulumi CLI")
+	}
+
+	// Wrap the transform in a callback function.
+	callback := func(innerCtx context.Context, req []byte) (proto.Message, error) {
+		var rpcReq pulumirpc.TransformInvokeRequest
+		if err := proto.Unmarshal(req, &rpcReq); err != nil {
+			return nil, fmt.Errorf("unmarshaling request: %w", err)
+		}
+
+		// Unmarshal the resource inputs.
+		args, err := plugin.UnmarshalProperties(rpcReq.Args, plugin.MarshalOptions{
+			KeepUnknowns:     true,
+			KeepSecrets:      true,
+			KeepResources:    true,
+			KeepOutputValues: true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling transform protobuf properties: %w", err)
+		}
+
+		unmarshalledArgs, err := unmarshalPropertyMap(ctx, args)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling transform properties: %w", err)
+		}
+
+		var opts InvokeOptions
+		if rpcReq.Options != nil {
+			if rpcReq.Options.Provider != "" {
+				opts.Provider = ctx.newDependencyProviderResourceFromRef(rpcReq.Options.Provider)
+			}
+			opts.Version = rpcReq.Options.Version
+			opts.PluginDownloadURL = rpcReq.Options.PluginDownloadUrl
+		}
+
+		transformArgs := &InvokeTransformArgs{
+			Token: rpcReq.Token,
+			Args:  unmarshalledArgs,
+			Opts:  opts,
+		}
+
+		res := t(innerCtx, transformArgs)
+		rpcRes := &pulumirpc.TransformInvokeResponse{
+			Args:    nil,
+			Options: nil,
+		}
+
+		if res != nil {
+			opts := res.Opts
+
+			umArgs := res.Args
+			if umArgs == nil {
+				umArgs = Map{}
+			}
+			mArgs, _, err := marshalInput(umArgs, anyType, true)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling properties: %w", err)
+			}
+
+			args = resource.PropertyMap{}
+			if mArgs.IsObject() {
+				args = mArgs.ObjectValue()
+			}
+
+			rpcRes.Args, err = plugin.MarshalProperties(
+				args,
+				plugin.MarshalOptions{
+					KeepUnknowns:  true,
+					KeepSecrets:   true,
+					KeepResources: ctx.state.keepResources,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling properties: %w", err)
+			}
+
+			rpcRes.Options = &pulumirpc.TransformInvokeOptions{}
+			rpcRes.Options.PluginDownloadUrl = opts.PluginDownloadURL
+
+			if opts.Provider != nil {
+				rpcRes.Options.Provider, err = ctx.resolveProviderReference(opts.Provider)
+				if err != nil {
+					return nil, fmt.Errorf("marshaling provider: %w", err)
+				}
+			}
 			rpcRes.Options.Version = opts.Version
 		}
 
@@ -2134,6 +2259,17 @@ func (ctx *Context) RegisterResourceTransform(t ResourceTransform) error {
 // Deprecated: Use RegisterResourceTransform instead.
 func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
 	return ctx.RegisterResourceTransform(t)
+}
+
+// RegisterStackInvokeTransform adds a transform to all future invokes in this Pulumi stack.
+func (ctx *Context) RegisterStackInvokeTransform(t InvokeTransform) error {
+	cb, err := ctx.registerInvokeTransform(t)
+	if err != nil {
+		return err
+	}
+
+	_, err = ctx.state.monitor.RegisterStackInvokeTransform(ctx.ctx, cb)
+	return err
 }
 
 func (ctx *Context) newOutputState(elementType reflect.Type, deps ...Resource) *OutputState {

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -58,7 +58,7 @@ type InvokeTransformArgs struct {
 	Opts InvokeOptions
 }
 
-// InvokeTransformResult is the result that must be returned by a invoke transform
+// InvokeTransformResult is the result that must be returned by an invoke transform
 // callback. It includes new values to use for the `args` and `opts` of the `Invoke` in place of
 // the originally provided values.
 type InvokeTransformResult struct {

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -68,7 +68,7 @@ type InvokeTransformResult struct {
 	Opts InvokeOptions
 }
 
-// ResourceTransform is the callback signature for the `transforms` resource option for invokes.  A
+// InvokeTransform is the callback signature for the `transforms` resource option for invokes.  A
 // transform is passed the same set of inputs provided to the `Invoke` constructor, and can
 // optionally return back alternate values for the `args` and/or `opts` prior to the invoke
 // actually being executed.  The effect will be as though those args and opts were passed in place

--- a/sdk/go/pulumi/transform.go
+++ b/sdk/go/pulumi/transform.go
@@ -47,3 +47,31 @@ type ResourceTransformResult struct {
 // of the original call to the `Resource` constructor.  If the transform returns nil,
 // this indicates that the resource will not be transformed.
 type ResourceTransform func(context.Context, *ResourceTransformArgs) *ResourceTransformResult
+
+// InvokeTransformArgs is the argument bag passed to a invoke transform.
+type InvokeTransformArgs struct {
+	// The token of the invoke.
+	Token string
+	// The original args passed to the resource constructor.
+	Args Map
+	// The original invoke options passed to the resource constructor.
+	Opts InvokeOptions
+}
+
+// InvokeTransformResult is the result that must be returned by a invoke transform
+// callback. It includes new values to use for the `args` and `opts` of the `Invoke` in place of
+// the originally provided values.
+type InvokeTransformResult struct {
+	// The new args to use in place of the original `args`.
+	Args Map
+	// The new invoke options to use in place of the original `opts`.
+	Opts InvokeOptions
+}
+
+// ResourceTransform is the callback signature for the `transforms` resource option for invokes.  A
+// transform is passed the same set of inputs provided to the `Invoke` constructor, and can
+// optionally return back alternate values for the `args` and/or `opts` prior to the invoke
+// actually being executed.  The effect will be as though those args and opts were passed in place
+// of the original call to the `Invoke`.  If the transform returns nil, this indicates that the Invoke
+// will not be transformed.
+type InvokeTransform func(context.Context, *InvokeTransformArgs) *InvokeTransformResult

--- a/tests/integration/transforms/go/simple/main.go
+++ b/tests/integration/transforms/go/simple/main.go
@@ -227,6 +227,38 @@ func main() {
 			return err
 		}
 
+		// Scenario #8 - run an invoke and change args
+		err = ctx.RegisterStackInvokeTransform(func(_ context.Context, ita *pulumi.InvokeTransformArgs) *pulumi.InvokeTransformResult {
+			ita.Args["length"] = pulumi.Float64(11)
+			return &pulumi.InvokeTransformResult{
+				Args: ita.Args,
+				Opts: ita.Opts,
+			}
+		})
+		if err != nil {
+			return err
+		}
+		res8, err := NewRandom(ctx, "res8", &RandomArgs{Length: pulumi.Int(10)})
+		if err != nil {
+			return err
+		}
+		args := map[string]interface{}{
+			"length": 10,
+			"prefix": "test",
+		}
+
+		result, err := res8.RandomInvoke(ctx, args)
+		if err != nil {
+			return err
+		}
+		length, _ := result["length"].(float64)
+		if length != 11 {
+			return fmt.Errorf("expected length to be 11, got %v", length)
+		}
+		if result["prefix"] != "test" {
+			return fmt.Errorf("expected prefix to be test, got %v", result["prefix"])
+		}
+
 		return nil
 	})
 }

--- a/tests/integration/transforms/go/simple/random.go
+++ b/tests/integration/transforms/go/simple/random.go
@@ -34,6 +34,15 @@ func NewRandom(ctx *pulumi.Context,
 	return &resource, nil
 }
 
+func (r *Random) RandomInvoke(ctx *pulumi.Context, args map[string]interface{}) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	err := ctx.Invoke("testprovider:index:returnArgs", args, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 type randomArgs struct {
 	Length int    `pulumi:"length"`
 	Prefix string `pulumi:"prefix"`

--- a/tests/integration/transforms/transforms_test.go
+++ b/tests/integration/transforms/transforms_test.go
@@ -27,7 +27,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes5 := false
 	foundRes6 := false
 	foundRes7 := false
-	foundRes8 := false
+	// foundRes8 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -94,9 +94,9 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			// we change the provider but because this is a remote component resource it ends up empty in state.
 			assert.Equal(t, "", res.Provider)
 		}
-		if res.URN.Name() == "res8" {
-			foundRes8 = true
-		}
+		// if res.URN.Name() == "res8" {
+		// 	foundRes8 = true
+		// }
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
@@ -105,5 +105,6 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	assert.True(t, foundRes5)
 	assert.True(t, foundRes6)
 	assert.True(t, foundRes7)
-	assert.True(t, foundRes8)
+	// TODO: uncomment this when we have support for invoke transforms in all languages
+	//	assert.True(t, foundRes8)
 }

--- a/tests/integration/transforms/transforms_test.go
+++ b/tests/integration/transforms/transforms_test.go
@@ -27,6 +27,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes5 := false
 	foundRes6 := false
 	foundRes7 := false
+	foundRes8 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -93,6 +94,9 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			// we change the provider but because this is a remote component resource it ends up empty in state.
 			assert.Equal(t, "", res.Provider)
 		}
+		if res.URN.Name() == "res8" {
+			foundRes8 = true
+		}
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
@@ -101,4 +105,5 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	assert.True(t, foundRes5)
 	assert.True(t, foundRes6)
 	assert.True(t, foundRes7)
+	assert.True(t, foundRes8)
 }

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -158,6 +158,11 @@ func (k *testproviderProvider) Parameterize(_ context.Context, req *rpc.Paramete
 // Invoke dynamically executes a built-in function in the provider.
 func (k *testproviderProvider) Invoke(_ context.Context, req *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
 	tok := req.GetTok()
+	if tok == "testprovider:index:returnArgs" {
+		return &rpc.InvokeResponse{
+			Return: req.Args,
+		}, nil
+	}
 	return nil, fmt.Errorf("Unknown Invoke token '%s'", tok)
 }
 


### PR DESCRIPTION
Add support to the Go SDK for invoke transforms.  This only adds support for setting transforms globally, not yet via a resource option, which resource transforms allow.