### PR TITLE
Pin node to 22.4.x to workaround breakage

### DIFF
--- a/changelog/pending/20240718--sdk-nodejs--pin-node-to-22-4-x-to-workaround-breakage.yaml
+++ b/changelog/pending/20240718--sdk-nodejs--pin-node-to-22-4-x-to-workaround-breakage.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Pin node to 22.4.x to workaround breakage

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -129,7 +129,10 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "8",
     "go": "1.22.x",
-    "nodejs": "22.x",
+    # TODO https://github.com/pulumi/pulumi/issues/16707
+    # Node 22.5.0 breaks yarn, the installation stops half way through with a succesfull exit code.
+    # Pin to 22.4.x for now to work around this.
+    "nodejs": "22.4.x",
     "python": "3.12.x",
 }
 


### PR DESCRIPTION
Node 22.5.0 breaks yarn, the installation stops half way through with a
succesfull exit code. Pin to 22.4.x for now to work around this.

Follow up to unpin https://github.com/pulumi/pulumi/issues/16707