### PR TITLE
Don't count plugins from a nested policy pack in GetRequiredPlugins

### DIFF
--- a/changelog/pending/20240711--sdk-nodejs--dont-count-plugins-from-a-nested-policy-pack-in-getrequiredplugins.yaml
+++ b/changelog/pending/20240711--sdk-nodejs--dont-count-plugins-from-a-nested-policy-pack-in-getrequiredplugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Don't count plugins from a nested policy pack in GetRequiredPlugins

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -398,7 +398,20 @@ func getPluginsFromDir(
 		}
 
 		if isDir {
-			// if a directory, recurse.
+			// If a directory, recurse into it. However we have to take care to avoid recursing
+			// into nested policy packs. The plugins in a policy pack are not dependencies of the
+			// program, so we should not include them in the list of plugins to install.
+			policyPack, err := workspace.DetectPolicyPackPathFrom(curr)
+			if err != nil {
+				allErrors = multierror.Append(allErrors, err)
+				continue
+			}
+			policyPackDir := filepath.Dir(policyPack)
+			if policyPack != "" && strings.Contains(curr, policyPackDir) {
+				// The path is within a policy pack, stop recursing.
+				continue
+			}
+
 			more, err := getPluginsFromDir(
 				curr,
 				pulumiPackagePathToVersionMap,

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -306,6 +306,63 @@ func TestGetRequiredPluginsSymlinkCycles2(t *testing.T) {
 	}, actual)
 }
 
+func TestGetRequiredPluginsNestedPolicyPack(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "testdir")
+	err := os.Mkdir(dir, 0o755)
+	require.NoError(t, err)
+
+	files := []struct {
+		path    string
+		content string
+	}{
+		{
+			filepath.Join(dir, "node_modules", "@pulumi", "foo", "package.json"),
+			`{ "name": "@pulumi/foo", "version": "1.2.3", "pulumi": { "resource": true } }`,
+		},
+		{
+			filepath.Join(dir, "node_modules", "@pulumi", "bar", "package.json"),
+			`{ "name": "@pulumi/bar", "version": "4.5.6", "pulumi": { "resource": true } }`,
+		},
+		{
+			filepath.Join(dir, "policy", "PulumiPolicy.yaml"),
+			`name: my-policy`,
+		},
+		{
+			filepath.Join(dir, "policy", "node_modules", "@pulumi", "baz", "package.json"),
+			`{ "name": "@pulumi/baz", "version": "7.8.9", "pulumi": { "resource": true } }`,
+		},
+	}
+	for _, file := range files {
+		err := os.MkdirAll(filepath.Dir(file.path), 0o755)
+		require.NoError(t, err)
+		err = os.WriteFile(file.path, []byte(file.content), 0o600)
+		require.NoError(t, err)
+	}
+
+	host := &nodeLanguageHost{}
+	resp, err := host.GetRequiredPlugins(context.Background(), &pulumirpc.GetRequiredPluginsRequest{
+		Program: dir,
+		Info: &pulumirpc.ProgramInfo{
+			RootDirectory:    dir,
+			ProgramDirectory: dir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+
+	actual := make(map[string]string)
+	for _, plugin := range resp.GetPlugins() {
+		actual[plugin.Name] = plugin.Version
+	}
+	assert.Equal(t, map[string]string{
+		"foo": "v1.2.3",
+		"bar": "v4.5.6",
+		// baz: v7.8.9 is not included because it is in a nested policy pack
+	}, actual)
+}
+
 func TestParseOptions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
For nodejs we look at the node_modules of all child directories of the
root path to find the required plugins. When a policy pack is nested
within a pulumi project, we were including its dependencies in the list
of required plugins. To avoid this, we stop recursing once we see a
directory that has a PulumiPolicy.yaml.

Fixes https://github.com/pulumi/pulumi/issues/16604
