### PR TITLE
sdk/python: add support for stack invoke transforms

### DIFF
--- a/changelog/pending/20240718--sdk-python--add-support-for-invoke-stack-transforms.yaml
+++ b/changelog/pending/20240718--sdk-python--add-support-for-invoke-stack-transforms.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add support for invoke stack transforms

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -46,6 +46,9 @@ from .errors import (
 
 from .invoke import (
     InvokeOptions,
+    InvokeTransform,
+    InvokeTransformArgs,
+    InvokeTransformResult,
 )
 
 from .metadata import (
@@ -127,6 +130,9 @@ __all__ = [
     "RunError",
     # invoke
     "InvokeOptions",
+    "InvokeTransform",
+    "InvokeTransformArgs",
+    "InvokeTransformResult",
     # metadata
     "get_organization",
     "get_project",

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -148,7 +148,7 @@ class InvokeTransformArgs:
 
     args: "Inputs"
     """
-    The original args passed to the Invoke call.
+    The original arguments passed to the invocation.
     """
 
     opts: "InvokeOptions"

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -176,7 +176,7 @@ class InvokeTransformResult:
 
     args: "Inputs"
     """
-    The new args to use in place of the original `args`.
+    The new arguments to use in place of the original `args`.
     """
 
     opts: "InvokeOptions"

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -153,7 +153,7 @@ class InvokeTransformArgs:
 
     opts: "InvokeOptions"
     """
-    The original invoke options passed to the Invoke call.
+    The original invoke options passed to the invocation.
     """
 
     def __init__(

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -143,7 +143,7 @@ class InvokeTransformArgs:
 
     token: str
     """
-    The token of the Invoke.
+    The token of the invoke.
     """
 
     args: "Inputs"
@@ -181,7 +181,7 @@ class InvokeTransformResult:
 
     opts: "InvokeOptions"
     """
-    The new invoke options to use in place of the original `opts`
+    The new invoke options to use in place of the original `opts`.
     """
 
     def __init__(self, args: "Inputs", opts: "InvokeOptions") -> None:

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from typing import Optional, TYPE_CHECKING
+from typing import (
+    Awaitable,
+    Callable,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+)
 
 if TYPE_CHECKING:
+    from .output import Inputs
     from .resource import Resource, ProviderResource
 
 
@@ -127,3 +134,70 @@ class InvokeOptions:
         dest.version = dest.version if source.version is None else source.version
 
         return dest
+
+
+class InvokeTransformArgs:
+    """
+    InvokeTransformArgs is the argument bag passed to a resource transform.
+    """
+
+    token: str
+    """
+    The token of the Invoke.
+    """
+
+    args: "Inputs"
+    """
+    The original args passed to the Invoke call.
+    """
+
+    opts: "InvokeOptions"
+    """
+    The original invoke options passed to the Invoke call.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        args: "Inputs",
+        opts: "InvokeOptions",
+    ) -> None:
+        self.token = token
+        self.args = args
+        self.opts = opts
+
+
+class InvokeTransformResult:
+    """
+    InvokeTransformResult is the result that must be returned by an invoke transform callback.
+    It includes new values to use for the `args` and `opts` of the `Invoke` in place of the
+    originally provided values.
+    """
+
+    args: "Inputs"
+    """
+    The new args to use in place of the original `args`.
+    """
+
+    opts: "InvokeOptions"
+    """
+    The new invoke options to use in place of the original `opts`
+    """
+
+    def __init__(self, args: "Inputs", opts: "InvokeOptions") -> None:
+        self.args = args
+        self.opts = opts
+
+
+InvokeTransform = Callable[
+    [InvokeTransformArgs],
+    Optional[Union[Awaitable[Optional[InvokeTransformResult]], InvokeTransformResult]],
+]
+"""
+InvokeTransform is the callback signature for the `transforms` invoke option.  A
+transform is passed the same set of inputs provided to the `Invoke` constructor, and can
+optionally return back alternate values for the `args` and/or `opts` prior to the invoke
+actually being called.  The effect will be as though those args and opts were passed in place
+of the original call to the `Invoke` call.  If the transform returns None,
+this indicates that the invoke will not be transformed.
+"""

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -138,7 +138,7 @@ class InvokeOptions:
 
 class InvokeTransformArgs:
     """
-    InvokeTransformArgs is the argument bag passed to a resource transform.
+    InvokeTransformArgs is the argument bag passed to an invoke transform.
     """
 
     token: str

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -47,6 +47,7 @@ from .stack import (
     register_stack_transformation,
     register_stack_transform,
     register_resource_transform,
+    register_invoke_transform,
 )
 
 from .invoke import (
@@ -90,6 +91,7 @@ __all__ = [
     "register_stack_transformation",
     "register_stack_transform",
     "register_resource_transform",
+    "register_invoke_transform",
     # invoke
     "invoke",
     "invoke_async",

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -333,6 +333,12 @@ def _sync_monitor_supports_transforms() -> bool:
     return SETTINGS.feature_support["transforms"]
 
 
+def _sync_monitor_supports_invoke_transforms() -> bool:
+    if "invokeTransforms" not in SETTINGS.feature_support:
+        return False
+    return SETTINGS.feature_support["invokeTransforms"]
+
+
 def reset_options(
     project: Optional[str] = None,
     stack: Optional[str] = None,
@@ -385,4 +391,5 @@ async def _load_monitor_feature_support():
         monitor_supports_feature("deletedWith"),
         monitor_supports_feature("aliasSpecs"),
         monitor_supports_feature("transforms"),
+        monitor_supports_feature("invokeTransforms"),
     )

--- a/tests/integration/transforms/python/simple/random_.py
+++ b/tests/integration/transforms/python/simple/random_.py
@@ -26,7 +26,10 @@ class Random(pulumi.CustomResource):
     @pulumi.getter
     def result(self) -> pulumi.Output[str]:
         return pulumi.get(self, "result")
-    
+
+    def invoke(self, args):
+        return pulumi.runtime.invoke("testprovider:index:returnArgs", args)
+
 
 class Component(pulumi.ComponentResource):
     def __init__(self,

--- a/tests/integration/transforms/transforms_test.go
+++ b/tests/integration/transforms/transforms_test.go
@@ -27,7 +27,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes5 := false
 	foundRes6 := false
 	foundRes7 := false
-	// foundRes8 := false
+	foundRes8 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -94,9 +94,9 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			// we change the provider but because this is a remote component resource it ends up empty in state.
 			assert.Equal(t, "", res.Provider)
 		}
-		// if res.URN.Name() == "res8" {
-		// 	foundRes8 = true
-		// }
+		if res.URN.Name() == "res8" {
+			foundRes8 = true
+		}
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
@@ -105,6 +105,5 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	assert.True(t, foundRes5)
 	assert.True(t, foundRes6)
 	assert.True(t, foundRes7)
-	// TODO: uncomment this when we have support for invoke transforms in all languages
-	//	assert.True(t, foundRes8)
+	assert.True(t, foundRes8)
 }


### PR DESCRIPTION
Similar to the NodeJS and Go SDK previously, also add support for stack invoke transforms to Python.