### PR TITLE
Default the import base path to something sensible

### DIFF
--- a/changelog/pending/20240715--sdkgen-go--importbasepath-will-default-to-a-pulumi-github-base-path.yaml
+++ b/changelog/pending/20240715--sdkgen-go--importbasepath-will-default-to-a-pulumi-github-base-path.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdkgen/go
-  description: importBasePath will default to a pulumi github base path.
+  description: Default importBasePath to a pulumi github base path

--- a/changelog/pending/20240715--sdkgen-go--importbasepath-will-default-to-a-pulumi-github-base-path.yaml
+++ b/changelog/pending/20240715--sdkgen-go--importbasepath-will-default-to-a-pulumi-github-base-path.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: importBasePath will default to a pulumi github base path.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3652,10 +3652,10 @@ func (pkg *pkgContext) getTypeImports(t schema.Type, recurse bool, importsAndAli
 }
 
 func extractImportBasePath(extPkg schema.PackageReference) string {
-	version := extPkg.Version().Major
 	var vPath string
-	if version > 1 {
-		vPath = fmt.Sprintf("/v%d", version)
+	version := extPkg.Version()
+	if version != nil && version.Major > 1 {
+		vPath = fmt.Sprintf("/v%d", version.Major)
 	}
 	return fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", extPkg.Name(), vPath, extPkg.Name())
 }
@@ -3974,10 +3974,17 @@ func generatePackageContextMap(tool string, pkg schema.PackageReference, goInfo 
 			if goInfo.InternalModuleName != "" {
 				internalModuleName = goInfo.InternalModuleName
 			}
+
+			importBasePath := goInfo.ImportBasePath
+			if importBasePath == "" {
+				// Default to a path based on the package name.
+				importBasePath = extractImportBasePath(pkg)
+			}
+
 			pack = &pkgContext{
 				pkg:                           pkg,
 				mod:                           mod,
-				importBasePath:                goInfo.ImportBasePath,
+				importBasePath:                importBasePath,
 				rootPackageName:               goInfo.RootPackageName,
 				typeDetails:                   map[schema.Type]*typeDetails{},
 				names:                         codegen.NewStringSet(),

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/init.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/init.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type pkg struct {

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 // The list of configurations.

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 // The list of product families.

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/provider.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/provider.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Provider struct {

--- a/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
+++ b/tests/testdata/codegen/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-myedgeorder/sdk/go/myedgeorder/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 var _ = internal.GetEnvOrDefault

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/config/config.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/config/config.go
@@ -4,9 +4,9 @@
 package config
 
 import (
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
-	"internal"
 )
 
 var _ = internal.GetEnvOrDefault

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/config/pulumiTypes.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/config/pulumiTypes.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 var _ = internal.GetEnvOrDefault

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 // Check codegen of functions with all optional inputs.

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/init.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/init.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type pkg struct {

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/provider.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/provider.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"reflect"
 
-	"config"
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/config"
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 type Provider struct {

--- a/tests/testdata/codegen/provider-config-schema/go/configstation/pulumiTypes.go
+++ b/tests/testdata/codegen/provider-config-schema/go/configstation/pulumiTypes.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pulumi/pulumi-configstation/sdk/go/configstation/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"internal"
 )
 
 var _ = internal.GetEnvOrDefault


### PR DESCRIPTION
This fixes go package generation so users don't _have_ to set the import base path explicitly in the go info part of the schema. This only really helps our packages (because we assume the path is "github.com/pulumi") but it fixes some of the generated test data and should also work for local SDKs, where they aren't _really_ at "github.com/pulumi" but also that it doesn't matter what URL is used as long as it's a valid one.

Fixes https://github.com/pulumi/pulumi/issues/13756