### PR TITLE
URL-based plugin source overrides via env var

### DIFF
--- a/changelog/pending/20240712--cli-plugin--enable-overriding-plugin-download-urls-for-air-gapped-environments-with-an-environment-variable.yaml
+++ b/changelog/pending/20240712--cli-plugin--enable-overriding-plugin-download-urls-for-air-gapped-environments-with-an-environment-variable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Enable overriding plugin download URLs for air-gapped environments with an environment variable

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -91,6 +91,18 @@ var SkipVersionCheck = env.Bool("AUTOMATION_API_SKIP_VERSION_CHECK",
 var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 	"Continue to perform the update/destroy operation despite the occurrence of errors.")
 
+// List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
+// be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
+//
+// For example, when set to "^https://foo=https://bar,^github://=https://buzz", HTTPS plugin URLs that start with
+// "foo" will use https://bar as the download URL and plugins hosted on github will use https://buzz
+//
+// Note that named regular expression groups can be used to capture parts of URLs and then reused for building
+// redirects. For example
+// ^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]=https://foo.com/downloads/${org}/${repo}
+// will capture any GitHub-hosted plugin and redirect to its corresponding folder under https://foo.com/downloads
+var PluginDownloadURLOverrides = env.String("PLUGIN_DOWNLOAD_URL_OVERRIDES", "")
+
 // Environment variables that affect the DIY backend.
 var (
 	DIYBackendNoLegacyWarning = env.Bool("DIY_BACKEND_NO_LEGACY_WARNING",

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -99,7 +99,7 @@ var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 //
 // Note that named regular expression groups can be used to capture parts of URLs and then reused for building
 // redirects. For example
-// ^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]=https://foo.com/downloads/${org}/${repo}
+// ^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)=https://foo.com/downloads/${org}/${repo}
 // will capture any GitHub-hosted plugin and redirect to its corresponding folder under https://foo.com/downloads
 var PluginDownloadURLOverrides = env.String("PLUGIN_DOWNLOAD_URL_OVERRIDES", "")
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -67,8 +67,13 @@ var enableLegacyPluginBehavior = os.Getenv("PULUMI_ENABLE_LEGACY_PLUGIN_SEARCH")
 // time, if necessary. When non-empty, it's parsed into `pluginDownloadURLOverridesParsed` in `init()`. The expected
 // format is `regexp=URL`, and multiple pairs can be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`.
 //
-// For example, when set to "^foo.*=https://foo,^bar.*=https://bar", plugin names that start with "foo" will use
-// https://foo as the download URL and names that start with "bar" will use https://bar.
+// For example, when set to "^https://foo=https://bar,^github://=https://buzz", HTTPS plugin URLs that start with
+// "foo" will use https://bar as the download URL and plugins hosted on github will use https://buzz
+//
+// Note that named regular expression groups can be used to capture parts of URLs and then reused for building
+// redirects. For example
+// ^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)=https://foo.com/downloads/${org}/${repo}
+// will capture any GitHub-hosted plugin and redirect to its corresponding folder under https://foo.com/downloads
 var pluginDownloadURLOverrides string
 
 // pluginDownloadURLOverridesParsed is the parsed array from `pluginDownloadURLOverrides`.
@@ -83,20 +88,36 @@ type pluginDownloadURLOverride struct {
 // pluginDownloadOverrideArray represents an array of overrides.
 type pluginDownloadOverrideArray []pluginDownloadURLOverride
 
-// get returns the URL and true if name matches an override's regular expression,
-// otherwise an empty string and false.
-func (overrides pluginDownloadOverrideArray) get(name string) (string, bool) {
+// get returns the URL and true if url matches an override's regular expression,
+// otherwise an empty string and false. The input url may contain placeholders
+// that match regular expression's named subgroups, the placeholders will be
+// replaced by matches values.
+func (overrides pluginDownloadOverrideArray) get(url string) (string, bool) {
 	for _, override := range overrides {
-		if override.reg.MatchString(name) {
-			return override.url, true
+		if match := override.reg.FindStringSubmatch(url); match != nil {
+			result := override.url
+			for i, name := range override.reg.SubexpNames() {
+				if i != 0 && name != "" {
+					placeholder := "${" + name + "}"
+					result = strings.ReplaceAll(result, placeholder, match[i])
+				}
+			}
+			return result, true
 		}
 	}
 	return "", false
 }
 
 func init() {
+	// Default to Plugin Download URL overrides passed as compile-time flags (if any).
+	overrides := pluginDownloadURLOverrides
+	// Environment variable takes precedence over compile-time flags.
+	if v := env.PluginDownloadURLOverrides.Value(); v != "" {
+		overrides = v
+	}
+	// Parse overrides into a strongly-typed collection.
 	var err error
-	if pluginDownloadURLOverridesParsed, err = parsePluginDownloadURLOverrides(pluginDownloadURLOverrides); err != nil {
+	if pluginDownloadURLOverridesParsed, err = parsePluginDownloadURLOverrides(overrides); err != nil {
 		panic(fmt.Errorf("error parsing `pluginDownloadURLOverrides`: %w", err))
 	}
 }
@@ -171,6 +192,9 @@ type PluginSource interface {
 	// GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
 	// plugins we can get from github releases.
 	GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error)
+	// A base URL that can uniquely identify the source. Has the same structure as the PluginDownloadURL
+	// schema option. Example: "github://api.github.com/pulumi/pulumi-aws".
+	URL() string
 }
 
 // standardAssetName returns the standard name for the asset that contains the given plugin.
@@ -186,12 +210,6 @@ type getPulumiSource struct {
 
 func newGetPulumiSource(name string, kind apitype.PluginKind) *getPulumiSource {
 	return &getPulumiSource{name: name, kind: kind}
-}
-
-func (source *getPulumiSource) GetLatestVersion(
-	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error),
-) (*semver.Version, error) {
-	return nil, errors.New("GetLatestVersion is not supported for plugins from get.pulumi.com")
 }
 
 func (source *getPulumiSource) Download(
@@ -309,6 +327,10 @@ func (source *gitlabSource) Download(
 		return nil, -1, err
 	}
 	return getHTTPResponse(req)
+}
+
+func (source *gitlabSource) URL() string {
+	return fmt.Sprintf("gitlab://%s/%s", source.host, source.project)
 }
 
 // githubSource can download a plugin from github releases
@@ -523,6 +545,10 @@ func (source *githubSource) Download(
 	return source.getHTTPResponse(getHTTPResponse, req)
 }
 
+func (source *githubSource) URL() string {
+	return fmt.Sprintf("github://%s/%s/%s", source.host, source.organization, source.repository)
+}
+
 // httpSource can download a plugin from a given http url, it doesn't support GetLatestVersion
 type httpSource struct {
 	name string
@@ -575,6 +601,10 @@ func (source *httpSource) Download(
 		return nil, -1, err
 	}
 	return getHTTPResponse(req)
+}
+
+func (source *httpSource) URL() string {
+	return source.url
 }
 
 // fallbackSource handles our current default logic of trying the pulumi public github then get.pulumi.com.
@@ -630,6 +660,14 @@ func (source *fallbackSource) Download(
 	// Fallback to get.pulumi.com
 	pulumi := newGetPulumiSource(source.name, source.kind)
 	return pulumi.Download(version, opSy, arch, getHTTPResponse)
+}
+
+func (source *fallbackSource) URL() string {
+	public, err := newGithubSource(urlMustParse("github://api.github.com/pulumi"), source.name, source.kind)
+	if err != nil {
+		return ""
+	}
+	return public.URL()
 }
 
 type checksumError struct {
@@ -709,6 +747,10 @@ func (source *checksumSource) Download(
 		hasher:   sha256.New(),
 		io:       response,
 	}, length, nil
+}
+
+func (source *checksumSource) URL() string {
+	return source.source.URL()
 }
 
 // ProjectPlugin Information about a locally installed plugin specified by the project.
@@ -878,44 +920,53 @@ func (info *PluginInfo) SetFileMetadata(path string) error {
 	return nil
 }
 
-func (spec PluginSpec) GetSource() (PluginSource, error) {
-	baseSource, err := func() (PluginSource, error) {
-		// The plugin has a set URL use that.
-		if spec.PluginDownloadURL != "" {
-			// Support schematised URLS if the URL has a "schema" part we recognize
-			url, err := url.Parse(spec.PluginDownloadURL)
-			if err != nil {
-				return nil, err
-			}
-
-			switch url.Scheme {
-			case "github":
-				return newGithubSource(url, spec.Name, spec.Kind)
-			case "gitlab":
-				return newGitlabSource(url, spec.Name, spec.Kind)
-			case "http", "https":
-				return newHTTPSource(spec.Name, spec.Kind, url), nil
-			default:
-				return nil, fmt.Errorf("unknown plugin source scheme: %s", url.Scheme)
-			}
-		}
-
-		// If the plugin name matches an override, download the plugin from the override URL.
-		if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
-			return newHTTPSource(spec.Name, spec.Kind, urlMustParse(url)), nil
-		}
-
-		// Use our default fallback behaviour of github then get.pulumi.com
-		return newFallbackSource(spec.Name, spec.Kind), nil
-	}()
+func newPluginSource(name string, kind apitype.PluginKind, pluginDownloadURL string) (PluginSource, error) {
+	url, err := url.Parse(pluginDownloadURL)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(spec.Checksums) != 0 {
-		return newChecksumSource(baseSource, spec.Checksums), nil
+	switch url.Scheme {
+	case "github":
+		return newGithubSource(url, name, kind)
+	case "gitlab":
+		return newGitlabSource(url, name, kind)
+	case "http", "https":
+		return newHTTPSource(name, kind, url), nil
+	default:
+		return nil, fmt.Errorf("unknown plugin source scheme: %s", url.Scheme)
 	}
-	return baseSource, nil
+}
+
+func (spec PluginSpec) GetSource() (PluginSource, error) {
+	var source PluginSource
+	var err error
+
+	// The plugin has a set URL use that.
+	if spec.PluginDownloadURL != "" {
+		source, err = newPluginSource(spec.Name, spec.Kind, spec.PluginDownloadURL)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Use our default fallback behaviour of github then get.pulumi.com
+		source = newFallbackSource(spec.Name, spec.Kind)
+	}
+
+	// If the plugin URL matches an override, download the plugin from the override URL.
+	if url, ok := pluginDownloadURLOverridesParsed.get(source.URL()); ok {
+		source, err = newPluginSource(spec.Name, spec.Kind, url)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Apply checksums if defined.
+	if len(spec.Checksums) != 0 {
+		source = newChecksumSource(source, spec.Checksums)
+	}
+
+	return source, nil
 }
 
 // GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -97,8 +97,12 @@ func (overrides pluginDownloadOverrideArray) get(url string) (string, bool) {
 		if match := override.reg.FindStringSubmatch(url); match != nil {
 			result := override.url
 			for i, name := range override.reg.SubexpNames() {
+				// Replace placeholders that match a group index like $1
+				placeholder := fmt.Sprintf("$%d", i)
+				result = strings.ReplaceAll(result, placeholder, match[i])
+				// Replace placeholders that match a group name like ${org}
 				if i != 0 && name != "" {
-					placeholder := "${" + name + "}"
+					placeholder := fmt.Sprintf("${%s}", name)
 					result = strings.ReplaceAll(result, placeholder, match[i])
 				}
 			}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1148,8 +1148,8 @@ plugins:
 	assert.Equal(t, "../bin/aws", proj.Plugins.Providers[0].Path)
 }
 
+//nolint:paralleltest // mutates pluginDownloadURLOverridesParsed
 func TestPluginSpec_GetSource(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name               string
 		spec               PluginSpec
@@ -1251,7 +1251,6 @@ func TestPluginSpec_GetSource(t *testing.T) {
 		},
 	}
 
-	//nolint:paralleltest // mutates pluginDownloadURLOverridesParsed
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pluginDownloadURLOverridesParsed = tt.overrides

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"testing"
 	"time"
@@ -993,6 +994,73 @@ func TestParsePluginDownloadURLOverride(t *testing.T) {
 	}
 }
 
+func TestPluginDownloadOverrideArray_Get(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		overrides     pluginDownloadOverrideArray
+		input         string
+		expectedURL   string
+		expectedMatch bool
+	}{
+		{
+			name: "No match",
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`^test-plugin$`), url: "https://example.com/test-plugin"},
+			},
+			input:         "another-plugin",
+			expectedURL:   "",
+			expectedMatch: false,
+		},
+		{
+			name: "Simple match",
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`^test-plugin$`), url: "https://example.com/test-plugin"},
+			},
+			input:         "test-plugin",
+			expectedURL:   "https://example.com/test-plugin",
+			expectedMatch: true,
+		},
+		{
+			name: "Match with placeholders",
+			overrides: pluginDownloadOverrideArray{
+				{
+					reg: regexp.MustCompile(`^(?P<org>[\w-]+)-v(?P<repo>\d+\.\d+\.\d+)$`),
+					url: "https://example.com/${org}/${repo}/plugin.zip",
+				},
+			},
+			input:         "my-plugin-v1.2.3",
+			expectedURL:   "https://example.com/my-plugin/1.2.3/plugin.zip",
+			expectedMatch: true,
+		},
+		{
+			name: "Multiple overrides, second matches",
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`^test-plugin$`), url: "https://example.com/test-plugin"},
+				{reg: regexp.MustCompile(`^another-plugin$`), url: "https://example.com/another-plugin"},
+			},
+			input:         "another-plugin",
+			expectedURL:   "https://example.com/another-plugin",
+			expectedMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualURL, actualMatch := tt.overrides.get(tt.input)
+			if actualURL != tt.expectedURL {
+				assert.Equal(t, tt.expectedURL, actualURL)
+			}
+			if actualMatch != tt.expectedMatch {
+				assert.Equal(t, tt.expectedMatch, actualMatch)
+			}
+		})
+	}
+}
+
 func TestDownloadToFile_retries(t *testing.T) {
 	t.Parallel()
 
@@ -1080,19 +1148,125 @@ plugins:
 	assert.Equal(t, "../bin/aws", proj.Plugins.Providers[0].Path)
 }
 
