### PR TITLE
continue-on-error: respect all dependency relationships

### DIFF
--- a/changelog/pending/20240712--engine--fix-an-issue-where-pulumi-up-continue-on-error-could-result-in-a-snapshot-integrity-failure.yaml
+++ b/changelog/pending/20240712--engine--fix-an-issue-where-pulumi-up-continue-on-error-could-result-in-a-snapshot-integrity-failure.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix an issue where `pulumi up --continue-on-error` could result in a snapshot integrity failure

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -434,11 +434,11 @@ func (ex *deploymentExecutor) performDeletes(
 }
 
 func doesStepDependOn(step Step, skipped mapset.Set[urn.URN]) bool {
-	if len(step.Res().Dependencies) > 0 && skipped.Contains(step.Res().Dependencies...) {
+	if len(step.Res().Dependencies) > 0 && skipped.ContainsAny(step.Res().Dependencies...) {
 		return true
 	}
 	for _, deps := range step.Res().PropertyDependencies {
-		if len(deps) > 0 && skipped.Contains(deps...) {
+		if len(deps) > 0 && skipped.ContainsAny(deps...) {
 			return true
 		}
 	}


### PR DESCRIPTION
When running `pulumi up --continue-on-error`, we can't bring up new resources that have dependencies that have failed, or have been skipped.  Since the resource would have a failed dependency, that dependency would not be in the snapshot, resulting in a snapshot integrity failure.  Also it simply does not make sense to `up` a resource that has a failed dependency.

We took care of that for the regular dependency relationship, however at the time we missed doing the same for other types of dependencies, namely parent-child relationships, deleted with relationships and property dependencies.

This can result in snapshot integrity failures for example when a parent fails to be created, but we still do the resource creation of the child, such as what happened in https://github.com/pulumi/pulumi/issues/16638.

Fix this by skipping the step when a resource with any type of dependency relationship fails or is skipped beforehand.

Fixes https://github.com/pulumi/pulumi/issues/16638