### PR TITLE
Fix incorrect YAML type checking of StackReference outputs

### DIFF
--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -15,7 +15,12 @@ func newPulumiPackage() *Package {
 			"pulumi:pulumi:StackReference": {
 				ObjectTypeSpec: ObjectTypeSpec{
 					Properties: map[string]PropertySpec{
-						"outputs": {TypeSpec: TypeSpec{Type: "object"}},
+						"outputs": {TypeSpec: TypeSpec{
+							Type: "object",
+							AdditionalProperties: &TypeSpec{
+								Ref: "pulumi.json#/Any",
+							},
+						}},
 					},
 					Required: []string{
 						"outputs",


### PR DESCRIPTION
Part of pulumi/pulumi-yaml#599.

Pulumi YAML uses the schema defined here to type check outputs from the `pulumi:pulumi:StackReference` resource. This changes the type of `outputs` from `map[string]string` to `map[string]any`, permitting list, map, and numeric outputs to be used as inputs to other resources.

To release this fix, we will need to release Pulumi twice and YAML once if we are to use our ordinary release process:

1. Merge this PR.
2. Release sdk and pkg dependencies with this update applied.
3. Merge https://github.com/pulumi/pulumi-yaml/pull/600
4. Create and merge a PR to update Pulumi YAML's dependency on `github.com/pulumi/pkg/v3`, as YAML links to the schema loader and will read the updated schema here:
 https://github.com/pulumi/pulumi/blob/7f48ca370d12e6d7fee29b7e1b6f87c9f558351e/pkg/codegen/schema/loader.go#L136-L140
 
5. Release Pulumi YAML
6. Create and merge a PR to update the YAML language plugin shipped with Pulumi
7. Release Pulumi