-func TestPluginBadSource(t *testing.T) {
+func TestPluginSpec_GetSource(t *testing.T) {
 	t.Parallel()
-
-	version := semver.MustParse("4.30.0")
-	spec := PluginSpec{
-		PluginDownloadURL: "strange-scheme://what.is.this?oh-no",
-		Name:              "mockdl",
-		Version:           &version,
-		Kind:              apitype.PluginKind("resource"),
+	tests := []struct {
+		name               string
+		spec               PluginSpec
+		overrides          pluginDownloadOverrideArray
+		expectedSourceType string
+		expectedURL        string
+		expectedErrMsg     string
+	}{
+		{
+			name: "Use PluginDownloadURL (HTTP)",
+			spec: PluginSpec{
+				Name:              "test-plugin",
+				Kind:              apitype.PluginKind("resource"),
+				PluginDownloadURL: "https://example.com/test-plugin",
+			},
+			expectedSourceType: "*workspace.httpSource",
+			expectedURL:        "https://example.com/test-plugin",
+		},
+		{
+			name: "Use PluginDownloadURL (GitHub)",
+			spec: PluginSpec{
+				Name:              "test-plugin",
+				Kind:              apitype.PluginKind("resource"),
+				PluginDownloadURL: "github://api.github.com/owner/repo",
+			},
+			expectedSourceType: "*workspace.githubSource",
+			expectedURL:        "github://api.github.com/owner/repo",
+		},
+		{
+			name: "Use PluginDownloadURL (GitLab)",
+			spec: PluginSpec{
+				Name:              "test-plugin",
+				Kind:              apitype.PluginKind("resource"),
+				PluginDownloadURL: "gitlab://mygitlab.example.com/proj1",
+			},
+			expectedSourceType: "*workspace.gitlabSource",
+			expectedURL:        "gitlab://mygitlab.example.com/proj1",
+		},
+		{
+			name: "Use fallback source",
+			spec: PluginSpec{
+				Name: "test-plugin",
+				Kind: apitype.PluginKind("resource"),
+			},
+			expectedSourceType: "*workspace.fallbackSource",
+			expectedURL:        "github://api.github.com/pulumi/pulumi-test-plugin",
+		},
+		{
+			name: "Apply override (HTTP)",
+			spec: PluginSpec{
+				Name: "test-plugin",
+				Kind: apitype.PluginKind("resource"),
+			},
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`test-plugin`), url: "https://example.com/test-plugin"},
+			},
+			expectedSourceType: "*workspace.httpSource",
+			expectedURL:        "https://example.com/test-plugin",
+		},
+		{
+			name: "Apply override (GitHub)",
+			spec: PluginSpec{
+				Name: "test-plugin",
+				Kind: apitype.PluginKind("resource"),
+			},
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`test-plugin`), url: "github://api.github.com/test-org/test-plugin"},
+			},
+			expectedSourceType: "*workspace.githubSource",
+			expectedURL:        "github://api.github.com/test-org/test-plugin",
+		},
+		{
+			name: "Apply checksums",
+			spec: PluginSpec{
+				Name:      "test-plugin",
+				Kind:      apitype.PluginKind("resource"),
+				Checksums: map[string][]byte{"checksum1": []byte("checksum2")},
+			},
+			expectedSourceType: "*workspace.checksumSource",
+			expectedURL:        "github://api.github.com/pulumi/pulumi-test-plugin",
+		},
+		{
+			name: "Invalid URL",
+			spec: PluginSpec{
+				Name:              "test-plugin",
+				Kind:              apitype.PluginKind("resource"),
+				PluginDownloadURL: "://invalid-url",
+			},
+			expectedErrMsg: "parse \"://invalid-url\": missing protocol scheme",
+		},
+		{
+			name: "Unknown scheme",
+			spec: PluginSpec{
+				Name:              "test-plugin",
+				Kind:              apitype.PluginKind("resource"),
+				PluginDownloadURL: "unknown://example.com/plugin",
+			},
+			expectedErrMsg: "unknown plugin source scheme: unknown",
+		},
 	}
