### PR TITLE
Support `--remove` for `destroy` in the Go, NodeJS and Python Automation API SDKs

### DIFF
--- a/changelog/pending/20240716--sdk-go-nodejs-python--support-remove-for-destroy-in-the-go-nodejs-and-python-automation-api-sdks.yaml
+++ b/changelog/pending/20240716--sdk-go-nodejs-python--support-remove-for-destroy-in-the-go-nodejs-and-python-automation-api-sdks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go,nodejs,python
+  description: Support `--remove` for `destroy` in the Go, NodeJS and Python Automation API SDKs

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -122,6 +122,14 @@ func ContinueOnError() Option {
 	})
 }
 
+// Remove the stack and its configuration after all resources in the stack have
+// been deleted.
+func Remove() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Remove = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -162,6 +170,9 @@ type Options struct {
 	SuppressOutputs bool
 	// Continue to perform the destroy operation despite the occurrence of errors.
 	ContinueOnError bool
+	// Remove the stack and its configuration after all resources in the stack
+	// have been deleted.
+	Remove bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -746,6 +746,16 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		summary = history[0]
 	}
 
+	// If `remove` was set, remove the stack now. We take this approach rather
+	// than passing `--remove` to `pulumi destroy` because the latter would make
+	// it impossible for us to retrieve a summary of the operation above for
+	// returning to the caller.
+	if destroyOpts.Remove {
+		if err := s.Workspace().RemoveStack(ctx, s.Name()); err != nil {
+			return res, fmt.Errorf("failed to remove stack: %w", err)
+		}
+	}
+
 	res = DestroyResult{
 		Summary: summary,
 		StdOut:  stdout,

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -667,6 +667,29 @@ describe("LocalWorkspace", () => {
         // we expect this error
         assert.rejects(stack.workspace.selectStack(stackName));
     });
+    it("runs through the stack lifecycle with an inline program, testing destroy with --remove", async () => {
+        // Arrange.
+        const program = async () => {
+            class MyResource extends ComponentResource {
+                constructor(name: string, opts?: ComponentResourceOptions) {
+                    super("my:module:MyResource", name, {}, opts);
+                }
+            }
+            new MyResource("res");
+            return {};
+        };
+        const projectName = "inline_node";
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
+        const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
+
+        await stack.up({ userAgent });
+
+        // Act.
+        await stack.destroy({ userAgent, remove: true });
+
+        // Assert.
+        await assert.rejects(stack.workspace.selectStack(stackName));
+    });
     it(`refreshes before preview`, async () => {
         // We create a simple program, and scan the output for an indication
         // that adding refresh: true will perfrom a refresh operation.

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -548,6 +548,7 @@ class Stack:
         suppress_outputs: Optional[bool] = None,
         suppress_progress: Optional[bool] = None,
         continue_on_error: Optional[bool] = None,
+        remove: Optional[bool] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -570,6 +571,7 @@ class Stack:
         :param suppress_outputs: Suppress display of stack outputs (in case they contain sensitive values)
         :param suppress_progress: Suppress display of periodic progress dots
         :param continue_on_error: Continue to perform the destroy operation despite the occurrence of errors
+        :param remove: Remove the stack and its configuration after all resources in the stack have been deleted.
         :returns: DestroyResult
         """
         # Disable unused-argument because pylint doesn't understand we process them in _parse_extra_args
@@ -602,6 +604,14 @@ class Stack:
         # load the project file.
         summary = self.info(show_secrets and not self._remote)
         assert summary is not None
+
+        # If `remove` was set, remove the stack now. We take this approach
+        # rather than passing `--remove` to `pulumi destroy` because the latter
+        # would make it impossible for us to retrieve a summary of the operation
+        # above for returning to the caller.
+        if remove:
+            self.workspace.remove_stack(self.name)
+
         return DestroyResult(
             stdout=destroy_result.stdout, stderr=destroy_result.stderr, summary=summary
         )

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -777,6 +777,23 @@ class TestLocalWorkspace(unittest.TestCase):
         with self.assertRaises(StackNotFoundError):
             stack.workspace.select_stack(stack_name)
 
+    def test_stack_lifecycle_inline_program_destroy_with_remove(self):
+        # Arrange.
+        project_name = "inline_python"
+        stack_name = stack_namer(project_name)
+        stack = create_stack(
+            stack_name, program=pulumi_program_with_resource, project_name=project_name
+        )
+
+        stack.up()
+
+        # Act.
+        stack.destroy(remove=True)
+
+        # Assert.
+        with self.assertRaises(StackNotFoundError):
+            stack.workspace.select_stack(stack_name)
+
     def test_stack_lifecycle_async_inline_program(self):
         project_name = "async_inline_python"
         stack_name = stack_namer(project_name)


### PR DESCRIPTION
By default, `pulumi destroy` removes all resources within a stack but leaves the stack and its configuration intact. If one passes the `--remove` option to `destroy`, however, the stack and its configuration will also be removed once the resources within the stack have been deleted. This commit updates the work of @Moon1706 in #11080 to add `remove` as an option to the Go, NodeJS and Python Automation API SDKs' `destroy` methods, which then perform an analogous clean-up.

Closes #11080