### PR TITLE
state_move: improve usage text

### DIFF
--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -51,14 +51,12 @@ func newStateMoveCommand() *cobra.Command {
 		Colorizer: cmdutil.GetGlobalColorization(),
 	}
 	cmd := &cobra.Command{
-		Use:   "move",
+		Use:   "move [flags] <urn>...",
 		Short: "Move resources from one stack to another",
 		Long: `Move resources from one stack to another
 
 This command can be used to move resources from one stack to another. This can be useful when
 splitting a stack into multiple stacks or when merging multiple stacks into one.
-
-EXPERIMENTAL: this feature is currently in development.
 `,
 		Args: cmdutil.MinimumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Correct the usage text, and mark the command not as non-experimental. The command should be ready for regular usage, so I think the "EXPERIMENTAL" comment can be dropped now.