-	source, err := spec.GetSource()
-	assert.ErrorContains(t, err, "unknown plugin source scheme: strange-scheme")
-	assert.Nil(t, source)
+
+	//nolint:paralleltest // mutates pluginDownloadURLOverridesParsed
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pluginDownloadURLOverridesParsed = tt.overrides
+
+			source, err := tt.spec.GetSource()
+			assert.Equal(t, tt.expectedErrMsg != "", err != nil)
+			if err != nil {
+				assert.Equal(t, tt.expectedErrMsg, err.Error())
+				return
+			}
+			actualSourceType := reflect.TypeOf(source).String()
+			assert.Equal(t, tt.expectedSourceType, actualSourceType)
+			assert.Equal(t, tt.expectedURL, source.URL())
+		})
+	}
 }
 
 func TestMissingErrorText(t *testing.T) {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1022,7 +1022,7 @@ func TestPluginDownloadOverrideArray_Get(t *testing.T) {
 			expectedMatch: true,
 		},
 		{
-			name: "Match with placeholders",
+			name: "Match with name placeholders",
 			overrides: pluginDownloadOverrideArray{
 				{
 					reg: regexp.MustCompile(`^(?P<org>[\w-]+)-v(?P<repo>\d+\.\d+\.\d+)$`),
@@ -1031,6 +1031,27 @@ func TestPluginDownloadOverrideArray_Get(t *testing.T) {
 			},
 			input:         "my-plugin-v1.2.3",
 			expectedURL:   "https://example.com/my-plugin/1.2.3/plugin.zip",
+			expectedMatch: true,
+		},
+		{
+			name: "Match with index placeholders",
+			overrides: pluginDownloadOverrideArray{
+				{
+					reg: regexp.MustCompile(`^(?P<org>[\w-]+)-v(?P<repo>\d+\.\d+\.\d+)$`),
+					url: "https://example.com/$1/$2/plugin.zip",
+				},
+			},
+			input:         "my-plugin-v1.2.3",
+			expectedURL:   "https://example.com/my-plugin/1.2.3/plugin.zip",
+			expectedMatch: true,
+		},
+		{
+			name: "Match with $0 placeholder",
+			overrides: pluginDownloadOverrideArray{
+				{reg: regexp.MustCompile(`^.+$`), url: "https://example.com/downloads?source=$0"},
+			},
+			input:         "test-plugin",
+			expectedURL:   "https://example.com/downloads?source=test-plugin",
 			expectedMatch: true,
 		},
 		{


### PR DESCRIPTION
### Motivation

Pulumi plugin binaries can be downloaded by the CLI from multiple sources. By default, it's downloaded from Pulumi's GitHub releases or get.pulumi.com, but plugins can also specify their binary sources via the `PluginDownloadURL` schema option. They can point to custom GitHub, Gitlab, or HTTP locations.

Enterprise customers ask for a way to isolate the CLI from downloads from random locations and to configure the CLI to go to their internal pre-approved artefact location instead. This way, Pulumi can run in "air-gapped" environments (which still have access to Cloud APIs, of course).

Related issues:
- https://github.com/pulumi/pulumi/issues/14459
- https://github.com/pulumi/pulumi/issues/16240

Currently, there is a basic mechanism to do so via the variable `pluginDownloadURLOverrides`, but it has two major limitations:
- The variable value is set via a compile-time flag, so it requires a custom build of the CLI
- The overrides are based on the plugin name, so the rules must be defined without access to the original URL, which makes it hard to provide universal rules and still distinguish between first-party, public third-party, or private in-house plugins
- We ignore overrides for all plugins that have `PluginDownloadURL` set
- Overrides can set a plugin replacement redirect only to HTTP(s) addresses

### Proposal

This PR makes two sets of changes:

1. It allows passing overrides via the `PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES` environment variable. The compile-time flag is still supported, but the env var takes priority.

    More configuration levers could be supported, but it not clear if we have good ones until [Support .pulumirc file for global config](https://github.com/pulumi/pulumi/issues/13484) is implemented. I don't expect users to want to set this via their stack configs, but I'm curious what others think. In any case, more sources can be added later.

2. The overrides now apply based on the original download URL, not just on plugin names. Actually, it's the base URL of a download source that is passed to the regexp matcher. Examples of possible options are:

    - `github://api.github.com/pulumi/pulumi-xyz` for a first-party plugin (note that we don't pass `get.pulumi.com`
    - `github://api.github.com/pulumiverse/pulumi-grafana` for a community plugin that sets `PluginDownloadURL`
    - `gitlab://gitlab-host/proj-name` for a community plugin hosted on Gitlab
    - `https://example.com/downloads/` for HTTP sources

    So, the override `^github://api.github.com/pulumi/pulumi-xyz=https://example.com/downloads/pulumi-xyz/` will override the single provider URL from our GitHub releases to the given HTTP location.

    On top of that, regular expressions may contain name groups to capture and use templated values. For example, `^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)=https://example.com/downloads/${org}/${repo}` captures any GitHub plugin and redirects it to its corresponding HTTP location. Group indices are also supported: the above override can also be written as `^github://api.github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)=https://example.com/downloads/$1/$2`, with `$0` meaning the full match.

    The override URLs have the same semantics as `PluginDownloadURL`, so they can point to GitHub, Gitlab, HTTP, or anything we introduce in the future.

### Impact

Technically, this is a breaking change, because name-based overrides will stop working. However, we are fairly certain that we have a single customer using the existing compile-time approach, and they indicated that they don't need the name-based overrides if they have URL-based overrides. I reviewed this PR with them and made sure they can migrate immediately after the change is released.

Backwards compatibility is slightly tricky, because we'd need to keep name-based override _and_ not applying them to third-party plugins. But we can do it if necessary.

Resolve #16240