### PR TITLE
Detect possible OOM errors when nodejs crashes

### DIFF
--- a/changelog/pending/20240718--sdk-nodejs--detect-possible-oom-errors-when-nodejs-crashes.yaml
+++ b/changelog/pending/20240718--sdk-nodejs--detect-possible-oom-errors-when-nodejs-crashes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description:  Detect possible OOM errors when nodejs crashes

--- a/changelog/pending/20240720--sdk-nodejs--ensure-no-output-is-lost-for-nodejs-commands-when-stdout-is-slow.yaml
+++ b/changelog/pending/20240720--sdk-nodejs--ensure-no-output-is-lost-for-nodejs-commands-when-stdout-is-slow.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Ensure no output is lost for nodejs commands when stdout is slow

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1546,10 +1546,12 @@ func (o *oomSniffer) Detected() bool {
 	return o.detected
 }
 
-// Wait waits for the OOM sniffer to either
+// Wait waits for the OOM sniffer to either:
 //   - detect an OOM error
 //   - the timeout to expire
 //   - the reader to be closed
+//
+// Call Wait to ensure we've read all the output from the scanned process after it exits.
 func (o *oomSniffer) Wait() {
 	select {
 	case <-o.waitChan:
@@ -1575,6 +1577,7 @@ func (o *oomSniffer) Scan(r io.Reader) {
 				strings.Contains(line, "Check failed: needs_context && current_scope_ = closure_scope_") {
 				o.detected = true
 				close(o.waitChan)
+				break
 			}
 		}
 		contract.IgnoreError(scanner.Err())

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1559,8 +1559,8 @@ func (o *oomSniffer) Wait() {
 
 func (o *oomSniffer) Message() string {
 	return "Detected a possible out of memory error. Consider increasing the memory available to the nodejs process " +
-		"by setting the `nodeargs` runtime option in Pulumi.yaml to `nodeargs: --max-old-space-size=<size>` where `<size>` is the " +
-		"maximum memory in megabytes that can be allocated to nodejs. " +
+		"by setting the `nodeargs` runtime option in Pulumi.yaml to `nodeargs: --max-old-space-size=<size>` where " +
+		"`<size>` is the maximum memory in megabytes that can be allocated to nodejs. " +
 		"See https://www.pulumi.com/docs/concepts/projects/project-file/#runtime-options"
 }
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1558,8 +1558,9 @@ func (o *oomSniffer) Wait() {
 
 func (o *oomSniffer) Message() string {
 	return "Detected a possible out of memory error. Consider increasing the memory available to the nodejs process " +
-		"by setting the `nodeargs` runtime option to `nodeargs: --max-old-space-size=<size>` where `<size>` is the " +
-		"maximum memory in megabytes that can be allocated to nodejs."
+		"by setting the `nodeargs` runtime option in Pulumi.yaml to `nodeargs: --max-old-space-size=<size>` where `<size>` is the " +
+		"maximum memory in megabytes that can be allocated to nodejs. " +
+		"See https://www.pulumi.com/docs/concepts/projects/project-file/#runtime-options"
 }
 
 func (o *oomSniffer) Scan(r io.Reader) {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1538,13 +1538,12 @@ func (o *oomSniffer) Scan(r io.Reader) {
 	go func() {
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, "<--- Last few GCs --->") /* "Normal" OOM output */ ||
+			if !o.detected && strings.Contains(line, "<--- Last few GCs --->") /* "Normal" OOM output */ ||
 				// Because we hook into the debugger API, the OOM error message can be obscured by
 				// a failed assertion in the debugger https://github.com/pulumi/pulumi/issues/16596.
 				strings.Contains(line, "Check failed: needs_context && current_scope_ = closure_scope_") {
 				o.detected = true
 				close(o.waitChan)
-				break
 			}
 		}
 		contract.IgnoreError(scanner.Err())

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -726,7 +726,8 @@ func (host *nodeLanguageHost) execNodejs(ctx context.Context, req *pulumirpc.Run
 		return &pulumirpc.RunResponse{Error: fmt.Errorf("failed to get stdout pipe: %w", err).Error()}
 	}
 	// Copy cmd.Stdout to os.Stdout. Nodejs sometimes changes the blocking mode of its stdout/stderr,
-	// so it's unsafe to assign cmd.Stdout directly to os.Stdout. See `copyOutput`.
+	// so it's unsafe to assign cmd.Stdout directly to os.Stdout. See the description of `copyOutput`
+	// for more details.
 	go func() {
 		_, err := io.Copy(os.Stdout, stdout)
 		contract.IgnoreError(err)

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2043,3 +2043,19 @@ func TestNodeJSReservedIdentifierShadowing(t *testing.T) {
 		},
 	})
 }
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestNodeOOM(t *testing.T) {
+	stderr := &bytes.Buffer{}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           filepath.Join("nodejs", "oom"),
+		Dependencies:  []string{"@pulumi/pulumi"},
+		ExpectFailure: true,
+		Stderr:        stderr,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			t.Logf("stdout: %s", stderr.String())
+			assert.Contains(t, stderr.String(), "Detected a possible out of memory error")
+		},
+	})
+}

--- a/tests/integration/nodejs/oom/Pulumi.yaml
+++ b/tests/integration/nodejs/oom/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: nodejs-oom
+runtime:
+  name: nodejs
+  options:
+    nodeargs: --max-old-space-size=2048

--- a/tests/integration/nodejs/oom/index.js
+++ b/tests/integration/nodejs/oom/index.js
@@ -1,0 +1,17 @@
+// Copyright 2024, Pulumi Corporation.  All rights reserved.
+
+// This program should fail with an out of memory error.
+
+const v8 = require('node:v8')
+
+function heapInfo() {
+    const stats = v8.getHeapStatistics();
+    console.log(`used: ${stats.used_heap_size / 1024 / 1024}, limit: ${stats.heap_size_limit / 1024 / 1024}`);
+}
+
+const data = []
+console.log()
+for (let i = 0; i < 1_000_000; i++) {
+    if (i % 100 === 0) heapInfo();
+    data.push(new Array(1_000_000).fill('a'))
+}

--- a/tests/integration/nodejs/oom/package.json
+++ b/tests/integration/nodejs/oom/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "oom",
+  "peerDependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  }
+}

--- a/tests/integration/nodejs/oom/tsconfig.json
+++ b/tests/integration/nodejs/oom/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+    }
+}


### PR DESCRIPTION
The typical nodejs OOM messages are sometimes obscured by our use of the
debugger API, making this hard to diagnose. Provide an actionable error
message when we detect a normal or obscured OOM crash.

Fixes https://github.com/pulumi/pulumi/issues/16596
