### PR TITLE
Exclude .git and sdk/proto from gofumpt

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -246,6 +246,8 @@ endif
 format::
 	$(call STEP_MESSAGE)
 	find . -iname "*.go" -not \( \
+		-path "./.git/*" -or \
+		-path "./sdk/proto/go/*" -or \
 		-path "./vendor/*" -or \
 		-path "./*/compilation_error/*" -or \
 		-path "./*/testdata/*" \


### PR DESCRIPTION
Don’t format files in .git and sdk/proto using gofumpt. The go files in sdk/proto are generated. If you have a branch name that ends with `.go`, gofumpt attempts to format this, which will fail.
