### PR TITLE
state_move: warn no resources are matched/error out when no resources move

### DIFF
--- a/changelog/pending/20240716--cli-state--warn-when-an-argument-matches-no-urn-in-the-source-snapshot-and-error-out-when-no-resources-are-being-moved-in-pulumi-state-move.yaml
+++ b/changelog/pending/20240716--cli-state--warn-when-an-argument-matches-no-urn-in-the-source-snapshot-and-error-out-when-no-resources-are-being-moved-in-pulumi-state-move.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Warn when an argument matches no URN in the source snapshot and error out when no resources are being moved in `pulumi state move`


### PR DESCRIPTION
Currently when no resources are moved, we just show no resources being moved, but let the command continue.  This can be quite confusing to the user.  Error out in that case instead.  Also when an argument doesn't match any resources in the source snapshot, we now warn the user about that.