### PR TITLE
improve UI output

### DIFF
--- a/changelog/pending/20240719--cli-state--improve-readability-of-the-resources-to-be-moved-output-of-the-state-move-command.yaml
+++ b/changelog/pending/20240719--cli-state--improve-readability-of-the-resources-to-be-moved-output-of-the-state-move-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/state
+  description: Improve readability of the resources to be moved output of the state move command

--- a/pkg/cmd/pulumi/state_move.go
+++ b/pkg/cmd/pulumi/state_move.go
@@ -252,10 +252,10 @@ func (cmd *stateMoveCmd) Run(
 		colors.SpecHeadline+"Planning to move the following resources from %s to %s:\n"+colors.Reset),
 		source.Ref().Name(), dest.Ref().Name())
 
+	fmt.Fprintf(cmd.Stdout, "\n")
 	for _, res := range resourcesToMoveOrdered {
-		fmt.Fprintf(cmd.Stdout, "  %s\n", res.URN)
+		fmt.Fprintf(cmd.Stdout, "  - %s\n", res.URN)
 	}
-
 	fmt.Fprintf(cmd.Stdout, "\n")
 
 	var brokenDestDependencies []brokenDependency

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -184,9 +184,9 @@ func TestChildrenAreBeingMoved(t *testing.T) {
 
 	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
 
-	assert.Contains(t, stdout.String(), "Planning to move the following resources from sourceStack to destStack:\n"+
+	assert.Contains(t, stdout.String(), "Planning to move the following resources from sourceStack to destStack:\n\n"+
 		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
-		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2\n")
+		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2")
 
 	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
 

--- a/pkg/cmd/pulumi/state_move_test.go
+++ b/pkg/cmd/pulumi/state_move_test.go
@@ -185,8 +185,8 @@ func TestChildrenAreBeingMoved(t *testing.T) {
 	sourceSnapshot, destSnapshot, stdout := runMove(t, sourceResources, []string{string(sourceResources[1].URN)})
 
 	assert.Contains(t, stdout.String(), "Planning to move the following resources from sourceStack to destStack:\n"+
-		"  urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
-		"  urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2\n")
+		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name\n"+
+		"  - urn:pulumi:sourceStack::test::d:e:f$a:b:c::name2\n")
 
 	assert.Equal(t, 1, len(sourceSnapshot.Resources)) // Only the provider should remain in the source stack
 


### PR DESCRIPTION
Change the output for resources to be moved from

```
Planning to move the following resources from dev to dev2:
  urn:pulumi:dev::aws-ts::pulumi:providers:aws::Provider_A
  urn:pulumi:dev::aws-ts::aws:iam/role:Role::Role_A

Do you want to perform this move?  [Use arrows to move, type to filter]
  yes
> no
```

to

```
Planning to move the following resources from dev to dev2:

 - urn:pulumi:dev::aws-ts::pulumi:providers:aws::Provider_A
 - urn:pulumi:dev::aws-ts::aws:iam/role:Role::Role_A

Do you want to perform this move?  [Use arrows to move, type to filter]
  yes
> no
```

for better readability.