### PR TITLE
Use python names for dictionary literals when inside a typed dictionary input

### DIFF
--- a/changelog/pending/20240715--sdk-python--use-python-names-for-dictionary-literals-when-inside-a-typed-dictionary-input.yaml
+++ b/changelog/pending/20240715--sdk-python--use-python-names-for-dictionary-literals-when-inside-a-typed-dictionary-input.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description:  Use python names for dictionary literals when inside a typed dictionary input

--- a/tests/testdata/codegen/typeddict-pp/python/typeddict.py
+++ b/tests/testdata/codegen/typeddict-pp/python/typeddict.py
@@ -3,10 +3,10 @@ import pulumi_typeddict as typeddict
 
 main = typeddict.ExampleComponent("main",
     my_type={
-        "stringProp": "hello",
-        "nestedProp": {
-            "nestedStringProp": "world",
-            "nestedNumberProp": "123",
+        "string_prop": "hello",
+        "nested_prop": {
+            "nested_string_prop": "world",
+            "nested_number_prop": "123",
         },
     },
     external_input=aws.s3.BucketWebsiteArgs(


### PR DESCRIPTION
When generating literals for inputs that have TypedDict types, we want
to use the pythonic names (snake_case) for keys.

We also have to take care of tracking the fact that we’re inisde a
TypedDict for nested dicts.

Fixes https://github.com/pulumi/pulumi/issues/16646