### PR TITLE
name invoke transforms RegisterInvokeTransform in the Go SDK

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2261,14 +2261,14 @@ func (ctx *Context) RegisterStackTransform(t ResourceTransform) error {
 	return ctx.RegisterResourceTransform(t)
 }
 
-// RegisterStackInvokeTransform adds a transform to all future invokes in this Pulumi stack.
-func (ctx *Context) RegisterStackInvokeTransform(t InvokeTransform) error {
+// RegisterInvokeTransform adds a transform to all future invokes in this Pulumi stack.
+func (ctx *Context) RegisterInvokeTransform(t InvokeTransform) error {
 	cb, err := ctx.registerInvokeTransform(t)
 	if err != nil {
 		return err
 	}
 
-	_, err = ctx.state.monitor.RegisterStackInvokeTransform(ctx.ctx, cb)
+	_, err = ctx.state.monitor.RegisterInvokeTransform(ctx.ctx, cb)
 	return err
 }
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2268,7 +2268,7 @@ func (ctx *Context) RegisterInvokeTransform(t InvokeTransform) error {
 		return err
 	}
 
-	_, err = ctx.state.monitor.RegisterInvokeTransform(ctx.ctx, cb)
+	_, err = ctx.state.monitor.RegisterStackInvokeTransform(ctx.ctx, cb)
 	return err
 }
 

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -270,7 +270,7 @@ func (m *mockMonitor) RegisterStackTransform(ctx context.Context, in *pulumirpc.
 	panic("not implemented")
 }
 
-func (m *mockMonitor) RegisterStackInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
+func (m *mockMonitor) RegisterInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
 	panic("not implemented")

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -270,7 +270,7 @@ func (m *mockMonitor) RegisterStackTransform(ctx context.Context, in *pulumirpc.
 	panic("not implemented")
 }
 
-func (m *mockMonitor) RegisterInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
+func (m *mockMonitor) RegisterStackInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
 	panic("not implemented")

--- a/tests/integration/transforms/go/simple/main.go
+++ b/tests/integration/transforms/go/simple/main.go
@@ -228,7 +228,7 @@ func main() {
 		}
 
 		// Scenario #8 - run an invoke and change args
-		err = ctx.RegisterStackInvokeTransform(func(_ context.Context, ita *pulumi.InvokeTransformArgs) *pulumi.InvokeTransformResult {
+		err = ctx.RegisterInvokeTransform(func(_ context.Context, ita *pulumi.InvokeTransformArgs) *pulumi.InvokeTransformResult {
 			ita.Args["length"] = pulumi.Float64(11)
 			return &pulumi.InvokeTransformResult{
 				Args: ita.Args,


### PR DESCRIPTION
This is more consistent with `RegisterResourceTransform`.  The `RegisterStackInvokeTransform` version has not been released yet, so we still have the option of making this consistent.