### PR TITLE
Refactor MissingError handling

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -72,12 +72,8 @@ func loadConverterPlugin(
 	if err != nil {
 		// If NewConverter returns a MissingError, we can try and install the plugin if it was missing and try again,
 		// unless auto plugin installs are turned off.
-		if env.DisableAutomaticPluginAcquisition.Value() {
-			return nil, fmt.Errorf("load %q: %w", name, err)
-		}
-
 		var me *workspace.MissingError
-		if !errors.As(err, &me) {
+		if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
 			// Not a MissingError, return the original error.
 			return nil, fmt.Errorf("load %q: %w", name, err)
 		}

--- a/pkg/cmd/pulumi/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin_run.go
@@ -69,15 +69,11 @@ func (cmd *pluginRunCmd) run(args []string) error {
 
 	path, err := workspace.GetPluginPath(d, kind, name, version, nil)
 	if err != nil {
+		// Try to install the plugin, unless auto plugin installs are turned off.
 		var me *workspace.MissingError
-		if !errors.As(err, &me) {
+		if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
 			// Not a MissingError, return the original error.
 			return fmt.Errorf("could not get plugin path: %w", err)
-		}
-
-		// Try to install the plugin, unless auto plugin installs are turned off.
-		if env.DisableAutomaticPluginAcquisition.Value() {
-			return err
 		}
 
 		pluginSpec := workspace.PluginSpec{


### PR DESCRIPTION
While looking at https://github.com/pulumi/pulumi/issues/16469, I noticed a lot of the missing errors were a bit repetitive for the not-a-missing-error case and disable-plugin-acquisition case. So this rejigs the if statements a bit to make them all a bit more standard of "if not a missing error, or if disable plugin acquisition is set, then just err immediately, else retry".