### PR TITLE
Don't use indentation in converted pyproject.toml files

### DIFF
--- a/changelog/pending/20240716--sdk-python--dont-use-indentation-in-converted-pyproject-toml-files.yaml
+++ b/changelog/pending/20240716--sdk-python--dont-use-indentation-in-converted-pyproject-toml-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Don't use indentation in converted pyproject.toml files

--- a/changelog/pending/20240716--sdk-python--dont-use-indentation-in-pyproject-toml.yaml
+++ b/changelog/pending/20240716--sdk-python--dont-use-indentation-in-pyproject-toml.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: sdk/python
-  description: Don't use indentation in pyproject.toml

--- a/changelog/pending/20240716--sdk-python--dont-use-indentation-in-pyproject-toml.yaml
+++ b/changelog/pending/20240716--sdk-python--dont-use-indentation-in-pyproject-toml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Don't use indentation in pyproject.toml

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -229,7 +229,9 @@ func (p *poetry) generatePyProjectTOML(dependencies map[string]string) (string, 
 	}
 
 	w := &bytes.Buffer{}
-	if err := toml.NewEncoder(w).Encode(pp); err != nil {
+	encoder := toml.NewEncoder(w)
+	encoder.Indent = "" // Disable indentation
+	if err := encoder.Encode(pp); err != nil {
 		return "", err
 	}
 	return w.String(), nil

--- a/sdk/python/toolchain/poetry_test.go
+++ b/sdk/python/toolchain/poetry_test.go
@@ -46,16 +46,16 @@ func TestGeneratePyProjectTOML(t *testing.T) {
 	s, err := p.generatePyProjectTOML(deps)
 	require.NoError(t, err)
 	require.Equal(t, `[build-system]
-  requires = ["poetry-core"]
-  build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool]
-  [tool.poetry]
-    package-mode = false
-    [tool.poetry.dependencies]
-      pulumi = ">=3.0.0,<4.0.0"
-      requests = ">1"
-      setuptools = "*"
-      spaces-before = "1.2.3"
+[tool.poetry]
+package-mode = false
+[tool.poetry.dependencies]
+pulumi = ">=3.0.0,<4.0.0"
+requests = ">1"
+setuptools = "*"
+spaces-before = "1.2.3"
 `, s)
 }

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -565,4 +565,18 @@ in-project = true`
 
 	require.True(t, e.PathExists("pyproject.toml"), "pyproject.toml was created")
 	require.False(t, e.PathExists("requirements.txt"), "requirements.txt was removed")
+
+	b, err := os.ReadFile(filepath.Join(e.RootPath, "pyproject.toml"))
+	require.NoError(t, err)
+	require.Equal(t, `[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool]
+[tool.poetry]
+package-mode = false
+[tool.poetry.dependencies]
+pulumi = ">=3.0.0,<4.0.0"
+python = "^3.8"
+`, string(b))
 }


### PR DESCRIPTION
When converting from a requirements.txt to a pyproject.toml, we were
previously indenting each logical level in the file. Disable the
indentation to match the style of pyproject.toml files as generated
directly by Poetry.

Fixes https://github.com/pulumi/pulumi/issues/16657
