### PR TITLE
sdk/python: avoid maximum recursion depth error

### DIFF
--- a/changelog/pending/20240716--sdk-python--fix-a-recursionerror-with-deeply-nested-componentresources.yaml
+++ b/changelog/pending/20240716--sdk-python--fix-a-recursionerror-with-deeply-nested-componentresources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix a RecursionError with deeply nested ComponentResources

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -291,7 +291,7 @@ async def _add_dependency(
                 os.getenv(ERROR_ON_DEPENDENCY_CYCLES_VAR, "true").lower() == "true"
             )
             if not error_on_cycles:
-                return
+                continue
             raise RuntimeError(
                 "We have detected a circular dependency involving a resource of type"
                 + f" {res._type} named {res._name}.\n"

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -274,6 +274,8 @@ async def _add_dependency(
     """
     from ..resource import Resource  # pylint: disable=import-outside-toplevel
 
+    # Note that a recursive algorithm here would be cleaner, but that results in a
+    # RecursionError with deeply nested hierarchies of ComponentResources.
     res_list = [(res, from_resource)]
     while len(res_list) > 0:
         res, from_resource = res_list.pop(0)


### PR DESCRIPTION
CPython doesn't optimize tail recursion, and because of that has a fairly low recursion limit set to avoid stack overflows.  This also means that where we rely on recursion we are prone to raising `RecursionError`s.  In this particular case, `_add_dependency` relies on recursion for finding all the child dependencies.

When deeply nested trees of `ComponentResources` are used, `_add_dependencies` can end up raising such an error.

Rewrite the function to be iterative instead of recursive to avoid that.

Fixes https://github.com/pulumi/pulumi/issues/16328

(I didn't manage to reproduce the exact stacktrace of the above issue, so there might be another thing hidden there.  But this should help with it either way)