### PR TITLE
Change Go dependency tests to use real dependencies

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -639,7 +639,7 @@ func (host *goLanguageHost) loadGomod(gobin, programDir string) (modDir string, 
 		return "", nil, err
 	}
 
-	f, err := modfile.ParseLax(modPath, body, nil)
+	f, err := modfile.Parse(modPath, body, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("parse: %w", err)
 	}

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -461,9 +461,9 @@ func testPluginsAndDependencies(t *testing.T, progDir string) {
 		}
 
 		assert.Equal(t, map[string]string{
-			"example.com/plugin":          "v1.2.3",
-			"example.com/dep":             "v1.5.0",
-			"example.com/indirect-dep/v2": "v2.1.0",
+			"github.com/pulumi/go-dependency-testdata/plugin":          "v1.2.3",
+			"github.com/pulumi/go-dependency-testdata/dep":             "v1.6.0",
+			"github.com/pulumi/go-dependency-testdata/indirect-dep/v2": "v2.1.0",
 		}, gotDeps)
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/sample/dep/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/dep/go.mod
@@ -1,7 +1,0 @@
-module example.com/dep
-
-go 1.18
-
-replace example.com/indirect-dep/v2 => ../indirect-dep
-
-require example.com/indirect-dep/v2 v2.1.0

--- a/sdk/go/pulumi-language-go/testdata/sample/dep/plug.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/dep/plug.go
@@ -1,8 +1,0 @@
-package dep
-
-import indirect "example.com/indirect-dep/v2"
-
-func Bar() string {
-	indirect.Baz()
-	return "bar"
-}

--- a/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/go.mod
@@ -1,3 +1,0 @@
-module example.com/indirect-dep/v2
-
-go 1.18

--- a/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/indirect.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/indirect-dep/indirect.go
@@ -1,3 +1,0 @@
-package indirect
-
-func Baz() {}

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/go.mod
@@ -1,3 +1,0 @@
-module example.com/plugin
-
-go 1.18

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/plug.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/plug.go
@@ -1,5 +1,0 @@
-package plugin
-
-func Foo() string {
-	return "foo"
-}

--- a/sdk/go/pulumi-language-go/testdata/sample/plugin/pulumi-plugin.json
+++ b/sdk/go/pulumi-language-go/testdata/sample/plugin/pulumi-plugin.json
@@ -1,5 +1,0 @@
-{
-  "resource": true,
-  "name": "example",
-  "server": "example.com/download"
-}

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/go.work.sum
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/go.work.sum
@@ -1,0 +1,3 @@
+github.com/pulumi/go-dependency-testdata/dep v1.6.0/go.mod h1:t9byisapw0AiX6vfRYXbsnV1P3KGcmJS3i9SsP1eIMk=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0/go.mod h1:kIcnZs58bSUyAFxJPdbkJXOzWGwOcODgwictOy8aMuI=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3/go.mod h1:S4PBUfQePMxlR58DPhZUpJAjgEb5qZlg/TR3cLdCkZ0=

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.mod
@@ -2,15 +2,9 @@ module example.com/prog
 
 go 1.18
 
-replace (
-	example.com/dep => ../../dep
-	example.com/indirect-dep/v2 => ../../indirect-dep
-	example.com/plugin => ../../plugin
-)
-
 require (
-	example.com/dep v1.5.0
-	example.com/plugin v1.2.3
+	github.com/pulumi/go-dependency-testdata/dep v1.6.0
+	github.com/pulumi/go-dependency-testdata/plugin v1.2.3
 )
 
