### PR TITLE
state_move: disallow provider moves

### DIFF
--- a/changelog/pending/20240719--cli-state--disallow-provider-moves-in-the-state-move-command.yaml
+++ b/changelog/pending/20240719--cli-state--disallow-provider-moves-in-the-state-move-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Disallow provider moves in the `state move` command

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -143,7 +143,7 @@ func (cmd *stateMoveCmd) Run(
 		matchedArg := resourceMatches(res, args)
 		if matchedArg != "" {
 			if strings.HasPrefix(string(res.Type), "pulumi:providers:") {
-				return errors.New("cannot move providers")
+				return errors.New("cannot move providers. Only resources can be moved, and providers will be included automatically")
 			}
 			resourcesToMove[string(res.URN)] = res
 			providersToCopy[res.Provider] = true

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -143,6 +143,7 @@ func (cmd *stateMoveCmd) Run(
 		matchedArg := resourceMatches(res, args)
 		if matchedArg != "" {
 			if strings.HasPrefix(string(res.Type), "pulumi:providers:") {
+				//nolint:lll
 				return errors.New("cannot move providers. Only resources can be moved, and providers will be included automatically")
 			}
 			resourcesToMove[string(res.URN)] = res

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -141,6 +142,9 @@ func (cmd *stateMoveCmd) Run(
 	for _, res := range sourceSnapshot.Resources {
 		matchedArg := resourceMatches(res, args)
 		if matchedArg != "" {
+			if strings.HasPrefix(string(res.Type), "pulumi:providers:") {
+				return errors.New("cannot move providers")
+			}
 			resourcesToMove[string(res.URN)] = res
 			providersToCopy[res.Provider] = true
 			unmatchedArgs.Remove(matchedArg)

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -82,8 +82,9 @@ func runMoveWithOptions(
 	t *testing.T, sourceResources []*resource.State, args []string, options *MoveOptions,
 ) (*deploy.Snapshot, *deploy.Snapshot, bytes.Buffer) {
 	ctx := context.Background()
-	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	tmpDir := t.TempDir()
+
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 
 	sourceStackName := "organization/test/sourceStack"

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -660,3 +660,61 @@ func TestProviderIsReparented(t *testing.T) {
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
 		destSnapshot.Resources[2].Parent)
 }
+
+func TestMoveProvider(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name2"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+		},
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	sourceStackName := "organization/test/sourceStack"
+
+	sourceStack := createStackWithResources(t, b, sourceStackName, sourceResources)
+
+	destResources := []*resource.State{}
+	destStackName := "organization/test/destStack"
+	destStack := createStackWithResources(t, b, destStackName, destResources)
+
+	mp := &secrets.MockProvider{}
+	mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+
+	var stdout bytes.Buffer
+
+	stateMoveCmd := stateMoveCmd{
+		Yes:       true,
+		Stdout:    &stdout,
+		Colorizer: colors.Never,
+	}
+	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(providerURN)}, mp)
+	assert.ErrorContains(t, err, "cannot move provider")
+
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(sourceSnapshot.Resources)) // No resources should be moved
+}

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -678,3 +678,51 @@ func TestProviderIsReparented(t *testing.T) {
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
 		destSnapshot.Resources[2].Parent)
 }
+
+func TestProviderIsReparented(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:a", "default_1_0_0")
+	sourceResources := []*resource.State{
+		{
+			URN:  resource.DefaultRootStackURN("sourceStack", "test"),
+			Type: "pulumi:pulumi:Stack",
+		},
+		{
+			URN:    providerURN,
+			Type:   "pulumi:providers:a::default_1_0_0",
+			ID:     "provider_id",
+			Custom: true,
+			Parent: resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+		{
+			URN:      resource.NewURN("sourceStack", "test", "d:e:f", "a:b:c", "name"),
+			Type:     "a:b:c",
+			Provider: string(providerURN) + "::provider_id",
+			Parent:   resource.DefaultRootStackURN("sourceStack", "test"),
+		},
+	}
+
+	sourceSnapshot, destSnapshot, _ := runMove(t, sourceResources, []string{string(sourceResources[2].URN)})
+
+	// Only the provider and the root stack should remain in the source stack
+	assert.Equal(t, 2, len(sourceSnapshot.Resources))
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:pulumi:Stack::test-sourceStack"),
+		sourceSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:sourceStack::test::pulumi:providers:a::default_1_0_0"),
+		sourceSnapshot.Resources[1].URN)
+
+	assert.Equal(t, 3, len(destSnapshot.Resources)) // We expect the root stack, the provider, and the moved resource
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[0].URN)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0"),
+		destSnapshot.Resources[1].URN)
+	assert.Equal(t, resource.DefaultRootStackURN("destStack", "test"),
+		destSnapshot.Resources[1].Parent)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::d:e:f$a:b:c::name"),
+		destSnapshot.Resources[2].URN)
+	assert.Equal(t, "urn:pulumi:destStack::test::pulumi:providers:a::default_1_0_0::provider_id",
+		destSnapshot.Resources[2].Provider)
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::pulumi:pulumi:Stack::test-destStack"),
+		destSnapshot.Resources[2].Parent)
+}


### PR DESCRIPTION
The `state move` command is designed to move resources with an underlying physical resource.  Otherwise it's easy enough to just re-create a resource in the resulting program.  Especially for providers, we usually don't want to move them, but rather want to copy them over.  Since there is not much point in moving a provider, just disallow that and error out if a user tries to do that.