### PR TITLE
Install policy or project dependencies based on nearest configuration file

### DIFF
--- a/changelog/pending/20240711--cli-new--install-policy-or-project-dependencies-based-on-nearest-configuration-file.yaml
+++ b/changelog/pending/20240711--cli-new--install-policy-or-project-dependencies-based-on-nearest-configuration-file.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Install policy or project dependencies based on nearest configuration file


### PR DESCRIPTION
When a policy pack is nested within a project, or vice-versa, install
the appropriate dependencies, based on where the command is run from.

If there are both policy pack and project files in the parent
directories of the current working directory, pick the one that is
closest.

Fixes https://github.com/pulumi/pulumi/issues/16605
