### PR TITLE
try to further reduce the pulumi bot token usage

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -38,7 +38,7 @@ jobs:
       release-notes: "${{ fromJSON(steps.notes.outputs.release-notes) }}"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -85,7 +85,7 @@ jobs:
           mv ./artifacts.tmp/artifacts-*/* ./artifacts
       - uses: ncipollo/release-action@3d2de22e3d0beab188d8129c27f103d8e91bf13a
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           name: v${{ inputs.version }}
           tag: v${{ inputs.version }}
           commit: "${{ fromJSON(steps.commit-info.outputs.sha) }}"

--- a/.github/workflows/on-pr-changelog.yml
+++ b/.github/workflows/on-pr-changelog.yml
@@ -38,7 +38,7 @@ jobs:
     name: comment
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/find-comment@v3
         id: fc
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ inputs.pr-number }}
           body-includes: "# Changelog"
       - name: Create or update comment

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: changes
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
             # If files matching any of these patterns change,
             # we will run codegen tests for pull requests.

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -28,7 +28,7 @@ jobs:
       timeout-minutes: 240
       runs-on: ubuntu-latest
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       strategy:
         matrix:
           provider: ["aws", "gcp", "azure", "azuread", "random"]
@@ -74,7 +74,7 @@ jobs:
         DOTNETVERSION: "6.x"
         JAVAVERSION: "11"
         AWS_REGION: us-west-2
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       steps:
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/pr-test-codegen-downstream.yml
+++ b/.github/workflows/pr-test-codegen-downstream.yml
@@ -28,7 +28,7 @@ jobs:
       timeout-minutes: 240
       runs-on: ubuntu-latest
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       strategy:
         matrix:
           provider: ["aws", "gcp", "azure", "azuread", "random"]
@@ -74,7 +74,7 @@ jobs:
         DOTNETVERSION: "6.x"
         JAVAVERSION: "11"
         AWS_REGION: us-west-2
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       steps:
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
There's a few instances where I *think* we can use the GITHUB_TOKEN we get from actions, so we can try to avoid ratelimits.

All of these jobs should be running during PRs, so it should be relatively safe if the CI tests pass.