### PR TITLE
Allow specifying project names with `pulumi convert`

### DIFF
--- a/changelog/pending/20240718--cli--allow-specifying-project-names-when-converting-with-pulumi-convert-name.yaml
+++ b/changelog/pending/20240718--cli--allow-specifying-project-names-when-converting-with-pulumi-convert-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow specifying project names when converting with `pulumi convert --name`


### PR DESCRIPTION
When converting a project from one language to another, `pulumi convert` will default to producing a project named after the source directory. So if one converts a project in `some_directory`, the resulting `Pulumi.yaml` will specify `name: some_directory`. This is generally the right behaviour, since conversion often implies that the target will supplant the source (and thus should use the same name). However, there are cases where it can be useful to override this default. This commit takes @FonsecaGoncalo's work in #15034 and extends `pulumi convert` so that it accepts an optional `--name` argument, which if supplied (and valid) will be used instead. As well as rebasing this work, we add a couple of tests to make sure that both cases work.

Fixes #14645
Closes #15034