### PR TITLE
Validate that we have Poetry >= 1.8.0

### DIFF
--- a/changelog/pending/20240717--sdk-python--validate-that-we-have-poetry-1-8-0.yaml
+++ b/changelog/pending/20240717--sdk-python--validate-that-we-have-poetry-1-8-0.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Validate that we have Poetry >= 1.8.0

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -30,7 +30,7 @@ type poetry struct {
 
 var _ Toolchain = &poetry{}
 
-const minPoetryVersion = "1.8.0"
+var minPoetryVersion = semver.Version{Major: 1, Minor: 8, Patch: 0}
 
 func newPoetry(directory string) (*poetry, error) {
 	poetryPath, err := exec.LookPath("poetry")
@@ -74,8 +74,7 @@ func validateVersion(versionOut string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse poetry version %q: %w", version, err)
 	}
-	min := semver.MustParse(minPoetryVersion)
-	if sem.LT(min) {
+	if sem.LT(minPoetryVersion) {
 		return fmt.Errorf("poetry version %s is less than the minimum required version %s", version, minPoetryVersion)
 	}
 	logging.V(9).Infof("Python toolchain: using poetry version %s", sem)

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -29,17 +30,56 @@ type poetry struct {
 
 var _ Toolchain = &poetry{}
 
+const minPoetryVersion = "1.8.0"
+
 func newPoetry(directory string) (*poetry, error) {
 	poetryPath, err := exec.LookPath("poetry")
 	if err != nil {
 		return nil, errors.New("Could not find `poetry` executable.\n" +
 			"Install poetry and make sure is is in your PATH, or set the toolchain option in Pulumi.yaml to `pip`.")
 	}
+	versionOut, err := poetryVersionOutput(poetryPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateVersion(versionOut); err != nil {
+		return nil, err
+	}
 	logging.V(9).Infof("Python toolchain: using poetry at %s in %s", poetryPath, directory)
 	return &poetry{
 		poetryExecutable: poetryPath,
 		directory:        directory,
 	}, nil
+}
+
+func poetryVersionOutput(poetryPath string) (string, error) {
+	cmd := exec.Command(poetryPath, "--version", "--no-ansi") //nolint:gosec
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to run poetry --version: %w", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func validateVersion(versionOut string) error {
+	re := regexp.MustCompile(`Poetry \(version (?P<version>\d+\.\d+(.\d+)?).*\)`)
+	matches := re.FindStringSubmatch(versionOut)
+	i := re.SubexpIndex("version")
+	if i < 0 || len(matches) < i {
+		return fmt.Errorf("unexpected output from poetry --version: %q", versionOut)
+	}
+	version := matches[i]
+	sem, err := semver.ParseTolerant(version)
+	if err != nil {
+		return fmt.Errorf("failed to parse poetry version %q: %w", version, err)
+	}
+	min := semver.MustParse(minPoetryVersion)
+	if sem.LT(min) {
+		return fmt.Errorf("poetry version %s is less than the minimum required version %s", version, minPoetryVersion)
+	}
+	logging.V(9).Infof("Python toolchain: using poetry version %s", sem)
+	return nil
 }
 
 func (p *poetry) InstallDependencies(ctx context.Context,

--- a/sdk/python/toolchain/poetry_test.go
+++ b/sdk/python/toolchain/poetry_test.go
@@ -59,3 +59,13 @@ setuptools = "*"
 spaces-before = "1.2.3"
 `, s)
 }
+
+func TestCheckVersion(t *testing.T) {
+	require.NoError(t, validateVersion("Poetry (version 1.8.3)"))
+	require.NoError(t, validateVersion("Poetry (version 2.1.2)"))
+	require.NoError(t, validateVersion("Poetry (version 3.0)"))
+	require.NoError(t, validateVersion("Poetry (version 1.9.0.dev0)"))
+	require.ErrorContains(t, validateVersion("Poetry (version 1.7.0)"), "is less than the minimum required version")
+	require.ErrorContains(t, validateVersion("invalid version string"), "unexpected output from poetry --version")
+	require.ErrorContains(t, validateVersion(""), "unexpected output from poetry --version")
+}

--- a/sdk/python/toolchain/poetry_test.go
+++ b/sdk/python/toolchain/poetry_test.go
@@ -61,6 +61,7 @@ spaces-before = "1.2.3"
 }
 
 func TestCheckVersion(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, validateVersion("Poetry (version 1.8.3)"))
 	require.NoError(t, validateVersion("Poetry (version 2.1.2)"))
 	require.NoError(t, validateVersion("Poetry (version 3.0)"))


### PR DESCRIPTION
The pyproject.toml files we generated when using the Poetry toolchain
require Poetry >= 1.8.0. Validate that we have at least this version,
and report a descriptive error if not.

Fixes https://github.com/pulumi/pulumi/issues/16656

Doc update: https://github.com/pulumi/docs/pull/12293