### PR TITLE
avoid duplicate error: prefix with `--expect-no-changes`

### DIFF
--- a/changelog/pending/20240718--cli--avoid-duplicate-error-prefix-with-expect-no-changes.yaml
+++ b/changelog/pending/20240718--cli--avoid-duplicate-error-prefix-with-expect-no-changes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: "Avoid duplicate error: prefix with `--expect-no-changes`"

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -291,7 +291,7 @@ func newRefreshCmd() *cobra.Command {
 			case res != nil:
 				return PrintEngineResult(res)
 			case expectNop && changes != nil && engine.HasChanges(changes):
-				return result.FromError(errors.New("error: no changes were expected but changes occurred"))
+				return result.FromError(errors.New("no changes were expected but changes occurred"))
 			default:
 				return nil
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -201,7 +201,7 @@ func newUpCmd() *cobra.Command {
 		case res != nil:
 			return PrintEngineResult(res)
 		case expectNop && changes != nil && engine.HasChanges(changes):
-			return result.FromError(errors.New("error: no changes were expected but changes occurred"))
+			return result.FromError(errors.New("no changes were expected but changes occurred"))
 		default:
 			return nil
 		}
@@ -414,7 +414,7 @@ func newUpCmd() *cobra.Command {
 		case res != nil:
 			return PrintEngineResult(res)
 		case expectNop && changes != nil && engine.HasChanges(changes):
-			return result.FromError(errors.New("error: no changes were expected but changes occurred"))
+			return result.FromError(errors.New("no changes were expected but changes occurred"))
 		default:
 			return nil
 		}


### PR DESCRIPTION
When printing an error we already prefix it with a `error:` prefix. Therefore new errors should not include that prefix again, otherwise we'll end up with a line like:

    error: error: no changes were expected but changes occurred

Just a small cleanup I noticed while testing something else.

(From a quick look at `git grep "\"error:"` I couldn't find other instances of this)