### PR TITLE
disallow OutputState to be deepcopied

### DIFF
--- a/changelog/pending/20240717--sdk-go--disallow-outputstate-from-being-deepcopied.yaml
+++ b/changelog/pending/20240717--sdk-go--disallow-outputstate-from-being-deepcopied.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Disallow OutputState from being deepcopied

--- a/sdk/go/common/util/deepcopy/copy.go
+++ b/sdk/go/common/util/deepcopy/copy.go
@@ -14,12 +14,19 @@
 
 package deepcopy
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
+)
 
 // Copy returns a deep copy of the provided value.
 //
 // If there are multiple references to the same value inside the provided value, the multiply-referenced value will be
 // copied multiple times.
+//
+// NOTE: Unexported members of structs will *not* be copied.
 func Copy(i interface{}) interface{} {
 	if i == nil {
 		return nil
@@ -31,6 +38,9 @@ func deepCopy(v reflect.Value) reflect.Value {
 	if !v.IsValid() {
 		return v
 	}
+
+	_, ok := v.Interface().(internal.OutputState)
+	contract.Assertf(!ok, "Outputs cannot be deep copied")
 
 	typ := v.Type()
 	switch typ.Kind() {

--- a/sdk/go/common/util/deepcopy/copy.go
+++ b/sdk/go/common/util/deepcopy/copy.go
@@ -39,8 +39,9 @@ func deepCopy(v reflect.Value) reflect.Value {
 		return v
 	}
 
-	_, ok := v.Interface().(internal.OutputState)
-	contract.Assertf(!ok, "Outputs cannot be deep copied")
+	if v.Type() == reflect.TypeFor[internal.OutputState]() {
+		contract.Failf("Outputs cannot be deep copied")
+	}
 
 	typ := v.Type()
 	switch typ.Kind() {

--- a/sdk/go/common/util/deepcopy/copy.go
+++ b/sdk/go/common/util/deepcopy/copy.go
@@ -39,7 +39,7 @@ func deepCopy(v reflect.Value) reflect.Value {
 		return v
 	}
 
-	if v.Type() == reflect.TypeFor[internal.OutputState]() {
+	if v.Type() == reflect.TypeOf(internal.OutputState{}) {
 		contract.Failf("Outputs cannot be deep copied")
 	}
 

--- a/sdk/go/common/util/deepcopy/copy_test.go
+++ b/sdk/go/common/util/deepcopy/copy_test.go
@@ -89,7 +89,7 @@ func TestDeepCopyDoesntCopyOutputState(t *testing.T) {
 	t.Parallel()
 
 	state := internal.OutputState{}
-	assert.PanicsWithValue(t, "fatal: An assertion has failed: Outputs cannot be deep copied", func() {
+	assert.PanicsWithValue(t, "fatal: A failure has occurred: Outputs cannot be deep copied", func() {
 		Copy(state)
 	})
 }

--- a/sdk/go/common/util/deepcopy/copy_test.go
+++ b/sdk/go/common/util/deepcopy/copy_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,4 +83,13 @@ func TestDeepCopy(t *testing.T) {
 			assert.EqualValues(t, c, Copy(c))
 		})
 	}
+}
+
+func TestDeepCopyDoesntCopyOutputState(t *testing.T) {
+	t.Parallel()
+
+	state := internal.OutputState{}
+	assert.PanicsWithValue(t, "fatal: An assertion has failed: Outputs cannot be deep copied", func() {
+		Copy(state)
+	})
 }


### PR DESCRIPTION
We have this deepcopy utility in our public API, but it does not work properly on structs with unexported values.  Make a note of that, and also disallow OutputState from being copied, since OutputState has required unexported fields that we can't deepcopy.

Not sure if we should special case `OutputState` here, which I've done since that has come up in particular, or maybe even disallow deepcopy'ing any values that have unexported fields?  That would be a breaking change though, so I've shied away from it for now.

Fixes https://github.com/pulumi/pulumi/issues/16634