### PR TITLE
Fix lookup for pulumi run script when using Volta to manage nodejs

### DIFF
--- a/changelog/pending/20240712--sdk-nodejs--fix-lookup-for-pulumi-run-script-when-using-volta-to-manage-nodejs.yaml
+++ b/changelog/pending/20240712--sdk-nodejs--fix-lookup-for-pulumi-run-script-when-using-volta-to-manage-nodejs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix lookup for pulumi run script when using Volta to manage nodejs


### PR DESCRIPTION
We run a short script with nodejs to find the path to the nodejs SDK
entrypoint. In https://github.com/pulumi/pulumi/pull/16160 this script
was changed and used newlines.

This broke when using the Volta package manager to manage different
nodejs versions. Volta adds shim programs into the user's path that
routes to the correct nodejs executable. Seemingly Volta does not handle
the newlines in the arguments.

To fix this, we ensure that the script is on a single line.

Fixes https://github.com/pulumi/pulumi/issues/16393
