### PR TITLE
avoid duplicate error output in some cases

### DIFF
--- a/changelog/pending/20240718--cli--avoid-duplicate-error-output-in-some-cases.yaml
+++ b/changelog/pending/20240718--cli--avoid-duplicate-error-output-in-some-cases.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Avoid duplicate error output in some cases

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -21,7 +21,6 @@ import (
 	"runtime/debug"
 
 	"github.com/pulumi/pulumi/pkg/v3/version"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // panicHandler displays an emergency error message to the user and a stack trace to
@@ -54,8 +53,6 @@ func main() {
 	defer panicHandler(finished)
 
 	if err := NewPulumiCmd().Execute(); err != nil {
-		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
-		contract.IgnoreError(err)
 		os.Exit(1)
 	}
 	*finished = true


### PR DESCRIPTION
Cobra has its own error reporting when a command returns an error. However we duplicate that in `main`.

Usually we don't notice this, because we have our own error reporter that exits the program early.  However in some cases, such as when the command is misspelled, that error reporter doesn't kick in, and we end up with a duplicated error output.

We can just rely on the cobra one in that case, instead of duplicating that.

Fixes: https://github.com/pulumi/pulumi/issues/16610