-require example.com/indirect-dep/v2 v2.1.0 // indirect
+require github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.sum
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/go.sum
@@ -1,0 +1,6 @@
+github.com/pulumi/go-dependency-testdata/dep v1.6.0 h1:+pE3tVvVIpmzkBTeF+SEXwzkXWKbaWgLaHJGDerrkPU=
+github.com/pulumi/go-dependency-testdata/dep v1.6.0/go.mod h1:t9byisapw0AiX6vfRYXbsnV1P3KGcmJS3i9SsP1eIMk=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 h1:Sj9+i/tlHlTp9uP4buJ8daySIZ5UJW/IT44Q81a0HBM=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0/go.mod h1:kIcnZs58bSUyAFxJPdbkJXOzWGwOcODgwictOy8aMuI=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3 h1:ouER+7c/L36grY9u+ksFw19fkyYzzDl05widnPfGWyg=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3/go.mod h1:S4PBUfQePMxlR58DPhZUpJAjgEb5qZlg/TR3cLdCkZ0=

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-gowork/prog/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"example.com/dep"
-	"example.com/plugin"
+	"github.com/pulumi/go-dependency-testdata/dep"
+	"github.com/pulumi/go-dependency-testdata/plugin"
 )
 
 func main() {

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.mod
@@ -2,15 +2,9 @@ module example.com/prog-subdir
 
 go 1.18
 
-replace (
-	example.com/dep => ../dep
-	example.com/indirect-dep/v2 => ../indirect-dep
-	example.com/plugin => ../plugin
-)
-
 require (
-	example.com/dep v1.5.0
-	example.com/plugin v1.2.3
+	github.com/pulumi/go-dependency-testdata/dep v1.6.0
+	github.com/pulumi/go-dependency-testdata/plugin v1.2.3
 )
 
-require example.com/indirect-dep/v2 v2.1.0 // indirect
+require github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.sum
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/go.sum
@@ -1,0 +1,6 @@
+github.com/pulumi/go-dependency-testdata/dep v1.6.0 h1:+pE3tVvVIpmzkBTeF+SEXwzkXWKbaWgLaHJGDerrkPU=
+github.com/pulumi/go-dependency-testdata/dep v1.6.0/go.mod h1:t9byisapw0AiX6vfRYXbsnV1P3KGcmJS3i9SsP1eIMk=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 h1:Sj9+i/tlHlTp9uP4buJ8daySIZ5UJW/IT44Q81a0HBM=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0/go.mod h1:kIcnZs58bSUyAFxJPdbkJXOzWGwOcODgwictOy8aMuI=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3 h1:ouER+7c/L36grY9u+ksFw19fkyYzzDl05widnPfGWyg=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3/go.mod h1:S4PBUfQePMxlR58DPhZUpJAjgEb5qZlg/TR3cLdCkZ0=

--- a/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog-subdir/infra/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"example.com/dep"
-	"example.com/plugin"
+	"github.com/pulumi/go-dependency-testdata/dep"
+	"github.com/pulumi/go-dependency-testdata/plugin"
 )
 
 func main() {

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/go.mod
@@ -2,15 +2,9 @@ module example.com/prog
 
 go 1.18
 
-replace (
-	example.com/dep => ../dep
-	example.com/indirect-dep/v2 => ../indirect-dep
-	example.com/plugin => ../plugin
-)
-
 require (
-	example.com/dep v1.5.0
-	example.com/plugin v1.2.3
+	github.com/pulumi/go-dependency-testdata/dep v1.6.0
+	github.com/pulumi/go-dependency-testdata/plugin v1.2.3
 )
 
-require example.com/indirect-dep/v2 v2.1.0 // indirect
+require github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 // indirect

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/go.sum
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/go.sum
@@ -1,0 +1,6 @@
+github.com/pulumi/go-dependency-testdata/dep v1.6.0 h1:+pE3tVvVIpmzkBTeF+SEXwzkXWKbaWgLaHJGDerrkPU=
+github.com/pulumi/go-dependency-testdata/dep v1.6.0/go.mod h1:t9byisapw0AiX6vfRYXbsnV1P3KGcmJS3i9SsP1eIMk=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0 h1:Sj9+i/tlHlTp9uP4buJ8daySIZ5UJW/IT44Q81a0HBM=
+github.com/pulumi/go-dependency-testdata/indirect-dep/v2 v2.1.0/go.mod h1:kIcnZs58bSUyAFxJPdbkJXOzWGwOcODgwictOy8aMuI=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3 h1:ouER+7c/L36grY9u+ksFw19fkyYzzDl05widnPfGWyg=
+github.com/pulumi/go-dependency-testdata/plugin v1.2.3/go.mod h1:S4PBUfQePMxlR58DPhZUpJAjgEb5qZlg/TR3cLdCkZ0=

--- a/sdk/go/pulumi-language-go/testdata/sample/prog/main.go
+++ b/sdk/go/pulumi-language-go/testdata/sample/prog/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"example.com/dep"
-	"example.com/plugin"
+	"github.com/pulumi/go-dependency-testdata/dep"
+	"github.com/pulumi/go-dependency-testdata/plugin"
 )
 
 func main() {


### PR DESCRIPTION
For conformance testing we want "replace" directives to be respected since they change the version of the dependency. These tests were all written using replace directives instead of just normal real dependencies and so fixing the Go host to respect "replace" broke these tests. 
This rewrites the tests to use real dependencies pulled from a separate repo at https://github.com/pulumi/go-dependency-testdata.