### PR TITLE
Respect replaceOnChanges when calculating dependent replacements of DBRs

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -2154,6 +2154,17 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 			NewInputs:     inputsForDiff,
 			AllowUnknowns: true,
 		})
+
+		goal, hasGoal := sg.deployment.goals.Load(r.URN)
+		if hasGoal {
+			// Update the diff to apply any replaceOnChanges annotations and to include initErrors in the diff.
+			hasInitErrors := len(r.InitErrors) > 0
+			diff, err = applyReplaceOnChanges(diff, goal.ReplaceOnChanges, hasInitErrors)
+			if err != nil {
+				return false, nil, err
+			}
+		}
+
 		if err != nil {
 			return false, nil, err
 		}


### PR DESCRIPTION
Right now replaceOnChanges isn't taken into account when traversing the dependencies of a resource that will be replaced with delete before replace (DBR).
This will lead to wrong replace orders and failures if the cloud providers verify whether a resource is still in use.

Let's take this pulumi AWS program for example:
```
const tg = new aws.alb.TargetGroup("my-test-tg", {
    name: "my-test-tg"
    port: 443,
    protocol: "HTTP",
    vpcId: "VPC_ID",
    targetType: "ip",
});

const listener = new aws.alb.Listener("http", {
    loadBalancerArn: alb.arn,
    port: 80,
    protocol: "HTTP",
    defaultActions: [{
        type: "forward",
        targetGroupArn: tg.arn,
    }],
}, { replaceOnChanges: ["defaultActions[*].targetGroupArn"] });
```

The Target Group is marked as delete before replace because it has a fixed name. When updating properties that cause replacements (e.g. port) Pulumi should first delete the listener (because it is using the target group) and then delete the target group itself before it re-creates them in the opposite order.

Right now it's trying to delete the Target Group first which fails because it's still used by the listener. We're not correctly detecting that the listener needs to be replaced in tandem with the target group because replaceOnChanges isn't taken into account when evaluating the dependent replaces of a DBR.

Relates to https://github.com/pulumi/pulumi-aws/issues/4220