### PR TITLE
Clean up PULUMI_HOME after program test

### DIFF
--- a/changelog/pending/20240715--pkg-testing--clean-up-pulumi_home-after-program-test.yaml
+++ b/changelog/pending/20240715--pkg-testing--clean-up-pulumi_home-after-program-test.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg/testing
+  description: Clean up PULUMI_HOME after program test

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1249,6 +1249,10 @@ func (pt *ProgramTester) TestCleanUp() {
 			contract.IgnoreError(os.RemoveAll(filepath.Join(pt.projdir, commandOutputFolderName)))
 		}
 	}
+
+	// Clean up the temporary PULUMI_HOME directory we created. This is necessary to reclaim the disk space
+	// of the plugins that were downloaded during the test.
+	contract.IgnoreError(os.RemoveAll(pt.pulumiHome))
 }
 
 // TestLifeCycleInitAndDestroy executes the test and cleans up


### PR DESCRIPTION
Clean up the temporary `PULUMI_HOME` directory we create during a program test.
This is necessary to reclaim the disk space of the plugins that were downloaded
during the test.

In pulumi-aws we started seeing test failures because the CI runners started running out of disk space due to plugins in `PULUMI_HOME` not being cleaned up.
