### PR TITLE
state_move: handle empty stacks correctly

### DIFF
--- a/changelog/pending/20240716--cli-state--fix-panic-in-state-move-when-either-the-source-or-destination-stack-are-empty.yaml
+++ b/changelog/pending/20240716--cli-state--fix-panic-in-state-move-when-either-the-source-or-destination-stack-are-empty.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Fix panic in state move when either the source or destination stack are empty

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -123,6 +124,13 @@ func (cmd *stateMoveCmd) Run(
 	err = sourceSnapshot.VerifyIntegrity()
 	if err != nil {
 		return fmt.Errorf("failed to verify integrity of source snapshot: %w", err)
+	}
+
+	if sourceSnapshot == nil {
+		return errors.New("source stack has no resources")
+	}
+	if destSnapshot == nil {
+		destSnapshot = &deploy.Snapshot{}
 	}
 
 	resourcesToMove := make(map[string]*resource.State)

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -456,6 +456,8 @@ func TestParentsAreBeingMoved(t *testing.T) {
 }
 
 func TestEmptySourceStack(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 	t.Cleanup(func() {
@@ -473,6 +475,8 @@ func TestEmptySourceStack(t *testing.T) {
 
 	destStackName := "organization/test/destStack"
 	destRef, err := b.ParseStackReference(destStackName)
+	require.NoError(t, err)
+
 	destStack, err := b.CreateStack(ctx, destRef, "", nil)
 	require.NoError(t, err)
 
@@ -490,6 +494,8 @@ func TestEmptySourceStack(t *testing.T) {
 }
 
 func TestEmptyDestStack(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 	t.Cleanup(func() {
@@ -518,6 +524,8 @@ func TestEmptyDestStack(t *testing.T) {
 
 	destStackName := "organization/test/destStack"
 	destRef, err := b.ParseStackReference(destStackName)
+	require.NoError(t, err)
+
 	destStack, err := b.CreateStack(ctx, destRef, "", nil)
 	require.NoError(t, err)
 
@@ -537,6 +545,8 @@ func TestEmptyDestStack(t *testing.T) {
 	assert.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destRef)
+	require.NoError(t, err)
+
 	destSnapshot, err := destStack.Snapshot(ctx, mp)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Currently when we have stacks with no snapshot, `pulumi state move` fails because it tries to use a nil pointer.  Handle this scenario correctly by:
 - erroring out if there is no snapshot in the source stack.  In this case there are no resources that can be moved, so there's nothing more that we can do other than showing the error.
 - creating a snapshot in the destination stack if necessary.  It's valid to move a resource to a currently empty stack, so we'll make this work.