### PR TITLE
Demonstrate an issue with Input/Output wrappers for interfaces

### DIFF
--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -1226,25 +1226,25 @@ func TestInputOutputWrappersForInterfaces(t *testing.T) {
 	var id = "x"
 	var ex Example = &example{id}
 
-	assert.Equal(t, id, getExampleId(ex))
+	assert.Equal(t, id, getExampleID(ex))
 
 	var exi ExampleInput = ex
-	assert.Equal(t, id, getExampleId(exi))
+	assert.Equal(t, id, getExampleID(exi))
 
 	var exOutput ExampleOutput = ToOutput(ex).(ExampleOutput)
-	assert.Equal(t, id, getExampleId(exOutput))
+	assert.Equal(t, id, getExampleID(exOutput))
 }
 
 type Example interface {
 	ExampleInput
-	Id() string
+	ID() string
 }
 
 var exampleType = reflect.TypeOf((*Example)(nil)).Elem()
 
 type example struct{ id string }
 
-func (e *example) Id() string {
+func (e *example) ID() string {
 	return e.id
 }
 
@@ -1254,12 +1254,12 @@ func (*example) ElementType() reflect.Type {
 	return exampleType
 }
 
-func (in *example) ToExampleOutput() ExampleOutput {
-	return ToOutput(in).(ExampleOutput)
+func (e *example) ToExampleOutput() ExampleOutput {
+	return ToOutput(e).(ExampleOutput)
 }
 
-func (in *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
-	return ToOutputWithContext(ctx, in).(ExampleOutput)
+func (e *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
+	return ToOutputWithContext(ctx, e).(ExampleOutput)
 }
 
 // ExampleInput is an input type that accepts Example and ExampleOutput values.
@@ -1286,10 +1286,10 @@ func (o ExampleOutput) ToExampleOutputWithContext(ctx context.Context) ExampleOu
 	return o
 }
 
-func getExampleId(input ExampleInput) string {
+func getExampleID(input ExampleInput) string {
 	c := make(chan string)
 	input.ToExampleOutput().ApplyT(func(x Example) int {
-		c <- x.Id()
+		c <- x.ID()
 		return 0
 	})
 	return <-c

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1220,81 +1221,99 @@ func TestApplyTCoerceRejectDifferentKinds(t *testing.T) {
 	}, "int-string should not be allowed")
 }
 
-// Here we want to have an interface type Example, and build ExampleInput/ExampleOutput types for it in the usual way.
-// Yet something is not quite right, as the failure of this test demonstrates.
+// Test taking an interface type ID1 and enhancing it with standard Input (ID1Input) and Output (ID1Output) types. This
+// currently does not work. The code is taken from the standard ID type and renamed to ID1, but unlike ID1, ID is an
+// interface, not a string.
 func TestInputOutputWrappersForInterfaces(t *testing.T) {
-	var id = "x"
-	var ex Example = &example{id}
+	id := "x"
+	var ex ID1 = &id1Impl{id}
 
-	assert.Equal(t, id, getExampleID(ex))
+	assert.Equal(t, id, extractID(ex))
 
-	var exi ExampleInput = ex
-	assert.Equal(t, id, getExampleID(exi))
+	var exi ID1Input = ex
+	assert.Equal(t, id, extractID(exi))
 
-	var exOutput ExampleOutput = ToOutput(ex).(ExampleOutput)
-	assert.Equal(t, id, getExampleID(exOutput))
+	var exOutput ID1Output = ToOutput(ex).(ID1Output)
+	assert.Equal(t, id, extractID(exOutput))
 }
 
-type Example interface {
-	ExampleInput
-	ID() string
-}
-
-var exampleType = reflect.TypeOf((*Example)(nil)).Elem()
-
-type example struct{ id string }
-
-func (e *example) ID() string {
-	return e.id
-}
-
-var _ Example = &example{}
-
-func (*example) ElementType() reflect.Type {
-	return exampleType
-}
-
-func (e *example) ToExampleOutput() ExampleOutput {
-	return ToOutput(e).(ExampleOutput)
-}
-
-func (e *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
-	return ToOutputWithContext(ctx, e).(ExampleOutput)
-}
-
-// ExampleInput is an input type that accepts Example and ExampleOutput values.
-type ExampleInput interface {
-	Input
-
-	ToExampleOutput() ExampleOutput
-	ToExampleOutputWithContext(ctx context.Context) ExampleOutput
-}
-
-// ExampleOutput is an Output that returns Example values.
-type ExampleOutput struct{ *OutputState }
-
-// ElementType returns the element type of this Output (Example).
-func (ExampleOutput) ElementType() reflect.Type {
-	return exampleType
-}
-
-func (o ExampleOutput) ToExampleOutput() ExampleOutput {
-	return o
-}
-
-func (o ExampleOutput) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
-	return o
-}
-
-func getExampleID(input ExampleInput) string {
+func extractID(i ID1Input) string {
 	c := make(chan string)
-	input.ToExampleOutput().ApplyT(func(x Example) int {
-		c <- x.ID()
+	i.ToID1Output().ApplyT(func(x ID1) int {
+		c <- x.GetID()
 		return 0
 	})
 	return <-c
 }
 
+type ID1 interface {
+	GetID() string
+
+	// ElementType() reflect.Type
+	// ToID1Output() ID1Output
+	// ToID1OutputWithContext(ctx context.Context) ID1Output
+	ID1Input
+}
+
+type id1Impl struct {
+	theId string
+}
+
+func (self *id1Impl) ToID1Output() ID1Output {
+	return ToOutput(self).(ID1Output)
+}
+
+func (self *id1Impl) ToID1OutputWithContext(ctx context.Context) ID1Output {
+	return ToOutputWithContext(ctx, self).(ID1Output)
+}
+
+func (self *id1Impl) ElementType() reflect.Type {
+	return id1Type
+}
+
+func (self *id1Impl) GetID() string {
+	return self.theId
+}
+
+// The following code adapts IDInput from type_builtins.go
+var id1Type = reflect.TypeOf((*ID1)(nil)).Elem()
+
+// IDInput is an input type that accepts ID1 and IDOutput1 values.
+type ID1Input interface {
+	Input
+
+	ToID1Output() ID1Output
+	ToID1OutputWithContext(ctx context.Context) ID1Output
+}
+
+// ID1Output is an Output that returns ID values.
+type ID1Output struct{ *OutputState }
+
+func (ID1Output) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("Outputs can not be marshaled to JSON")
+}
+
+func (o ID1Output) ToOutput(ctx context.Context) pulumix.Output[ID1] {
+	return pulumix.Output[ID1]{
+		OutputState: o.OutputState,
+	}
+}
+
+// ElementType returns the element type of this Output (ID1).
+func (ID1Output) ElementType() reflect.Type {
+	return id1Type
+}
+
+func (o ID1Output) ToID1Output() ID1Output {
+	return o
+}
+
+func (o ID1Output) ToID1OutputWithContext(ctx context.Context) ID1Output {
+	return o
+}
+
 func init() {
-	RegisterOutputType(ExampleOutput{})
+	var exampleId ID1 = &id1Impl{""}
+	RegisterInputType(reflect.TypeOf((*ID1Input)(nil)).Elem(), exampleId)
+	RegisterOutputType(ID1Output{})
 }


### PR DESCRIPTION
There are some limitations still in the Go SDK that make it hard to code-gen Input and Output wrappers for a base type T when this type is an interface. Resurfacing an old PR, though the original fix no longer applies and needs to be redone. The original intent for working with these types was trying to build a ResourceInput type so that Resource could be auto-passed into ResourceInput. Perhaps there's a better way to solve this with generics these days.