### PR TITLE
Remove unused PropertySet type

### DIFF
--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -32,9 +32,6 @@ import (
 // PropertyKey is the name of a property.
 type PropertyKey tokens.Name
 
-// PropertySet is a simple set keyed by property name.
-type PropertySet map[PropertyKey]bool
-
 // PropertyMap is a simple map keyed by property name with "JSON-like" values.
 type PropertyMap map[PropertyKey]PropertyValue
 


### PR DESCRIPTION
Doesn't look like anything uses this, and chances are we'll want to add _actual_ sets of property values at some point which clashes with this name.