### PR TITLE
Improve TypeDocs for `sdk/nodejs/runtime`

### DIFF
--- a/sdk/nodejs/runtime/asyncIterableUtil.ts
+++ b/sdk/nodejs/runtime/asyncIterableUtil.ts
@@ -17,23 +17,32 @@ import { AsyncIterable } from "@pulumi/query/interfaces";
 type CloseValue = "7473659d-924c-414d-84e5-b1640b2a6296";
 const closeValue: CloseValue = "7473659d-924c-414d-84e5-b1640b2a6296";
 
-// PushableAsyncIterable is an `AsyncIterable` that data can be pushed to. It is useful for turning
-// push-based callback APIs into pull-based `AsyncIterable` APIs. For example, a user can write:
-//
-//     const queue = new PushableAsyncIterable();
-//     call.on("data", (thing: any) => queue.push(live));
-//
-// And then later consume `queue` as any other `AsyncIterable`:
-//
-//     for await (const l of list) {
-//         console.log(l.metadata.name);
-//     }
-//
-// Note that this class implements `AsyncIterable<T | undefined>`. This is for a fundamental reason:
-// the user can call `complete` at any time. `AsyncIteratable` would normally know when an element
-// is the last, but in this case it can't. Or, another way to look at it is, the last element is
-// guaranteed to be `undefined`.
-/** @internal */
+/**
+ * {@link PushableAsyncIterable} is an {@link AsyncIterable} that data can be
+ * pushed to. It is useful for turning push-based callback APIs into pull-based
+ * {@link AsyncIterable} APIs. For example, a user can write:
+ *
+ * ```typescript
+ * const queue = new PushableAsyncIterable();
+ * call.on("data", (thing: any) => queue.push(live));
+ * ```
+ *
+ * And then later consume `queue` as any other {@link AsyncIterable}:
+ *
+ * ```typescript
+ * for await (const l of list) {
+ *     console.log(l.metadata.name);
+ * }
+ * ```
+ *
+ * Note that this class implements `AsyncIterable<T | undefined>`. This is for a
+ * fundamental reason: the user can call `complete` at any time. `AsyncIterable`
+ * would normally know when an element is the last, but in this case it can't.
+ * Or, another way to look at it is, the last element is guaranteed to be
+ * `undefined`.
+ *
+ * @internal
+ */
 export class PushableAsyncIterable<T> implements AsyncIterable<T | undefined> {
     private bufferedData: T[] = [];
     private nextQueue: ((payload: T | CloseValue) => void)[] = [];

--- a/sdk/nodejs/runtime/callbacks.ts
+++ b/sdk/nodejs/runtime/callbacks.ts
@@ -40,8 +40,11 @@ import {
 import { mapAliasesForRequest } from "./resource";
 import { deserializeProperties, serializeProperties, unknownValue } from "./rpc";
 
-// maxRPCMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
-/** @internal */
+/**
+ * Raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
+ *
+ * @internal
+ */
 const maxRPCMessageSize: number = 1024 * 1024 * 400;
 
 type CallbackFunction = (args: Uint8Array) => Promise<jspb.Message>;

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -27,28 +27,28 @@ import { ResourceError } from "../../errors";
 import { Resource } from "../../resource";
 
 /**
- * Options for controlling what gets returned by [computeCodePaths].
+ * Options for controlling what gets returned by {@link computeCodePaths}.
  */
 export interface CodePathOptions {
     /**
-     * Local file/directory paths that we always want to include when producing the Assets to be
-     * included for a serialized closure.
+     * Local file/directory paths that we always want to include when producing
+     * the assets to be included for a serialized closure.
      */
     extraIncludePaths?: string[];
 
     /**
-     * Extra packages to include when producing the Assets for a serialized closure.  This can be
-     * useful if the packages are acquired in a way that the serialization code does not understand.
-     * For example, if there was some sort of module that was pulled in based off of a computed
-     * string.
+     * Extra packages to include when producing the assets for a serialized
+     * closure. This can be useful if the packages are acquired in a way that
+     * the serialization code does not understand. For example, if there was
+     * some sort of module that was pulled in based off of a computed string.
      */
     extraIncludePackages?: string[];
 
     /**
-     * Packages to explicitly exclude from the Assets for a serialized closure.  This can be used
-     * when clients want to trim down the size of a closure, and they know that some package won't
-     * ever actually be needed at runtime, but is still a dependency of some package that is being
-     * used at runtime.
+     * Packages to explicitly exclude from the assets for a serialized closure.
+     * This can be used when clients want to trim down the size of a closure,
+     * and they know that some package won't ever actually be needed at runtime,
+     * but is still a dependency of some package that is being used at runtime.
      */
     extraExcludePackages?: string[];
 
@@ -59,29 +59,34 @@ export interface CodePathOptions {
 }
 
 /**
- * computeCodePaths computes the local node_module paths to include in an uploaded cloud 'Lambda'.
- * Specifically, it will examine the package.json for the caller's code, and will transitively walk
- * it's 'dependencies' section to determine what packages should be included.
+ * Computes the local `node_module` paths to include in an uploaded cloud
+ * "lambda". Specifically, it will examine the `package.json` for the caller's
+ * code and transitively walk its `dependencies` section to determine what
+ * packages should be included.
  *
- * During this walk, if a package is encountered that contains a `"pulumi": { ... }` section then
- * the normal `"dependencies": { ... }` section of that package will not be included.  These are
- * "pulumi" packages, and those dependencies are only intended for use at deployment time. However,
- * a "pulumi" package can also specify package that should be available at cloud-runtime.  These
- * packages are found in a `"runtimeDependencies": { ... }` section in the package.json file with
- * the same format as the normal "dependencies" section.
+ * During this walk, if a package is encountered that contains a `"pulumi": {
+ * ... }` section then the normal `"dependencies": { ... }` section of that
+ * package will not be included.  These are "pulumi" packages, and those
+ * dependencies are only intended for use at deployment time. However, a
+ * "pulumi" package can also specify package that should be available at
+ * cloud-runtime.  These packages are found in a `"runtimeDependencies": { ...
+ * }` section in the `package.json` file with the same format as the normal
+ * `dependencies` section.
  *
- * See [CodePathOptions] for information on ways to control and configure the final set of paths
- * included in the resultant asset/archive map.
+ * See {@link CodePathOptions} for information on ways to control and configure
+ * the final set of paths included in the resultant asset/archive map.
  *
- * Note: this functionality is specifically intended for use by downstream library code that is
- * determining what is needed for a cloud-lambda.  i.e. the aws.serverless.Function or
- * azure.serverless.FunctionApp libraries.  In general, other clients should not need to use this
- * helper.
+ * Note: this functionality is specifically intended for use by downstream
+ * library code that is determining what is needed for a cloud-lambda.  i.e. the
+ * `aws.serverless.Function` or `azure.serverless.FunctionApp` libraries. In
+ * general, other clients should not need to use this helper.
  */
 export async function computeCodePaths(options?: CodePathOptions): Promise<Map<string, asset.Asset | asset.Archive>>;
 
 /**
- * @deprecated Use the [computeCodePaths] overload that takes a [CodePathOptions] instead.
+ * @deprecated
+ *  Use the {@link computeCodePaths} overload that takes a
+ *  {@link CodePathOptions} instead.
  */
 export async function computeCodePaths(
     extraIncludePaths?: string[],
@@ -166,10 +171,10 @@ function isSubsumedByHigherPath(normalizedPath: string, normalizedPathSet: Set<s
 }
 
 /**
- * searchUp searches for and returns the first directory path
- * starting from a given directory that contains the given file to find.
- * Recursively searches up the directory tree until it finds the file or returns null
- * when it can't find anything.
+ * Searches for and returns the first directory path starting from a given
+ * directory that contains the given file to find. Recursively searches up the
+ * directory tree until it finds the file or returns `null` when it can't find
+ * anything.
  * */
 function searchUp(currentDir: string, fileToFind: string): string | null {
     if (fs.existsSync(upath.join(currentDir, fileToFind))) {
@@ -183,10 +188,10 @@ function searchUp(currentDir: string, fileToFind: string): string | null {
 }
 
 /**
+ * Detects if we are in a Yarn/NPM workspace setup, and returns the root of the
+ * workspace. If we are not in a workspace setup, it returns `null`.
+ *
  * @internal
- * findWorkspaceRoot detects if we are in a yarn/npm workspace setup, and
- * returns the root of the workspace. If we are not in a workspace setup, it
- * returns null.
  */
 export async function findWorkspaceRoot(startingPath: string): Promise<string | null> {
     const stat = fs.statSync(startingPath);
@@ -233,8 +238,10 @@ function parseWorkspaces(packageJsonPath: string): string[] {
     return [];
 }
 
-// allFolders computes the set of package folders that are transitively required by the root
-// 'dependencies' node in the client's project.json file.
+/**
+ * Computes the set of package folders that are transitively required by the root
+ * `dependencies` node in the client's `package.json` file.
+ */
 async function allFoldersForPackages(
     includedPackages: Set<string>,
     excludedPackages: Set<string>,
@@ -335,8 +342,11 @@ function computeDependenciesDirectlyFromPackageFile(path: string, logResource: R
     }
 }
 
-// addPackageAndDependenciesToSet adds all required dependencies for the requested pkg name from the given root package
-// into the set.  It will recurse into all dependencies of the package.
+/**
+ * Adds all required dependencies for the requested package name from the given
+ * root package into the set. It will recurse into all dependencies of the
+ * package.
+ */
 function addPackageAndDependenciesToSet(
     root: arborist.Node,
     pkg: string,
@@ -399,10 +409,13 @@ function addPackageAndDependenciesToSet(
     }
 }
 
-// findDependency searches the package tree starting at a root node (possibly a child) for a match
-// for the given name. It is assumed that the tree was correctly constructed such that dependencies
-// are resolved to compatible versions in the closest available match starting at the provided root
-// and walking up to the head of the tree.
+/**
+ * Searches the package tree starting at a root node (possibly a child) for a
+ * match for the given name. It is assumed that the tree was correctly
+ * constructed such that dependencies are resolved to compatible versions in the
+ * closest available match starting at the provided root and walking up to the
+ * head of the tree.
+ */
 function findDependency(
     root: arborist.Node | undefined | null,
     name: string,

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -27,136 +27,208 @@ import { getModuleFromPath } from "./package";
 import * as utils from "./utils";
 import * as v8 from "./v8";
 
-/** @internal */
+/**
+ * @internal
+ */
 export interface ObjectInfo {
-    // information about the prototype of this object/function.  If this is an object, we only store
-    // this if the object's prototype is not Object.prototype.  If this is a function, we only store
-    // this if the function's prototype is not Function.prototype.
+    /**
+     * Information about the prototype of this object/function. If this is an
+     * object, we only store this if the object's prototype is not
+     * `Object.prototype`. If this is a function, we only store this if the
+     * function's prototype is not `Function.prototype`.
+     */
     proto?: Entry;
 
-    // information about the properties of the object.  We store all properties of the object,
-    // regardless of whether they have string or symbol names.
+    /**
+     * Information about the properties of the object. We store all properties
+     * of the object, regardless of whether they have string or symbol names.
+     */
     env: PropertyMap;
 }
 
-// Information about a javascript function.  Note that this derives from ObjectInfo as all functions
-// are objects in JS, and thus can have their own proto and properties.
-/** @internal */
+/**
+ * Information about a JavaScript function. Note that this derives from
+ * {@link ObjectInfo} as all functions are objects in JavaScript, and thus can
+ * have their own proto and properties.
+ *
+ * @internal
+ */
 export interface FunctionInfo extends ObjectInfo {
-    // a serialization of the function's source code as text.
+    /**
+     * A serialization of the function's source code as text.
+     */
     code: string;
 
-    // the captured lexical environment of names to values, if any.
+    /**
+     * The captured lexical environment of names to values, if any.
+     */
     capturedValues: PropertyMap;
 
-    // Whether or not the real 'this' (i.e. not a lexically captured this) is used in the function.
+    /**
+     * Whether or not the real `this` (i.e. not a lexically-captured `this`) is
+     * used in the function.
+     */
     usesNonLexicalThis: boolean;
 
-    // name that the function was declared with.  used only for trying to emit a better
-    // name into the serialized code for it.
+    /**
+     * The name that the function was declared with. Used only for trying to
+     * emit a better name into the serialized code for it.
+     */
     name: string | undefined;
 
-    // Number of parameters this function is declared to take.  Used to generate a serialized
-    // function with the same number of parameters.  This is valuable as some 3rd party libraries
-    // (like senchalabs: https://github.com/senchalabs/connect/blob/fa8916e6350e01262e86ccee82f490c65e04c728/index.js#L232-L241)
-    // will introspect function param count to decide what to do.
+    /**
+     * The number of parameters this function is declared to take.  Used to
+     * generate a serialized function with the same number of parameters. This
+     * is valuable as some third-party libraries (like senchalabs:
+     * https://github.com/senchalabs/connect/blob/fa8916e6350e01262e86ccee82f490c65e04c728/index.js#L232-L241)
+     * will introspect function parameter counts to decide what to do.
+     */
     paramCount: number;
 }
 
-// Similar to PropertyDescriptor.  Helps describe an Entry in the case where it is not
-// simple.
-/** @internal */
+/**
+ * Similar to {@link PropertyDescriptor}. Helps describe an Entry in the case
+ * where it is not simple.
+ *
+ * @internal
+ */
 export interface PropertyInfo {
-    // If the property has a value we should directly provide when calling .defineProperty
+    /**
+     * If the property has a value we should directly provide when calling `.defineProperty`
+     */
     hasValue: boolean;
 
-    // same as PropertyDescriptor
+    // These have the same meanings as in `PropertyDescriptor`.
+
     configurable?: boolean;
     enumerable?: boolean;
     writable?: boolean;
 
     // The entries we've made for custom getters/setters if the property is defined that
     // way.
+    //
     get?: Entry;
     set?: Entry;
 }
 
-// Information about a property.  Specifically the actual entry containing the data about it and
-// then an optional PropertyInfo in the case that this isn't just a common property.
-/** @internal */
+/**
+ * Information about a property. Specifically the actual entry containing the
+ * data about it and then an optional {@link PropertyInfo} in the case that this
+ * isn't just a common property.
+ *
+ * @internal
+ */
 export interface PropertyInfoAndValue {
     info?: PropertyInfo;
     entry: Entry;
 }
 
-// A mapping between the name of a property (symbolic or string) to information about the
-// value for that property.
-/** @internal */
+/**
+ * A mapping between the name of a property (symbolic or string) to information about the
+ * value for that property.
+ *
+ * @internal
+ */
 export type PropertyMap = Map<Entry, PropertyInfoAndValue>;
 
 /**
- * Entry is the environment slot for a named lexically captured variable.
+ * Entry is the environment slot for a named lexically-captured variable.
+ *
+ * @internal
  */
-/** @internal */
 export interface Entry {
-    // a value which can be safely json serialized.
+    /**
+     * A value which can be safely json serialized.
+     */
     json?: any;
 
-    // An RegExp. Will be serialized as 'new RegExp(re.source, re.flags)'
+    /**
+     * A RegExp, which will be serialized as `new RegExp(re.source, re.flags)`
+     */
     regexp?: { source: string; flags: string };
 
-    // a closure we are dependent on.
+    /**
+     * A closure we are dependent on.
+     */
     function?: FunctionInfo;
 
-    // An object which may contain nested closures.
-    // Can include an optional proto if the user is not using the default Object.prototype.
+    /**
+     * An object which may contain nested closures. Can include an optional
+     * proto if the user is not using the default `Object.prototype`.
+     */
     object?: ObjectInfo;
 
-    // an array which may contain nested closures.
+    /**
+     * An array which may contain nested closures.
+     */
     array?: Entry[];
 
-    // a reference to a requirable module name.
+    /**
+     * A reference to a requirable module name.
+     */
     module?: string;
 
-    // A promise value.  this will be serialized as the underlyign value the promise
-    // points to.  And deserialized as Promise.resolve(<underlying_value>)
+    /**
+     * A promise value. This will be serialized as the underlying value the promise
+     * points to, and deserialized as `Promise.resolve(<underlying_value>)`
+     */
     promise?: Entry;
 
-    // an Output<T> property.  It will be serialized over as a get() method that
-    // returns the raw underlying value.
+    /**
+     * An `Output<T>` property. This will be serialized over as a `get()` method that
+     * returns the raw underlying value.
+     */
     output?: Entry;
 
-    // a simple expression to use to represent this instance.  For example "global.Number";
+    /**
+     * A simple expression to use to represent this instance. For example "global.Number";
+     */
     expr?: string;
 }
 
 interface Context {
-    // The cache stores a map of objects to the entries we've created for them.  It's used so that
-    // we only ever create a single environemnt entry for a single object. i.e. if we hit the same
-    // object multiple times while walking the memory graph, we only emit it once.
+    /**
+     * The cache stores a map of objects to the entries we've created for them.
+     * It's used so that we only ever create a single environemnt entry for a
+     * single object. i.e. if we hit the same object multiple times while
+     * walking the memory graph, we only emit it once.
+     */
     cache: Map<Object, Entry>;
 
-    // The 'frames' we push/pop as we're walking the object graph serializing things.
-    // These frames allow us to present a useful error message to the user in the context
-    // of their code as opposed the async callstack we have while serializing.
+    /**
+     * The 'frames' we push/pop as we're walking the object graph serializing
+     * things. These frames allow us to present a useful error message to the
+     * user in the context of their code as opposed the async callstack we have
+     * while serializing.
+     */
     frames: ContextFrame[];
 
-    // A mapping from a class method/constructor to the environment entry corresponding to the
-    // __super value.  When we emit the code for any class member we will end up adding
-    //
-    //  with ( { __super: <...> })
-    //
-    // We will also rewrite usages of "super" in the methods to refer to __super.  This way we can
-    // accurately serialize out the class members, while preserving functionality.
+    /**
+     * A mapping from a class method/constructor to the environment entry corresponding to the
+     * `__super` value.  When we emit the code for any class member we will end up adding
+     *
+     * ```
+     * with ( { __super: <...> })
+     * ```
+     *
+     * We will also rewrite usages of "super" in the methods to refer to
+     * `__super`.  This way we can accurately serialize out the class members,
+     * while preserving functionality.
+     */
     classInstanceMemberToSuperEntry: Map<Function, Entry>;
+
     classStaticMemberToSuperEntry: Map<Function, Entry>;
 
-    // A list of 'simple' functions.  Simple functions do not capture anything, do not have any
-    // special properties on them, and do not have a custom prototype.  If we run into multiple
-    // functions that are simple, and share the same code, then we can just emit the function once
-    // for them.  A good example of this is the __awaiter function.  Normally, there will be one
-    // __awaiter per .js file that uses 'async/await'.  Instead of needing to generate serialized
-    // functions for each of those, we can just serialize out the function once.
+    /**
+     * A list of "simple" functions. Simple functions do not capture anything,
+     * do not have any special properties on them, and do not have a custom
+     * prototype. If we run into multiple functions that are simple, and share
+     * the same code, then we can just emit the function once for them.  A good
+     * example of this is the `__awaiter` function. Normally, there will be one
+     * `__awaiter` per `.js` file that uses `async`/`await`. Instead of needing
+     * to generate serialized functions for each of those, we can just serialize
+     * out the function once.
+     */
     simpleFunctions: FunctionInfo[];
 
     /**
@@ -187,9 +259,16 @@ interface ContextFrame {
 }
 
 interface ClosurePropertyDescriptor {
-    /** name of the property for a normal property. either 'name' or 'symbol' will be present.  but not both. */
+    /**
+     * The name of the property for a normal property. Either `name` or `symbol`
+     * will be present, but not both.
+     * */
     name?: string;
-    /** symbol-name of the property.  either 'name' or 'symbol' will be present.  but not both. */
+
+    /**
+     * The symbol name of the property. Either `name` or `symbol` will be
+     * present, but not both.
+     */
     symbol?: symbol;
 
     configurable?: boolean;
@@ -200,14 +279,16 @@ interface ClosurePropertyDescriptor {
     set?: (v: any) => void;
 }
 
-/*
- * SerializedOutput is the type we convert real deployment time outputs to when we serialize them
- * into the environment for a closure.  The output will go from something you call 'apply' on to
- * transform during deployment, to something you call .get on to get the raw underlying value from
- * inside a cloud callback.
+/**
+ * {@link SerializedOutput} is the type we convert real deployment-time outputs
+ * to when we serialize them into the environment for a closure.  The output
+ * will go from something you call `apply` on to transform during deployment, to
+ * something you call `.get` on to get the raw underlying value from inside a
+ * cloud callback.
  *
- * IMPORTANT: Do not change the structure of this type.  Closure serialization code takes a
- * dependency on the actual shape (including the names of properties like 'value').
+ * IMPORTANT: Do not change the structure of this type. Closure serialization
+ * code takes a dependency on the actual shape (including the names of
+ * properties like `value`).
  */
 class SerializedOutput<T> {
     public constructor(private readonly value: T) {}
@@ -229,10 +310,10 @@ export interface ClosureInfo {
 }
 
 /**
- * createFunctionInfo serializes a function and its closure environment into a form that is
- * amenable to persistence as simple JSON.  Like toString, it includes the full text of the
- * function's source code, suitable for execution. Unlike toString, it actually includes information
- * about the captured environment.
+ * Serializes a function and its closure environment into a form that is
+ * amenable to persistence as simple JSON. Like {@link toString}, it includes
+ * the full text of the function's source code, suitable for execution. Unlike
+ * `toString`, it actually includes information about the captured environment.
  *
  * @internal
  */
@@ -380,8 +461,8 @@ export async function createClosureInfoAsync(
 (<any>createClosureInfoAsync).doNotCapture = true;
 
 /**
- * analyzeFunctionInfoAsync does the work to create an asynchronous dataflow graph that resolves to a
- * final FunctionInfo.
+ * Does the work to create an asynchronous dataflow graph that resolves to a
+ * final {@link FunctionInfo}.
  */
 async function analyzeFunctionInfoAsync(
     func: Function,
@@ -881,9 +962,10 @@ function getOrCreateNameEntryAsync(
 }
 
 /**
- * serializeAsync serializes an object, deeply, into something appropriate for an environment
- * entry.  If propNames is provided, and is non-empty, then only attempt to serialize out those
- * specific properties.  If propNames is not provided, or is empty, serialize out all properties.
+ * Deeply serializes an object into something appropriate for an environment
+ * entry.  If `propNames` is provided, and is non-empty, then only attempt to
+ * serialize out those specific properties.  If `propNames` is not provided, or
+ * is empty, serialize out all properties.
  */
 async function getOrCreateEntryAsync(
     obj: any,
@@ -1120,7 +1202,7 @@ async function getOrCreateEntryAsync(
         // actually is.  On the other end, we'll use Object.create(deserializedProto) to set
         // things up properly.
         //
-        // We don't need to capture the prototype if the user is not capturing 'this' either.
+        // We don't need to capture the prototype if the user is not capturing `this` either.
         if (!object.proto) {
             const proto = Object.getPrototypeOf(obj);
             if (proto !== Object.prototype) {
@@ -1215,7 +1297,7 @@ async function getOrCreateEntryAsync(
 
                 const infos = propChains.map((chain) => chain.infos[0]);
                 if (propInfoUsesNonLexicalThis(infos, propertyInfo, valEntry)) {
-                    // the referenced function captured 'this'.  Have to serialize out
+                    // the referenced function captured `this`.  Have to serialize out
                     // this entire object.  Undo the work we did to just serialize out a
                     // few properties.
                     object.env.clear();
@@ -1247,7 +1329,7 @@ async function getOrCreateEntryAsync(
         }
 
         // if we're accessing a getter/setter, and that getter/setter uses
-        // 'this', then we need to serialize out this object entirely.
+        // `this`, then we need to serialize out this object entirely.
 
         if (
             usesNonLexicalThis(propertyInfo ? propertyInfo.get : undefined) ||
@@ -1391,9 +1473,11 @@ async function getOrCreateEntryAsync(
     }
 }
 
-// Is this a constructor derived from a noCapture constructor.  if so, we don't want to
-// emit it.  We would be unable to actually hook up the "super()" call as one of the base
-// constructors was set to not be captured.
+/**
+ * Returns true if this is a constructor derived from a `noCapture` constructor.
+ * If so, we don't want to emit it.  We would be unable to actually hook up the
+ * `super()` call as one of the base constructors was set to not be captured.
+ */
 function isDerivedNoCaptureConstructor(func: Function): boolean {
     for (let current: any = func; current; current = Object.getPrototypeOf(current)) {
         if (hasTrueBooleanMember(current, "doNotCapture")) {
@@ -1436,14 +1520,17 @@ function getBuiltInModules(): Promise<Map<any, string>> {
     }
 }
 
-// findNormalizedModuleName attempts to find a global name bound to the object, which can be used as
-// a stable reference across serialization.  For built-in modules (i.e. "os", "fs", etc.) this will
-// return that exact name of the module.  Otherwise, this will return the relative path to the
-// module from the current working directory of the process.  This will normally be something of the
-// form ./node_modules/<package_name>...
-//
-// This function will also always return modules in a normalized form (i.e. all path components will
-// be '/').
+/**
+ * Attempts to find a global name bound to the object, which can be used as a
+ * stable reference across serialization.  For built-in modules (i.e. `os`,
+ * `fs`, etc.) this will return that exact name of the module.  Otherwise, this
+ * will return the relative path to the module from the current working
+ * directory of the process.  This will normally be something of the form
+ * `./node_modules/<package_name>...`
+ *
+ * This function will also always return modules in a normalized form (i.e. all path components will
+ * be `/`).
+ */
 async function findNormalizedModuleNameAsync(obj: any): Promise<string | undefined> {
     // First, check the built-in modules
     const modules = await getBuiltInModules();

--- a/sdk/nodejs/runtime/closure/rewriteSuper.ts
+++ b/sdk/nodejs/runtime/closure/rewriteSuper.ts
@@ -105,7 +105,9 @@ function getFactory(transformationContext: typescript.TransformationContext): Fa
     };
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function rewriteSuperReferences(code: string, isStatic: boolean): string {
     const ts: typeof typescript = require("../../typescript-shim");
     const sourceFile = ts.createSourceFile("", code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -18,78 +18,103 @@ import * as closure from "./createClosure";
 import * as utils from "./utils";
 
 /**
- * SerializeFunctionArgs are arguments used to serialize a JavaScript function
+ * {@link SerializeFunctionArgs} are arguments used to serialize a JavaScript
+ * function.
  */
 export interface SerializeFunctionArgs {
     /**
-     * The name to export from the module defined by the generated module text.  Defaults to 'handler'.
+     * The name to export from the module defined by the generated module text.
+     * Defaults to `handler`.
      */
     exportName?: string;
+
     /**
-     * A function to prevent serialization of certain objects captured during the serialization.  Primarily used to
-     * prevent potential cycles.
+     * A function to prevent serialization of certain objects captured during
+     * the serialization. Primarily used to prevent potential cycles.
      */
     serialize?: (o: any) => boolean;
+
     /**
-     * If this is a function which, when invoked, will produce the actual entrypoint function.
-     * Useful for when serializing a function that has high startup cost that only wants to be
-     * run once. The signature of this function should be:  () => (provider_handler_args...) => provider_result
+     * True if this is a function which, when invoked, will produce the actual
+     * entrypoint function. Useful for when serializing a function that has high
+     * startup cost that we'd ideally only run once. The signature of this
+     * function should be `() => (provider_handler_args...) => provider_result`.
      *
-     * This will then be emitted as: `exports.[exportName] = serialized_func_name();`
+     * This will then be emitted as `exports.[exportName] =
+     * serialized_func_name();`
      *
-     * In other words, the function will be invoked (once) and the resulting inner function will
-     * be what is exported.
+     * In other words, the function will be invoked (once) and the resulting
+     * inner function will be what is exported.
      */
     isFactoryFunction?: boolean;
+
     /**
      * The resource to log any errors we encounter against.
      */
     logResource?: Resource;
+
     /**
-     * If true, allow secrets to be serialized into the function. This should only be set to true if the calling
-     * code will handle this and propoerly wrap the resulting text in a Secret before passing it into any Resources
-     * or serializing it to any other output format. If set, the `containsSecrets` property on the returned
-     * SerializedFunction object will indicate whether secrets were serialized into the function text.
+     * If true, allow secrets to be serialized into the function. This should
+     * only be set to true if the calling code will handle this and propoerly
+     * wrap the resulting text in a secret before passing it into any resources
+     * or serializing it to any other output format. If set, the
+     * `containsSecrets` property on the returned {@link SerializedFunction}
+     * object will indicate whether secrets were serialized into the function
+     * text.
      */
     allowSecrets?: boolean;
 }
 
 /**
- * SerializeFunction is a representation of a serialized JavaScript function.
+ * {@link SerializedFunction} is a representation of a serialized JavaScript
+ * function.
  */
 export interface SerializedFunction {
     /**
-     * The text of a JavaScript module which exports a single name bound to an appropriate value.
-     * In the case of a normal function, this value will just be serialized function.  In the case
-     * of a factory function this value will be the result of invoking the factory function.
+     * The text of a JavaScript module which exports a single name bound to an
+     * appropriate value. In the case of a normal function, this value will just
+     * be serialized function. In the case of a factory function this value
+     * will be the result of invoking the factory function.
      */
     text: string;
+
     /**
      * The name of the exported module member.
      */
     exportName: string;
+
     /**
-     * True if the serialized function text includes serialization of secret
+     * True if the serialized function text includes serialized secrets.
      */
     containsSecrets: boolean;
 }
 
 /**
- * serializeFunction serializes a JavaScript function into a text form that can be loaded in another execution context,
- * for example as part of a function callback associated with an AWS Lambda.  The function serialization captures any
- * variables captured by the function body and serializes those values into the generated text along with the function
- * body.  This process is recursive, so that functions referenced by the body of the serialized function will themselves
- * be serialized as well.  This process also deeply serializes captured object values, including prototype chains and
- * property descriptors, such that the semantics of the function when deserialized should match the original function.
+ * Serializes a JavaScript function into a text form that can be loaded in
+ * another execution context, for example as part of a function callback
+ * associated with an AWS Lambda. The function serialization captures any
+ * variables captured by the function body and serializes those values into the
+ * generated text along with the function body.  This process is recursive, so
+ * that functions referenced by the body of the serialized function will
+ * themselves be serialized as well.  This process also deeply serializes
+ * captured object values, including prototype chains and property descriptors,
+ * such that the semantics of the function when deserialized should match the
+ * original function.
  *
  * There are several known limitations:
- * - If a native function is captured either directly or indirectly, closure serialization will return an error.
- * - Captured values will be serialized based on their values at the time that `serializeFunction` is called.  Mutations
- *   to these values after that (but before the deserialized function is used) will not be observed by the deserialized
- *   function.
  *
- * @param func The JavaScript function to serialize.
- * @param args Arguments to use to control the serialization of the JavaScript function.
+ * - If a native function is captured either directly or indirectly, closure
+ *   serialization will return an error.
+ *
+ * - Captured values will be serialized based on their values at the time that
+ *   `serializeFunction` is called.  Mutations to these values after that (but
+ *   before the deserialized function is used) will not be observed by the
+ *   deserialized function.
+ *
+ * @param func
+ *  The JavaScript function to serialize.
+ * @param args
+ *  Arguments to use to control the serialization of the JavaScript function.
  */
 export async function serializeFunction(func: Function, args: SerializeFunctionArgs = {}): Promise<SerializedFunction> {
     const exportName = args.exportName || "handler";
@@ -104,7 +129,8 @@ export async function serializeFunction(func: Function, args: SerializeFunctionA
 }
 
 /**
- * @deprecated Please use 'serializeFunction' instead.
+ * @deprecated
+ *  Please use {@link serializeFunction} instead.
  */
 export async function serializeFunctionAsync(func: Function, serialize?: (o: any) => boolean): Promise<string> {
     log.warn("'function serializeFunctionAsync' is deprecated.  Please use 'serializeFunction' instead.");
@@ -118,10 +144,9 @@ export async function serializeFunctionAsync(func: Function, serialize?: (o: any
 }
 
 /**
- * serializeJavaScriptText converts a FunctionInfo object into a string representation of a Node.js module body which
- * exposes a single function `exports.handler` representing the serialized function.
- *
- * @param c The FunctionInfo to be serialized into a module string.
+ * Converts a {@link FunctionInfo} object into a string representation of a
+ * NodeJS module body which exposes a single function `exports.handler`
+ * representing the serialized function.
  */
 function serializeJavaScriptText(
     outerClosure: closure.ClosureInfo,
@@ -559,12 +584,14 @@ function deepContainsObjOrArrayOrRegExp(env: closure.Entry): boolean {
 }
 
 /**
- * Converts an environment object into a string which can be embedded into a serialized function
- * body.  Note that this is not JSON serialization, as we may have property values which are
- * variable references to other global functions. In other words, there can be free variables in the
- * resulting object literal.
+ * Converts an environment object into a string which can be embedded into a
+ * serialized function body.  Note that this is not JSON serialization, as we
+ * may have property values which are variable references to other global
+ * functions. In other words, there can be free variables in the resulting
+ * object literal.
  *
- * @param envObj The environment object to convert to a string.
+ * @param envObj
+ *  The environment object to convert to a string.
  */
 function envObjToString(envObj: Record<string, string>): string {
     return `{ ${Object.keys(envObj)

--- a/sdk/nodejs/runtime/closure/utils.ts
+++ b/sdk/nodejs/runtime/closure/utils.ts
@@ -17,12 +17,16 @@ import * as typescript from "typescript";
 
 const legalNameRegex = /^[a-zA-Z_][0-9a-zA-Z_]*$/;
 
-/** @internal */
+/**
+ * @internal
+ */
 export function isLegalMemberName(n: string) {
     return legalNameRegex.test(n);
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function isLegalFunctionName(n: string) {
     if (!isLegalMemberName(n)) {
         return false;

--- a/sdk/nodejs/runtime/closure/v8.ts
+++ b/sdk/nodejs/runtime/closure/v8.ts
@@ -28,8 +28,10 @@ import * as vm from "vm";
 import * as v8Hooks from "./v8Hooks";
 
 /**
- * Given a function, returns the file, line and column number in the file where this function was
- * defined. Returns { "", 0, 0 } if the location cannot be found or if the given function has no Script.
+ * Given a function, returns the file, line and column number in the file where
+ * this function was defined. Returns `{ "", 0, 0 }` if the location cannot be
+ * found or if the given function has no script.
+ *
  * @internal
  */
 export async function getFunctionLocationAsync(func: Function) {
@@ -57,14 +59,21 @@ export async function getFunctionLocationAsync(func: Function) {
 }
 
 /**
- * Given a function and a free variable name, lookupCapturedVariableValue looks up the value of that free variable
- * in the scope chain of the provided function. If the free variable is not found, `throwOnFailure` indicates
- * whether or not this function should throw or return `undefined.
+ * Given a function and a free variable name, looks up the value of that free
+ * variable in the scope chain of the provided function. If the free variable is
+ * not found, `throwOnFailure` indicates whether or not this function should
+ * throw or return `undefined`.
  *
- * @param func The function whose scope chain is to be analyzed
- * @param freeVariable The name of the free variable to inspect
- * @param throwOnFailure If true, throws if the free variable can't be found.
- * @returns The value of the free variable. If `throwOnFailure` is false, returns `undefined` if not found.
+ * @param func
+ *  The function whose scope chain is to be analyzed
+ * @param freeVariable
+ *  The name of the free variable to inspect
+ * @param throwOnFailure
+ *  If true, throws if the free variable can't be found.
+ * @returns
+ *  The value of the free variable. If `throwOnFailure` is false, returns
+ *  `undefined` if not found.
+ *
  * @internal
  */
 export async function lookupCapturedVariableValueAsync(
@@ -121,7 +130,7 @@ export async function lookupCapturedVariableValueAsync(
 }
 
 // We want to call util.promisify on inspector.Session.post. However, due to all the overloads of
-// that method, promisify gets confused.  To prevent this, we cast our session object down to an
+// that method, promisify gets confused. To prevent this, we cast our session object down to an
 // interface containing only the single overload we care about.
 type PostSession<TMethod, TParams, TReturn> = {
     post(method: TMethod, params?: TParams, callback?: (err: Error | null, params: TReturn) => void): void;
@@ -159,6 +168,7 @@ type InflightContext = {
     calls: Record<string, any>;
     currentCallId: number;
 };
+
 // Isolated singleton context accessible from the inspector.
 // Used instead of `global` object to support executions with multiple V8 vm contexts as, e.g., done by Jest.
 let inflightContextCache: Promise<InflightContext> | undefined;
@@ -169,6 +179,7 @@ function inflightContext() {
     inflightContextCache = createContext();
     return inflightContextCache;
 }
+
 async function createContext(): Promise<InflightContext> {
     const context: InflightContext = {
         contextId: 0,

--- a/sdk/nodejs/runtime/closure/v8Hooks.ts
+++ b/sdk/nodejs/runtime/closure/v8Hooks.ts
@@ -54,8 +54,10 @@ async function createInspectorSessionAsync(): Promise<import("inspector").Sessio
 }
 
 /**
- * Returns the inspector session that can be used to query the state of this running Node instance.
- * Must only be called on Node11 and above. On Node10 and below, this will throw.
+ * Returns the inspector session that can be used to query the state of this
+ * running Node instance. Must only be called on Node11 and above. On Node10 and
+ * below, this will throw.
+ *
  * @internal
  */
 export async function getSessionAsync() {
@@ -63,8 +65,9 @@ export async function getSessionAsync() {
 }
 
 /**
- * Returns a promise that can be used to determine when the v8hooks have been injected properly and
- * code that depends on them can continue executing.
+ * Returns a promise that can be used to determine when the v8hooks have been
+ * injected properly and code that depends on them can continue executing.
+ *
  * @internal
  */
 export async function isInitializedAsync() {
@@ -73,6 +76,7 @@ export async function isInitializedAsync() {
 
 /**
  * Maps from a script-id to the local file url it corresponds to.
+ *
  * @internal
  */
 export function getScriptUrl(id: import("inspector").Runtime.ScriptId) {

--- a/sdk/nodejs/runtime/config.ts
+++ b/sdk/nodejs/runtime/config.ts
@@ -15,22 +15,23 @@
 import { getStore } from "./state";
 
 /**
- * configEnvKey is the environment variable key that the language plugin uses to set configuration values.
+ * The environment variable key that the language plugin uses to set
+ * configuration values.
  *
  * @internal
  */
 export const configEnvKey = "PULUMI_CONFIG";
 
 /**
- * configSecretKeysEnvKey is the environment variable key that the language plugin uses to set configuration keys that
- * contain secrets.
+ * The environment variable key that the language plugin uses to set
+ * configuration keys that contain secrets.
  *
  * @internal
  */
 export const configSecretKeysEnvKey = "PULUMI_CONFIG_SECRET_KEYS";
 
 /**
- * allConfig returns a copy of the full config map.
+ * Returns a copy of the full configuration map.
  */
 export function allConfig(): { [key: string]: string } {
     const config = parseConfig();
@@ -38,7 +39,7 @@ export function allConfig(): { [key: string]: string } {
 }
 
 /**
- * setAllConfig overwrites the config map.
+ * Overwrites the configuration map.
  */
 export function setAllConfig(c: { [key: string]: string }, secretKeys?: string[]) {
     const obj: { [key: string]: string } = {};
@@ -49,7 +50,7 @@ export function setAllConfig(c: { [key: string]: string }, secretKeys?: string[]
 }
 
 /**
- * setConfig sets a configuration variable.
+ * Sets a configuration variable.
  */
 export function setConfig(k: string, v: string): void {
     const config = parseConfig();
@@ -58,7 +59,7 @@ export function setConfig(k: string, v: string): void {
 }
 
 /**
- * getConfig returns a configuration variable's value or undefined if it is unset.
+ * Returns a configuration variable's value, or `undefined` if it is unset.
  */
 export function getConfig(k: string): string | undefined {
     const config = parseConfig();
@@ -66,7 +67,8 @@ export function getConfig(k: string): string | undefined {
 }
 
 /**
- * isConfigSecret returns true if the key contains a secret value.
+ * Returns true if the key contains a secret value.
+ *
  * @internal
  */
 export function isConfigSecret(k: string): boolean {
@@ -82,9 +84,9 @@ export function isConfigSecret(k: string): boolean {
 }
 
 /**
- * parseConfig reads config from the source of truth, the environment.
- * config must always be read this way because automation api introduces
- * new program lifetime semantics where program lifetime != module lifetime.
+ * Reads configuration from the source of truth, the environment. Configuration
+ * must always be read this way because the Automation API introduces new
+ * program lifetime semantics where program lifetime != module lifetime.
  */
 function parseConfig() {
     const { config } = getStore();
@@ -101,8 +103,8 @@ function parseConfig() {
 }
 
 /**
- * persistConfig writes config to the environment.
- * config changes must always be persisted to the environment because automation api introduces
+ * Writes configuration to the environment. Configuration changes must always be
+ * persisted to the environment this way because the Automation API introduces
  * new program lifetime semantics where program lifetime != module lifetime.
  */
 function persistConfig(config: { [key: string]: string }, secretKeys?: string[]) {
@@ -114,11 +116,13 @@ function persistConfig(config: { [key: string]: string }, secretKeys?: string[])
 }
 
 /**
- * cleanKey takes a configuration key, and if it is of the form "<string>:config:<string>" removes
- * the ":config:" portion. Previously, our keys always had the string ":config:" in them, and we'd
- * like to remove it. However, the language host needs to continue to set it so we can be compatible
- * with older versions of our packages. Once we stop supporting older packages, we can change the
- * language host to not add this :config: thing and remove this function.
+ * Takes a configuration key and, if it is of the form
+ * "<string>:config:<string>" removes the ":config:" portion. Previously, our
+ * keys always had the string ":config:" in them, and we'd like to remove it.
+ * However, the language host needs to continue to set it so we can be
+ * compatible with older versions of our packages. Once we stop supporting older
+ * packages, we can change the language host to not add this :config: thing and
+ * remove this function.
  */
 function cleanKey(key: string): string {
     const idx = key.indexOf(":");

--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -14,17 +14,23 @@
 
 import * as log from "../log";
 import * as state from "./state";
-/** @internal
+
+/**
  * debugPromiseLeaks can be set to enable promises leaks debugging.
+ *
+ * @internal
  */
 export const debugPromiseLeaks: boolean = !!process.env.PULUMI_DEBUG_PROMISE_LEAKS;
 
 /**
- * leakDetectorScheduled is true when the promise leak detector is scheduled for process exit.
+ * leakDetectorScheduled is true when the promise leak detector is scheduled for
+ * process exit.
  */
 let leakDetectorScheduled: boolean = false;
 
-/** @internal */
+/**
+ * @internal
+ */
 export function leakedPromises(): [Set<Promise<any>>, string] {
     const localStore = state.getStore();
     const leaked = localStore.leakCandidates;
@@ -55,7 +61,9 @@ export function leakedPromises(): [Set<Promise<any>>, string] {
     return [leaked, message];
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function promiseDebugString(p: Promise<any>): string {
     return `CONTEXT(${(<any>p)._debugId}): ${(<any>p)._debugCtx}\n` + `STACK_TRACE:\n` + `${(<any>p)._debugStackTrace}`;
 }
@@ -63,7 +71,9 @@ export function promiseDebugString(p: Promise<any>): string {
 let promiseId = 0;
 
 /**
- * debuggablePromise optionally wraps a promise with some goo to make it easier to debug common problems.
+ * Optionally wraps a promise with some goo to make it easier to debug common
+ * problems.
+ *
  * @internal
  */
 export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
@@ -116,7 +126,9 @@ export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
 }
 
 /**
- * errorString produces a string from an error, conditionally including additional diagnostics.
+ * Produces a string from an error, conditionally including additional
+ * diagnostics.
+ *
  * @internal
  */
 export function errorString(err: Error): string {

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -38,46 +38,51 @@ import * as resourceproto from "../proto/resource_pb";
 import * as providerproto from "../proto/provider_pb";
 
 /**
- * `invoke` dynamically invokes the function, `tok`, which is offered by a provider plugin. `invoke`
- * behaves differently in the case that options contains `{async:true}` or not.
+ * Dynamically invokes the function `tok`, which is offered by a provider
+ * plugin. `invoke` behaves differently in the case that options contains
+ * `{async:true}` or not.
  *
  * In the case where `{async:true}` is present in the options bag:
  *
- * 1. the result of `invoke` will be a Promise resolved to the result value of the provider plugin.
- * 2. the `props` inputs can be a bag of computed values (including, `T`s, `Promise<T>`s,
- *    `Output<T>`s etc.).
+ * 1. the result of `invoke` will be a Promise resolved to the result value of
+ *    the provider plugin.
  *
+ * 2. the `props` inputs can be a bag of computed values (including, `T`s,
+ *   `Promise<T>`s, `Output<T>`s etc.).
  *
- * In the case where `{async:true}` is not present in the options bag:
+ * In the case where `{ async:true }` is not present in the options bag:
  *
- * 1. the result of `invoke` will be a Promise resolved to the result value of the provider call.
- *    However, that Promise will *also* have the respective values of the Provider result exposed
- *    directly on it as properties.
+ * 1. the result of `invoke` will be a Promise resolved to the result value of
+ *    the provider call. However, that Promise will *also* have the respective
+ *    values of the Provider result exposed directly on it as properties.
  *
- * 2. The inputs must be a bag of simple values, and the result is the result that the Provider
- *    produced.
+ * 2. The inputs must be a bag of simple values, and the result is the result
+ *    that the Provider produced.
  *
  * Simple values are:
+ *
  *  1. `undefined`, `null`, string, number or boolean values.
  *  2. arrays of simple values.
  *  3. objects containing only simple values.
  *
  * Importantly, simple values do *not* include:
+ *
  *  1. `Promise`s
  *  2. `Output`s
  *  3. `Asset`s or `Archive`s
  *  4. `Resource`s.
  *
- * All of these contain async values that would prevent `invoke from being able to operate
- * synchronously.
+ * All of these contain async values that would prevent `invoke from being able
+ * to operate synchronously.
  */
 export function invoke(tok: string, props: Inputs, opts: InvokeOptions = {}): Promise<any> {
     return invokeAsync(tok, props, opts);
 }
 
 /*
- * `invokeSingle` dynamically invokes the function, `tok`, which is offered by a provider plugin.
- * Similar to `invoke`, but returns a single value instead of an object with a single key.
+ * Dynamically invokes the function `tok`, which is offered by a
+ * provider plugin. Similar to `invoke`, but returns a single value instead of
+ * an object with a single key.
  */
 export function invokeSingle(tok: string, props: Inputs, opts: InvokeOptions = {}): Promise<any> {
     return invokeAsync(tok, props, opts).then((outputs) => {
@@ -185,8 +190,11 @@ async function invokeAsync(tok: string, props: Inputs, opts: InvokeOptions): Pro
     }
 }
 
-// StreamInvokeResponse represents a (potentially infinite) streaming response to `streamInvoke`,
-// with facilities to gracefully cancel and clean up the stream.
+/**
+ * {@link StreamInvokeResponse} represents a (potentially infinite) streaming
+ * response to `streamInvoke`, with facilities to gracefully cancel and clean up
+ * the stream.
+ */
 export class StreamInvokeResponse<T> implements AsyncIterable<T> {
     constructor(
         private source: AsyncIterable<T>,
@@ -246,7 +254,7 @@ function deserializeResponse(
 }
 
 /**
- * `call` dynamically calls the function, `tok`, which is offered by a provider plugin.
+ * Dynamically calls the function `tok`, which is offered by a provider plugin.
  */
 export function call<T>(tok: string, props: Inputs, res?: Resource): Output<T> {
     const label = `Calling function: tok=${tok}`;

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -21,11 +21,12 @@ import * as provproto from "../proto/provider_pb";
 import * as resproto from "../proto/resource_pb";
 
 /**
- * MockResourceArgs is used to construct a newResource Mock.
+ * {@link MockResourceArgs} is used to construct a new resource mock.
  */
 export interface MockResourceArgs {
     /**
-     * The token that indicates which resource type is being constructed. This token is of the form "package:module:type".
+     * The token that indicates which resource type is being constructed. This
+     * token is of the form "package:module:type".
      */
     type: string;
 
@@ -40,24 +41,28 @@ export interface MockResourceArgs {
     inputs: any;
 
     /**
-     * If provided, the identifier of the provider instance being used to manage this resource.
+     * If provided, the identifier of the provider instance being used to manage
+     * this resource.
      */
     provider?: string;
 
     /**
-     * Specifies whether or not the resource is Custom (i.e. managed by a resource provider).
+     * Specifies whether or not the resource is Custom (i.e. managed by a
+     * resource provider).
      */
     custom?: boolean;
 
     /**
-     * If provided, the physical identifier of an existing resource to read or import.
+     * If provided, the physical identifier of an existing resource to read or
+     * import.
      */
     id?: string;
 }
 
 /**
- * MockResourceResult is the result of a newResource Mock, returning a physical identifier and the output properties
- * for the resource being constructed.
+ * {@link MockResourceResult} is the result of a new resource mock, returning a
+ * physical identifier and the output properties for the resource being
+ * constructed.
  */
 export type MockResourceResult = {
     id: string | undefined;
@@ -65,11 +70,12 @@ export type MockResourceResult = {
 };
 
 /**
- * MockResourceArgs is used to construct call Mock.
+ * {@link MockResourceArgs} is used to construct call mocks.
  */
 export interface MockCallArgs {
     /**
-     * The token that indicates which function is being called. This token is of the form "package:module:function".
+     * The token that indicates which function is being called. This token is of
+     * the form "package:module:function".
      */
     token: string;
 
@@ -79,31 +85,35 @@ export interface MockCallArgs {
     inputs: any;
 
     /**
-     * If provided, the identifier of the provider instance being used to make the call.
+     * If provided, the identifier of the provider instance being used to make
+     * the call.
      */
     provider?: string;
 }
 
 /**
- * MockCallResult is the result of a call Mock.
+ * {@link MockCallResult} is the result of a call mock.
  */
 export type MockCallResult = Record<string, any>;
 
 /**
- * Mocks allows implementations to replace operations normally implemented by the Pulumi engine with
- * their own implementations. This can be used during testing to ensure that calls to provider functions and resource constructors
- * return predictable values.
+ * {@link Mocks} allows implementations to replace operations normally
+ * implemented by the Pulumi engine with their own implementations. This can be
+ * used during testing to ensure that calls to provider functions and resource
+ * constructors return predictable values.
  */
 export interface Mocks {
     /**
-     * Mocks provider-implemented function calls (e.g. aws.get_availability_zones).
+     * Mocks provider-implemented function calls (e.g. `aws.get_availability_zones`).
      *
      * @param args MockCallArgs
      */
     call(args: MockCallArgs): MockCallResult | Promise<MockCallResult>;
+
     /**
-     * Mocks resource construction calls. This function should return the physical identifier and the output properties
-     * for the resource being constructed.
+     * Mocks resource construction calls. This function should return the
+     * physical identifier and the output properties for the resource being
+     * constructed.
      *
      * @param args MockResourceArgs
      */
@@ -232,13 +242,18 @@ export class MockMonitor {
 }
 
 /**
- * setMocks configures the Pulumi runtime to use the given mocks for testing.
+ * Configures the Pulumi runtime to use the given mocks for testing.
  *
- * @param mocks The mocks to use for calls to provider functions and resource construction.
- * @param project If provided, the name of the Pulumi project. Defaults to "project".
- * @param stack If provided, the name of the Pulumi stack. Defaults to "stack".
- * @param preview If provided, indicates whether or not the program is running a preview. Defaults to false.
- * @param organization If provided, the name of the Pulumi organization. Defaults to nothing.
+ * @param mocks
+ *  The mocks to use for calls to provider functions and resource construction.
+ * @param project
+ *  If provided, the name of the Pulumi project. Defaults to "project".
+ * @param stack
+ *  If provided, the name of the Pulumi stack. Defaults to "stack".
+ * @param preview
+ *  If provided, indicates whether or not the program is running a preview. Defaults to false.
+ * @param organization
+ *  If provided, the name of the Pulumi organization. Defaults to nothing.
  */
 export async function setMocks(
     mocks: Mocks,

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -89,35 +89,74 @@ function marshalSourcePosition(sourcePosition?: SourcePosition) {
 }
 
 interface ResourceResolverOperation {
-    // A resolver for a resource's URN.
+    /**
+     * A resolver for a resource's URN.
+     */
     resolveURN: (urn: URN, err?: Error) => void;
-    // A resolver for a resource's ID (for custom resources only).
+
+    /**
+     * A resolver for a resource's ID (for custom resources only).
+     */
     resolveID: ((v: ID, performApply: boolean, err?: Error) => void) | undefined;
-    // A collection of resolvers for a resource's properties.
+
+    /**
+     * A collection of resolvers for a resource's properties.
+     */
     resolvers: OutputResolvers;
-    // A parent URN, fully resolved, if any.
+
+    /**
+     * A fully-resolved parent URN, if any.
+     */
     parentURN: URN | undefined;
-    // A provider reference, fully resolved, if any.
+
+    /**
+     * A fully-resolved provider reference, if any.
+     */
     providerRef: string | undefined;
-    // A map of provider references, fully resolved, if any.
+
+    /**
+     * A map of fully-resolved provider references, if any.
+     */
     providerRefs: Map<string, string>;
-    // All serialized properties, fully awaited, serialized, and ready to go.
+
+    /**
+     * All serialized properties, fully awaited, serialized, and ready to go.
+     */
     serializedProps: Record<string, any>;
-    // A set of URNs that this resource is directly dependent upon.  These will all be URNs of
-    // custom resources, not component resources.
+
+    /**
+     * A set of URNs that this resource is directly dependent upon. These will
+     * all be URNs of custom resources, not component resources.
+     */
     allDirectDependencyURNs: Set<URN>;
-    // Set of URNs that this resource is directly dependent upon, keyed by the property that causes
-    // the dependency.  All urns in this map must exist in [allDirectDependencyURNs].  These will
-    // all be URNs of custom resources, not component resources.
+
+    /**
+     * A set of URNs that this resource is directly dependent upon, keyed by the
+     * property that causes the dependency. All URNs in this map must exist in
+     * {@link allDirectDependencyURNs}. These will all be URNs of custom
+     * resources, not component resources.
+     */
     propertyToDirectDependencyURNs: Map<string, Set<URN>>;
-    // A list of aliases applied to this resource.
+
+    /**
+     * A list of aliases applied to this resource.
+     */
     aliases: (Alias | URN)[];
-    // An ID to import, if any.
+
+    /**
+     * An ID to import, if any.
+     */
     import: ID | undefined;
-    // Any important feature support from the monitor.
+
+    /**
+     * Any important feature support from the monitor.
+     */
     monitorSupportsStructuredAliases: boolean;
-    // If set, the providers Delete method will not be called for this resource
-    // if specified is being deleted as well.
+
+    /**
+     * If set, the provider's `Delete` method will not be called for this
+     * resource if the URN specified is being deleted as well.
+     */
     deletedWithURN: URN | undefined;
 }
 
@@ -246,8 +285,9 @@ export function getResource(
 }
 
 /**
- * Reads an existing custom resource's state from the resource monitor.  Note that resources read in this way
- * will not be part of the resulting stack's state, as they are presumed to belong to another.
+ * Reads an existing custom resource's state from the resource monitor.  Note
+ * that resources read in this way will not be part of the resulting stack's
+ * state, as they are presumed to belong to another.
  */
 export function readResource(
     res: Resource,
@@ -423,9 +463,11 @@ export function mapAliasesForRequest(
 }
 
 /**
- * registerResource registers a new resource object with a given type t and name.  It returns the auto-generated
- * URN and the ID that will resolve after the deployment has completed.  All properties will be initialized to property
- * objects that the registration operation will resolve at the right time (or remain unresolved for deployments).
+ * registerResource registers a new resource object with a given type `t` and
+ * `name`. It returns the auto-generated URN and the ID that will resolve after
+ * the deployment has completed.  All properties will be initialized to property
+ * objects that the registration operation will resolve at the right time (or
+ * remain unresolved for deployments).
  */
 export function registerResource(
     res: Resource,
@@ -641,9 +683,11 @@ export function registerResource(
     );
 }
 
-/** @internal
- * Prepares for an RPC that will manufacture a resource, and hence deals with input and output
- * properties.
+/**
+ * Prepares for an RPC that will manufacture a resource, and hence deals with
+ * input and output properties.
+ *
+ * @internal
  */
 export async function prepareResource(
     label: string,
@@ -885,7 +929,9 @@ function addAll<T>(to: Set<T>, from: Set<T>) {
     }
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export async function getAllTransitivelyReferencedResourceURNs(
     resources: Set<Resource>,
     exclude: Set<Resource>,
@@ -933,8 +979,9 @@ export async function getAllTransitivelyReferencedResourceURNs(
 }
 
 /**
- * Recursively walk the resources passed in, returning them and all resources reachable from
- * [Resource.__childResources] through any **Component** resources we encounter.
+ * Recursively walk the resources passed in, returning them and all resources
+ * reachable from {@link Resource.__childResources} through any **component**
+ * resources we encounter.
  */
 async function getTransitivelyReferencedChildResourcesOfComponentResources(
     resources: Set<Resource>,
@@ -976,7 +1023,8 @@ async function addTransitivelyReferencedChildResourcesOfComponentResources(
 }
 
 /**
- * Gathers explicit dependent Resources from a list of Resources (possibly Promises and/or Outputs).
+ * Gathers explicit dependent Resources from a list of Resources (possibly
+ * Promises and/or Outputs).
  */
 async function gatherExplicitDependencies(
     dependsOn: Input<Input<Resource>[]> | Input<Resource> | undefined,
@@ -1012,7 +1060,8 @@ async function gatherExplicitDependencies(
 }
 
 /**
- * Finishes a resource creation RPC operation by resolving its outputs to the resulting RPC payload.
+ * Finishes a resource creation RPC operation by resolving its outputs to the
+ * resulting RPC payload.
  */
 async function resolveOutputs(
     res: Resource,
@@ -1052,7 +1101,8 @@ async function resolveOutputs(
 }
 
 /**
- * registerResourceOutputs completes the resource registration, attaching an optional set of computed outputs.
+ * Completes a resource registration, attaching an optional set of computed
+ * outputs.
  */
 export function registerResourceOutputs(res: Resource, outputs: Inputs | Promise<Inputs> | Output<Inputs>) {
     // Now run the operation. Note that we explicitly do not serialize output registration with
@@ -1124,17 +1174,19 @@ function isAny(o: any): o is any {
 }
 
 /**
- * listResourceOutputs returns the resource outputs (if any) for a stack, or an error if the stack
- * cannot be found. Resources are retrieved from the latest stack snapshot, which may include
- * ongoing updates.
+ * Returns the resource outputs (if any) for a stack, or an error if the stack
+ * cannot be found. Resources are retrieved from the latest stack snapshot,
+ * which may include ongoing updates. For example:
  *
- * @param stackName Name of stack to retrieve resource outputs for. Defaults to the current stack.
- * @param typeFilter A [type
- * guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards)
- * that specifies which resource types to list outputs of.
- *
- * @example
+ * ```typescript
  * const buckets = pulumi.runtime.listResourceOutput(aws.s3.Bucket.isInstance);
+ * ```
+ *
+ * @param stackName
+ *  Name of stack to retrieve resource outputs for. Defaults to the current stack.
+ * @param typeFilter
+ *  A [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards)
+ *  that specifies which resource types to list outputs of.
  */
 export function listResourceOutputs<U extends Resource>(
     typeFilter?: (o: any) => o is U,
@@ -1157,15 +1209,20 @@ export function listResourceOutputs<U extends Resource>(
 }
 
 /**
- * resourceChain is used to serialize all resource requests.  If we don't do this, all resource operations will be
- * entirely asynchronous, meaning the dataflow graph that results will determine ordering of operations.  This
- * causes problems with some resource providers, so for now we will serialize all of them.  The issue
- * pulumi/pulumi#335 tracks coming up with a long-term solution here.
+ * resourceChain is used to serialize all resource requests.  If we don't do
+ * this, all resource operations will be entirely asynchronous, meaning the
+ * dataflow graph that results will determine ordering of operations.  This
+ * causes problems with some resource providers, so for now we will serialize
+ * all of them.  The issue pulumi/pulumi#335 tracks coming up with a long-term
+ * solution here.
  */
 let resourceChain: Promise<void> = Promise.resolve();
 let resourceChainLabel: string | undefined = undefined;
 
-// runAsyncResourceOp runs an asynchronous resource operation, possibly serializing it as necessary.
+/**
+ * Runs an asynchronous resource operation, possibly serializing it as
+ * necessary.
+ */
 function runAsyncResourceOp(label: string, callback: () => Promise<void>, serial?: boolean): void {
     // Serialize the invocation if necessary.
     if (serial === undefined) {
@@ -1200,7 +1257,8 @@ function runAsyncResourceOp(label: string, callback: () => Promise<void>, serial
 }
 
 /**
- * Extract the pkg from the type token of the form "pkg:module:member".
+ * Extracts the package from the type token of the form "pkg:module:member".
+ *
  * @internal
  */
 export function pkgFromType(type: string): string | undefined {

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -31,16 +31,18 @@ export type OutputResolvers = Record<
 >;
 
 /**
- * transferProperties mutates the 'onto' resource so that it has Promise-valued properties for all
- * the 'props' input/output props.  *Importantly* all these promises are completely unresolved. This
- * is because we don't want anyone to observe the values of these properties until the rpc call to
- * registerResource actually returns.  This is because the registerResource call may actually
- * override input values, and we only want people to see the final value.
+ * Mutates the `onto` resource so that it has Promise-valued properties for all
+ * the `props` input/output props. *Importantly* all these promises are
+ * completely unresolved. This is because we don't want anyone to observe the
+ * values of these properties until the rpc call to registerResource actually
+ * returns. This is because the registerResource call may actually override
+ * input values, and we only want people to see the final value.
  *
- * The result of this call (beyond the stateful changes to 'onto') is the set of Promise resolvers
- * that will be called post-RPC call.  When the registerResource RPC call comes back, the values
- * that the engine actualy produced will be used to resolve all the unresolved promised placed on
- * 'onto'.
+ * The result of this call (beyond the stateful changes to `onto`) is the set of
+ * {@link Promise} resolvers that will be called post-RPC call.  When the
+ * {@link registerResource} RPC call comes back, the values that the engine
+ * actualy produced will be used to resolve all the unresolved promised placed
+ * on `onto`.
  */
 export function transferProperties(onto: Resource, label: string, props: Inputs): OutputResolvers {
     const resolvers: OutputResolvers = {};
@@ -126,16 +128,16 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
  */
 export interface SerializationOptions {
     /**
-     * true if we are keeping output values.
-     * If the monitor does not support output values, they will not be kept, even when this is set to true.
+     * True if we are keeping output values. If the monitor does not support
+     * output values, they will not be kept, even when this is set to true.
      */
     keepOutputValues?: boolean;
 }
 
 /**
- * serializeFilteredProperties walks the props object passed in, awaiting all interior promises for
- * properties with keys that match the provided filter, creating a reasonable POJO object that can
- * be remoted over to registerResource.
+ * Walks the props object passed in, awaiting all interior promises for
+ * properties with keys that match the provided filter, creating a reasonable
+ * POJO object that can be remoted over to {@link registerResource}.
  */
 async function serializeFilteredProperties(
     label: string,
@@ -162,29 +164,32 @@ async function serializeFilteredProperties(
 }
 
 /**
- * serializeResourceProperties walks the props object passed in, awaiting all interior promises besides those for `id`
- * and `urn`, creating a reasonable POJO object that can be remoted over to registerResource.
+ * Walks the props object passed in, awaiting all interior promises besides
+ * those for `id` and `urn`, creating a reasonable POJO object that can be
+ * remoted over to {@link registerResource}.
  */
 export async function serializeResourceProperties(label: string, props: Inputs, opts?: SerializationOptions) {
     return serializeFilteredProperties(label, props, (key) => key !== "id" && key !== "urn", opts);
 }
 
 /**
- * serializeProperties walks the props object passed in, awaiting all interior promises, creating a reasonable
- * POJO object that can be remoted over to registerResource.
+ * Walks the props object passed in, awaiting all interior promises, creating a
+ * reasonable POJO object that can be remoted over to {@link registerResource}.
  */
 export async function serializeProperties(label: string, props: Inputs, opts?: SerializationOptions) {
     const [result] = await serializeFilteredProperties(label, props, (_) => true, opts);
     return result;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export async function serializePropertiesReturnDeps(label: string, props: Inputs, opts?: SerializationOptions) {
     return serializeFilteredProperties(label, props, (_) => true, opts);
 }
 
 /**
- * deserializeProperties fetches the raw outputs and deserializes them from a gRPC call result.
+ * Fetches the raw outputs and deserializes them from a gRPC call result.
  */
 export function deserializeProperties(outputsStruct: gstruct.Struct, keepUnknowns?: boolean): Inputs {
     const props: Inputs = {};
@@ -199,12 +204,14 @@ export function deserializeProperties(outputsStruct: gstruct.Struct, keepUnknown
 }
 
 /**
- * resolveProperties takes as input a gRPC serialized proto.google.protobuf.Struct and resolves all
- * of the resource's matching properties to the values inside.
+ * Takes as input a gRPC serialized `proto.google.protobuf.Struct` and resolves
+ * all of the resource's matching properties to the values inside.
  *
- * NOTE: it is imperative that the properties in `allProps` were produced by `deserializeProperties` in order for
- * output properties to work correctly w.r.t. knowns/unknowns: this function assumes that any undefined value in
- * `allProps`represents an unknown value that was returned by an engine operation.
+ * NOTE: it is imperative that the properties in `allProps` were produced by
+ * `deserializeProperties` in order for output properties to work correctly
+ * w.r.t. knowns/unknowns: this function assumes that any undefined value in
+ * `allProps`represents an unknown value that was returned by an engine
+ * operation.
  */
 export function resolveProperties(
     res: Resource,
@@ -289,37 +296,59 @@ export function resolveProperties(
  * Unknown values are encoded as a distinguished string value.
  */
 export const unknownValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9";
+
 /**
- * specialSigKey is sometimes used to encode type identity inside of a map. See sdk/go/common/resource/properties.go.
+ * {@link specialSigKey} is sometimes used to encode type identity inside of a
+ * map.
+ *
+ * @see sdk/go/common/resource/properties.go.
  */
 export const specialSigKey = "4dabf18193072939515e22adb298388d";
+
 /**
- * specialAssetSig is a randomly assigned hash used to identify assets in maps. See sdk/go/common/resource/asset.go.
+ * {@link specialAssetSig} is a randomly assigned hash used to identify assets
+ * in maps.
+ *
+ * @see sdk/go/common/resource/asset.go.
  */
 export const specialAssetSig = "c44067f5952c0a294b673a41bacd8c17";
+
 /**
- * specialArchiveSig is a randomly assigned hash used to identify archives in maps. See sdk/go/common/resource/asset.go.
+ * {@link specialArchiveSig} is a randomly assigned hash used to identify
+ * archives in maps.
+ *
+ * @see sdk/go/common/resource/asset.go.
  */
 export const specialArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7";
+
 /**
- * specialSecretSig is a randomly assigned hash used to identify secrets in maps.
- * See sdk/go/common/resource/properties.go.
+ * {@link specialSecretSig} is a randomly assigned hash used to identify secrets
+ * in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
  */
 export const specialSecretSig = "1b47061264138c4ac30d75fd1eb44270";
+
 /**
- * specialResourceSig is a randomly assigned hash used to identify resources in maps.
- * See sdk/go/common/resource/properties.go.
+ * {@link specialResourceSig} is a randomly assigned hash used to identify
+ * resources in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
  */
 export const specialResourceSig = "5cf8f73096256a8f31e491e813e4eb8e";
+
 /**
- * specialOutputValueSig is a randomly assigned hash used to identify outputs in maps.
- * See sdk/go/common/resource/properties.go.
+ * {@link specialOutputValueSig} is a randomly assigned hash used to identify
+ * outputs in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
  */
 export const specialOutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4";
 
 /**
- * serializeProperty serializes properties deeply.  This understands how to wait on any unresolved promises, as
- * appropriate, in addition to translating certain "special" values so that they are ready to go on the wire.
+ * Serializes properties deeply.  This understands how to wait on any unresolved
+ * promises, as appropriate, in addition to translating certain "special" values
+ * so that they are ready to go on the wire.
  */
 export async function serializeProperty(
     ctx: string,
@@ -542,14 +571,16 @@ export async function serializeProperty(
 }
 
 /**
- * isRpcSecret returns true if obj is a wrapped secret value (i.e. it's an object with the special key set).
+ * Returns true if the given object is a wrapped secret value (i.e. it's an
+ * object with the special key set).
  */
 export function isRpcSecret(obj: any): boolean {
     return obj && obj[specialSigKey] === specialSecretSig;
 }
 
 /**
- * unwrapRpcSecret returns the underlying value for a secret, or the value itself if it was not a secret.
+ * Returns the underlying value for a secret, or the value itself if it was not
+ * a secret.
  */
 export function unwrapRpcSecret(obj: any): any {
     if (!isRpcSecret(obj)) {
@@ -559,7 +590,8 @@ export function unwrapRpcSecret(obj: any): any {
 }
 
 /**
- * deserializeProperty unpacks some special types, reversing the above process.
+ * Unpacks some special types, reversing the process undertaken by
+ * {@link serializeProperty}.
  */
 export function deserializeProperty(prop: any, keepUnknowns?: boolean): any {
     if (prop === undefined) {
@@ -713,8 +745,8 @@ export function deserializeProperty(prop: any, keepUnknowns?: boolean): any {
 }
 
 /**
- * suppressUnhandledGrpcRejections silences any unhandled promise rejections that occur due to gRPC errors. The input
- * promise may still be rejected.
+ * Silences any unhandled promise rejections that occur due to gRPC errors. The
+ * input promise may still be rejected.
  */
 export function suppressUnhandledGrpcRejections<T>(p: Promise<T>): Promise<T> {
     p.catch((err) => {
@@ -737,7 +769,9 @@ function checkVersion(want?: semver.SemVer, have?: semver.SemVer): boolean {
     return have.major === want.major && have.minor >= want.minor && have.patch >= want.patch;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function register<T extends { readonly version?: string }>(
     source: Map<string, T[]>,
     registrationType: string,
@@ -770,7 +804,9 @@ export function register<T extends { readonly version?: string }>(
     return true;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function getRegistration<T extends { readonly version?: string }>(
     source: Map<string, T[]>,
     key: string,
@@ -794,7 +830,8 @@ export function getRegistration<T extends { readonly version?: string }>(
 }
 
 /**
- * A ResourcePackage is a type that understands how to construct resource providers given a name, type, args, and URN.
+ * A {@link ResourcePackage} is a type that understands how to construct
+ * resource providers given a name, type, args, and URN.
  */
 export interface ResourcePackage {
     readonly version?: string;
@@ -803,14 +840,18 @@ export interface ResourcePackage {
 
 const resourcePackages = new Map<string, ResourcePackage[]>();
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _resetResourcePackages() {
     resourcePackages.clear();
 }
 
 /**
- * registerResourcePackage registers a resource package that will be used to construct providers for any URNs matching
- * the package name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
+ * Registers a resource package that will be used to construct providers for any
+ * URNs matching the package name and version that are deserialized by the
+ * current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourcePackage(pkg: string, resourcePackage: ResourcePackage) {
     register(resourcePackages, "package", pkg, resourcePackage);
@@ -821,7 +862,8 @@ export function getResourcePackage(pkg: string, version: string | undefined): Re
 }
 
 /**
- * A ResourceModule is a type that understands how to construct resources given a name, type, args, and URN.
+ * A {@link ResourceModule} is a type that understands how to construct
+ * resources given a name, type, args, and URN.
  */
 export interface ResourceModule {
     readonly version?: string;
@@ -834,14 +876,18 @@ function moduleKey(pkg: string, mod: string): string {
     return `${pkg}:${mod}`;
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _resetResourceModules() {
     resourceModules.clear();
 }
 
 /**
- * registerResourceModule registers a resource module that will be used to construct resources for any URNs matching
- * the module name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
+ * Registers a resource module that will be used to construct resources for any
+ * URNs matching the module name and version that are deserialized by the
+ * current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourceModule(pkg: string, mod: string, module: ResourceModule) {
     const key = moduleKey(pkg, mod);

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -25,34 +25,83 @@ import * as engproto from "../proto/engine_pb";
 import * as resrpc from "../proto/resource_grpc_pb";
 import * as resproto from "../proto/resource_pb";
 
-// maxRPCMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
-/** @internal */
+/**
+ * Raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb).
+ *
+ * @internal
+ */
 export const maxRPCMessageSize: number = 1024 * 1024 * 400;
 const grpcChannelOptions = { "grpc.max_receive_message_length": maxRPCMessageSize };
 
 /**
- * excessiveDebugOutput enables, well, pretty excessive debug output pertaining to resources and properties.
+ * excessiveDebugOutput enables, well, pretty excessive debug output pertaining
+ * to resources and properties.
  */
 export const excessiveDebugOutput: boolean = false;
 
 /**
- * Options is a bag of settings that controls the behavior of previews and deployments
+ * {@link Options} is a bag of settings that controls the behavior of previews
+ * and deployments.
  */
 export interface Options {
-    readonly project?: string; // the name of the current project.
-    readonly stack?: string; // the name of the current stack being deployed into.
-    readonly parallel?: number; // the degree of parallelism for resource operations (default is serial).
-    readonly engineAddr?: string; // a connection string to the engine's RPC, in case we need to reestablish.
-    readonly monitorAddr?: string; // a connection string to the monitor's RPC, in case we need to reestablish.
-    readonly dryRun?: boolean; // whether we are performing a preview (true) or a real deployment (false).
-    readonly testModeEnabled?: boolean; // true if we're in testing mode (allows execution without the CLI).
-    readonly queryMode?: boolean; // true if we're in query mode (does not allow resource registration).
-    readonly legacyApply?: boolean; // true if we will resolve missing outputs to inputs during preview.
-    readonly cacheDynamicProviders?: boolean; // true if we will cache serialized dynamic providers on the program side.
-    readonly organization?: string; // the name of the current organization.
+    /**
+     * The name of the current project.
+     */
+    readonly project?: string;
 
     /**
-     * Directory containing the send/receive files for making synchronous invokes to the engine.
+     * The name of the current stack being deployed into.
+     */
+    readonly stack?: string;
+
+    /**
+     * The degree of parallelism for resource operations (default is serial).
+     */
+    readonly parallel?: number;
+
+    /**
+     * A connection string to the engine's RPC, in case we need to reestablish.
+     */
+    readonly engineAddr?: string;
+
+    /**
+     * A connection string to the monitor's RPC, in case we need to reestablish.
+     */
+    readonly monitorAddr?: string;
+
+    /**
+     * Whether we are performing a preview (true) or a real deployment (false).
+     */
+    readonly dryRun?: boolean;
+
+    /**
+     * True if we're in testing mode (allows execution without the CLI).
+     */
+    readonly testModeEnabled?: boolean;
+
+    /**
+     * True if we're in query mode (does not allow resource registration).
+     */
+    readonly queryMode?: boolean;
+
+    /**
+     * True if we will resolve missing outputs to inputs during preview.
+     */
+    readonly legacyApply?: boolean;
+
+    /**
+     * True if we will cache serialized dynamic providers on the program side.
+     */
+    readonly cacheDynamicProviders?: boolean;
+
+    /**
+     * The name of the current organization.
+     */
+    readonly organization?: string;
+
+    /**
+     * A directory containing the send/receive files for making synchronous
+     * invokes to the engine.
      */
     readonly syncDir?: string;
 }
@@ -60,8 +109,10 @@ export interface Options {
 let monitor: resrpc.ResourceMonitorClient | undefined;
 let engine: engrpc.EngineClient | undefined;
 
-// reset options resets nodejs runtime global state (such as rpc clients),
-// and sets nodejs runtime option env vars to the specified values.
+/**
+ * Resets NodeJS runtime global state (such as RPC clients), and sets NodeJS
+ * runtime option environment variables to the specified values.
+ */
 export function resetOptions(
     project: string,
     stack: string,
@@ -124,24 +175,28 @@ export function setMockOptions(
     monitor = mockMonitor;
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _setIsDryRun(val: boolean) {
     const { settings } = getStore();
     settings.options.dryRun = val;
 }
 
 /**
- * Returns whether or not we are currently doing a preview.
+ * Returns true if we are currently doing a preview.
  *
- * When writing unit tests, you can set this flag via either `setMocks` or `_setIsDryRun`.
+ * When writing unit tests, you can set this flag via either `setMocks` or
+ * `_setIsDryRun`.
  */
 export function isDryRun(): boolean {
     return options().dryRun === true;
 }
 
 /**
- * monitorSupportsFeature returns a promise that when resolved tells you if the resource monitor we are connected
- * to is able to support a particular feature.
+ * Returns a promise that when resolved tells you if the resource monitor we are
+ * connected to is able to support a particular feature.
  *
  * @internal
  */
@@ -176,7 +231,8 @@ async function monitorSupportsFeature(monitorClient: resrpc.IResourceMonitorClie
 }
 
 /**
- * Queries the resource monitor for its capabilities and sets the appropriate flags in the store.
+ * Queries the resource monitor for its capabilities and sets the appropriate
+ * flags in the store.
  *
  * @internal
  **/
@@ -193,13 +249,19 @@ export async function awaitFeatureSupport(): Promise<void> {
     }
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _setQueryMode(val: boolean) {
     const { settings } = getStore();
     settings.options.queryMode = val;
 }
 
-/** @internal Used only for testing purposes */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _reset(): void {
     resetOptions("", "", -1, "", "", false, "");
 }
@@ -212,14 +274,16 @@ export function isQueryMode(): boolean {
 }
 
 /**
- * Returns true if we will resolve missing outputs to inputs during preview (PULUMI_ENABLE_LEGACY_APPLY).
+ * Returns true if we will resolve missing outputs to inputs during preview
+ * (`PULUMI_ENABLE_LEGACY_APPLY`).
  */
 export function isLegacyApplyEnabled(): boolean {
     return options().legacyApply === true;
 }
 
 /**
- * Returns true (default) if we will cache serialized dynamic providers on the program side
+ * Returns true if we will cache serialized dynamic providers on the program
+ * side (the default is true).
  */
 export function cacheDynamicProviders(): boolean {
     return options().cacheDynamicProviders === true;
@@ -239,7 +303,10 @@ export function getOrganization(): string {
     throw new Error("Missing organization name; for test mode, please call `pulumi.runtime.setMocks`");
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _setOrganization(val: string | undefined) {
     const { settings } = getStore();
     settings.options.organization = val;
@@ -254,7 +321,10 @@ export function getProject(): string {
     return project || "";
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _setProject(val: string | undefined) {
     const { settings } = getStore();
     settings.options.project = val;
@@ -269,7 +339,10 @@ export function getStack(): string {
     return stack || "";
 }
 
-/** @internal Used only for testing purposes. */
+/**
+ * @internal
+ *  Used only for testing purposes.
+ */
 export function _setStack(val: string | undefined) {
     const { settings } = getStore();
     settings.options.stack = val;
@@ -277,14 +350,15 @@ export function _setStack(val: string | undefined) {
 }
 
 /**
- * hasMonitor returns true if we are currently connected to a resource monitoring service.
+ * Returns true if we are currently connected to a resource monitoring service.
  */
 export function hasMonitor(): boolean {
     return !!monitor && !!options().monitorAddr;
 }
 
 /**
- * getMonitor returns the current resource monitoring service client for RPC communications.
+ * Returns the current resource monitoring service client for RPC
+ * communications.
  */
 export function getMonitor(): resrpc.IResourceMonitorClient | undefined {
     const { settings } = getStore();
@@ -327,7 +401,7 @@ export async function awaitStackRegistrations(): Promise<void> {
 }
 
 /**
- * getCallbacks returns the current callbacks for RPC communications.
+ * Returns the current callbacks for RPC communications.
  */
 export function getCallbacks(): ICallbackServer | undefined {
     const store = getStore();
@@ -346,7 +420,9 @@ export function getCallbacks(): ICallbackServer | undefined {
     return callbackServer;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export interface SyncInvokes {
     requests: number;
     responses: number;
@@ -354,7 +430,9 @@ export interface SyncInvokes {
 
 let syncInvokes: SyncInvokes | undefined;
 
-/** @internal */
+/**
+ * @internal
+ */
 export function tryGetSyncInvokes(): SyncInvokes | undefined {
     const syncDir = options().syncDir;
     if (syncInvokes === undefined && syncDir) {
@@ -367,14 +445,15 @@ export function tryGetSyncInvokes(): SyncInvokes | undefined {
 }
 
 /**
- * hasEngine returns true if we are currently connected to an engine.
+ * Returns true if we are currently connected to an engine.
  */
 export function hasEngine(): boolean {
     return !!engine && !!options().engineAddr;
 }
 
 /**
- * getEngine returns the current engine, if any, for RPC communications back to the resource engine.
+ * Returns the current engine, if any, for RPC communications back to the
+ * resource engine.
  */
 export function getEngine(): engrpc.IEngineClient | undefined {
     const { settings } = getStore();
@@ -404,22 +483,25 @@ export function terminateRpcs() {
 }
 
 /**
- * serialize returns true if resource operations should be serialized.
+ * Returns true if resource operations should be serialized.
  */
 export function serialize(): boolean {
     return options().parallel === 1;
 }
 
 /**
- * options returns the options from the environment, which is the source of truth. Options are global per process.
- * For CLI driven programs, pulumi-language-nodejs sets environment variables prior to the user program loading,
- * meaning that options could be loaded up front and cached.
- * Automation API and multi-language components introduced more complex lifecycles for runtime options().
- * These language hosts manage the lifecycle of options manually throughout the lifetime of the nodejs process.
- * In addition, node module resolution can lead to duplicate copies of @pulumi/pulumi and thus duplicate options
- *  objects that may not be synced if options are cached upfront. Mutating options must write to the environment
+ * Returns the options from the environment, which is the source of truth.
+ * Options are global per process.
+ *
+ * For CLI driven programs, `pulumi-language-nodejs` sets environment variables
+ * prior to the user program loading, meaning that options could be loaded up
+ * front and cached. Automation API and multi-language components introduced
+ * more complex lifecycles for runtime `options()`. These language hosts manage
+ * the lifecycle of options manually throughout the lifetime of the NodeJS
+ * process. In addition, NodeJS module resolution can lead to duplicate copies
+ * of `@pulumi/pulumi` and thus duplicate options objects that may not be synced
+ * if options are cached upfront. Mutating options must write to the environment
  * and reading options must always read directly from the environment.
-
  */
 function options(): Options {
     const { settings } = getStore();
@@ -428,14 +510,17 @@ function options(): Options {
 }
 
 /**
- * disconnect permanently disconnects from the server, closing the connections.  It waits for the existing RPC
- * queue to drain.  If any RPCs come in afterwards, however, they will crash the process.
+ * Permanently disconnects from the server, closing the connections. It waits
+ * for the existing RPC queue to drain.  If any RPCs come in afterwards,
+ * however, they will crash the process.
  */
 export function disconnect(): Promise<void> {
     return waitForRPCs(/*disconnectFromServers*/ true);
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function waitForRPCs(disconnectFromServers = false): Promise<void> {
     const localStore = getStore();
     let done: Promise<any> | undefined;
@@ -454,7 +539,7 @@ export function waitForRPCs(disconnectFromServers = false): Promise<void> {
 }
 
 /**
- * getMaximumListeners returns the configured number of process listeners available
+ * Returns the configured number of process listeners available.
  */
 export function getMaximumListeners(): number {
     const { settings } = getStore();
@@ -462,8 +547,9 @@ export function getMaximumListeners(): number {
 }
 
 /**
- * disconnectSync permanently disconnects from the server, closing the connections. Unlike `disconnect`. it does not
- * wait for the existing RPC queue to drain. Any RPCs that come in after this call will crash the process.
+ * Permanently disconnects from the server, closing the connections. Unlike
+ * `disconnect`. it does not wait for the existing RPC queue to drain. Any RPCs
+ * that come in after this call will crash the process.
  */
 export function disconnectSync(): void {
     // Otherwise, actually perform the close activities (ignoring errors and crashes).
@@ -492,8 +578,9 @@ export function disconnectSync(): void {
 }
 
 /**
- * rpcKeepAlive registers a pending call to ensure that we don't prematurely disconnect from the server.  It returns
- * a function that, when invoked, signals that the RPC has completed.
+ * Registers a pending call to ensure that we don't prematurely disconnect from
+ * the server.  It returns a function that, when invoked, signals that the RPC
+ * has completed.
  */
 export function rpcKeepAlive(): () => void {
     const localStore = getStore();
@@ -510,7 +597,8 @@ export function rpcKeepAlive(): () => void {
 }
 
 /**
- * setRootResource registers a resource that will become the default parent for all resources without explicit parents.
+ * Registers a resource that will become the default parent for all resources
+ * without explicit parents.
  */
 export async function setRootResource(res: ComponentResource): Promise<void> {
     // This is the first async point of program startup where we can query the resource monitor for its capabilities.

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -21,15 +21,16 @@ import { getCallbacks, isDryRun, isQueryMode, setRootResource } from "./settings
 import { getStore, setStackResource, getStackResource as stateGetStackResource } from "./state";
 
 /**
- * rootPulumiStackTypeName is the type name that should be used to construct the root component in the tree of Pulumi
- * resources allocated by a deployment.  This must be kept up to date with
- * `github.com/pulumi/pulumi/sdk/v3/go/common/resource/stack.RootStackType`.
+ * The type name that should be used to construct the root component in the tree
+ * of Pulumi resources allocated by a deployment. This must be kept up to date
+ * with `github.com/pulumi/pulumi/sdk/v3/go/common/resource/stack.RootStackType`.
  */
 export const rootPulumiStackTypeName = "pulumi:pulumi:Stack";
 
 /**
- * runInPulumiStack creates a new Pulumi stack resource and executes the callback inside of it.  Any outputs
- * returned by the callback will be stored as output properties on this resulting Stack object.
+ * Creates a new Pulumi stack resource and executes the callback inside of it.
+ * Any outputs returned by the callback will be stored as output properties on
+ * this resulting Stack object.
  */
 export function runInPulumiStack(init: () => Promise<any>): Promise<Inputs | undefined> {
     if (!isQueryMode()) {
@@ -41,8 +42,9 @@ export function runInPulumiStack(init: () => Promise<any>): Promise<Inputs | und
 }
 
 /**
- * Stack is the root resource for a Pulumi stack. Before invoking the `init` callback, it registers itself as the root
- * resource with the Pulumi engine.
+ * {@link Stack} is the root resource for a Pulumi stack. Before invoking the
+ * `init` callback, it registers itself as the root resource with the Pulumi
+ * engine.
  */
 export class Stack extends ComponentResource<Inputs> {
     /**
@@ -61,10 +63,12 @@ export class Stack extends ComponentResource<Inputs> {
     }
 
     /**
-     * runInit invokes the given init callback with this resource set as the root resource. The return value of init is
-     * used as the stack's output properties.
+     * Invokes the given `init` callback with this resource set as the root
+     * resource. The return value of init is used as the stack's output
+     * properties.
      *
-     * @param args.init The callback to run in the context of this Pulumi stack
+     * @param args.init
+     *  The callback to run in the context of this Pulumi stack
      */
     async initialize(args: { init: () => Promise<Inputs> }): Promise<Inputs> {
         await setRootResource(this);
@@ -209,7 +213,8 @@ async function massageComplex(prop: any, objectStack: any[]): Promise<any> {
 }
 
 /**
- * Add a transformation to all future resources constructed in this Pulumi stack.
+ * Add a transformation to all future resources constructed in this Pulumi
+ * stack.
  */
 export function registerStackTransformation(t: ResourceTransformation) {
     const stackResource = getStackResource();
@@ -220,7 +225,8 @@ export function registerStackTransformation(t: ResourceTransformation) {
 }
 
 /**
- * Add a transformation to all future resources constructed in this Pulumi stack.
+ * Add a transformation to all future resources constructed in this Pulumi
+ * stack.
  */
 export function registerResourceTransform(t: ResourceTransform): void {
     if (!getStore().supportsTransforms) {
@@ -234,9 +240,11 @@ export function registerResourceTransform(t: ResourceTransform): void {
 }
 
 /**
- * Add a transformation to all future resources constructed in this Pulumi stack.
+ * Add a transformation to all future resources constructed in this Pulumi
+ * stack.
  *
- * @deprecated Use `registerResourceTransform` instead.
+ * @deprecated
+ *  Use `registerResourceTransform` instead.
  */
 export function registerStackTransform(t: ResourceTransform) {
     registerResourceTransform(t);

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -29,8 +29,11 @@ const nodeEnvKeys = {
     monitorAddr: "PULUMI_NODEJS_MONITOR",
     engineAddr: "PULUMI_NODEJS_ENGINE",
     syncDir: "PULUMI_NODEJS_SYNC",
-    // this value is not set by the CLI and is controlled via a user set env var unlike the values above
+
+    // Unlike the values above, this value is not set by the CLI and is
+    // controlled via a user-set environment variable.
     cacheDynamicProviders: "PULUMI_NODEJS_CACHE_DYNAMIC_PROVIDERS",
+
     organization: "PULUMI_NODEJS_ORGANIZATION",
 };
 
@@ -38,30 +41,86 @@ const pulumiEnvKeys = {
     legacyApply: "PULUMI_ENABLE_LEGACY_APPLY",
 };
 
-/** @internal */
+/**
+ * @internal
+ */
 export const asyncLocalStorage = new AsyncLocalStorage<Store>();
 
-/** @internal */
+/**
+ * @internal
+ */
 export interface WriteableOptions {
-    project?: string; // the name of the current project.
-    stack?: string; // the name of the current stack being deployed into.
-    parallel?: number; // the degree of parallelism for resource operations (default is serial).
-    engineAddr?: string; // a connection string to the engine's RPC, in case we need to reestablish.
-    monitorAddr?: string; // a connection string to the monitor's RPC, in case we need to reestablish.
-    dryRun?: boolean; // whether we are performing a preview (true) or a real deployment (false).
-    testModeEnabled?: boolean; // true if we're in testing mode (allows execution without the CLI).
-    queryMode?: boolean; // true if we're in query mode (does not allow resource registration).
-    legacyApply?: boolean; // true if we will resolve missing outputs to inputs during preview.
-    cacheDynamicProviders?: boolean; // true if we will cache serialized dynamic providers on the program side.
-    organization?: string; // the name of the current organization (if available).
-    maximumProcessListeners: number; // the number of process listeners which can be registered before writing a warning.
     /**
-     * Directory containing the send/receive files for making synchronous invokes to the engine.
+     * The name of the current project.
+     */
+    project?: string;
+
+    /**
+     * The name of the current stack being deployed into.
+     */
+    stack?: string;
+
+    /**
+     * The degree of parallelism for resource operations (default is serial).
+     */
+    parallel?: number;
+
+    /**
+     * A connection string to the engine's RPC, in case we need to reestablish.
+     */
+    engineAddr?: string;
+
+    /**
+     * A connection string to the monitor's RPC, in case we need to reestablish.
+     */
+    monitorAddr?: string;
+
+    /**
+     * Whether we are performing a preview (true) or a real deployment (false).
+     */
+    dryRun?: boolean;
+
+    /**
+     * True if we're in testing mode (allows execution without the CLI).
+     */
+    testModeEnabled?: boolean;
+
+    /**
+     * True if we're in query mode (does not allow resource registration).
+     */
+    queryMode?: boolean;
+
+    /**
+     * True if we will resolve missing outputs to inputs during preview.
+     */
+    legacyApply?: boolean;
+
+    /**
+     * True if we will cache serialized dynamic providers on the program side.
+     */
+    cacheDynamicProviders?: boolean;
+
+    /**
+     * The name of the current organization (if available).
+     */
+    organization?: string;
+
+    /**
+     * The number of process listeners which can be registered before writing a
+     * warning.
+     */
+    maximumProcessListeners: number;
+
+    /**
+     * A directory containing the send/receive files for making synchronous
+     * invokes to the engine.
      */
     syncDir?: string;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export interface Store {
     settings: {
         options: WriteableOptions;
@@ -77,53 +136,56 @@ export interface Store {
     logErrorCount: number;
 
     /**
-     * monitorSupportsSecrets returns a promise that when resolved tells you if the resource monitor we are connected
-     * to is able to support secrets across its RPC interface. When it does, we marshal outputs marked with the secret
-     * bit in a special way.
+     * Tells us if the resource monitor we are connected to is able to support
+     * secrets across its RPC interface. When it does, we marshal outputs marked
+     * with the secret bit in a special way.
      */
     supportsSecrets: boolean;
 
     /**
-     * monitorSupportsResourceReferences returns a promise that when resolved tells you if the resource monitor we are
-     * connected to is able to support resource references across its RPC interface. When it does, we marshal resources
-     * in a special way.
+     * Tells us if the resource monitor we are connected to is able to support
+     * resource references across its RPC interface. When it does, we marshal
+     * resources in a special way.
      */
     supportsResourceReferences: boolean;
 
     /**
-     * monitorSupportsOutputValues returns a promise that when resolved tells you if the resource monitor we are
-     * connected to is able to support output values across its RPC interface. When it does, we marshal outputs
+     * Tells u if the resource monitor we are connected to is able to support
+     * output values across its RPC interface. When it does, we marshal outputs
      * in a special way.
      */
     supportsOutputValues: boolean;
 
     /**
-     * monitorSupportsDeletedWith returns a promise that when resolved tells you if the resource monitor we are
-     * connected to is able to support the deletedWith resource option across its RPC interface.
+     * Tells us if the resource monitor we are connected to is able to support
+     * the `deletedWith` resource option across its RPC interface.
      */
     supportsDeletedWith: boolean;
 
     /**
-     * monitorSupportsAliasSpecs returns a promise that when resolved tells you if the resource monitor we are
-     * connected to is able to support alias specs across its RPC interface. When it does, we marshal aliases
-     * in a special way.
+     * Tells us if the resource monitor we are connected to is able to support
+     * alias specs across its RPC interface. When it does, we marshal aliases in
+     * a special way.
      */
     supportsAliasSpecs: boolean;
 
     /**
-     * supportsTransforms returns a promise that when resolved tells you if the resource monitor we are
-     * connected to is able to support remote transforms across its RPC interface. When it does, we marshal
+     * Tells us if the resource monitor we are connected to is able to support
+     * remote transforms across its RPC interface. When it does, we marshal
      * transforms to the monitor instead of running them locally.
      */
     supportsTransforms: boolean;
 
     /**
-     * callback service running for this deployment. This registers callbacks and forwards them to the engine.
+     * The callback service running for this deployment. This registers
+     * callbacks and forwards them to the engine.
      */
     callbacks?: ICallbackServer;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export class LocalStore implements Store {
     settings = {
         options: {
@@ -149,7 +211,7 @@ export class LocalStore implements Store {
     stackResource = undefined;
 
     /**
-     * leakCandidates tracks the list of potential leak candidates.
+     * Tracks the list of potential leak candidates.
      */
     leakCandidates = new Set<Promise<any>>();
 
@@ -163,7 +225,9 @@ export class LocalStore implements Store {
     supportsTransforms = false;
 }
 
-/** Get the root stack resource for the current stack deployment
+/**
+ * Get the root stack resource for the current stack deployment.
+ *
  * @internal
  */
 export function getStackResource(): Stack | undefined {
@@ -171,7 +235,9 @@ export function getStackResource(): Stack | undefined {
     return stackResource;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function setStackResource(newStackResource?: Stack) {
     const localStore = getStore();
     globalThis.stackResource = newStackResource;
@@ -184,7 +250,9 @@ declare global {
     var stackResource: Stack | undefined;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function getLocalStore(): Store | undefined {
     return asyncLocalStorage.getStore();
 }
@@ -199,7 +267,9 @@ export function getLocalStore(): Store | undefined {
     return returnFunc;
 };
 
-/** @internal */
+/**
+ * @internal
+ */
 export const getStore = () => {
     const localStore = getLocalStore();
     if (localStore === undefined) {


### PR DESCRIPTION
This commit improves the TypeScript TypeDocs for `runtime` modules in the NodeJS SDK. Specifically:

* It adds documentation to interfaces, properties, etc. that are missing it.

* It transforms would-be TypeDoc comments erroneously written using either `/*` (a single asterisk) or `//` (a normal line comment) to actual TypeDoc comments.

* It standardises on TypeDoc's `{@link Name}` syntax for linking identifiers, as opposed to the mixture of backticks and square brackets we have today.

* It fixes typos and generally cleans up the formatting here and there, as well as introducing more consistency where the same concepts crop up in multiple places.