### PR TITLE
Improve TypeDocs for `sdk/nodejs`

### DIFF
--- a/sdk/nodejs/asset/archive.ts
+++ b/sdk/nodejs/asset/archive.ts
@@ -16,19 +16,21 @@ import * as utils from "../utils";
 import { Asset } from "./asset";
 
 /**
- * An Archive represents a collection of named assets.
+ * An {@link Archive} represents a collection of named assets.
  */
 export abstract class Archive {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __pulumiArchive: boolean = true;
 
     /**
-     * Returns true if the given object is an instance of an Archive.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is an {@link Archive}. This is designed
+     * to work even when multiple copies of the Pulumi SDK have been loaded into
+     * the same process.
      */
     public static isInstance(obj: any): obj is Archive {
         return utils.isInstance<Archive>(obj, "__pulumiArchive");
@@ -36,12 +38,13 @@ export abstract class Archive {
 }
 
 /**
- * AssetMap is a map of assets.
+ * A map of assets.
  */
 export type AssetMap = { [name: string]: Asset | Archive };
 
 /**
- * An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
+ * An {@link AssetArchive} is an archive created from an in-memory collection of
+ * named assets or other archives.
  */
 export class AssetArchive extends Archive {
     /**
@@ -56,8 +59,9 @@ export class AssetArchive extends Archive {
 }
 
 /**
- * A FileArchive is a file-based archive, or a collection of file-based assets.  This can be a raw directory or a
- * single archive file in one of the supported formats (.tar, .tar.gz, or .zip).
+ * A {@link FileArchive} is a file-based archive, or a collection of file-based
+ * assets. This can be a raw directory or a single archive file in one of the
+ * supported formats (`.tar`, `.tar.gz`, or `.zip`).
  */
 export class FileArchive extends Archive {
     /**
@@ -72,9 +76,11 @@ export class FileArchive extends Archive {
 }
 
 /**
- * A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates the
- * protocol for fetching the archive's contents: `file://` is a local file (just like a FileArchive), `http://` and
- * `https://` specify HTTP and HTTPS, respectively, and specific providers may recognize custom schemes.
+ * A {@link RemoteArchive} is a file-based archive fetched from a remote
+ * location. The URI's scheme dictates the protocol for fetching the archive's
+ * contents: `file://` is a local file (just like a {@link FileArchive}),
+ * `http://` and `https://` specify HTTP and HTTPS, respectively, and specific
+ * providers may recognize custom schemes.
  */
 export class RemoteArchive extends Archive {
     /**

--- a/sdk/nodejs/asset/asset.ts
+++ b/sdk/nodejs/asset/asset.ts
@@ -15,19 +15,22 @@
 import * as utils from "../utils";
 
 /**
- * Asset represents a single blob of text or data that is managed as a first class entity.
+ * {@link Asset} represents a single blob of text or data that is managed as a
+ * first-class entity.
  */
 export abstract class Asset {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __pulumiAsset: boolean = true;
 
     /**
-     * Returns true if the given object is an instance of an Asset.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is an {@link Asset}. This is designed to
+     * work even when multiple copies of the Pulumi SDK have been loaded into
+     * the same process.
      */
     public static isInstance(obj: any): obj is Asset {
         return utils.isInstance<Asset>(obj, "__pulumiAsset");
@@ -35,18 +38,8 @@ export abstract class Asset {
 }
 
 /**
- * Blob is a kind of asset produced from an in-memory blob represented as a byte array.
- */
-/* IDEA: enable this once Uint8Array is supported.
-export class Blob extends Asset {
-    constructor(data: Uint8Array) {
-        super();
-    }
-}
-*/
-
-/**
- * FileAsset is a kind of asset produced from a given path to a file on the local filesystem.
+ * {@link FileAsset} is a kind of asset produced from a given path to a file on
+ * the local filesystem.
  */
 export class FileAsset extends Asset {
     /**
@@ -61,7 +54,8 @@ export class FileAsset extends Asset {
 }
 
 /**
- * StringAsset is a kind of asset produced from an in-memory UTF8-encoded string.
+ * {@link StringAsset} is a kind of asset produced from an in-memory
+ * UTF8-encoded string.
  */
 export class StringAsset extends Asset {
     /**
@@ -76,9 +70,11 @@ export class StringAsset extends Asset {
 }
 
 /**
- * RemoteAsset is a kind of asset produced from a given URI string.  The URI's scheme dictates the protocol for fetching
- * contents: `file://` specifies a local file, `http://` and `https://` specify HTTP and HTTPS, respectively.  Note that
- * specific providers may recognize alternative schemes; this is merely the base-most set that all providers support.
+ * {@link RemoteAsset} is a kind of asset produced from a given URI string. The
+ * URI's scheme dictates the protocol for fetching contents: `file://` specifies
+ * a local file, `http://` and `https://` specify HTTP and HTTPS, respectively.
+ * Note that specific providers may recognize alternative schemes; this is
+ * merely the smallest set that all providers support.
  */
 export class RemoteAsset extends Asset {
     /**

--- a/sdk/nodejs/dynamic/index.ts
+++ b/sdk/nodejs/dynamic/index.ts
@@ -18,7 +18,7 @@ import * as settings from "../runtime/settings";
 import * as serializeClosure from "../runtime/closure/serializeClosure";
 
 /**
- * CheckResult represents the results of a call to `ResourceProvider.check`.
+ * {@link CheckResult} represents the results of a call to {@link ResourceProvider.check}.
  */
 export interface CheckResult<Inputs = any> {
     /**
@@ -33,7 +33,8 @@ export interface CheckResult<Inputs = any> {
 }
 
 /**
- * CheckFailure represents a single failure in the results of a call to `ResourceProvider.check`
+ * {@link CheckFailure} represents a single failure in the results of a call to
+ * {@link ResourceProvider.check}.
  */
 export interface CheckFailure {
     /**
@@ -48,7 +49,8 @@ export interface CheckFailure {
 }
 
 /**
- * DiffResult represents the results of a call to `ResourceProvider.diff`.
+ * {@link DiffResult} represents the results of a call to
+ * {@link ResourceProvider.diff}.
  */
 export interface DiffResult {
     /**
@@ -67,14 +69,16 @@ export interface DiffResult {
     readonly stables?: string[];
 
     /**
-     * If true, and a replacement occurs, the resource will first be deleted before being recreated.  This is to
-     * void potential side-by-side issues with the default create before delete behavior.
+     * If true, and a replacement occurs, the resource will first be deleted
+     * before being recreated.  This is to avoid potential side-by-side issues
+     * with the default create before delete behavior.
      */
     readonly deleteBeforeReplace?: boolean;
 }
 
 /**
- * CreateResult represents the results of a call to `ResourceProvider.create`.
+ * {@link CreateResult} represents the results of a call to
+ * {@link ResourceProvider.create}.
  */
 export interface CreateResult<Outputs = any> {
     /**
@@ -88,6 +92,10 @@ export interface CreateResult<Outputs = any> {
     readonly outs?: Outputs;
 }
 
+/**
+ * {@link ReadResult} represents the results of a call to
+ * {@link ResourceProvider.read}.
+ */
 export interface ReadResult<Outputs = any> {
     /**
      * The ID of the resource ready back (or blank if missing).
@@ -100,7 +108,8 @@ export interface ReadResult<Outputs = any> {
 }
 
 /**
- * UpdateResult represents the results of a call to `ResourceProvider.update`.
+ * {@link UpdateResult} represents the results of a call to
+ * {@link ResourceProvider.update}.
  */
 export interface UpdateResult<Outputs = any> {
     /**
@@ -110,54 +119,70 @@ export interface UpdateResult<Outputs = any> {
 }
 
 /**
- * ResourceProvider represents an object that provides CRUD operations for a particular type of resource.
+ * {@link ResourceProvider} represents an object that provides CRUD operations
+ * for a particular type of resource.
  */
 export interface ResourceProvider<Inputs = any, Outputs = any> {
     /**
-     * Check validates that the given property bag is valid for a resource of the given type.
+     * Validates that the given property bag is valid for a resource of the given type.
      *
-     * @param olds The old input properties to use for validation.
-     * @param news The new input properties to use for validation.
+     * @param olds
+     *  The old input properties to use for validation.
+     * @param news
+     *  The new input properties to use for validation.
      */
     check?: (olds: Inputs, news: Inputs) => Promise<CheckResult<Inputs>>;
 
     /**
-     * Diff checks what impacts a hypothetical update will have on the resource's properties.
+     * Checks what impacts a hypothetical update will have on the resource's
+     * properties.
      *
-     * @param id The ID of the resource to diff.
-     * @param olds The old values of properties to diff.
-     * @param news The new values of properties to diff.
+     * @param id
+     *  The ID of the resource to diff.
+     * @param olds
+     *  The old values of properties to diff.
+     * @param news
+     *  The new values of properties to diff.
      */
     diff?: (id: resource.ID, olds: Outputs, news: Inputs) => Promise<DiffResult>;
 
     /**
-     * Create allocates a new instance of the provided resource and returns its unique ID afterwards.
-     * If this call fails, the resource must not have been created (i.e., it is "transactional").
+     * Allocates a new instance of the provided resource and returns its unique
+     * ID afterwards. If this call fails, the resource must not have been
+     * created (i.e., it is "transactional").
      *
-     * @param inputs The properties to set during creation.
+     * @param inputs
+     *  The properties to set during creation.
      */
     create: (inputs: Inputs) => Promise<CreateResult<Outputs>>;
 
     /**
-     * Reads the current live state associated with a resource.  Enough state must be included in the inputs to uniquely
-     * identify the resource; this is typically just the resource ID, but it may also include some properties.
+     * Reads the current live state associated with a resource. Enough state
+     * must be included in the inputs to uniquely identify the resource; this is
+     * typically just the resource ID, but it may also include some properties.
      */
     read?: (id: resource.ID, props?: Outputs) => Promise<ReadResult<Outputs>>;
 
     /**
-     * Update updates an existing resource with new values.
+     * Updates an existing resource with new values.
      *
-     * @param id The ID of the resource to update.
-     * @param olds The old values of properties to update.
-     * @param news The new values of properties to update.
+     * @param id
+     *  The ID of the resource to update.
+     * @param olds
+     *  The old values of properties to update.
+     * @param news
+     *  The new values of properties to update.
      */
     update?: (id: resource.ID, olds: Outputs, news: Inputs) => Promise<UpdateResult<Outputs>>;
 
     /**
-     * Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+     * Tears down an existing resource with the given ID.  If it fails,
+     * the resource is assumed to still exist.
      *
-     * @param id The ID of the resource to delete.
-     * @param props The current properties on the resource.
+     * @param id
+     *  The ID of the resource to delete.
+     * @param props
+     *  The current properties on the resource.
      */
     delete?: (id: resource.ID, props: Outputs) => Promise<void>;
 }
@@ -200,19 +225,26 @@ function serializeFunctionMaybeSecret(provider: ResourceProvider): Output<string
 }
 
 /**
- * Resource represents a Pulumi Resource that incorporates an inline implementation of the Resource's CRUD operations.
+ * {@link Resource} represents a Pulumi resource that incorporates an inline
+ * implementation of the Resource's CRUD operations.
  */
 export abstract class Resource extends resource.CustomResource {
     /**
      * Creates a new dynamic resource.
      *
-     * @param provider The implementation of the resource's CRUD operations.
-     * @param name The name of the resource.
-     * @param props The arguments to use to populate the new resource. Must not define the reserved
-     *              property "__provider".
-     * @param opts A bag of options that control this resource's behavior.
-     * @param module The module of the resource.
-     * @param type The type of the resource.
+     * @param provider
+     *  The implementation of the resource's CRUD operations.
+     * @param name
+     *  The name of the resource.
+     * @param props
+     *  The arguments to use to populate the new resource. Must not define the
+     *  reserved property "__provider".
+     * @param opts
+     *  A bag of options that control this resource's behavior.
+     * @param module
+     *  The module of the resource.
+     * @param type
+     *  The type of the resource.
      */
     constructor(
         provider: ResourceProvider,

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -18,22 +18,25 @@ import { Resource } from "./resource";
 import * as utils from "./utils";
 
 /**
- * RunError can be used for terminating a program abruptly, but resulting in a clean exit rather
- * than the usual verbose unhandled error logic which emits the source program text and complete
- * stack trace.  This type should be rarely used.  Ideally ResourceError should always be used so
- * that as many errors as possible can be associated with a Resource.
+ * {@link RunError} can be used for terminating a program abruptly, but
+ * resulting in a clean exit rather than the usual verbose unhandled error logic
+ * which emits the source program text and complete stack trace. This type
+ * should be rarely used. Ideally {@link ResourceError} should always be used so
+ * that as many errors as possible can be associated with a resource.
  */
 export class RunError extends Error {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __pulumiRunError: boolean = true;
 
     /**
-     * Returns true if the given object is an instance of a RunError.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is a {@link RunError}. This is designed
+     * to work even when multiple copies of the Pulumi SDK have been loaded into
+     * the same process.
      */
     public static isInstance(obj: any): obj is RunError {
         return utils.isInstance<RunError>(obj, "__pulumiRunError");
@@ -41,22 +44,25 @@ export class RunError extends Error {
 }
 
 /**
- * ResourceError can be used for terminating a program abruptly, specifically associating the
- * problem with a Resource.  Depending on the nature of the problem, clients can choose whether or
- * not a call stack should be returned as well.  This should be very rare, and would only indicate
- * no usefulness of presenting that stack to the user.
+ * {@link ResourceError} can be used for terminating a program abruptly,
+ * specifically associating the problem with a {@link Resource}. Depending on
+ * the nature of the problem, clients can choose whether or not the call stack
+ * should be hidden as well. This should be very rare, and would only indicate
+ * that presenting the stack to the user would not be useful/be detrimental.
  */
 export class ResourceError extends Error {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle, id-blacklist, id-match
     public readonly __pulumResourceError: boolean = true;
 
     /**
-     * Returns true if the given object is an instance of a ResourceError.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is a {@link ResourceError}. This is
+     * designed to work even when multiple copies of the Pulumi SDK have been
+     * loaded into the same process.
      */
     public static isInstance(obj: any): obj is ResourceError {
         return utils.isInstance<ResourceError>(obj, "__pulumResourceError");

--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -15,8 +15,9 @@
 import { Input } from "./output";
 import { ProviderResource, Resource } from "./resource";
 
-/*
- * InvokeOptions is a bag of options that control the behavior of a call to runtime.invoke.
+/**
+ * {@link InvokeOptions} is a bag of options that control the behavior of a call
+ * to `runtime.invoke`.
  */
 export interface InvokeOptions {
     /**
@@ -31,8 +32,8 @@ export interface InvokeOptions {
     provider?: ProviderResource;
 
     /**
-     * An optional version, corresponding to the version of the provider plugin that should be used when performing this
-     * invoke.
+     * An optional version, corresponding to the version of the provider plugin
+     * that should be used when performing this invoke.
      */
     version?: string;
 

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -15,8 +15,9 @@
 import { Input, Output } from "../output";
 
 /**
- * toObject takes an array of T values, and a selector that produces key/value pairs from those inputs,
- * and converts this array into an output object with those keys and values.
+ * {@link toObject} takes an array of T values, and a selector that produces
+ * key/value pairs from those inputs, and converts this array into an output
+ * object with those keys and values.
  *
  * For instance, given an array as follows
  *
@@ -47,9 +48,10 @@ export function toObject<T, V>(
 }
 
 /**
- * groupBy takes an array of T values, and a selector that prduces key/value pairs from those inputs,
- * and converts this array into an output object, with those keys, and where each property is an array of values,
- * in the case that the same key shows up multiple times in the input.
+ * {@link groupBy} takes an array of T values, and a selector that prduces
+ * key/value pairs from those inputs, and converts this array into an output
+ * object, with those keys, and where each property is an array of values, in
+ * the case that the same key shows up multiple times in the input.
  *
  * For instance, given an array as follows
  *

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -30,14 +30,14 @@ const messageLevels = {
 };
 
 /**
- * hasErrors returns true if any errors have occurred in the program.
+ * Returns true if any errors have occurred in the program.
  */
 export function hasErrors(): boolean {
     return getStore().logErrorCount > 0;
 }
 
 /**
- * debug logs a debug-level message that is generally hidden from end-users.
+ * Logs a debug-level message that is generally hidden from end-users.
  */
 export function debug(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     const engine = getEngine();
@@ -49,7 +49,8 @@ export function debug(msg: string, resource?: resourceTypes.Resource, streamId?:
 }
 
 /**
- * info logs an informational message that is generally printed to stdout during resource operations.
+ * Logs an informational message that is generally printed to standard output
+ * during resource operations.
  */
 export function info(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     const engine = getEngine();
@@ -62,7 +63,8 @@ export function info(msg: string, resource?: resourceTypes.Resource, streamId?: 
 }
 
 /**
- * warn logs a warning to indicate that something went wrong, but not catastrophically so.
+ * Logs a warning to indicate that something went wrong, but not
+ * catastrophically so.
  */
 export function warn(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     const engine = getEngine();
@@ -75,7 +77,8 @@ export function warn(msg: string, resource?: resourceTypes.Resource, streamId?: 
 }
 
 /**
- * error logs a fatal condition. Consider raising an exception after calling error to stop the Pulumi program.
+ * Logs a fatal condition. Consider raising an exception after calling error to
+ * stop the Pulumi program.
  */
 export function error(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     getStore().logErrorCount++; // remember the error so we can suppress leaks.

--- a/sdk/nodejs/metadata.ts
+++ b/sdk/nodejs/metadata.ts
@@ -17,19 +17,19 @@
 import * as settings from "./runtime/settings";
 
 /**
- * getOrganization returns the current organization name.
+ * Returns the current organization name.
  */
 export function getOrganization(): string {
     return settings.getOrganization();
 }
 /**
- * getProject returns the current project name. It throws an exception if none is registered.
+ * Returns the current project name. Throws an exception if none is registered.
  */
 export function getProject(): string {
     return settings.getProject();
 }
 /**
- * getStack returns the current stack name. It throws an exception if none is registered.
+ * Returns the current stack name. Throws an exception if none is registered.
  */
 export function getStack(): string {
     return settings.getStack();

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -120,7 +120,6 @@ class OutputImpl<T> implements OutputInstance<T> {
      *
      * To get the value of an {@link Output} as an `Output<string>` consider
      * either:
-     *
      * 1. `o.apply(v => ``prefix${v}suffix``)` or
      * 2. `pulumi.interpolate ``prefix${v}suffix`` `
      *
@@ -144,7 +143,6 @@ class OutputImpl<T> implements OutputInstance<T> {
      *
      * To get the value of an {@link Output} as a JSON value or JSON string consider
      * either:
-     *
      * 1. `o.apply(v => v.toJSON())` or
      * 2. `o.apply(v => JSON.stringify(v))`
      *

--- a/sdk/nodejs/provider/internals.ts
+++ b/sdk/nodejs/provider/internals.ts
@@ -24,7 +24,9 @@
 //
 // The code can prepend `--logtostderr` and verbosity e.g. `-v=9`
 // arguments. We ignore these for the moment.
-/** @internal */
+/**
+ * @internal
+ */
 export function parseArgs(args: string[]): { engineAddress: string } | undefined {
     const cleanArgs = [];
 

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -16,7 +16,8 @@ import { Input, Inputs } from "../output";
 import * as resource from "../resource";
 
 /**
- * CheckResult represents the results of a call to `ResourceProvider.check`.
+ * {@link CheckResult} represents the results of a call to
+ * {@link ResourceProvider.check}.
  */
 export interface CheckResult {
     /**
@@ -31,7 +32,8 @@ export interface CheckResult {
 }
 
 /**
- * CheckFailure represents a single failure in the results of a call to `ResourceProvider.check`
+ * {@link CheckFailure} represents a single failure in the results of a call to
+ * {@link ResourceProvider.check}.
  */
 export interface CheckFailure {
     /**
@@ -46,7 +48,8 @@ export interface CheckFailure {
 }
 
 /**
- * DiffResult represents the results of a call to `ResourceProvider.diff`.
+ * {@link DiffResult} represents the results of a call to
+ * {@link ResourceProvider.diff}.
  */
 export interface DiffResult {
     /**
@@ -65,14 +68,16 @@ export interface DiffResult {
     readonly stables?: string[];
 
     /**
-     * If true, and a replacement occurs, the resource will first be deleted before being recreated.  This is to
-     * avoid potential side-by-side issues with the default create before delete behavior.
+     * If true, and a replacement occurs, the resource will first be deleted
+     * before being recreated.  This is to avoid potential side-by-side issues
+     * with the default create before delete behavior.
      */
     readonly deleteBeforeReplace?: boolean;
 }
 
 /**
- * CreateResult represents the results of a call to `ResourceProvider.create`.
+ * {@link CreateResult} represents the results of a call to
+ * {@link ResourceProvider.create}.
  */
 export interface CreateResult {
     /**
@@ -86,6 +91,10 @@ export interface CreateResult {
     readonly outs?: any;
 }
 
+/**
+ * {@link ReadResult} represents the results of a call to
+ * {@link ResourceProvider.read}.
+ */
 export interface ReadResult {
     /**
      * The ID of the resource ready back (or blank if missing).
@@ -102,7 +111,8 @@ export interface ReadResult {
 }
 
 /**
- * UpdateResult represents the results of a call to `ResourceProvider.update`.
+ * {@link UpdateResult} represents the results of a call to
+ * {@link ResourceProvider.update}.
  */
 export interface UpdateResult {
     /**
@@ -112,7 +122,8 @@ export interface UpdateResult {
 }
 
 /**
- * ConstructResult represents the results of a call to `ResourceProvider.construct`.
+ * {@link ConstructResult} represents the results of a call to
+ * {@link ResourceProvider.construct}.
  */
 export interface ConstructResult {
     /**
@@ -127,7 +138,8 @@ export interface ConstructResult {
 }
 
 /**
- * InvokeResult represents the results of a call to `ResourceProvider.invoke`.
+ * {@link InvokeResult} represents the results of a call to
+ * {@link ResourceProvider.invoke}.
  */
 export interface InvokeResult {
     /**
@@ -142,7 +154,8 @@ export interface InvokeResult {
 }
 
 /**
- * Provider represents an object that implements the resources and functions for a particular Pulumi package.
+ * {@link Provider} represents an object that implements the resources and
+ * functions for a particular Pulumi package.
  */
 export interface Provider {
     /**
@@ -156,60 +169,79 @@ export interface Provider {
     schema?: string;
 
     /**
-     * Check validates that the given property bag is valid for a resource of the given type.
+     * Validates that the given property bag is valid for a resource of the
+     * given type.
      *
-     * @param olds The old input properties to use for validation.
-     * @param news The new input properties to use for validation.
+     * @param olds
+     *  The old input properties to use for validation.
+     * @param news
+     *  The new input properties to use for validation.
      */
     check?: (urn: resource.URN, olds: any, news: any) => Promise<CheckResult>;
 
     /**
-     * Diff checks what impacts a hypothetical update will have on the resource's properties.
+     * Checks what impacts a hypothetical update will have on the resource's properties.
      *
-     * @param id The ID of the resource to diff.
-     * @param olds The old values of properties to diff.
-     * @param news The new values of properties to diff.
+     * @param id
+     *  The ID of the resource to diff.
+     * @param olds
+     *  The old values of properties to diff.
+     * @param news
+     *  The new values of properties to diff.
      */
     diff?: (id: resource.ID, urn: resource.URN, olds: any, news: any) => Promise<DiffResult>;
 
     /**
-     * Create allocates a new instance of the provided resource and returns its unique ID afterwards.
-     * If this call fails, the resource must not have been created (i.e., it is "transactional").
+     * Allocates a new instance of the provided resource and returns its unique
+     * ID afterwards. If this call fails, the resource must not have been
+     * created (i.e., it is "transactional").
      *
-     * @param inputs The properties to set during creation.
+     * @param inputs
+     *  The properties to set during creation.
      */
     create?: (urn: resource.URN, inputs: any) => Promise<CreateResult>;
 
     /**
-     * Reads the current live state associated with a resource.  Enough state must be included in the inputs to uniquely
-     * identify the resource; this is typically just the resource ID, but it may also include some properties.
+     * Reads the current live state associated with a resource. Enough state
+     * must be included in the inputs to uniquely identify the resource; this is
+     * typically just the resource ID, but it may also include some properties.
      */
     read?: (id: resource.ID, urn: resource.URN, props?: any) => Promise<ReadResult>;
 
     /**
      * Update updates an existing resource with new values.
      *
-     * @param id The ID of the resource to update.
-     * @param olds The old values of properties to update.
-     * @param news The new values of properties to update.
+     * @param id
+     *  The ID of the resource to update.
+     * @param olds
+     *  The old values of properties to update.
+     * @param news
+     *  The new values of properties to update.
      */
     update?: (id: resource.ID, urn: resource.URN, olds: any, news: any) => Promise<UpdateResult>;
 
     /**
-     * Delete tears down an existing resource with the given ID.  If it fails, the resource is assumed to still exist.
+     * Tears down an existing resource with the given ID.  If it fails, the
+     * resource is assumed to still exist.
      *
-     * @param id The ID of the resource to delete.
-     * @param props The current properties on the resource.
+     * @param id
+     *  The ID of the resource to delete.
+     * @param props
+     *  The current properties on the resource.
      */
     delete?: (id: resource.ID, urn: resource.URN, props: any) => Promise<void>;
 
     /**
-     * Construct creates a new component resource.
+     * Creates a new component resource.
      *
-     * @param name The name of the resource to create.
-     * @param type The type of the resource to create.
-     * @param inputs The inputs to the resource.
-     * @param options the options for the resource.
+     * @param name
+     *  The name of the resource to create.
+     * @param type
+     *  The type of the resource to create.
+     * @param inputs
+     *  The inputs to the resource.
+     * @param options
+     *  The options for the resource.
      */
     construct?: (
         name: string,
@@ -219,18 +251,22 @@ export interface Provider {
     ) => Promise<ConstructResult>;
 
     /**
-     * Call calls the indicated method.
+     * Calls the indicated method.
      *
-     * @param token The token of the method to call.
-     * @param inputs The inputs to the method.
+     * @param token
+     *  The token of the method to call.
+     * @param inputs
+     *  The inputs to the method.
      */
     call?: (token: string, inputs: Inputs) => Promise<InvokeResult>;
 
     /**
-     * Invoke calls the indicated function.
+     * Calls the indicated function.
      *
-     * @param token The token of the function to call.
-     * @param inputs The inputs to the function.
+     * @param token
+     *  The token of the function to call.
+     * @param inputs
+     *  The inputs to the function.
      */
     invoke?: (token: string, inputs: any) => Promise<InvokeResult>;
 }

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -490,7 +490,8 @@ async function configureRuntime(req: any, engineAddr: string | undefined) {
 }
 
 /**
- * deserializeInputs deserializes the inputs struct and applies appropriate dependencies.
+ * Deserializes the inputs struct and applies appropriate dependencies.
+ *
  * @internal
  */
 export async function deserializeInputs(inputsStruct: gstruct.Struct, inputDependencies: any): Promise<Inputs> {
@@ -536,7 +537,9 @@ async function isResourceReference(input: any, deps: string[]): Promise<boolean>
 }
 
 /**
- * Returns true if the deserialized input contains Outputs (deeply), excluding properties of Resources.
+ * Returns true if the deserialized input contains outputs (deeply), excluding
+ * properties of resources.
+ *
  * @internal
  */
 export function containsOutputs(input: any): boolean {
@@ -565,11 +568,14 @@ export function containsOutputs(input: any): boolean {
     return false;
 }
 
-// grpcResponseFromError creates a gRPC response representing an error from a dynamic provider's
-// resource. This is typically either a creation error, in which the API server has (virtually)
-// rejected the resource, or an initialization error, where the API server has accepted the
-// resource, but it failed to initialize (e.g., the app code is continually crashing and the
-// resource has failed to become alive).
+/**
+ * Creates a gRPC response representing an error from a dynamic provider's
+ * resource. This is typically either a creation error, in which the API server
+ * has (virtually) rejected the resource, or an initialization error, where the
+ * API server has accepted the resource, but it failed to initialize (e.g., the
+ * app code is continually crashing and the resource has failed to become
+ * alive).
+ */
 function grpcResponseFromError(e: { id: string; properties: any; message: string; reasons?: string[] }) {
     // Create response object.
     const resp = new statusproto.Status();

--- a/sdk/nodejs/queryable/index.ts
+++ b/sdk/nodejs/queryable/index.ts
@@ -16,9 +16,11 @@ import { OutputInstance } from "../index";
 import { Resource } from "../resource";
 
 /**
- * ResolvedResource is a `Resource` with all fields containing `Output` values fully resolved. This
- * is useful primarily when we're querying over resource outputs (e.g., using
- * `pulumi.runtime.listResourceOutputs`), and we expect all values to be present and fully-resolved.
+ * {@link ResolvedResource} is a {@link Resource} with all fields containing
+ * {@link Output} values fully resolved. This is useful primarily when we're
+ * querying over resource outputs (e.g., using
+ * `pulumi.runtime.listResourceOutputs`), and we expect all values to be present
+ * and fully-resolved.
  */
 export type ResolvedResource<T extends Resource> = Omit<Resolved<T>, "urn" | "getProvider">;
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -33,8 +33,8 @@ export type ID = string; // a provider-assigned ID.
 export type URN = string; // an automatically generated logical URN, used to stably identify resources.
 
 /**
- * createUrn computes a URN from the combination of a resource name, resource type, optional parent,
- * optional project and optional stack.
+ * {@link createUrn} computes a URN from the combination of a resource name,
+ * resource type, optional parent, optional project and optional stack.
  */
 export function createUrn(
     name: Input<string>,
@@ -66,9 +66,10 @@ export function createUrn(
 }
 
 /**
- * inheritedChildAlias computes the alias that should be applied to a child based on an alias applied to it's parent.
- * This may involve changing the name of the resource in cases where the resource has a named derived from the name of
- * the parent, and the parent name changed.
+ * {@link inheritedChildAlias} computes the alias that should be applied to a
+ * child based on an alias applied to its parent. This may involve changing the
+ * name of the resource in cases where the resource has a named derived from the
+ * name of the parent, and the parent name changed.
  */
 function inheritedChildAlias(
     childName: string,
@@ -111,10 +112,12 @@ function urnTypeAndName(urn: URN) {
 }
 
 /**
- * allAliases computes the full set of aliases for a child resource given a set of aliases applied to the child and
- * parent resources. This includes the child resource's own aliases, as well as aliases inherited from the parent.
- * If there are N child aliases, and M parent aliases, there will be (M+1)*(N+1)-1 total aliases,
- * or, as calculated in the logic below, N+(M*(1+N)).
+ * {@link allAliases} computes the full set of aliases for a child resource
+ * given a set of aliases applied to the child and parent resources. This
+ * includes the child resource's own aliases, as well as aliases inherited from
+ * the parent. If there are N child aliases, and M parent aliases, there will be
+ * (M+1)*(N+1)-1 total aliases, or, as calculated in the logic below,
+ * N+(M*(1+N)).
  */
 export function allAliases(
     childAliases: Input<URN | Alias>[],
@@ -145,17 +148,19 @@ export function allAliases(
 }
 
 /**
- * Resource represents a class whose CRUD operations are implemented by a provider plugin.
+ * {@link Resource} represents a class whose CRUD operations are implemented by
+ * a provider plugin.
  */
 export abstract class Resource {
     /**
-     * A regexp for use with sourcePosition.
+     * A regexp for use with {@link sourcePosition}.
      */
     private static sourcePositionRegExp =
         /Error:\s*\n\s*at new Resource \(.*\)\n\s*at new \S*Resource \(.*\)\n(\s*at new \S* \(.*\)\n)?[^(]*\((?<file>.*):(?<line>[0-9]+):(?<col>[0-9]+)\)\n/;
 
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
@@ -163,21 +168,25 @@ export abstract class Resource {
 
     /**
      * The optional parent of this resource.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __parentResource: Resource | undefined;
 
     /**
-     * The child resources of this resource.  We use these (only from a ComponentResource) to allow
-     * code to dependOn a ComponentResource and have that effectively mean that it is depending on
-     * all the CustomResource children of that component.
+     * The child resources of this resource. We use these (only from a
+     * {@link ComponentResource}) to allow code to depend on a
+     * {@link ComponentResource} and have that effectively mean that it is
+     * depending on all the {@link CustomResource} children of that component.
      *
-     * Important!  We only walk through ComponentResources.  They're the only resources that serve
-     * as an aggregation of other primitive (i.e. custom) resources.  While a custom resource can be
-     * a parent of other resources, we don't want to ever depend on those child resource.  If we do,
-     * it's simple to end up in a situation where we end up depending on a child resource that has a
-     * data cycle dependency due to the data passed into it.
+     * Important! We only walk through {@link ComponentResources}. They're the
+     * only resources that serve as an aggregation of other primitive (i.e.
+     * custom) resources. While a custom resource can be a parent of other
+     * resources, we don't want to ever depend on those child resources. If we
+     * do, it's simple to end up in a situation where we end up depending on a
+     * child resource that has a data cycle dependency due to the data passed
+     * into it.
      *
      * An example of how this would be bad is:
      *
@@ -187,13 +196,14 @@ export abstract class Resource {
      *     var c3 = new CustomResource("c3", { parentId: c1.id }, { parent: c1 });
      * ```
      *
-     * The problem here is that 'c2' has a data dependency on 'c1'.  If it tries to wait on 'c1' it
-     * will walk to the children and wait on them.  This will mean it will wait on 'c3'.  But 'c3'
-     * will be waiting in the same manner on 'c2', and a cycle forms.
+     * The problem here is that 'c2' has a data dependency on 'c1'.  If it tries
+     * to wait on `c1` it will walk to the children and wait on them. This will
+     * mean it will wait on `c3`.  But `c3` will be waiting in the same manner
+     * on `c2`, and a cycle forms.
      *
-     * This normally does not happen with ComponentResources as they do not have any data flowing
-     * into them. The only way you would be able to have a problem is if you had this sort of coding
-     * pattern:
+     * This normally does not happen with component resources as they do not
+     * have any data flowing into them. The only way you would be able to have a
+     * problem is if you had this sort of coding pattern:
      *
      * ```ts
      *     var c1 = new ComponentResource("c1");
@@ -201,9 +211,9 @@ export abstract class Resource {
      *     var c3 = new CustomResource("c3", { parentId: c1.urn }, { parent: c1 });
      * ```
      *
-     * However, this would be pretty nonsensical as there is zero need for a custom resource to ever
-     * need to reference the urn of a component resource.  So it's acceptable if that sort of
-     * pattern failed in practice.
+     * However, this would be pretty nonsensical as there is zero need for a
+     * custom resource to ever need to reference the URN of a component
+     * resource. So it's acceptable if that sort of pattern fails in practice.
      *
      * @internal
      */
@@ -211,24 +221,28 @@ export abstract class Resource {
     public __childResources: Set<Resource> | undefined;
 
     /**
-     * urn is the stable logical URN used to distinctly address a resource, both before and after
-     * deployments.
+     * The stable logical URN used to distinctly address a resource, both before
+     * and after deployments.
      */
     public readonly urn!: Output<URN>;
 
     /**
-     * When set to true, protect ensures this resource cannot be deleted.
+     * When set to true, ensures that this resource cannot be deleted.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     private readonly __protect: boolean;
 
     /**
-     * A collection of transformations to apply as part of resource registration.
+     * A collection of transformations to apply as part of resource
+     * registration.
      *
-     * Note: This is marked optional only because older versions of this library may not have had
-     * this property, and marking optional forces consumers of the property to defensively handle
-     * cases where they are passed "old" resources.
+     * Note: This is marked optional only because older versions of this library
+     * may not have had this property, and marking it as optional forces
+     * consumers of the property to defensively handle cases where they are
+     * passed "old" resources.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
@@ -237,9 +251,11 @@ export abstract class Resource {
     /**
      * A list of aliases applied to this resource.
      *
-     * Note: This is marked optional only because older versions of this library may not have had
-     * this property, and marking optional forces consumers of the property to defensively handle
-     * cases where they are passed "old" resources.
+     * Note: This is marked optional only because older versions of this library
+     * may not have had this property, and marking it as optional forces
+     * consumers of the property to defensively handle cases where they are
+     * passed "old" resources.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
@@ -248,25 +264,31 @@ export abstract class Resource {
     /**
      * The name assigned to the resource at construction.
      *
-     * Note: This is marked optional only because older versions of this library may not have had
-     * this property, and marking optional forces consumers of the property to defensively handle
-     * cases where they are passed "old" resources.
+     * Note: This is marked optional only because older versions of this library
+     * may not have had this property, and marking it as optional forces
+     * consumers of the property to defensively handle cases where they are
+     * passed "old" resources.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     readonly __name?: string;
 
     /**
-     * The set of providers to use for child resources. Keyed by package name (e.g. "aws").
+     * The set of providers to use for child resources. Keyed by package name
+     * (e.g. "aws").
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     private readonly __providers: Record<string, ProviderResource>;
 
     /**
-     * The specified provider or provider determined from the parent for custom or remote resources.
-     * It is passed along in the `Call` gRPC request for resource method calls (when set) so that the
-     * call goes to the same provider as the resource.
+     * The specified provider or provider determined from the parent for custom
+     * or remote resources. It is passed along in the `Call` gRPC request for
+     * resource method calls (when set) so that the call goes to the same
+     * provider as the resource.
+     *
      * @internal
      */
     // Note: This is deliberately not named `__provider` as that conflicts with the property
@@ -276,6 +298,7 @@ export abstract class Resource {
 
     /**
      * The specified provider version.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
@@ -283,14 +306,16 @@ export abstract class Resource {
 
     /**
      * The specified provider download URL.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     readonly __pluginDownloadURL?: string;
 
     /**
-     * Private field containing the type ID for this object. Useful for implementing `isInstance` on
-     * classes that inherit from `Resource`.
+     * A private field containing the type ID for this object. Useful for
+     * implementing `isInstance` on classes that inherit from `Resource`.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
@@ -301,26 +326,31 @@ export abstract class Resource {
     }
 
     /**
-     * sourcePosition returns the source position of the user code that instantiated this resource.
+     * Returns the source position of the user code that instantiated this
+     * resource.
      *
      * This is somewhat brittle in that it expects a call stack of the form:
-     * - Resource class constructor
-     * - abstract Resource subclass constructor
-     * - concrete Resource subclass constructor
+     *
+     * - {@link Resource} class constructor
+     * - abstract {@link Resource} subclass constructor
+     * - concrete {@link Resource} subclass constructor
      * - user code
      *
-     * This stack reflects the expected class hierarchy of "cloud resource / component resource < customresource/componentresource < resource".
+     * This stack reflects the expected class hierarchy of:
      *
-     * For example, consider the AWS S3 Bucket resource. When user code instantiates a Bucket, the stack will look like
-     * this:
+     * Resource > Custom/Component resource > Cloud/Component resource
+     *
+     * For example, consider the AWS S3 Bucket resource. When user code
+     * instantiates a Bucket, the stack will look like this:
      *
      *     new Resource (/path/to/resource.ts:123:45)
      *     new CustomResource (/path/to/resource.ts:678:90)
      *     new Bucket (/path/to/bucket.ts:987:65)
      *     <user code> (/path/to/index.ts:4:3)
      *
-     * Because Node can only give us the stack trace as text, we parse out the source position using a regex that
-     * matches traces of this form (see stackTraceRegExp above).
+     * Because Node can only give us the stack trace as text, we parse out the
+     * source position using a regex that matches traces of this form (see
+     * the {@link sourcePositionRegExp} above).
      */
     private static sourcePosition(): SourcePosition | undefined {
         const stackObj: any = {};
@@ -361,18 +391,26 @@ export abstract class Resource {
     }
 
     /**
-     * Creates and registers a new resource object.  [t] is the fully qualified type token and
-     * [name] is the "name" part to use in creating a stable and globally unique URN for the object.
-     * dependsOn is an optional list of other resources that this resource depends on, controlling
-     * the order in which we perform resource operations.
+     * Creates and registers a new resource object. `t` is the fully qualified
+     * type token and `name` is the "name" part to use in creating a stable and
+     * globally unique URN for the object. `dependsOn` is an optional list of
+     * other resources that this resource depends on, controlling the order in
+     * which we perform resource operations.
      *
-     * @param t The type of the resource.
-     * @param name The _unique_ name of the resource.
-     * @param custom True to indicate that this is a custom resource, managed by a plugin.
-     * @param props The arguments to use to populate the new resource.
-     * @param opts A bag of options that control this resource's behavior.
-     * @param remote True if this is a remote component resource.
-     * @param dependency True if this is a synthetic resource used internally for dependency tracking.
+     * @param t
+     *  The type of the resource.
+     * @param name
+     *  The _unique_ name of the resource.
+     * @param custom
+     *  True to indicate that this is a custom resource, managed by a plugin.
+     * @param props
+     *  The arguments to use to populate the new resource.
+     * @param opts
+     *  A bag of options that control this resource's behavior.
+     * @param remote
+     *  True if this is a remote component resource.
+     * @param dependency
+     *  True if this is a synthetic resource used internally for dependency tracking.
      */
     constructor(
         t: string,
@@ -551,40 +589,45 @@ function convertToProvidersMap(providers: Record<string, ProviderResource> | Pro
 (<any>Resource).doNotCapture = true;
 
 /**
- * Constant to represent the 'root stack' resource for a Pulumi application.  The purpose of this is
- * solely to make it easy to write an [Alias] like so:
+ * A constant to represent the "root stack" resource for a Pulumi application.
+ * The purpose of this is solely to make it easy to write an {@link Alias} like
+ * so:
  *
  * `aliases: [{ parent: rootStackResource }]`.
  *
- * This indicates that the prior name for a resource was created based on it being parented directly
- * by the stack itself and no other resources.  Note: this is equivalent to:
+ * This indicates that the prior name for a resource was created based on it
+ * being parented directly by the stack itself and no other resources. Note:
+ * this is equivalent to:
  *
  * `aliases: [{ parent: undefined }]`
  *
- * However, the former form is preferable as it is more self-descriptive, while the latter may look
- * a bit confusing and may incorrectly look like something that could be removed without changing
- * semantics.
+ * However, the former form is preferable as it is more self-descriptive, while
+ * the latter may look a bit confusing and may incorrectly look like something
+ * that could be removed without changing semantics.
  */
 export const rootStackResource: Resource = undefined!;
 
 /**
- * Alias is a partial description of prior named used for a resource. It can be processed in the
- * context of a resource creation to determine what the full aliased URN would be.
+ * {@link Alias} is a partial description of prior names used for a resource. It
+ * can be processed in the context of a resource creation to determine what the
+ * full aliased URN would be.
  *
- * Note there is a semantic difference between properties being absent from this type and properties
- * having the `undefined` value. Specifically, there is a difference between:
+ * Note there is a semantic difference between properties being absent from this
+ * type and properties having the `undefined` value. Specifically, there is a
+ * difference between:
  *
  * ```ts
  * { name: "foo", parent: undefined } // and
  * { name: "foo" }
  * ```
  *
- * The presence of a property indicates if its value should be used.  If absent, then the value is
- * not used.  So, in the above while `alias.parent` is `undefined` for both, the first alias means
- * "the original urn had no parent" while the second alias means "use the current parent".
+ * The presence of a property indicates if its value should be used.  If absent,
+ * then the value is not used. So, in the above while `alias.parent` is
+ * `undefined` for both, the first alias means "the original URN had no parent"
+ * while the second alias means "use the current parent".
  *
- * Note: to indicate that a resource was previously parented by the root stack, it is recommended
- * that you use:
+ * Note: to indicate that a resource was previously parented by the root stack,
+ * it is recommended that you use:
  *
  * `aliases: [{ parent: pulumi.rootStackResource }]`
  *
@@ -594,29 +637,35 @@ export const rootStackResource: Resource = undefined!;
  */
 export interface Alias {
     /**
-     * The previous name of the resource.  If not provided, the current name of the resource is
-     * used.
+     * The previous name of the resource. If not provided, the current name of
+     * the resource is used.
      */
     name?: Input<string>;
+
     /**
-     * The previous type of the resource.  If not provided, the current type of the resource is used.
+     * The previous type of the resource. If not provided, the current type of
+     * the resource is used.
      */
     type?: Input<string>;
 
     /**
-     * The previous parent of the resource.  If not provided (i.e. `{ name: "foo" }`), the current
-     * parent of the resource is used (`opts.parent` if provided, else the implicit stack resource
-     * parent).
+     * The previous parent of the resource. If not provided (i.e. `{ name: "foo"
+     * }`), the current parent of the resource is used (`opts.parent` if
+     * provided, else the implicit stack resource parent).
      *
      * To specify no original parent, use `{ parent: pulumi.rootStackResource }`.
      */
     parent?: Resource | Input<URN>;
+
     /**
-     * The previous stack of the resource.  If not provided, defaults to `pulumi.getStack()`.
+     * The previous stack of the resource. If not provided, defaults to
+     * `pulumi.getStack()`.
      */
     stack?: Input<string>;
+
     /**
-     * The previous project of the resource. If not provided, defaults to `pulumi.getProject()`.
+     * The previous project of the resource. If not provided, defaults to
+     * `pulumi.getProject()`.
      */
     project?: Input<string>;
 }
@@ -655,7 +704,8 @@ function collapseAliasToUrn(
 }
 
 /**
- * ResourceOptions is a bag of optional settings that control a resource's behavior.
+ * {@link ResourceOptions} is a bag of optional settings that control a
+ * resource's behavior.
  */
 export interface ResourceOptions {
     // !!! IMPORTANT !!! If you add a new field to this type, make sure to add test that verifies that
@@ -666,38 +716,46 @@ export interface ResourceOptions {
      * An optional existing ID to load, rather than create.
      */
     id?: Input<ID>;
+
     /**
      * An optional parent resource to which this resource belongs.
      */
     parent?: Resource;
+
     /**
      * An optional additional explicit dependencies on other resources.
      */
     dependsOn?: Input<Input<Resource>[]> | Input<Resource>;
+
     /**
      * When set to true, protect ensures this resource cannot be deleted.
      */
     protect?: boolean;
+
     /**
      * Ignore changes to any of the specified properties.
      */
     ignoreChanges?: string[];
+
     /**
      * Changes to any of these property paths will force a replacement.  If this list includes `"*"`, changes to any
      * properties will force a replacement.  Initialization errors from previous deployments will require replacement
      * instead of update only if `"*"` is passed.
      */
     replaceOnChanges?: string[];
+
     /**
      * An optional version, corresponding to the version of the provider plugin that should be used when operating on
      * this resource. This version overrides the version information inferred from the current package and should
      * rarely be used.
      */
     version?: string;
+
     /**
      * An optional list of aliases to treat this resource as matching.
      */
     aliases?: Input<URN | Alias>[];
+
     /**
      * An optional provider to use for this resource's CRUD operations. If no provider is supplied,
      * the default provider for the resource's package will be used. The default provider is pulled
@@ -706,10 +764,12 @@ export interface ResourceOptions {
      * If this is a [ComponentResourceOptions] do not provide both [provider] and [providers]
      */
     provider?: ProviderResource;
+
     /**
      * An optional customTimeouts configuration block.
      */
     customTimeouts?: CustomTimeouts;
+
     /**
      * Optional list of transformations to apply to this resource during construction. The
      * transformations are applied in order, and are applied prior to transformation applied to
@@ -730,16 +790,19 @@ export interface ResourceOptions {
      * The URN of a previously-registered resource of this type to read from the engine.
      */
     urn?: URN;
+
     /**
      * An option to specify the URL from which to download this resources
      * associated plugin. This version overrides the URL information inferred
      * from the current package and should rarely be used.
      */
     pluginDownloadURL?: string;
+
     /**
      * If set to True, the providers Delete method will not be called for this resource.
      */
     retainOnDelete?: boolean;
+
     /**
      * If set, the providers Delete method will not be called for this resource
      * if specified is being deleted as well.
@@ -755,10 +818,12 @@ export interface CustomTimeouts {
      * The optional create timeout represented as a string e.g. 5m, 40s, 1d.
      */
     create?: string;
+
     /**
      * The optional update timeout represented as a string e.g. 5m, 40s, 1d.
      */
     update?: string;
+
     /**
      * The optional delete timeout represented as a string e.g. 5m, 40s, 1d.
      */
@@ -766,63 +831,73 @@ export interface CustomTimeouts {
 }
 
 /**
- * ResourceTransformation is the callback signature for the `transformations` resource option.  A
- * transformation is passed the same set of inputs provided to the `Resource` constructor, and can
- * optionally return back alternate values for the `props` and/or `opts` prior to the resource
- * actually being created.  The effect will be as though those props and opts were passed in place
- * of the original call to the `Resource` constructor.  If the transformation returns undefined,
- * this indicates that the resource will not be transformed.
+ * {@link ResourceTransformation} is the callback signature for the
+ * `transformations` resource option.  A transformation is passed the same set
+ * of inputs provided to the {@link Resource} constructor, and can optionally
+ * return back alternate values for the `props` and/or `opts` prior to the
+ * resource actually being created.  The effect will be as though those props
+ * and opts were passed in place of the original call to the {@link Resource}
+ * constructor. If the transformation returns `undefined`, this indicates that
+ * the resource will not be transformed.
  */
 export type ResourceTransformation = (args: ResourceTransformationArgs) => ResourceTransformationResult | undefined;
 
 /**
- * ResourceTransform is the callback signature for the `transforms` resource option.  A
- * transform is passed the same set of inputs provided to the `Resource` constructor, and can
- * optionally return back alternate values for the `props` and/or `opts` prior to the resource
- * actually being created.  The effect will be as though those props and opts were passed in place
- * of the original call to the `Resource` constructor.  If the transform returns undefined,
- * this indicates that the resource will not be transformed.
+ * {@link ResourceTransform} is the callback signature for the `transforms`
+ * resource option.  A transform is passed the same set of inputs provided to
+ * the {@link Resource} constructor, and can optionally return back alternate
+ * values for the `props` and/or `opts` prior to the resource actually being
+ * created.  The effect will be as though those props and opts were passed in
+ * place of the original call to the {@link Resource} constructor.  If the
+ * transform returns `undefined`, this indicates that the resource will not be
+ * transformed.
  */
 export type ResourceTransform = (
     args: ResourceTransformArgs,
 ) => Promise<ResourceTransformResult | undefined> | ResourceTransformResult | undefined;
 
 /**
- * ResourceTransformArgs is the argument bag passed to a resource transform.
+ * {@link ResourceTransformArgs} is the argument bag passed to a resource transform.
  */
 export interface ResourceTransformArgs {
     /**
-     * If the resource is a custom or component resource.
+     * True if the resource is a custom resource, false if it is a component resource.
      */
     custom: boolean;
+
     /**
-     * The type of the Resource.
+     * The type of the resource.
      */
     type: string;
+
     /**
-     * The name of the Resource.
+     * The name of the resource.
      */
     name: string;
+
     /**
-     * The original properties passed to the Resource constructor.
+     * The original properties passed to the resource constructor.
      */
     props: Inputs;
+
     /**
-     * The original resource options passed to the Resource constructor.
+     * The original resource options passed to the resource constructor.
      */
     opts: ResourceOptions;
 }
 
 /**
- * ResourceTransformResult is the result that must be returned by a resource transformation
- * callback.  It includes new values to use for the `props` and `opts` of the `Resource` in place of
- * the originally provided values.
+ * {@link ResourceTransformResult} is the result that must be returned by a
+ * resource transformation callback.  It includes new values to use for the
+ * `props` and `opts` of the {@link Resource} in place of the originally
+ * provided values.
  */
 export interface ResourceTransformResult {
     /**
      * The new properties to use in place of the original `props`
      */
     props: Inputs;
+
     /**
      * The new resource options to use in place of the original `opts`
      */
@@ -830,41 +905,48 @@ export interface ResourceTransformResult {
 }
 
 /**
- * ResourceTransformationArgs is the argument bag passed to a resource transformation.
+ * {@link ResourceTransformationArgs} is the argument bag passed to a resource
+ * transformation.
  */
 export interface ResourceTransformationArgs {
     /**
-     * The Resource instance that is being transformed.
+     * The {@link Resource} instance that is being transformed.
      */
     resource: Resource;
+
     /**
-     * The type of the Resource.
+     * The type of the resource.
      */
     type: string;
+
     /**
-     * The name of the Resource.
+     * The name of the resource.
      */
     name: string;
+
     /**
-     * The original properties passed to the Resource constructor.
+     * The original properties passed to the resource constructor.
      */
     props: Inputs;
+
     /**
-     * The original resource options passed to the Resource constructor.
+     * The original resource options passed to the resource constructor.
      */
     opts: ResourceOptions;
 }
 
 /**
- * ResourceTransformationResult is the result that must be returned by a resource transformation
- * callback.  It includes new values to use for the `props` and `opts` of the `Resource` in place of
- * the originally provided values.
+ * {@link ResourceTransformationResult} is the result that must be returned by a
+ * resource transformation callback.  It includes new values to use for the
+ * `props` and `opts` of the {@link Resource} in place of the originally
+ * provided values.
  */
 export interface ResourceTransformationResult {
     /**
      * The new properties to use in place of the original `props`
      */
     props: Inputs;
+
     /**
      * The new resource options to use in place of the original `opts`
      */
@@ -872,30 +954,33 @@ export interface ResourceTransformationResult {
 }
 
 /**
- * CustomResourceOptions is a bag of optional settings that control a custom resource's behavior.
+ * {@link CustomResourceOptions} is a bag of optional settings that control a
+ * custom resource's behavior.
  */
 export interface CustomResourceOptions extends ResourceOptions {
     // !!! IMPORTANT !!! If you add a new field to this type, make sure to add test that verifies
     // that mergeOptions works properly for it.
 
     /**
-     * When set to true, deleteBeforeReplace indicates that this resource should be deleted before its replacement
-     * is created when replacement is necessary.
+     * When set to true, indicates that this resource should be deleted before
+     * its replacement is created when replacement is necessary.
      */
     deleteBeforeReplace?: boolean;
 
     /**
-     * The names of outputs for this resource that should be treated as secrets. This augments the list that
-     * the resource provider and pulumi engine already determine based on inputs to your resource. It can be used
-     * to mark certain ouputs as a secrets on a per resource basis.
+     * The names of outputs for this resource that should be treated as secrets.
+     * This augments the list that the resource provider and Pulumi engine
+     * already determine based on inputs to your resource. It can be used to
+     * mark certain ouputs as a secrets on a per resource basis.
      */
     additionalSecretOutputs?: string[];
 
     /**
-     * When provided with a resource ID, import indicates that this resource's provider should import its state from
-     * the cloud resource with the given ID. The inputs to the resource's constructor must align with the resource's
-     * current state. Once a resource has been imported, the import property must be removed from the resource's
-     * options.
+     * When provided with a resource ID, indicates that this resource's provider
+     * should import its state from the cloud resource with the given ID. The
+     * inputs to the resource's constructor must align with the resource's
+     * current state. Once a resource has been imported, the import property
+     * must be removed from the resource's options.
      */
     import?: ID;
 
@@ -904,16 +989,17 @@ export interface CustomResourceOptions extends ResourceOptions {
 }
 
 /**
- * ComponentResourceOptions is a bag of optional settings that control a component resource's behavior.
+ * {@link ComponentResourceOptions} is a bag of optional settings that control a
+ * component resource's behavior.
  */
 export interface ComponentResourceOptions extends ResourceOptions {
     // !!! IMPORTANT !!! If you add a new field to this type, make sure to add test that verifies
     // that mergeOptions works properly for it.
 
     /**
-     * An optional set of providers to use for child resources. Either keyed by package name (e.g.
-     * "aws"), or just provided as an array.  In the latter case, the package name will be retrieved
-     * from the provider itself.
+     * An optional set of providers to use for child resources. Either keyed by
+     * package name (e.g. "aws"), or just provided as an array.  In the latter
+     * case, the package name will be retrieved from the provider itself.
      *
      * Note: only a list should be used. Mapping keys are not respected.
      */
@@ -924,46 +1010,56 @@ export interface ComponentResourceOptions extends ResourceOptions {
 }
 
 /**
- * CustomResource is a resource whose create, read, update, and delete (CRUD) operations are managed
- * by performing external operations on some physical entity.  The engine understands how to diff
- * and perform partial updates of them, and these CRUD operations are implemented in a dynamically
+ * {@link CustomResource} is a resource whose create, read, update, and delete
+ * (CRUD) operations are managed by performing external operations on some
+ * physical entity.  The engine understands how to diff and perform partial
+ * updates of them, and these CRUD operations are implemented in a dynamically
  * loaded plugin for the defining package.
  */
 export abstract class CustomResource extends Resource {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
      * @internal
+     *
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __pulumiCustomResource: boolean;
 
     /**
-     * id is the provider-assigned unique ID for this managed resource.  It is set during
-     * deployments and may be missing (undefined) during planning phases.
+     * The provider-assigned unique ID for this managed resource. It is set
+     * during deployments and may be missing (undefined) during planning phases.
      */
     public readonly id!: Output<ID>;
 
     /**
-     * Returns true if the given object is an instance of CustomResource.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is a {@link CustomResource}. This is
+     * designed to work even when multiple copies of the Pulumi SDK have been
+     * loaded into the same process.
      */
     public static isInstance(obj: any): obj is CustomResource {
         return utils.isInstance<CustomResource>(obj, "__pulumiCustomResource");
     }
 
     /**
-     * Creates and registers a new managed resource.  t is the fully qualified type token and name
-     * is the "name" part to use in creating a stable and globally unique URN for the object.
-     * dependsOn is an optional list of other resources that this resource depends on, controlling
-     * the order in which we perform resource operations. Creating an instance does not necessarily
-     * perform a create on the physical entity which it represents, and instead, this is dependent
-     * upon the diffing of the new goal state compared to the current known resource state.
+     * Creates and registers a new managed resource. `t` is the fully qualified
+     * type token and `name` is the "name" part to use in creating a stable and
+     * globally unique URN for the object. `dependsOn` is an optional list of
+     * other resources that this resource depends on, controlling the order in
+     * which we perform resource operations. Creating an instance does not
+     * necessarily perform a create on the physical entity which it represents.
+     * Instead, this is dependent upon the diffing of the new goal state
+     * compared to the current known resource state.
      *
-     * @param t The type of the resource.
-     * @param name The _unique_ name of the resource.
-     * @param props The arguments to use to populate the new resource.
-     * @param opts A bag of options that control this resource's behavior.
-     * @param dependency True if this is a synthetic resource used internally for dependency tracking.
+     * @param t
+     *  The type of the resource.
+     * @param name
+     *  The _unique_ name of the resource.
+     * @param props
+     *  The arguments to use to populate the new resource.
+     * @param opts
+     *  A bag of options that control this resource's behavior.
+     * @param dependency
+     *  True if this is a synthetic resource used internally for dependency tracking.
      */
     constructor(t: string, name: string, props?: Inputs, opts: CustomResourceOptions = {}, dependency = false) {
         if ((<ComponentResourceOptions>opts).providers) {
@@ -981,14 +1077,19 @@ export abstract class CustomResource extends Resource {
 (<any>CustomResource).doNotCapture = true;
 
 /**
- * ProviderResource is a resource that implements CRUD operations for other custom resources. These resources are
- * managed similarly to other resources, including the usual diffing and update semantics.
+ * {@link ProviderResource} is a resource that implements CRUD operations for
+ * other custom resources. These resources are managed similarly to other
+ * resources, including the usual diffing and update semantics.
  */
 export abstract class ProviderResource extends CustomResource {
-    /** @internal */
+    /**
+     * @internal
+     */
     private readonly pkg: string;
 
-    /** @internal */
+    /**
+     * @internal
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public __registrationId?: string;
 
@@ -1009,68 +1110,90 @@ export abstract class ProviderResource extends CustomResource {
     /**
      * Creates and registers a new provider resource for a particular package.
      *
-     * @param pkg The package associated with this provider.
-     * @param name The _unique_ name of the provider.
-     * @param props The configuration to use for this provider.
-     * @param opts A bag of options that control this provider's behavior.
-     * @param dependency True if this is a synthetic resource used internally for dependency tracking.
+     * @param pkg
+     *  The package associated with this provider.
+     * @param name
+     *  The _unique_ name of the provider.
+     * @param props
+     *  The configuration to use for this provider.
+     * @param opts
+     *  A bag of options that control this provider's behavior.
+     * @param dependency
+     *  True if this is a synthetic resource used internally for dependency tracking.
      */
     constructor(pkg: string, name: string, props?: Inputs, opts: ResourceOptions = {}, dependency: boolean = false) {
         super(`pulumi:providers:${pkg}`, name, props, opts, dependency);
         this.pkg = pkg;
     }
 
-    /** @internal */
+    /**
+     * @internal
+     */
     public getPackage() {
         return this.pkg;
     }
 }
 
 /**
- * ComponentResource is a resource that aggregates one or more other child resources into a higher
- * level abstraction. The component resource itself is a resource, but does not require custom CRUD
- * operations for provisioning.
+ * {@link ComponentResource} is a resource that aggregates one or more other
+ * child resources into a higher level abstraction. The component resource
+ * itself is a resource, but does not require custom CRUD operations for
+ * provisioning.
  */
 export class ComponentResource<TData = any> extends Resource {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
+     *
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __pulumiComponentResource = true;
 
-    /** @internal */
+    /**
+     * @internal
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __data: Promise<TData>;
 
-    /** @internal */
+    /**
+     * @internal
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     private __registered = false;
 
-    /** @internal */
+    /**
+     * @internal
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
     public readonly __remote: boolean;
 
     /**
-     * Returns true if the given object is an instance of CustomResource.  This is designed to work even when
-     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     * Returns true if the given object is a {@link CustomResource}. This is
+     * designed to work even when multiple copies of the Pulumi SDK have been
+     * loaded into the same process.
      */
     public static isInstance(obj: any): obj is ComponentResource {
         return utils.isInstance<ComponentResource>(obj, "__pulumiComponentResource");
     }
 
     /**
-     * Creates and registers a new component resource.  [type] is the fully qualified type token and
-     * [name] is the "name" part to use in creating a stable and globally unique URN for the object.
-     * [opts.parent] is the optional parent for this component, and [opts.dependsOn] is an optional
-     * list of other resources that this resource depends on, controlling the order in which we
-     * perform resource operations.
+     * Creates and registers a new component resource. `type` is the fully
+     * qualified type token and `name` is the "name" part to use in creating a
+     * stable and globally unique URN for the object. `opts.parent` is the
+     * optional parent for this component, and `opts.dependsOn` is an optional
+     * list of other resources that this resource depends on, controlling the
+     * order in which we perform resource operations.
      *
-     * @param type The type of the resource.
-     * @param name The _unique_ name of the resource.
-     * @param args Information passed to [initialize] method.
-     * @param opts A bag of options that control this resource's behavior.
-     * @param remote True if this is a remote component resource.
+     * @param type
+     *  The type of the resource.
+     * @param name
+     *  The _unique_ name of the resource.
+     * @param args
+     *  Information passed to [initialize] method.
+     * @param opts
+     *  A bag of options that control this resource's behavior.
+     * @param remote
+     *  True if this is a remote component resource.
      */
     constructor(
         type: string,
@@ -1093,7 +1216,9 @@ export class ComponentResource<TData = any> extends Resource {
         this.__data = remote || opts?.urn ? Promise.resolve(<TData>{}) : this.initializeAndRegisterOutputs(args);
     }
 
-    /** @internal */
+    /**
+     * @internal
+     */
     private async initializeAndRegisterOutputs(args: Inputs) {
         const data = await this.initialize(args);
         this.registerOutputs();
@@ -1101,29 +1226,32 @@ export class ComponentResource<TData = any> extends Resource {
     }
 
     /**
-     * Can be overridden by a subclass to asynchronously initialize data for this Component
-     * automatically when constructed.  The data will be available immediately for subclass
-     * constructors to use.  To access the data use `.getData`.
+     * Can be overridden by a subclass to asynchronously initialize data for this component
+     * automatically when constructed. The data will be available immediately for subclass
+     * constructors to use. To access the data use {@link getData}.
      */
     protected async initialize(args: Inputs): Promise<TData> {
         return <TData>undefined!;
     }
 
     /**
-     * Retrieves the data produces by [initialize].  The data is immediately available in a
-     * derived class's constructor after the `super(...)` call to `ComponentResource`.
+     * Retrieves the data produces by {@link initialize}. The data is
+     * immediately available in a derived class's constructor after the
+     * `super(...)` call to `ComponentResource`.
      */
     protected getData(): Promise<TData> {
         return this.__data;
     }
 
     /**
-     * registerOutputs registers synthetic outputs that a component has initialized, usually by
-     * allocating other child sub-resources and propagating their resulting property values.
+     * Registers synthetic outputs that a component has initialized, usually by
+     * allocating other child sub-resources and propagating their resulting
+     * property values.
      *
-     * ComponentResources can call this at the end of their constructor to indicate that they are
-     * done creating child resources.  This is not strictly necessary as this will automatically be
-     * called after the `initialize` method completes.
+     * Component resources can call this at the end of their constructor to
+     * indicate that they are done creating child resources.  This is not
+     * strictly necessary as this will automatically be called after the {@link
+     * initialize} method completes.
      */
     protected registerOutputs(outputs?: Inputs | Promise<Inputs> | Output<Inputs>): void {
         if (this.__registered) {
@@ -1140,25 +1268,32 @@ export class ComponentResource<TData = any> extends Resource {
 (<any>ComponentResource.prototype).initialize.doNotCapture = true;
 (<any>ComponentResource.prototype).initializeAndRegisterOutputs.doNotCapture = true;
 
-/** @internal */
+/**
+ * @internal
+ */
 export const testingOptions = {
     isDryRun: false,
 };
 
 /**
- * [mergeOptions] takes two ResourceOptions values and produces a new ResourceOptions with the
- * respective properties of `opts2` merged over the same properties in `opts1`.  The original
- * options objects will be unchanged.
+ * {@link mergeOptions} takes two {@link ResourceOptions} values and produces a new
+ * {@link ResourceOptions} with the respective properties of `opts2` merged over the
+ * same properties in `opts1`. The original options objects will be unchanged.
  *
  * Conceptually property merging follows these basic rules:
- *  1. if the property is a collection, the final value will be a collection containing the values
- *     from each options object.
- *  2. Simple scaler values from `opts2` (i.e. strings, numbers, bools) will replace the values of
- *     `opts1`.
- *  3. `opts2` can have properties explicitly provided with `null` or `undefined` as the value. If
- *     explicitly provided, then that will be the final value in the result.
- *  4. For the purposes of merging `dependsOn`, `provider` and `providers` are always treated as
- *     collections, even if only a single value was provided.
+ *
+ *  1. if the property is a collection, the final value will be a collection
+ *     containing the values from each options object.
+ *
+ *  2. Simple scaler values from `opts2` (i.e. strings, numbers, bools) will
+ *     replace the values of `opts1`.
+ *
+ *  3. `opts2` can have properties explicitly provided with `null` or
+ *     `undefined` as the value. If explicitly provided, then that will be the
+ *     final value in the result.
+ *
+ *  4. For the purposes of merging `dependsOn`, `provider` and `providers` are
+ *     always treated as collections, even if only a single value was provided.
  */
 export function mergeOptions(
     opts1: CustomResourceOptions | undefined,
@@ -1205,7 +1340,9 @@ function isPromiseOrOutput(val: any): boolean {
     return val instanceof Promise || Output.isInstance(val);
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function expandProviders(options: ComponentResourceOptions) {
     // Convert 'providers' map to array form.
     if (options.providers && !Array.isArray(options.providers)) {
@@ -1237,7 +1374,10 @@ function normalizeProviders(opts: ComponentResourceOptions) {
     }
 }
 
-/** @internal for testing purposes. */
+/**
+ * @internal
+ *  This is exported for testing purposes.
+ */
 export function merge(dest: any, source: any, alwaysCreateArray: boolean): any {
     // unwind any top level promise/outputs.
     if (isPromiseOrOutput(dest)) {
@@ -1269,8 +1409,9 @@ function addToArray(resultArray: any[], value: any) {
 }
 
 /**
- * A DependencyResource is a resource that is used to indicate that an Output has a dependency on a particular
- * resource. These resources are only created when dealing with remote component resources.
+ * A {@link DependencyResource} is a resource that is used to indicate that an
+ * {@link Output} has a dependency on a particular resource. These resources are
+ * only created when dealing with remote component resources.
  */
 export class DependencyResource extends CustomResource {
     constructor(urn: URN) {
@@ -1287,8 +1428,9 @@ export class DependencyResource extends CustomResource {
 }
 
 /**
- * A DependencyProviderResource is a resource that is used by the provider SDK as a stand-in for a provider that
- * is only used for its reference. Its only valid properties are its URN and ID.
+ * A {@link DependencyProviderResource} is a resource that is used by the
+ * provider SDK as a stand-in for a provider that is only used for its
+ * reference. Its only valid properties are its URN and ID.
  */
 export class DependencyProviderResource extends ProviderResource {
     constructor(ref: string) {
@@ -1320,7 +1462,8 @@ export class DependencyProviderResource extends ProviderResource {
 }
 
 /**
- * parseResourceReference parses the URN and ID out of the provider reference.
+ * Parses the URN and ID out of the provider reference.
+ *
  * @internal
  */
 export function parseResourceReference(ref: string): [string, string] {

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -16,8 +16,9 @@ import { all, Input, Output, output } from "./output";
 import { CustomResource, CustomResourceOptions } from "./resource";
 
 /**
- * Manages a reference to a Pulumi stack. The referenced stack's outputs are available via the
- * `outputs` property or the `output` method.
+ * Manages a reference to a Pulumi stack. The referenced stack's outputs are
+ * available via the {@link StackReference.outputs} property or the
+ * {@link StackReference.output} method.
  */
 export class StackReference extends CustomResource {
     /**
@@ -36,13 +37,18 @@ export class StackReference extends CustomResource {
     public readonly secretOutputNames!: Output<string[]>;
 
     /**
-     * Create a StackReference resource with the given unique name, arguments, and options.
+     * Create a {@link StackReference} resource with the given unique name,
+     * arguments, and options.
      *
-     * If args is not specified, the name of the referenced stack will be the name of the StackReference resource.
+     * If args is not specified, the name of the referenced stack will be the
+     * name of the {@link StackReference} resource.
      *
-     * @param name The _unique_ name of the stack reference.
-     * @param args The arguments to use to populate this resource's properties.
-     * @param opts A bag of options that control this resource's behavior.
+     * @param name
+     *  The _unique_ name of the stack reference.
+     * @param args
+     *  The arguments to use to populate this resource's properties.
+     * @param opts
+     *  A bag of options that control this resource's behavior.
      */
     constructor(name: string, args?: StackReferenceArgs, opts?: CustomResourceOptions) {
         args = args || {};
@@ -62,9 +68,11 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value of the named stack output, or undefined if the stack output was not found.
+     * Fetches the value of the named stack output, or `undefined` if the stack
+     * output was not found.
      *
-     * @param name The name of the stack output to fetch.
+     * @param name
+     *  The name of the stack output to fetch.
      */
     public getOutput(name: Input<string>): Output<any> {
         // Note that this is subtly different from "apply" here. A default "apply" will set the secret bit if any
@@ -84,9 +92,11 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value of the named stack output, or throws an error if the output was not found.
+     * Fetches the value of the named stack output, or throws an error if the
+     * output was not found.
      *
-     * @param name The name of the stack output to fetch.
+     * @param name
+     *  The name of the stack output to fetch.
      */
     public requireOutput(name: Input<string>): Output<any> {
         const value = all([output(this.name), output(name), this.outputs]).apply(([stackname, n, os]) => {
@@ -105,14 +115,15 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value of the named stack output
-     * and builds a StackReferenceOutputDetails with it.
+     * Fetches the value of the named stack output and builds a
+     * {@link StackReferenceOutputDetails} with it.
      *
-     * The returned object has its `value` or `secretValue` fields set
-     * depending on wehther the output is a secret.
-     * Neither field is set if the output was not found.
+     * The returned object has its `value` or `secretValue` fields set depending
+     * on wehther the output is a secret. Neither field is set if the output was
+     * not found.
      *
-     * @param name The name of the stack output to fetch.
+     * @param name
+     *  The name of the stack output to fetch.
      */
     public async getOutputDetails(name: string): Promise<StackReferenceOutputDetails> {
         const [out, isSecret] = await this.readOutputValue("getOutputValueDetails", name, false /*required*/);
@@ -124,12 +135,14 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value promptly of the named stack output. May return undefined if the value is
-     * not known for some reason.
+     * Fetches the value promptly of the named stack output. May return
+     * undefined if the value is not known for some reason.
      *
-     * This operation is not supported (and will throw) if the named stack output is a secret.
+     * This operation is not supported (and will throw) if the named stack
+     * output is a secret.
      *
-     * @param name The name of the stack output to fetch.
+     * @param name
+     *  The name of the stack output to fetch.
      */
     public async getOutputValue(name: string): Promise<any> {
         const [out, isSecret] = await this.readOutputValue("getOutputValue", name, false /*required*/);
@@ -142,12 +155,14 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value promptly of the named stack output. Throws an error if the stack output is
-     * not found.
+     * Fetches the value promptly of the named stack output. Throws an error if
+     * the stack output is not found.
      *
-     * This operation is not supported (and will throw) if the named stack output is a secret.
+     * This operation is not supported (and will throw) if the named stack
+     * output is a secret.
      *
-     * @param name The name of the stack output to fetch.
+     * @param name
+     *  The name of the stack output to fetch.
      */
     public async requireOutputValue(name: string): Promise<any> {
         const [out, isSecret] = await this.readOutputValue("requireOutputSync", name, true /*required*/);
@@ -166,7 +181,7 @@ export class StackReference extends CustomResource {
 }
 
 /**
- * The set of arguments for constructing a StackReference resource.
+ * The set of arguments for constructing a {@link StackReference} resource.
  */
 export interface StackReferenceArgs {
     /**
@@ -176,18 +191,20 @@ export interface StackReferenceArgs {
 }
 
 /**
- * Records the output of a StackReference.
- * At most one of th evalue and secretValue fields will be set.
+ * Records the output of a {@link StackReference}. Exactly one of `value` or
+ * `secretValue` will be set.
  */
 export interface StackReferenceOutputDetails {
     /**
-     * Output value returned by the StackReference.
-     * This is null if the value is a secret or it does not exist.
+     * An output value returned by the {@link StackReference}.
+     *
+     * This is `null` if the value is a secret or it does not exist.
      */
     readonly value?: any;
     /**
-     * Secret value returned by the StackReference.
-     * This is null if the value is not a secret or it does not exist.
+     * A secret value returned by the {@link StackReference}.
+     *
+     * This is `null` if the value is not a secret or it does not exist.
      */
     readonly secretValue?: any;
 }

--- a/sdk/nodejs/tsutils.ts
+++ b/sdk/nodejs/tsutils.ts
@@ -19,7 +19,9 @@ import * as fs from "fs";
 import * as path from "path";
 import * as log from "./log";
 
-/** @internal */
+/**
+ * @internal
+ */
 export function loadTypeScriptCompilerOptions(tsConfigPath: string): object {
     try {
         const tsConfigString = fs.readFileSync(tsConfigPath).toString();
@@ -35,7 +37,9 @@ export function loadTypeScriptCompilerOptions(tsConfigPath: string): object {
 }
 
 /**
- * @internal Determine the strings used for requiring typescript and ts-node.
+ * Determine the strings used for requiring `typescript` and `ts-node`.
+ *
+ * @internal
  */
 export function typeScriptRequireStrings(): { typescriptRequire: string; tsnodeRequire: string } {
     let typescriptRequire = "typescript";

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -27,7 +27,9 @@ export function isInstance<T>(obj: any, name: keyof T): obj is T {
     return hasTrueBooleanMember(obj, name);
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function hasTrueBooleanMember(obj: any, memberName: string | number | symbol): boolean {
     if (obj === undefined || obj === null) {
         return false;
@@ -41,7 +43,9 @@ export function hasTrueBooleanMember(obj: any, memberName: string | number | sym
     return val === true;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function hasFunctionMember(obj: any, memberName: string | number | symbol): boolean {
     if (obj === undefined || obj === null) {
         return false;
@@ -55,7 +59,6 @@ export function hasFunctionMember(obj: any, memberName: string | number | symbol
     return true;
 }
 
-// Workaround errors we sometimes get on some machines saying that Object.values is not available.
 /**
  * A polyfill for Object.values
  *
@@ -69,16 +72,22 @@ export function values(obj: object): any[] {
     return result;
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export function union<T>(set1: Set<T>, set2: Set<T>) {
     return new Set([...set1, ...set2]);
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 export const disableResourceReferences: boolean =
     process.env.PULUMI_DISABLE_RESOURCE_REFERENCES === "1" ||
     (process.env.PULUMI_DISABLE_RESOURCE_REFERENCES ?? "").toUpperCase() === "TRUE";
 
-/** @internal */
+/**
+ * @internal
+ */
 export const errorOutputString: boolean =
     process.env.PULUMI_ERROR_OUTPUT_STRING === "1" || process.env.PULUMI_ERROR_OUTPUT_STRING?.toUpperCase() === "TRUE";


### PR DESCRIPTION
This commit improves the TypeScript TypeDocs for the remaining modules in the NodeJS SDK. Specifically:

* It adds documentation to interfaces, properties, etc. that are missing it.

* It transforms would-be TypeDoc comments erroneously written using either `/*` (a single asterisk) or `//` (a normal line comment) to actual TypeDoc comments.

* It standardises on TypeDoc's `{@link Name}` syntax for linking identifiers, as opposed to the mixture of backticks and square brackets we have today.

* It fixes typos and generally cleans up the formatting here and there, as well as introducing more consistency where the same concepts crop up in multiple places.