### PR TITLE
Enable the l1-empty test for Go

### DIFF
--- a/cmd/pulumi-test-language/interface.go
+++ b/cmd/pulumi-test-language/interface.go
@@ -880,6 +880,12 @@ func (eng *languageTestServer) RunLanguageTest(
 				if expected == actual {
 					return true
 				}
+				// Actual might be the empty string, some languages can't always return versions especially for local
+				// dependencies. In this case we treat it as matching as this is just supposed to be a best effort check.
+				if actual == "" {
+					return true
+				}
+
 				// Expected _will_ be a semver (because we got it from the provider version), but actual could be
 				// _anything_. We assume it will at least have the major.minor.patch part from the expected semver.
 				expectedSV := semver.MustParse(expected)

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -532,7 +532,7 @@ resource main "auto-deploy:index:AutoDeployer" {
 	require.NoError(t, err)
 	require.False(t, diags.HasErrors())
 
-	files, diags, err := GenerateProjectFiles(workspace.Project{}, program)
+	files, diags, err := GenerateProjectFiles(workspace.Project{}, program, nil)
 	assert.NotNil(t, files, "Files were generated")
 	require.NoError(t, err)
 	require.False(t, diags.HasErrors())

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Excluding tests that have their dependencies code-generated but under .gitignore.
-EXCLUDE="tests/integration/construct_component_configure_provider/go/go.mod"
+EXCLUDE="-e tests/integration/construct_component_configure_provider/go/go.mod -e sdk/go/pulumi-language-go/testdata/projects"
 
-for f in $(git ls-files '**go.mod' | grep -v "$EXCLUDE")
+for f in $(git ls-files '**go.mod' | grep -v $EXCLUDE)
 do
     (cd "$(dirname "${f}")" && go mod tidy -compat=1.20)
 done

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -172,7 +172,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // TODO: These tests are not working yet because of issues in sdkgen and programgen
 var expectedFailures = map[string]string{
-	"l1-empty":                           "dependency pulumi has unexpected version",
 	"l1-main":                            "error in compiling Go",
 	"l1-output-array":                    "error in compiling Go",
 	"l1-output-bool":                     "error in compiling Go",

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-empty/Pulumi.yaml
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-empty/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-empty
+runtime: go

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-empty/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-empty/go.mod
@@ -1,0 +1,7 @@
+module l1-empty
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.30.0
+
+replace github.com/pulumi/pulumi/sdk/v3/ => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3

--- a/sdk/go/pulumi-language-go/testdata/projects/l1-empty/main.go
+++ b/sdk/go/pulumi-language-go/testdata/projects/l1-empty/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		return nil
+	})
+}


### PR DESCRIPTION
Enable the l1-empty test for Go.

This required some changes in reporting versions from the Go language host (replaced dependencies don't really have a version anymore, because they've been replaced by a local artefact and that doesn't contain any version info itself). This then cascaded that the conformance test had to be less strict about checking versions from GetDependencies because Go now returns empty versions for these local deps.