### PR TITLE
state_move: mark command as non-hidden

### DIFF
--- a/changelog/pending/20240711--cli-state--introduce-a-state-move-command-that-can-be-used-to-move-resources-between-stacks-projects.yaml
+++ b/changelog/pending/20240711--cli-state--introduce-a-state-move-command-that-can-be-used-to-move-resources-between-stacks-projects.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/state
+  description: Introduce a state move command that can be used to move resources between stacks/projects

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -59,8 +59,6 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 EXPERIMENTAL: this feature is currently in development.
 `,
 		Args: cmdutil.MinimumNArgs(1),
-		// TODO: this command should be hidden until it is fully implemented
-		Hidden: true,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 


### PR DESCRIPTION
Now that we implemented all the features for this command we can remove the hidden flag, and actually start letting users use it.