### PR TITLE
Fix an incorrect error check in NodeJS integration tests

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -870,7 +870,7 @@ func TestCloudSecretProvider(t *testing.T) {
 	}
 
 	gcpKmsKey := os.Getenv("PULUMI_TEST_GCP_KEY")
-	if azureKeyVault == "" {
+	if gcpKmsKey == "" {
 		t.Skipf("Skipping: PULUMI_TEST_GCP_KEY is not set")
 	}
 


### PR DESCRIPTION
This commit fixes a small error in one of our integration tests that happened to be spotted in #14543, but was never addressed separately/has not been addressed since that PR has not yet been merged.