### PR TITLE
state_move: show resources to be moved correctly

### DIFF
--- a/changelog/pending/20240716--cli-state--fix-resources-to-be-moved-not-being-shown-in-pulumi-state-move.yaml
+++ b/changelog/pending/20240716--cli-state--fix-resources-to-be-moved-not-being-shown-in-pulumi-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix resources to be moved not being shown in `pulumi state move`

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -227,6 +227,16 @@ func (cmd *stateMoveCmd) Run(
 		destSnapshot.Resources = append(destSnapshot.Resources, r)
 	}
 
+	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
+		colors.SpecHeadline+"Planning to move the following resources from %s to %s:\n"+colors.Reset),
+		source.Ref().Name(), dest.Ref().Name())
+
+	for _, res := range resourcesToMoveOrdered {
+		fmt.Fprintf(cmd.Stdout, "  %s\n", res.URN)
+	}
+
+	fmt.Fprintf(cmd.Stdout, "\n")
+
 	var brokenDestDependencies []brokenDependency
 	for _, res := range resourcesToMoveOrdered {
 		if _, ok := resourcesToMove[string(res.Parent)]; !ok {
@@ -249,18 +259,6 @@ func (cmd *stateMoveCmd) Run(
 
 		destSnapshot.Resources = append(destSnapshot.Resources, res)
 	}
-
-	fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(
-		colors.SpecHeadline+"Planning to move the following resources from %s to %s:\n"+colors.Reset),
-		source.Ref().Name(), dest.Ref().Name())
-
-	for _, res := range sourceSnapshot.Resources {
-		if _, ok := resourcesToMove[string(res.URN)]; ok {
-			fmt.Fprintf(cmd.Stdout, "  %s\n", res.URN)
-		}
-	}
-
-	fmt.Fprintf(cmd.Stdout, "\n")
 
 	if len(brokenSourceDependencies) > 0 {
 		fmt.Fprintf(cmd.Stdout, cmd.Colorizer.Colorize(

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -182,7 +182,11 @@ func TestChildrenAreBeingMoved(t *testing.T) {
 		},
 	}
 
-	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
+	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
+
+	assert.Contains(t, stdout.String(), "Planning to move the following resources from sourceStack to destStack:\n"+
+		"  urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
+		"  urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2\n")
 
 	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
 


### PR DESCRIPTION
At some point while moving the code around we lost the output for the resources to be moved.  We would look for them in the source snapshot for correct ordering, but the code happened after the URN renaming, so the resources would not match the ones in the source snapshot anymore.

Fix this by using the resourcesToMoveOrdered list to print the resources, and also moving this code a bit earlier, as we want to show the resource URNs from the source snapshot, instead of the rewritten ones.