### PR TITLE
Fix YAML serialization of project settings in the Python Automation API

### DIFF
--- a/changelog/pending/20240715--sdk-python--fix-yaml-serialization-of-project-settings-in-the-python-automation-api.yaml
+++ b/changelog/pending/20240715--sdk-python--fix-yaml-serialization-of-project-settings-in-the-python-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix YAML serialization of project settings in the Python Automation API

--- a/sdk/python/lib/pulumi/automation/__init__.py
+++ b/sdk/python/lib/pulumi/automation/__init__.py
@@ -155,8 +155,10 @@ from ._output import OutputMap, OutputValue
 
 from ._project_settings import (
     ProjectBackend,
-    ProjectSettings,
     ProjectRuntimeInfo,
+    ProjectSettings,
+    ProjectTemplate,
+    ProjectTemplateConfigValue,
 )
 
 from ._stack_settings import StackSettings
@@ -225,8 +227,10 @@ __all__ = [
     "OutputValue",
     # _project_settings
     "ProjectBackend",
-    "ProjectSettings",
     "ProjectRuntimeInfo",
+    "ProjectSettings",
+    "ProjectTemplate",
+    "ProjectTemplateConfigValue",
     # _stack_settings
     "StackSettings",
     # _stack

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -164,11 +164,7 @@ class LocalWorkspace(Workspace):
                 found_ext = ext
                 break
         path = os.path.join(self.work_dir, f"Pulumi{found_ext}")
-        writable_settings = {
-            key: settings.__dict__[key]
-            for key in settings.__dict__
-            if settings.__dict__[key] is not None
-        }
+        writable_settings = settings.to_dict()
         with open(path, "w", encoding="utf-8") as file:
             if found_ext == ".json":
                 json.dump(writable_settings, file, indent=4)
@@ -854,7 +850,7 @@ def _load_project_settings(work_dir: str) -> ProjectSettings:
             continue
         with open(project_path, "r", encoding="utf-8") as file:
             settings = json.load(file) if ext == ".json" else yaml.safe_load(file)
-            return ProjectSettings(**settings)
+            return ProjectSettings.from_dict(settings)
     raise FileNotFoundError(
         f"failed to find project settings file in workdir: {work_dir}"
     )

--- a/sdk/python/lib/pulumi/automation/_project_settings.py
+++ b/sdk/python/lib/pulumi/automation/_project_settings.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Mapping, Any, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 
 class ProjectRuntimeInfo:
@@ -24,6 +32,23 @@ class ProjectRuntimeInfo:
     def __init__(self, name: str, options: Optional[Mapping[str, Any]] = None):
         self.name = name
         self.options = options
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ProjectRuntimeInfo":
+        """Deserialize a ProjectRuntimeInfo from a dictionary."""
+        return ProjectRuntimeInfo(
+            name=data["name"],
+            options=data.get("options"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize a ProjectRuntimeInfo to a dictionary."""
+        return _to_dict(
+            [
+                ("name", self.name),
+                ("options", self.options),
+            ]
+        )
 
 
 class ProjectTemplateConfigValue:
@@ -42,6 +67,25 @@ class ProjectTemplateConfigValue:
         self.description = description
         self.default = default
         self.secret = secret
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ProjectTemplateConfigValue":
+        """Deserialize a ProjectTemplateConfigValue from a dictionary."""
+        return ProjectTemplateConfigValue(
+            description=data.get("description"),
+            default=data.get("default"),
+            secret=data.get("secret", False),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize a ProjectTemplateConfigValue to a dictionary."""
+        return _to_dict(
+            [
+                ("description", self.description),
+                ("default", self.default),
+                ("secret", self.secret),
+            ]
+        )
 
 
 class ProjectTemplate:
@@ -64,6 +108,30 @@ class ProjectTemplate:
         self.config = config or {}
         self.important = important
 
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ProjectTemplate":
+        """Deserialize a ProjectTemplate from a dictionary."""
+        return ProjectTemplate(
+            description=data.get("description"),
+            quickstart=data.get("quickstart"),
+            config={
+                k: ProjectTemplateConfigValue.from_dict(v)
+                for k, v in data.get("config", {}).items()
+            },
+            important=data.get("important"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize a ProjectTemplate to a dictionary."""
+        return _to_dict(
+            [
+                ("description", self.description),
+                ("quickstart", self.quickstart),
+                ("config", {k: v.to_dict() for k, v in self.config.items()}),
+                ("important", self.important),
+            ]
+        )
+
 
 class ProjectBackend:
     """Configuration for the project's Pulumi state storage backend."""
@@ -72,6 +140,21 @@ class ProjectBackend:
 
     def __init__(self, url: Optional[str] = None):
         self.url = url
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ProjectBackend":
+        """Deserialize a ProjectBackend from a dictionary."""
+        return ProjectBackend(
+            url=data.get("url"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize a ProjectBackend to a dictionary."""
+        return _to_dict(
+            [
+                ("url", self.url),
+            ]
+        )
 
 
 class ProjectSettings:
@@ -121,3 +204,60 @@ class ProjectSettings:
         self.config = config
         self.template = template
         self.backend = backend
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ProjectSettings":
+        """Deserialize a ProjectSettings from a dictionary."""
+        runtime = data["runtime"]
+        if isinstance(runtime, dict):
+            runtime = ProjectRuntimeInfo.from_dict(runtime)
+
+        template = data.get("template")
+        if template is not None:
+            template = ProjectTemplate.from_dict(template)
+
+        backend = data.get("backend")
+        if backend is not None:
+            backend = ProjectBackend.from_dict(backend)
+
+        return ProjectSettings(
+            name=data["name"],
+            runtime=runtime,
+            main=data.get("main"),
+            description=data.get("description"),
+            author=data.get("author"),
+            website=data.get("website"),
+            license=data.get("license"),
+            config=data.get("config"),
+            template=template,
+            backend=backend,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize a ProjectSettings to a dictionary."""
+        return _to_dict(
+            [
+                ("name", self.name),
+                (
+                    "runtime",
+                    (
+                        self.runtime.to_dict()
+                        if isinstance(self.runtime, ProjectRuntimeInfo)
+                        else self.runtime
+                    ),
+                ),
+                ("main", self.main),
+                ("description", self.description),
+                ("author", self.author),
+                ("website", self.website),
+                ("license", self.license),
+                ("config", self.config),
+                ("template", self.template.to_dict() if self.template else None),
+                ("backend", self.backend.to_dict() if self.backend else None),
+            ]
+        )
+
+
+def _to_dict(kvs: Iterable[Tuple[str, Any]]) -> Dict[str, Any]:
+    """Convert a list of key-value pairs into a dictionary, filtering out None values."""
+    return {k: v for k, v in kvs if v is not None}

--- a/sdk/python/lib/test/automation/test_project_settings.py
+++ b/sdk/python/lib/test/automation/test_project_settings.py
@@ -1,0 +1,117 @@
+# Copyright 2024, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+from pulumi.automation import (
+    LocalWorkspace,
+    ProjectBackend,
+    ProjectRuntimeInfo,
+    ProjectSettings,
+    ProjectTemplate,
+    ProjectTemplateConfigValue,
+)
+
+
+class TestProjectSettings(unittest.TestCase):
+    def test_serialize_deserialize_project_settings(self):
+        """Tests that ProjectSettings serialization and deserialization is a
+        round-trip operation."""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Arrange.
+            expected = ProjectSettings(
+                name="project_name",
+                runtime=ProjectRuntimeInfo(
+                    name="python",
+                    options={"venv": "venv"},
+                ),
+                main="main.py",
+                description="Project description",
+                author="Pulumi",
+                website="https://pulumi.com",
+                license="Apache-2.0",
+                template=ProjectTemplate(
+                    description="Template description",
+                    quickstart="Template quickstart",
+                    config={
+                        "key": ProjectTemplateConfigValue(
+                            description="Key description",
+                            default="value",
+                            secret=False,
+                        ),
+                    },
+                ),
+                backend=ProjectBackend(
+                    url="file://~",
+                ),
+            )
+
+            ws = LocalWorkspace(work_dir=tmp_dir)
+
+            # Act.
+            ws.save_project_settings(expected)
+            actual = ws.project_settings()
+
+            # Assert.
+            self.assertDictEqual(expected.to_dict(), actual.to_dict())
+
+    def test_serialize_project_settings_to_plain_yaml(self):
+        """Tests that ProjectSettings serialize to a plain YAML file with no
+        pyyaml specifics (e.g. class tags)."""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Arrange.
+            project_settings = ProjectSettings(
+                name="project_name",
+                runtime=ProjectRuntimeInfo(
+                    name="python",
+                    options={"venv": "venv"},
+                ),
+                main="main.py",
+                description="Project description",
+                author="Pulumi",
+                website="https://pulumi.com",
+                license="Apache-2.0",
+                template=ProjectTemplate(
+                    description="Template description",
+                    quickstart="Template quickstart",
+                    config={
+                        "key": ProjectTemplateConfigValue(
+                            description="Key description",
+                            default="value",
+                            secret=False,
+                        ),
+                    },
+                ),
+                backend=ProjectBackend(
+                    url="file://~",
+                ),
+            )
+
+            ws = LocalWorkspace(work_dir=tmp_dir)
+            ws.save_project_settings(project_settings)
+
+            # Act.
+            with open(os.path.join(tmp_dir, "Pulumi.yaml"), "r") as f:
+                actual = f.read()
+
+            # Assert.
+            self.assertNotIn(
+                "!!python",
+                actual,
+                "YAML file contains Python-specific tags",
+            )


### PR DESCRIPTION
The Python Automation API SDK serializes project settings (the contents of `Pulumi.yaml` files) using Python's `pyyaml` package. Project settings in the Python Automation API SDK are represented as instances of the `ProjectSettings` class. By default, `pyyaml` will serialize class instances as YAML objects "tagged" with a string that indicates their class. This is so that, upon deserialization, it can construct objects of the appropriate class (as opposed to, just dictionaries). As an example, the following Python program:

```python
class Person:
  def __init(self, name: str, age: int) -> None:
    self.name = name
    self.age = age

will = Person("will", 37)
yaml.dump(will)
```

will produce the following YAML:

```yaml
!!python/object:__main__.Person
age: 37
name: will
```

The string `!!python/object:__main__.Person` is the _tag_ indicating the class that Python will need to instantiate if e.g. this YAML is deserialized with `yaml.load` or similar.

Outside of the various Automation APIs, `Pulumi.yaml` files are "plain-old YAML files" -- language- or library-specific concepts such as class tags are nowhere to be seen. We thus don't really want this behaviour when we serialize project settings to YAML. Fortunately, there is a relatively simple workaround -- instead of passing instances of `ProjectSettings` to `yaml.dump`, we can just pass vanilla dictionaries containing the same data. These will be rendered as YAML objects with no tags, which is what we want.

<em>Un</em>fortunately, we must turn _all_ objects in a hierarchy into plain dictionaries, or tags will appear at some point. Presently, this is not the case in the Python SDK, which just uses `ProjectSettings.__dict__` to get the dictionary for the top-level object. If there are nested objects in this dictionary (such as e.g. `ProjectBackend` or `ProjectRuntimeInfo` objects), these are _not_ converted into dictionaries and `pyyaml` writes them as tagged objects, which will later fail to deserialize.

This commit fixes this issue, adding explicit `to_dict` and `from_dict` methods to settings classes for the purposes of recursively converting objects to and from dictionaries. It also:
* adds a test that confirms serialization/deserialization of configurations containing nested objects now works.
* in order to write this test, exports some types (`ProjectTemplate` and friends) that appear to be part of the public API but have until now not been exported.